### PR TITLE
NativeAOT-LLVM: Add call helper for gc/nongc statics node/RhpAssignRef for STOREIND

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -199,8 +199,8 @@ Value* buildCnsInt(llvm::IRBuilder<>& builder, GenTree* node)
 
 void importStoreInd(llvm::IRBuilder<>& builder, GenTree* node)
 {
-    Value* address = getTreeIdValue(node->AsOpRef()->gtOp1);
-    Value* toStore = getTreeIdValue(reinterpret_cast<GenTreeOp*>(node)->gtOp2);
+    Value* address = getTreeIdValue(node->AsOp()->gtOp1);
+    Value* toStore = getTreeIdValue(node->AsOp()->gtOp2);
     // TODO: delete this temporary check for supported stores
     if (!address->getType()->isPointerTy() || !toStore->getType()->isPointerTy())
     {

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -208,7 +208,7 @@ void importStoreInd(llvm::IRBuilder<>& builder, GenTree* node)
         failFunctionCompilation();
     }
 
-    // dont think RhpAssignRef will ever reverse PInvoke, so probably ok not to store the shadow stack here
+    // RhpAssignRef will never reverse PInvoke, so do not need to store the shadow stack here
     builder.CreateCall(getOrCreateRhpAssignRef(), ArrayRef<Value*>{address, toStore});
 }
 

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -199,7 +199,7 @@ Value* buildCnsInt(llvm::IRBuilder<>& builder, GenTree* node)
 
 void importStoreInd(llvm::IRBuilder<>& builder, GenTree* node)
 {
-    Value* address = getTreeIdValue(reinterpret_cast<GenTreeOp*>(node)->gtOp1);
+    Value* address = getTreeIdValue(node->AsOpRef()->gtOp1);
     Value* toStore = getTreeIdValue(reinterpret_cast<GenTreeOp*>(node)->gtOp2);
     // TODO: delete this temporary check for supported stores
     if (!address->getType()->isPointerTy() || !toStore->getType()->isPointerTy())
@@ -217,7 +217,7 @@ Value* visitNode(llvm::IRBuilder<> &builder, GenTree* node)
     switch (node->OperGet())
     {
         case GT_ADD:
-            return buildAdd(builder, node, getTreeIdValue(reinterpret_cast<GenTreeOp*>(node)->gtOp1), getTreeIdValue(reinterpret_cast<GenTreeOp*>(node)->gtOp2));
+            return buildAdd(builder, node, getTreeIdValue(node->AsOp()->gtOp1), getTreeIdValue(node->AsOp()->gtOp2));
         case GT_CALL:
             return buildCall(builder, node);
         case GT_CNS_INT:

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -20,7 +20,10 @@
 #define IMAGE_FILE_MACHINE_WASM32             0xFFFF
 #define IMAGE_FILE_MACHINE_WASM64             0xFFFE // TODO: appropriate values for this?  Used to check compilation is for intended target
 
-extern "C" void registerLlvmCallbacks(void* thisPtr, const char* outputFileName, const char* triple, const char* dataLayout, const char* (*getMangledMethodNamePtr)(void*, CORINFO_METHOD_STRUCT_*));
+extern "C" void registerLlvmCallbacks(void* thisPtr, const char* outputFileName, const char* triple, const char* dataLayout,
+    const char* (*getMangledMethodNamePtr)(void*, CORINFO_METHOD_STRUCT_*),
+    const char* (*_getMangledSymbolNamePtr)(void*, void*),
+    const char* (*addCodeReloc)(void*, void*));
 
 class Llvm
 {

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/AssemblyStubNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/AssemblyStubNode.cs
@@ -68,6 +68,10 @@ namespace ILCompiler.DependencyAnalysis
                     arm64Emitter.Builder.AddSymbol(this);
                     return arm64Emitter.Builder.ToObjectData();
 
+                case TargetArchitecture.Wasm32:
+                case TargetArchitecture.Wasm64:
+                    return new ObjectData(null, null, 0, null);
+
                 default:
                     throw new NotImplementedException();
             }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -95,10 +95,6 @@ namespace ILCompiler.DependencyAnalysis
             symbolAddress = module.AddGlobalInAddressSpace(intPtrType, symbolAddressGlobalName, 0);
             symbolAddress.IsGlobalConstant = true;
             symbolAddress.Linkage = LLVMLinkage.LLVMInternalLinkage;
-            if (symbolAddressGlobalName.Contains("NonGCStaticBase_Bool"))
-            {
-            }
-
             s_symbolValues.Add(symbolAddressGlobalName, symbolAddress);
             return symbolAddress;
         }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -14,6 +14,7 @@ using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 using LLVMSharp.Interop;
 using ILCompiler.DependencyAnalysis;
 using Internal.IL;
+using Internal.TypeSystem.Ecma;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -78,18 +79,28 @@ namespace ILCompiler.DependencyAnalysis
                 ThrowHelper.ThrowInvalidProgramException();
             }
 
