### PR TITLE
ARM64&Unix: New unwinder (#8345)

### DIFF
--- a/src/coreclr/src/nativeaot/Runtime/unix/UnixContext.cpp
+++ b/src/coreclr/src/nativeaot/Runtime/unix/UnixContext.cpp
@@ -8,6 +8,7 @@
 #include "daccess.h"
 #include "PalRedhawkCommon.h"
 #include "regdisplay.h"
+#include "ICodeManager.h"
 #include "config.h"
 
 #include <libunwind.h>
@@ -630,7 +631,7 @@ bool FindProcInfo(uintptr_t controlPC, uintptr_t* startAddress, uintptr_t* lsda)
 }
 
 // Virtually unwind stack to the caller of the context specified by the REGDISPLAY
-bool VirtualUnwind(REGDISPLAY* pRegisterSet)
+bool VirtualUnwind(MethodInfo* pMethodInfo, REGDISPLAY* pRegisterSet)
 {
-    return UnwindHelpers::StepFrame(pRegisterSet);
+    return UnwindHelpers::StepFrame(pMethodInfo, pRegisterSet);
 }

--- a/src/coreclr/src/nativeaot/Runtime/unix/UnixContext.h
+++ b/src/coreclr/src/nativeaot/Runtime/unix/UnixContext.h
@@ -4,6 +4,8 @@
 #ifndef __UNIX_CONTEXT_H__
 #define __UNIX_CONTEXT_H__
 
+#include "ICodeManager.h"
+
 // Convert Unix native context to PAL_LIMITED_CONTEXT
 void NativeContextToPalContext(const void* context, PAL_LIMITED_CONTEXT* palContext);
 // Redirect Unix native context to the PAL_LIMITED_CONTEXT and also set the first two argument registers
