### PR TITLE
Make it possible to disable non-filestream support in XmlDownloadManager

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -13,6 +13,11 @@ namespace Internal.Runtime.CompilerHelpers
     /// </summary>
     public static class ThrowHelpers
     {
+        internal static void ThrowBodyRemoved()
+        {
+            throw new NotSupportedException(SR.NotSupported_BodyRemoved);
+        }
+
         public static void ThrowOverflowException()
         {
             throw new OverflowException();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3079,6 +3079,9 @@
   <data name="Encoding_UTF7_Disabled" xml:space="preserve">
     <value>Support for UTF-7 is disabled. See {0} for more information.</value>
   </data>
+  <data name="NotSupported_BodyRemoved" xml:space="preserve">
+    <value>The feature associated with this method was removed.</value>
+  </data>
   <data name="Arg_MustBeHalf" xml:space="preserve">
     <value>Object must be of type Half.</value>
   </data>

--- a/src/libraries/System.Private.Xml/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Private.Xml/src/ILLink/ILLink.Substitutions.xml
@@ -2,4 +2,7 @@
   <type fullname="System.Xml.Serialization.XmlSerializer" featurevalue="true" feature="System.Xml.Serialization.XmlSerializer.IsReflectionOnly">
     <method signature="System.Xml.Serialization.SerializationMode get_Mode()" body="stub" value="1" />
   </type>
+  <type fullname="System.Xml.XmlDownloadManager" featurevalue="false" feature="System.Xml.XmlDownloadManager.IsNonFileStreamSupported">
+    <method signature="System.Threading.Tasks.Task`1&lt;System.IO.Stream&gt; GetNonFileStreamAsync(System.Uri,System.Net.ICredentials,System.Net.IWebProxy)" body="remove" />
+  </type>
 </linker>


### PR DESCRIPTION
`new XmlDocument().Load("foo")` brings the entire .NET web stack since `foo` could have a non-local URL in it. Adding a feature switch to allow disabling this support. Saves megabytes in terms of resulting EXE file size.