+            return AddOrReturnGlobalSymbol(module, symbol, nameMangler);
+        }
+
+        public static LLVMValueRef AddOrReturnGlobalSymbol(LLVMModuleRef module, ISymbolNode symbol, NameMangler nameMangler)
+        {
             string symbolAddressGlobalName = symbol.GetMangledName(nameMangler) + "___SYMBOL";
             LLVMValueRef symbolAddress;
             if (s_symbolValues.TryGetValue(symbolAddressGlobalName, out symbolAddress))
             {
                 return symbolAddress;
             }
+
             var intPtrType = LLVMTypeRef.CreatePointer(LLVMTypeRef.Int32, 0);
-            var myGlobal = module.AddGlobalInAddressSpace(intPtrType, symbolAddressGlobalName, 0);
-            myGlobal.IsGlobalConstant = true;
-            myGlobal.Linkage = LLVMLinkage.LLVMInternalLinkage;
-            s_symbolValues.Add(symbolAddressGlobalName, myGlobal);
-            return myGlobal;
+            symbolAddress = module.AddGlobalInAddressSpace(intPtrType, symbolAddressGlobalName, 0);
+            symbolAddress.IsGlobalConstant = true;
+            symbolAddress.Linkage = LLVMLinkage.LLVMInternalLinkage;
+            if (symbolAddressGlobalName.Contains("NonGCStaticBase_Bool"))
+            {
+            }
+
+            s_symbolValues.Add(symbolAddressGlobalName, symbolAddress);
+            return symbolAddress;
         }
 
         private static int GetNumericOffsetFromBaseSymbolValue(ISymbolNode symbol)
@@ -729,6 +740,12 @@ namespace ILCompiler.DependencyAnalysis
                         continue;
                     }
 