@@ -12,7 +14,7 @@ void RedirectNativeContext(void* context, const PAL_LIMITED_CONTEXT* palContext,
 // Find LSDA and start address for a function at address controlPC
 bool FindProcInfo(uintptr_t controlPC, uintptr_t* startAddress, uintptr_t* lsda);
 // Virtually unwind stack to the caller of the context specified by the REGDISPLAY
-bool VirtualUnwind(REGDISPLAY* pRegisterSet);
+bool VirtualUnwind(MethodInfo* pMethodInfo, REGDISPLAY* pRegisterSet);
 
 #ifdef HOST_AMD64
 // Get value of a register from the native context. The index is the processor specific

--- a/src/coreclr/src/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/src/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -24,9 +24,11 @@
 #define UBF_FUNC_KIND_HANDLER   0x01
 #define UBF_FUNC_KIND_FILTER    0x02
 
-#define UBF_FUNC_HAS_EHINFO             0x04
-#define UBF_FUNC_REVERSE_PINVOKE        0x08
-#define UBF_FUNC_HAS_ASSOCIATED_DATA    0x10
+#define UBF_FUNC_HAS_EHINFO              0x04
+#define UBF_FUNC_REVERSE_PINVOKE         0x08
+#define UBF_FUNC_HAS_ASSOCIATED_DATA     0x10
+#define UBF_FUNC_HAS_FULL_UNWIND_INFO    0x20
+#define UBF_FUNC_HAS_COMPACT_UNWIND_INFO 0x40
 
 struct UnixNativeMethodInfo
 {
@@ -144,6 +146,12 @@ void UnixNativeCodeManager::EnumGcRefs(MethodInfo *    pMethodInfo,
     if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)
         p += sizeof(int32_t);
 
+    if ((unwindBlockFlags & UBF_FUNC_HAS_FULL_UNWIND_INFO) != 0)
+        p += sizeof(int32_t);
+
+    if ((unwindBlockFlags & UBF_FUNC_HAS_COMPACT_UNWIND_INFO) != 0)
+        p += sizeof(int16_t);
+
     uint32_t codeOffset = (uint32_t)(PINSTRToPCODE(dac_cast<TADDR>(safePointAddress)) - PINSTRToPCODE(dac_cast<TADDR>(pNativeMethodInfo->pMethodStartAddress)));
 
     GcInfoDecoder decoder(
@@ -192,6 +200,12 @@ uintptr_t UnixNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Method
         if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)
             p += sizeof(int32_t);
 
+        if ((unwindBlockFlags & UBF_FUNC_HAS_FULL_UNWIND_INFO) != 0)
+            p += sizeof(int32_t);
+
+        if ((unwindBlockFlags & UBF_FUNC_HAS_COMPACT_UNWIND_INFO) != 0)
+            p += sizeof(int16_t);
+
         GcInfoDecoder decoder(GCInfoToken(p), DECODE_REVERSE_PINVOKE_VAR);
         INT32 slot = decoder.GetReversePInvokeFrameStackSlot();
         assert(slot != NO_REVERSE_PINVOKE_FRAME);
@@ -216,7 +230,7 @@ uintptr_t UnixNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Method
         // The passed in pRegisterSet should be left intact
         REGDISPLAY localRegisterSet = *pRegisterSet;
 
-        bool result = VirtualUnwind(&localRegisterSet);
+        bool result = VirtualUnwind(pMethodInfo, &localRegisterSet);
         assert(result);
 
         // All common ABIs have outgoing arguments under caller SP (minus slot reserved for return address).
@@ -249,6 +263,12 @@ bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
         if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)
             p += sizeof(int32_t);
 
+        if ((unwindBlockFlags & UBF_FUNC_HAS_FULL_UNWIND_INFO) != 0)
+            p += sizeof(int32_t);
+
+        if ((unwindBlockFlags & UBF_FUNC_HAS_COMPACT_UNWIND_INFO) != 0)
+            p += sizeof(int16_t);
+
         GcInfoDecoder decoder(GCInfoToken(p), DECODE_REVERSE_PINVOKE_VAR);
         INT32 slot = decoder.GetReversePInvokeFrameStackSlot();
         assert(slot != NO_REVERSE_PINVOKE_FRAME);
@@ -269,7 +289,7 @@ bool UnixNativeCodeManager::UnwindStackFrame(MethodInfo *    pMethodInfo,
 
     *ppPreviousTransitionFrame = NULL;
 
-    if (!VirtualUnwind(pRegisterSet))
+    if (!VirtualUnwind(pMethodInfo, pRegisterSet))
     {
         return false;
     }
@@ -442,6 +462,37 @@ PTR_VOID UnixNativeCodeManager::GetAssociatedData(PTR_VOID ControlPC)
     if ((unwindBlockFlags & UBF_FUNC_HAS_ASSOCIATED_DATA) == 0)
         return NULL;
 
+    return dac_cast<PTR_VOID>(p + *dac_cast<PTR_Int32>(p));
+}
+
+PTR_VOID UnixNativeCodeManager::GetMethodUnwindInfo(MethodInfo* pMethodInfo, int8_t& mode)
+{
+    UnixNativeMethodInfo* pNativeMethodInfo = (UnixNativeMethodInfo*)pMethodInfo;
+
+    PTR_UInt8 p = pNativeMethodInfo->pLSDA;
+
+    uint8_t unwindBlockFlags = *p++;
+    if ((unwindBlockFlags & (UBF_FUNC_HAS_FULL_UNWIND_INFO | UBF_FUNC_HAS_COMPACT_UNWIND_INFO)) == 0)
+        return NULL;
+
+    if (pNativeMethodInfo->pLSDA != pNativeMethodInfo->pMainLSDA)
+    {
+        p += sizeof(int32_t) * 2;
+    }
+
+    if ((unwindBlockFlags & UBF_FUNC_HAS_ASSOCIATED_DATA) != 0)
+        p += sizeof(int32_t);
+
+    if ((unwindBlockFlags & UBF_FUNC_HAS_EHINFO) != 0)
+        p += sizeof(int32_t);
+
+    if ((unwindBlockFlags & UBF_FUNC_HAS_COMPACT_UNWIND_INFO) != 0)
+    {
+        mode = 0;
+        return p;
+    }
+        
+    mode = 1;
     return dac_cast<PTR_VOID>(p + *dac_cast<PTR_Int32>(p));
 }
 

--- a/src/coreclr/src/nativeaot/Runtime/unix/UnixNativeCodeManager.h
+++ b/src/coreclr/src/nativeaot/Runtime/unix/UnixNativeCodeManager.h
@@ -66,4 +66,6 @@ public:
     PTR_VOID GetAssociatedData(PTR_VOID ControlPC);
 
     PTR_VOID GetOsModuleHandle();
+
+    static PTR_VOID GetMethodUnwindInfo(MethodInfo* pMethodInfo, int8_t& mode);
 };

