### PR TITLE
NativeAot-LLVM: Consistency in test host OS checking

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <RunScriptInputName Condition="$([MSBuild]::IsOSPlatform('windows'))">RunnerTemplate.cmd</RunScriptInputName>
-    <RunScriptInputName Condition="!$([MSBuild]::IsOSPlatform('windows'))">RunnerTemplate.sh</RunScriptInputName>
+    <RunScriptInputName Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunnerTemplate.cmd</RunScriptInputName>
+    <RunScriptInputName Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">AppleRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Android'">AndroidRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Browser' and '$(__TestBuildMode)' != 'nativeaot'">WasmRunnerTemplate.sh</RunScriptInputName>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -8,15 +8,15 @@
 
     <RunScriptInputPath>$(MSBuildThisFileDirectory)$(RunScriptInputName)</RunScriptInputPath>
 
-    <RunScriptOutputName Condition="$([MSBuild]::IsOSPlatform('windows'))">RunTests.cmd</RunScriptOutputName>
-    <RunScriptOutputName Condition="!$([MSBuild]::IsOSPlatform('windows'))">RunTests.sh</RunScriptOutputName>
+    <RunScriptOutputName Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunTests.cmd</RunScriptOutputName>
+    <RunScriptOutputName Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(OutDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
 
-    <RunScriptHostDir Condition="$([MSBuild]::IsOSPlatform('windows'))">%RUNTIME_PATH%\</RunScriptHostDir>
-    <RunScriptHostDir Condition="!$([MSBuild]::IsOSPlatform('windows'))">$RUNTIME_PATH/</RunScriptHostDir>
+    <RunScriptHostDir Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">%RUNTIME_PATH%\</RunScriptHostDir>
+    <RunScriptHostDir Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
 
-    <RunScriptHost Condition="$([MSBuild]::IsOSPlatform('windows'))">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
-    <RunScriptHost Condition="!$([MSBuild]::IsOSPlatform('windows'))">$(RunScriptHostDir)dotnet</RunScriptHost>
+    <RunScriptHost Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
+    <RunScriptHost Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -52,8 +52,8 @@
   <Target Name="GenerateRunScript">
     <PropertyGroup>
       <!-- RSP file support. -->
-      <RunScriptCommand Condition="'$(TargetOS)' == 'windows'">$(RunScriptCommand) %RSP_FILE%</RunScriptCommand>
-      <RunScriptCommand Condition="'$(TargetOS)' != 'windows'">$(RunScriptCommand) $RSP_FILE</RunScriptCommand>
+      <RunScriptCommand Condition="'!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')'">$(RunScriptCommand) %RSP_FILE%</RunScriptCommand>
+      <RunScriptCommand Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$(RunScriptCommand) $RSP_FILE</RunScriptCommand>
 
       <!-- Escape potential user input. -->
       <RunScriptCommand>$([MSBuild]::Escape('$(RunScriptCommand)'))</RunScriptCommand>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -1,22 +1,22 @@
 <Project>
   <PropertyGroup>
-    <RunScriptInputName Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunnerTemplate.cmd</RunScriptInputName>
-    <RunScriptInputName Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunnerTemplate.sh</RunScriptInputName>
+    <RunScriptInputName Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunnerTemplate.cmd</RunScriptInputName>
+    <RunScriptInputName Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">AppleRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Android'">AndroidRunnerTemplate.sh</RunScriptInputName>
     <RunScriptInputName Condition="'$(TargetOS)' == 'Browser' and '$(__TestBuildMode)' != 'nativeaot'">WasmRunnerTemplate.sh</RunScriptInputName>
 
     <RunScriptInputPath>$(MSBuildThisFileDirectory)$(RunScriptInputName)</RunScriptInputPath>
 
-    <RunScriptOutputName Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunTests.cmd</RunScriptOutputName>
-    <RunScriptOutputName Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
+    <RunScriptOutputName Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">RunTests.cmd</RunScriptOutputName>
+    <RunScriptOutputName Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">RunTests.sh</RunScriptOutputName>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(OutDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
 
-    <RunScriptHostDir Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">%RUNTIME_PATH%\</RunScriptHostDir>
-    <RunScriptHostDir Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
+    <RunScriptHostDir Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">%RUNTIME_PATH%\</RunScriptHostDir>
+    <RunScriptHostDir Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$RUNTIME_PATH/</RunScriptHostDir>
 
-    <RunScriptHost Condition="!($(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
-    <RunScriptHost Condition="$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
+    <RunScriptHost Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
+    <RunScriptHost Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/tests/run.proj
+++ b/src/tests/run.proj
@@ -5,8 +5,8 @@
     <XunitTestBinBase Condition="'$(XunitTestBinBase)'==''" >$(BaseOutputPathWithConfig)</XunitTestBinBase>
     <XunitWrapperGeneratedCSDirBase>$(XunitTestBinBase)\TestWrappers\</XunitWrapperGeneratedCSDirBase>
     <MSBuildEnableAllPropertyFunctions>1</MSBuildEnableAllPropertyFunctions>
-    <TestScriptExtension Condition="!$([MSBuild]::IsOSPlatform('windows'))">sh</TestScriptExtension>
-    <TestScriptExtension Condition="$([MSBuild]::IsOSPlatform('windows'))">cmd</TestScriptExtension>
+    <TestScriptExtension Condition="'$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT'">sh</TestScriptExtension>
+    <TestScriptExtension Condition="!('$(TargetOS)' != 'windows' and '$(OS)' != 'Windows_NT')">cmd</TestScriptExtension>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Following from https://github.com/dotnet/runtime/pull/46105, this PR updates the remaining test for checking the host OS to be in sync with other places.