+                    if (node is ReadyToRunHelperNode readyToRunHelperNode)
+                    {
+                        objectWriter.GetCodeForReadyToRunHelper(compilation, readyToRunHelperNode, factory);
+                        continue;
+                    }
+
                     if (node is TentativeMethodNode tentativeMethodNode)
                     {
                         objectWriter.GetCodeForTentativeMethod(compilation, tentativeMethodNode, factory);
@@ -1027,6 +1044,91 @@ namespace ILCompiler.DependencyAnalysis
             else
             {
                 builder.BuildRetVoid();
+            }
+        }
+
+        private void GetCodeForReadyToRunHelper(LLVMCodegenCompilation compilation, ReadyToRunHelperNode node, NodeFactory factory)
+        {
+            LLVMBuilderRef builder = compilation.Module.Context.CreateBuilder();
+
+            LLVMValueRef helperFunc = Module.AddFunction(node.GetMangledName(factory.NameMangler), LLVMTypeRef.CreateFunction(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) /* shadow stack */}));
+
+            var helperBlock = helperFunc.AppendBasicBlock("readyToRunHelper");
+            builder.PositionAtEnd(helperBlock);
+            var importer = new ILImporter(builder, compilation, Module, helperFunc, null);
+
+            LLVMValueRef resVar;
+            switch (node.Id)
+            {
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)node.Target;
+                        
+                        var symbolNode = factory.TypeNonGCStaticsSymbol(target);
+                        LLVMValueRef addressOfAddress = GetSymbolValuePointer(Module, symbolNode, factory.NameMangler, false);
+                        LLVMValueRef ptr = builder.BuildLoad(addressOfAddress, "LoadAddressOfSymbolNode");
+
+                        if (compilation.HasLazyStaticConstructor(target))
+                        {
+                            importer.OutputCodeForTriggerCctor(target, ptr);
+                        }
+                        resVar = builder.BuildPointerCast(ptr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
+                    }
+                    break;
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)node.Target;
+                        
+                        var symbolNode = factory.TypeGCStaticsSymbol(target);
+                        LLVMValueRef addressOfAddress = GetSymbolValuePointer(Module, symbolNode, factory.NameMangler, false);
+                        LLVMValueRef basePtrPtr = builder.BuildLoad(addressOfAddress, "LoadAddressOfSymbolNode");
+                        LLVMValueRef ptr = builder.BuildLoad(builder.BuildLoad(builder.BuildPointerCast(basePtrPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.CreatePointer(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), 0), 0), "castBasePtrPtr"), "basePtr"), "base");
+                        
+                        if (compilation.HasLazyStaticConstructor(target))
+                        {
+                            var nonGcSymbolNode = factory.TypeNonGCStaticsSymbol(target);
+                            LLVMValueRef nonGcAddressOfAddress = GetSymbolValuePointer(Module, nonGcSymbolNode, factory.NameMangler, false);
+                            LLVMValueRef nonGcBase = builder.BuildLoad(nonGcAddressOfAddress, "LoadAddressOfSymbolNode");
+                        
+                            importer.OutputCodeForTriggerCctor(target, nonGcBase);
+                        }
+                        resVar = builder.BuildPointerCast(ptr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
+                    }
+                    break;
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    {
+                        throw new NotImplementedException();
+                        // MetadataType target = (MetadataType)node.Target;
+                        //
+                        // if (compilation.HasLazyStaticConstructor(target))
+                        // {
+                        //     GenericLookupResult nonGcRegionLookup = factory.GenericLookup.TypeNonGCStaticBase(target);
+                        //     var threadStaticBase = OutputCodeForDictionaryLookup(builder, factory, node, nonGcRegionLookup, ctx, "tsGep");
+                        //     importer.OutputCodeForTriggerCctor(target, threadStaticBase);
+                        // }
+                        // resVar = importer.OutputCodeForGetThreadStaticBaseForType(resVar).ValueAsType(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), builder);
+                    }
+
+                case ReadyToRunHelperId.DelegateCtor:
+                    {
+                        throw new NotImplementedException();
+                        // DelegateCreationInfo target = (DelegateCreationInfo)node.Target;
+                        // MethodDesc constructor = target.Constructor.Method;
+                        // var fatPtr = ILImporter.MakeFatPointer(builder, resVar, compilation);
+                        // importer.OutputCodeForDelegateCtorInit(builder, helperFunc, constructor, fatPtr);
+                    }
+
+                default:
+                    throw new NotImplementedException();
+            }
+
+            if (node.Id == ReadyToRunHelperId.DelegateCtor)
+            {
+                builder.BuildRetVoid();
+            }
+            else
+            {
+                builder.BuildRet(resVar);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMMethodCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMMethodCodeNode.cs
@@ -63,6 +63,13 @@ namespace ILCompiler.DependencyAnalysis
 
         public void SetCode(ObjectNode.ObjectData data, bool isFoldable)
         {
+            DependencyListEntry[] entries = new DependencyListEntry[data.Relocs.Length];
+            for (int i = 0; i < data.Relocs.Length; i++)
+            {
+                entries[i] = new DependencyListEntry(data.Relocs[i].Target, "ObjectData Reloc");
+            }
+
+            _dependencies = new DependencyList(entries);
         }
 
         public void InitializeFrameInfos(FrameInfo[] frameInfos)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -126,7 +126,7 @@ namespace ILCompiler
                     sig.IsStatic) // speed up
                 {
                     corInfo.RegisterLlvmCallbacks((IntPtr)Unsafe.AsPointer(ref corInfo), _outputFile, Module.Target, Module.DataLayout);
-                    corInfo.CompileMethod(methodCodeNodeNeedingCode);   
+                    corInfo.CompileMethod(methodCodeNodeNeedingCode);
                     methodCodeNodeNeedingCode.CompilationCompleted = true;
                     // TODO: delete this external function when old module is gone
                     LLVMValueRef externFunc = Module.AddFunction(NodeFactory.NameMangler.GetMangledMethodName(method).ToString(), GetLLVMSignatureForMethod(sig, method.RequiresInstArg()));

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -68,7 +68,7 @@ namespace ILCompiler
 
             CorInfoImpl.Shutdown(); // writes the LLVM bitcode
 
-            Console.WriteLine($"RyuJIT compilation results, total methods {totalMethodCount} RyuJit Methods {ryuJitMethodCount} % {((decimal)ryuJitMethodCount * 100 / totalMethodCount):n4}");
+            Console.WriteLine($"RyuJIT compilation results, total methods {totalMethodCount} RyuJit Methods {ryuJitMethodCount} {((decimal)ryuJitMethodCount * 100 / totalMethodCount):n4}%");
         }
 
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)
@@ -126,9 +126,8 @@ namespace ILCompiler
                     sig.IsStatic) // speed up
                 {
                     corInfo.RegisterLlvmCallbacks((IntPtr)Unsafe.AsPointer(ref corInfo), _outputFile, Module.Target, Module.DataLayout);
-                    corInfo.CompileMethod(methodCodeNodeNeedingCode);
+                    corInfo.CompileMethod(methodCodeNodeNeedingCode);   
                     methodCodeNodeNeedingCode.CompilationCompleted = true;
-                    methodCodeNodeNeedingCode.SetDependencies(new DependencyNodeCore<NodeFactory>.DependencyList()); // TODO: how to track - check RyuJITCompilation
                     // TODO: delete this external function when old module is gone
                     LLVMValueRef externFunc = Module.AddFunction(NodeFactory.NameMangler.GetMangledMethodName(method).ToString(), GetLLVMSignatureForMethod(sig, method.RequiresInstArg()));
                     externFunc.Linkage = LLVMLinkage.LLVMExternalLinkage;
@@ -236,6 +235,11 @@ namespace ILCompiler
         public TypeDesc GetWellKnownType(WellKnownType wellKnownType)
         {
             return TypeSystemContext.GetWellKnownType(wellKnownType);
+        }
+
+        public override void AddOrReturnGlobalSymbol(ISortableSymbolNode gcStaticSymbol, NameMangler nameMangler)
+        {
+            LLVMObjectWriter.AddOrReturnGlobalSymbol(Module, gcStaticSymbol, nameMangler);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -190,6 +190,10 @@ namespace ILCompiler
 
             return base.GetMethodIL(method);
         }
+
+        public virtual void AddOrReturnGlobalSymbol(ISortableSymbolNode gcStaticSymbol, NameMangler nameMangler)
+        {
+        }
     }
 
     [Flags]

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -1,11 +1,49 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using ILCompiler;
+using ILCompiler.DependencyAnalysis;
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Internal.JitInterface
 {
     public unsafe sealed partial class CorInfoImpl
     {
+        [UnmanagedCallersOnly]
+        public static void addCodeReloc(IntPtr thisHandle, void* handle)
+        {
+            var _this = GetThis(thisHandle);
+
+            var node = (ReadyToRunHelperNode)_this.HandleToObject((IntPtr)handle);
+            _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0, node));
+            MetadataType target = (MetadataType)node.Target;
+            switch (node.Id)
+            {
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    if (target.Name.Contains("Bool"))
+                    {
+
+                    }
+
+                    _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0, _this._compilation.NodeFactory.TypeGCStaticsSymbol(target)));
+                    if (_this._compilation.HasLazyStaticConstructor(target))
+                    {
+                        var nonGcStaticSymbol = _this._compilation.NodeFactory.TypeNonGCStaticsSymbol(target);
+                        _this.AddOrReturnGlobalSymbol(nonGcStaticSymbol, _this._compilation.NameMangler);
+                    }
+
+                    break;
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0, _this._compilation.NodeFactory.TypeNonGCStaticsSymbol(target)));
+                    break;
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0, _this._compilation.NodeFactory.TypeThreadStaticsSymbol(target)));
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
         [UnmanagedCallersOnly]
         public static byte* getMangledMethodName(IntPtr thisHandle, CORINFO_METHOD_STRUCT_* ftn)
         {
@@ -16,15 +54,39 @@ namespace Internal.JitInterface
             return (byte*)_this.GetPin(_this._compilation.NameMangler.GetMangledMethodName(method).UnderlyingArray);
         }
 