--- a/src/coreclr/src/nativeaot/Runtime/unix/UnwindHelpers.cpp
+++ b/src/coreclr/src/nativeaot/Runtime/unix/UnwindHelpers.cpp
@@ -4,6 +4,8 @@
 #include "common.h"
 #include "daccess.h"
 #include "rhassert.h"
+#include "ICodeManager.h"
+#include "UnixNativeCodeManager.h"
 
 #define UNW_STEP_SUCCESS 1
 #define UNW_STEP_END     0
@@ -16,7 +18,9 @@
 #include "UnwindHelpers.h"
 
 // libunwind headers
+#ifndef TARGET_ARM64
 #include <libunwind.h>
+#endif
 #include <src/config.h>
 #include <src/Registers.hpp>
 #include <src/AddressSpace.hpp>
@@ -31,7 +35,7 @@ using libunwind::Registers_x86_64;
 #elif defined(TARGET_ARM)
 using libunwind::Registers_arm;
 #elif defined(TARGET_ARM64)
-using libunwind::Registers_arm64;
+//Nothing to do here for ARM64 but we need to avoid the unsupported architecture error
 #elif defined(TARGET_X86)
 using libunwind::Registers_x86;
 #else
@@ -473,287 +477,7 @@ void Registers_arm_rt::setRegister(int num, uint32_t value, uint32_t location)
 
 #endif // TARGET_ARM
 
-#if defined(TARGET_ARM64)
-
-// Shim that implements methods required by libunwind over REGDISPLAY
-struct Registers_REGDISPLAY : REGDISPLAY
-{
-    inline static int  getArch() { return libunwind::REGISTERS_ARM64; }
-    inline static int  lastDwarfRegNum() { return _LIBUNWIND_HIGHEST_DWARF_REGISTER_ARM64; }
-
-    bool        validRegister(int num) const;
-    bool        validFloatRegister(int num) { return false; };
-    bool        validVectorRegister(int num) const;
-
-    uint64_t    getRegister(int num) const;
-    void        setRegister(int num, uint64_t value, uint64_t location);
-
-    double      getFloatRegister(int num) {abort();}
-    void        setFloatRegister(int num, double value) {abort();}
-
-    libunwind::v128    getVectorRegister(int num) const;
-    void        setVectorRegister(int num, libunwind::v128 value);
-
-    uint64_t    getSP() const         { return SP;}
-    void        setSP(uint64_t value, uint64_t location) { SP = value;}
-    uint64_t    getIP() const         { return IP;}
-    void        setIP(uint64_t value, uint64_t location)
-    { IP = value; pIP = (PTR_UIntNative)location; }
-};
-
-inline bool Registers_REGDISPLAY::validRegister(int num) const {
-    if (num == UNW_REG_SP || num == UNW_ARM64_SP)
-        return true;
-
-    if (num == UNW_ARM64_FP)
-        return true;
-
-    if (num == UNW_ARM64_LR)
-        return true;
-
-    if (num == UNW_REG_IP)
-        return true;
-
-    if (num >= UNW_ARM64_X0 && num <= UNW_ARM64_X28)
-        return true;
-
-    return false;
-}
-
-bool Registers_REGDISPLAY::validVectorRegister(int num) const
-{
-    if (num >= UNW_ARM64_D8 && num <= UNW_ARM64_D15)
-        return true;
-
-    return false;
-}
-
-inline uint64_t Registers_REGDISPLAY::getRegister(int regNum) const {
-    if (regNum == UNW_REG_SP || regNum == UNW_ARM64_SP)
-        return SP;
-
-    if (regNum == UNW_ARM64_FP)
-        return *pFP;
-
-    if (regNum == UNW_ARM64_LR)
-        return *pLR;
-
-    if (regNum == UNW_REG_IP)
-        return IP;
-
-    switch (regNum)
-    {
-    case (UNW_ARM64_X0):
-        return *pX0;
-    case (UNW_ARM64_X1):
-        return *pX1;
-    case (UNW_ARM64_X2):
-        return *pX2;
-    case (UNW_ARM64_X3):
-        return *pX3;
-    case (UNW_ARM64_X4):
-        return *pX4;
-    case (UNW_ARM64_X5):
-        return *pX5;
-    case (UNW_ARM64_X6):
-        return *pX6;
-    case (UNW_ARM64_X7):
-        return *pX7;
-    case (UNW_ARM64_X8):
-        return *pX8;
-    case (UNW_ARM64_X9):
-        return *pX9;
-    case (UNW_ARM64_X10):
-        return *pX10;
-    case (UNW_ARM64_X11):
-        return *pX11;
-    case (UNW_ARM64_X12):
-        return *pX12;
-    case (UNW_ARM64_X13):
-        return *pX13;
-    case (UNW_ARM64_X14):
-        return *pX14;
-    case (UNW_ARM64_X15):
-        return *pX15;
-    case (UNW_ARM64_X16):
-        return *pX16;
-    case (UNW_ARM64_X17):
-        return *pX17;
-    case (UNW_ARM64_X18):
-        return *pX18;
-    case (UNW_ARM64_X19):
-        return *pX19;
-    case (UNW_ARM64_X20):
-        return *pX20;
-    case (UNW_ARM64_X21):
-        return *pX21;
-    case (UNW_ARM64_X22):
-        return *pX22;
-    case (UNW_ARM64_X23):
-        return *pX23;
-    case (UNW_ARM64_X24):
-        return *pX24;
-    case (UNW_ARM64_X25):
-        return *pX25;
-    case (UNW_ARM64_X26):
-        return *pX26;
-    case (UNW_ARM64_X27):
-        return *pX27;
-    case (UNW_ARM64_X28):
-        return *pX28;
-    }
-
-    PORTABILITY_ASSERT("unsupported arm64 register");
-}
-
-void Registers_REGDISPLAY::setRegister(int num, uint64_t value, uint64_t location)
-{
-    if (num == UNW_REG_SP || num == UNW_ARM64_SP) {
-        SP = (uintptr_t )value;
-        return;
-    }
-
-    if (num == UNW_ARM64_FP) {
-        pFP = (PTR_UIntNative)location;
-        return;
-    }
-
-    if (num == UNW_ARM64_LR) {
-        pLR = (PTR_UIntNative)location;
-        return;
-    }
-
-    if (num == UNW_REG_IP) {
-        IP = value;
-        return;
-    }
-
-    switch (num)
-    {
-    case (UNW_ARM64_X0):
-        pX0 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X1):
-        pX1 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X2):
-        pX2 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X3):
-        pX3 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X4):
-        pX4 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X5):
-        pX5 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X6):
-        pX6 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X7):
-        pX7 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X8):
-        pX8 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X9):
-        pX9 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X10):
-        pX10 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X11):
-        pX11 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X12):
-        pX12 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X13):
-        pX13 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X14):
-        pX14 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X15):
-        pX15 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X16):
-        pX16 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X17):
-        pX17 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X18):
-        pX18 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X19):
-        pX19 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X20):
-        pX20 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X21):
-        pX21 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X22):
-        pX22 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X23):
-        pX23 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X24):
-        pX24 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X25):
-        pX25 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X26):
-        pX26 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X27):
-        pX27 = (PTR_UIntNative)location;
-        break;
-    case (UNW_ARM64_X28):
-        pX28 = (PTR_UIntNative)location;
-        break;
-    default:
-        PORTABILITY_ASSERT("unsupported arm64 register");
-    }
-}
-
-libunwind::v128 Registers_REGDISPLAY::getVectorRegister(int num) const
-{
-    num -= UNW_ARM64_D8;
-
-    if (num < 0 || num >= sizeof(D) / sizeof(uint64_t))
-    {
-        PORTABILITY_ASSERT("unsupported arm64 vector register");
-    }
-
-    libunwind::v128 result;
-
-    result.vec[0] = 0;
-    result.vec[1] = 0;
-    result.vec[2] = D[num] >> 32;
-    result.vec[3] = D[num] & 0xFFFFFFFF;
-
-    return result;
-}
-
-void Registers_REGDISPLAY::setVectorRegister(int num, libunwind::v128 value)
-{
-    num -= UNW_ARM64_D8;
-
-    if (num < 0 || num >= sizeof(D) / sizeof(uint64_t))
-    {
-        PORTABILITY_ASSERT("unsupported arm64 vector register");
-    }
-
-    D[num] = (uint64_t)value.vec[2] << 32 | (uint64_t)value.vec[3];
-}
-
-#endif // TARGET_ARM64
+#ifndef TARGET_ARM64
 
 bool DoTheStep(uintptr_t pc, UnwindInfoSections uwInfoSections, REGDISPLAY *regs)
 {
@@ -761,8 +485,6 @@ bool DoTheStep(uintptr_t pc, UnwindInfoSections uwInfoSections, REGDISPLAY *regs
     libunwind::UnwindCursor<LocalAddressSpace, Registers_x86_64> uc(_addressSpace);
 #elif defined(TARGET_ARM)
     libunwind::UnwindCursor<LocalAddressSpace, Registers_arm_rt> uc(_addressSpace, regs);
-#elif defined(TARGET_ARM64)
-    libunwind::UnwindCursor<LocalAddressSpace, Registers_arm64> uc(_addressSpace, regs);
 #elif defined(HOST_X86)
     libunwind::UnwindCursor<LocalAddressSpace, Registers_x86> uc(_addressSpace, regs);
 #else
@@ -792,9 +514,7 @@ bool DoTheStep(uintptr_t pc, UnwindInfoSections uwInfoSections, REGDISPLAY *regs
         return false;
     }
 
-#if !defined(TARGET_ARM64)
     regs->pIP = PTR_PCODE(regs->SP - sizeof(TADDR));
-#endif
 
 #elif defined(_LIBUNWIND_ARM_EHABI)
     uc.setInfoBasedOnIPRegister(true);
@@ -808,8 +528,27 @@ bool DoTheStep(uintptr_t pc, UnwindInfoSections uwInfoSections, REGDISPLAY *regs
     return true;
 }
 
-bool UnwindHelpers::StepFrame(REGDISPLAY *regs)
+#endif //!TARGET_ARM64
+
+bool UnwindHelpers::StepFrame(MethodInfo* pMethodInfo, REGDISPLAY *regs)
 {
+#ifdef TARGET_ARM64
+    int8_t mode;
+
+    PTR_VOID pUnwindInfo = UnixNativeCodeManager::GetMethodUnwindInfo(pMethodInfo, mode);
+
+    if (pUnwindInfo != NULL)
+    {
+        if (mode == 0)
+        {
+            return StepFrameCompact(regs, pUnwindInfo);
+        }
+
+        return StepFrame(regs, pUnwindInfo);
+    }
+
+    return false;
+#else
     UnwindInfoSections uwInfoSections;
 #if _LIBUNWIND_SUPPORT_DWARF_UNWIND
     uintptr_t pc = regs->GetIP();
@@ -818,6 +557,8 @@ bool UnwindHelpers::StepFrame(REGDISPLAY *regs)
         return false;
     }
     return DoTheStep(pc, uwInfoSections, regs);
+
+    //return DoTheStep(pc, uwInfoSections, regs);
 #elif defined(_LIBUNWIND_ARM_EHABI)
     // unwind section is located later for ARM
     // pc will be taked from regs parameter
@@ -825,4 +566,96 @@ bool UnwindHelpers::StepFrame(REGDISPLAY *regs)
 #else
     PORTABILITY_ASSERT("StepFrame");
 #endif
+#endif // TARGET_ARM64
 }
+
+#ifdef TARGET_ARM64
+
+bool UnwindHelpers::StepFrame(REGDISPLAY* regs, PTR_VOID unwindInfo)
+{
+    uint8_t* pData = (uint8_t*)unwindInfo;
+
+    int cfaRegister = *pData++;
+    uint32_t cfaOffset = *((uint16_t*)pData) * 8;
+    pData += sizeof(uint16_t);
+
+    uint8_t* baseLocation;
+
+    if (cfaRegister <= 30)
+    {
+        baseLocation = (uint8_t*)*((&regs->pX0)[cfaRegister]);
+    }
+    else
+    {
+        ASSERT(cfaRegister == 31);
+        baseLocation = (uint8_t*)regs->GetSP();
+    }
+
+    regs->SetSP((UIntNative)baseLocation + cfaOffset);
+
+    while (*pData != 0xFF)
+    {
+        int reg = *pData++;
+        uint32_t offset = *((uint16_t*)pData) * 8;
+        pData += sizeof(uint16_t);
+
+        if (reg >= 0 && reg <= 32)
+        {
+            (&regs->pX0)[reg] = (PTR_UIntNative)(baseLocation + offset);
+        }
+        else
+        {
+            ASSERT(reg < 40);
+            regs->D[reg - 32] = *((UInt64*)(baseLocation + offset));
+        }
+    }
+    
+    regs->SetAddrOfIP(regs->pLR);
+    regs->SetIP(*regs->GetAddrOfIP());
+
+    return true;
+}
+
+bool UnwindHelpers::StepFrameCompact(REGDISPLAY* regs, PTR_VOID unwindInfo)
+{
+    // Encoding
+    // FSSR RRRO OOOO OOOO
+    // F = Frame type 0 = FP ; 1 = SP
+    // O = CFA offset / 8
+    // R = number of additional registers X19 - X28
+    // S = Offset for FP/LR / 8
+
+    uint16_t code = *(uint16_t*)unwindInfo;
+    uint32_t cfaOffset = (code & 0x1F) * 8;
+    int regCount = (code >> 9) & 0xF;
+    int frameOffset = ((code >> 13) & 0x3) * 8;
+    uint8_t* baseLocation;
+
+    if ((code & 0x8000) == 0x8000)
+    {
+        baseLocation = (uint8_t*)regs->GetSP();
+    }
+    else
+    {
+        baseLocation = (uint8_t*)*regs->pFP;
+    }
+
+    PTR_UIntNative regLocation = (PTR_UIntNative)baseLocation + (-8 + cfaOffset - regCount * 8);
+
+    for (int i = 0; i < regCount; i++)
+    {
+        (&regs->pX0)[19 + i] = regLocation++;
+    }
+
+    regs->pFP = (PTR_UIntNative)(baseLocation + frameOffset);
+    regs->pLR = (PTR_UIntNative)(baseLocation + frameOffset + 8);
+
+    regs->SetSP((UIntNative)baseLocation + cfaOffset);
+
+    regs->SetAddrOfIP(regs->pLR);
+    regs->SetIP(*regs->GetAddrOfIP());
+
+    return true;
+}
+
+#endif // TARGET_ARM64

--- a/src/coreclr/src/nativeaot/Runtime/unix/UnwindHelpers.h
+++ b/src/coreclr/src/nativeaot/Runtime/unix/UnwindHelpers.h
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "common.h"
+#include "ICodeManager.h"
 
 // This class is used to encapsulate the internals of our unwinding implementation
 // and any custom versions of libunwind structures that we use for performance
@@ -9,5 +10,10 @@
 class UnwindHelpers
 {
 public:
-    static bool StepFrame(REGDISPLAY *regs);
+    static bool StepFrame(MethodInfo* pMethodInfo, REGDISPLAY *regs);
+
+#ifdef TARGET_ARM64
+    static bool StepFrame(REGDISPLAY* regs, PTR_VOID unwindInfo);
+    static bool StepFrameCompact(REGDISPLAY* regs, PTR_VOID unwindInfo);
+#endif
 };

--- a/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/INodeWithCodeInfo.cs
+++ b/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/INodeWithCodeInfo.cs
@@ -8,12 +8,14 @@ namespace ILCompiler.DependencyAnalysis
     [Flags]
     public enum FrameInfoFlags
     {
-        Handler             = 0x01,
-        Filter              = 0x02,
+        Handler              = 0x01,
+        Filter               = 0x02,
 
-        HasEHInfo           = 0x04,
-        ReversePInvoke      = 0x08,
-        HasAssociatedData   = 0x10,
+        HasEHInfo            = 0x04,
+        ReversePInvoke       = 0x08,
+        HasAssociatedData    = 0x10,
+        HasFullUnwindInfo    = 0x20,
+        HasCompactUnwindInfo = 0x40
     }
 
     public struct FrameInfo
@@ -22,13 +24,15 @@ namespace ILCompiler.DependencyAnalysis
         public readonly int StartOffset;
         public readonly int EndOffset;
         public readonly byte[] BlobData;
+        public readonly byte[] UnwindData;
 
-        public FrameInfo(FrameInfoFlags flags, int startOffset, int endOffset, byte[] blobData)
+        public FrameInfo(FrameInfoFlags flags, int startOffset, int endOffset, byte[] blobData, byte[] unwindData)
         {
             Flags = flags;
             StartOffset = startOffset;
             EndOffset = endOffset;
             BlobData = blobData;
+            UnwindData = unwindData;
         }
     }
 

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2894,6 +2894,7 @@ namespace Internal.JitInterface
             }
 
             byte[] blobData = new byte[unwindSize];