+        [UnmanagedCallersOnly]
+        public static byte* getSymbolMangledName(IntPtr thisHandle, void* handle)
+        {
+            var _this = GetThis(thisHandle);
+
+            var node = (ISymbolNode)_this.HandleToObject((IntPtr)handle);
+            Utf8StringBuilder sb = new Utf8StringBuilder();
+            node.AppendMangledName(_this._compilation.NameMangler, sb);
+            return (byte*)_this.GetPin(sb.UnderlyingArray);
+        }
+
         [DllImport(JitLibrary)]
-        private extern static void registerLlvmCallbacks(IntPtr thisHandle, byte* outputFileName, byte* triple, byte* dataLayout, delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*> getMangedMethodNamePtr);
+        private extern static void registerLlvmCallbacks(IntPtr thisHandle, byte* outputFileName, byte* triple, byte* dataLayout,
+            delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*> getMangedMethodNamePtr,
+            delegate* unmanaged<IntPtr, void*, byte*> getSymbolMangledName,
+            delegate* unmanaged<IntPtr, void*, void> addCodeReloc
+        );
 
         public void RegisterLlvmCallbacks(IntPtr corInfoPtr, string outputFileName, string triple, string dataLayout)
         {
             registerLlvmCallbacks(corInfoPtr, (byte*)GetPin(StringToUTF8(outputFileName)),
                 (byte*)GetPin(StringToUTF8(triple)),
                 (byte*)GetPin(StringToUTF8(dataLayout)),
-                (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*>) &getMangledMethodName);
+                &getMangledMethodName,
+                &getSymbolMangledName,
+                &addCodeReloc
+                );
+        }
+
+
+        void AddOrReturnGlobalSymbol(ISortableSymbolNode gcStaticSymbol, NameMangler nameMangler)
+        {
+            _compilation.AddOrReturnGlobalSymbol(gcStaticSymbol, nameMangler);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -20,11 +20,6 @@ namespace Internal.JitInterface
             switch (node.Id)
             {
                 case ReadyToRunHelperId.GetGCStaticBase:
-                    if (target.Name.Contains("Bool"))
-                    {
-
-                    }
-
                     _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0, _this._compilation.NodeFactory.TypeGCStaticsSymbol(target)));
                     if (_this._compilation.HasLazyStaticConstructor(target))
                     {


### PR DESCRIPTION
This PR adds support for a few more LIR instructions:

- Calls to the helpers for GC and non GC Static bases
- Add for pointers and ints -  LLVM GEPs
- CNSINT for TYP_INT, only 32bit not sure how to identify others yet, and for nullptrs TYP_REF when IconVal == 0
- STOREIND for storing a reference type, calls RhpAssignRef.