+            byte[] unwindData = null;
 
             for (uint i = 0; i < unwindSize; i++)
             {
@@ -2904,18 +2905,21 @@ namespace Internal.JitInterface
 
             if (target.Architecture == TargetArchitecture.ARM64 && target.OperatingSystem == TargetOS.Linux)
             {
-                blobData = CompressARM64CFI(blobData);
+                blobData = CompressARM64CFI(blobData, out unwindData);
             }
 
-            _frameInfos[_usedFrameInfos++] = new FrameInfo(flags, (int)startOffset, (int)endOffset, blobData);
+            _frameInfos[_usedFrameInfos++] = new FrameInfo(flags, (int)startOffset, (int)endOffset, blobData, unwindData);
         }
 
         // Get the CFI data in the same shape as clang/LLVM generated one. This improves the compatibility with libunwind and other unwind solutions
         // - Combine in one single block for the whole prolog instead of one CFI block per assembler instruction
         // - Store CFA definition first
         // - Store all used registers in ascending order
-        private byte[] CompressARM64CFI(byte[] blobData)
+
+        private byte[] CompressARM64CFI(byte[] blobData, out byte[] unwindData)
         {
+            unwindData = null;
+
             if (blobData == null || blobData.Length == 0)
             {
                 return blobData;
@@ -2994,9 +2998,15 @@ namespace Internal.JitInterface
                 }
             }
 
+            ArrayBuilder<byte> unwind = new ArrayBuilder<byte>();
+            uint compactCode;
+
             using (MemoryStream cfiStream = new MemoryStream())
             {
                 int storeOffset = 0;
+
+                int unwindRegister = 0;
+                int unwindOffset = 0;
 
                 using (BinaryWriter cfiWriter = new BinaryWriter(cfiStream))
                 {
@@ -3007,6 +3017,9 @@ namespace Internal.JitInterface
                         cfiWriter.Write(cfaRegister);
                         cfiWriter.Write(cfaOffset);
                         storeOffset = cfaOffset;
+
+                        unwindRegister = cfaRegister;
+                        unwindOffset = cfaOffset;
                     }
                     else
                     {
@@ -3016,6 +3029,9 @@ namespace Internal.JitInterface
                             cfiWriter.Write((byte)CFI_OPCODE.CFI_ADJUST_CFA_OFFSET);
                             cfiWriter.Write((short)-1);
                             cfiWriter.Write(cfaOffset);
+
+                            unwindRegister = 31;
+                            unwindOffset = cfaOffset;
                         }
 
                         if (spOffset != 0)
@@ -3024,23 +3040,190 @@ namespace Internal.JitInterface
                             cfiWriter.Write((byte)CFI_OPCODE.CFI_DEF_CFA);
                             cfiWriter.Write((short)31); 
                             cfiWriter.Write(spOffset);
+
+                            unwindRegister = 31;
+                            unwindOffset = spOffset;
                         }
                     }
+
+                    Debug.Assert(unwindRegister >= 0 && unwindRegister <= 31);
+                    Debug.Assert(unwindOffset % 8 == 0);
+                    Debug.Assert(unwindOffset >= 0);
+
+                    compactCode = GenerateARM64CompactUnwindCode(unwindRegister, unwindOffset, registerOffset);
+
+                    unwindOffset /= 8;
+
+                    Debug.Assert(unwindOffset <= ushort.MaxValue);
+
+                    unwind.Add((byte)unwindRegister);
+                    unwind.Add((byte)(unwindOffset & 0xFF));
+                    unwind.Add((byte)((unwindOffset >> 8) & 0xFF));
 
                     for (int i = registerOffset.Length - 1; i >= 0; i--)
                     {
                         if (registerOffset[i] != int.MinValue)
                         {
+                            unwindRegister = i;
+                            unwindOffset = registerOffset[i] + storeOffset;
+
                             cfiWriter.Write((byte)codeOffset);
                             cfiWriter.Write((byte)CFI_OPCODE.CFI_REL_OFFSET);
-                            cfiWriter.Write((short)i);
-                            cfiWriter.Write(registerOffset[i] + storeOffset);
+                            cfiWriter.Write((short)unwindRegister);
+                            cfiWriter.Write(unwindOffset);
+
+                            Debug.Assert(unwindOffset % 8 == 0);
+                            Debug.Assert(unwindOffset >= 0);
+
+                            // X0 - X31
+                            if (unwindRegister >= 0 && unwindRegister < 32)
+                            {
+                            }
+                            // D8 - D16
+                            else if (unwindRegister >= 72 && unwindRegister < 81)
+                            {
+                                unwindRegister -= 40;
+                            }
+                            else
+                            {
+                                continue;
+                            }
+
+                            unwindOffset /= 8;
+
+                            Debug.Assert(unwindOffset <= byte.MaxValue);
+
+                            unwind.Add((byte)unwindRegister);
+
+                            unwind.Add((byte)(unwindOffset & 0xFF));
+                            unwind.Add((byte)((unwindOffset >> 8) & 0xFF));
                         }
                     }
                 }
 
+                if (compactCode != 0)
+                {
+                    unwindData = BitConverter.GetBytes((ushort)compactCode);
+                }
+                else
+                {
+                    unwind.Add(0xFF);
+                    unwindData = unwind.ToArray();
+                }
+
                 return cfiStream.ToArray();
             }
+        }
+
+        uint GenerateARM64CompactUnwindCode (int cfaRegister, int cfaOffset, int[] registerOffsets)
+        {
+            if (cfaOffset >= 512*8)
+            {
+                return 0;
+            }
+
+            for (int i = 0; i < 18; i++)
+            {
+                if (registerOffsets[i] != int.MinValue)
+                {
+                    return 0;
+                }
+            }
+
+            for (int i = 31; i < registerOffsets.Length; i++)
+            {
+                if (registerOffsets[i] != int.MinValue)
+                {
+                    return 0;
+                }
+            }
+
+            uint code = 0;
+
+            code |= (uint)(cfaOffset / 8);
+
+            int regCount = 0;
+            int reg = 19;
+            int lastRegOffset = int.MinValue;
+
+            if (registerOffsets[reg] != int.MinValue)
+            {
+                int offset = registerOffsets[reg];
+                reg++;
+                regCount++;
+
+                for (; reg <= 28; reg++)
+                {
+                    if (registerOffsets[reg] == int.MinValue)
+                        break;
+
+                    if (registerOffsets[reg] != offset + 8)
+                    {
+                        return 0;
+                    }
+
+                    regCount++;
+                    offset = registerOffsets[reg];
+                }
+
+                lastRegOffset = offset;
+            }
+
+            for (; reg <= 28; reg++)
+            {
+                if (registerOffsets[reg] != int.MinValue)
+                {
+                    return 0;
+                }
+            }
+
+            code |= (uint)(regCount << 9);
+
+            switch (cfaRegister)
+            {
+                case 29:
+                    {
+                        if (registerOffsets[29] != -cfaOffset || registerOffsets[30] != -cfaOffset + 8)
+                        {
+                            return 0;
+                        }
+
+                        if (regCount > 0 && lastRegOffset != -8)
+                        {
+                            return 0;
+                        }
+                    }
+                    break;
+
+                case 31:
+                    {
+                        if (regCount > 0 && lastRegOffset + 8 != cfaOffset)
+                        {
+                            return 0;
+                        }
+
+                        if (registerOffsets[29] + 8 != registerOffsets[30])
+                        {
+                            return 0;
+                        }
+
+                        int frameOffset = registerOffsets[29] / 8;
+
+                        if (frameOffset > 3)
+                        {
+                            return 0;
+                        }
+
+                        code |= 0x8000;
+                        code |= (uint)(frameOffset << 13);
+                    }
+                    break;
+
+                default:
+                    return 0;
+            }
+
+            return code;
         }
 
         private void* allocGCInfo(UIntPtr size)


### PR DESCRIPTION
Implements a custom unwinder for ARM64 that does not need the generic CFI based libunwind functions. This way we only need to loop just once over all used registers instead of doing the complicated CFI process.This will improve the performances for everything that needs a stack walk.

Additional unwind data are generated and stored as part of the LSDA. 
-4 byte for a relative offset
-3 byte for the CFA
-3 byte for each register that is part of the prolog save
-1 byte end marker

We still keep the CFI data for the debugger. Maybe the could be removed for a build without debug information.

A possible future optimization would be to introduce a compact format for the information used by the most common cases. This could be stored in the relative offset. But compared to the replacement of libunwind the wins would be rather small.

The same can be done for any  other supported architecture but each one will require a custom unwind function