### PR TITLE
Use static CRT for ObjWriter, fix parallelism factor

### DIFF
--- a/samples/prerequisites.md
+++ b/samples/prerequisites.md
@@ -28,10 +28,6 @@ Notes:
 - The `--installPath` option affects Build Tools installation only. Visual Studio Installer is always installed into
 the `%ProgramFiles(x86)%\Microsoft Visual Studio\Installer` directory.
 
-If you have no `vcruntime140.dll` library installed in your `%SystemRoot%\System32` directory, you also need to install Visual C++ 2019 Redistributable package, which ILCompiler depends on:
-- [vc_redist.x64.exe](https://aka.ms/vs/16/release/vc_redist.x64.exe) (for x64 machine)
-- [vc_redist.arm64.exe](https://aka.ms/vs/16/release/vc_redist.arm64.exe) (for ARM64 machine)
-
 # Fedora (31+)
 
 * Install `clang` and developer packages for libraries that .NET Core depends on:

--- a/src/coreclr/tools/aot/ObjWriter/build.cmd
+++ b/src/coreclr/tools/aot/ObjWriter/build.cmd
@@ -97,7 +97,8 @@ set "ExtraCMakeArgs=%~3"
     -DCORECLR_INCLUDE_DIR="%RepoRoot%src\coreclr\inc" ^
     || goto Error
 
-"%CMakePath%" --build "build\%Arch%" --config %BuildType% --target %Target% -j 10 || goto Error
+echo Executing "%CMakePath%" --build "build\%Arch%" --config %BuildType% --target %Target% -- -m
+"%CMakePath%" --build "build\%Arch%" --config %BuildType% --target %Target% -- -m || goto Error
 exit /b 0
 
 :Error

--- a/src/coreclr/tools/aot/ObjWriter/build.sh
+++ b/src/coreclr/tools/aot/ObjWriter/build.sh
@@ -89,4 +89,19 @@ fi
     -DCORECLR_INCLUDE_DIR="${RepoRoot}src/coreclr/inc" \
     || exit 1
 
-cmake --build "build/$TargetArch" --config "$BuildType" --target objwriter -j 10 || exit 1
+# Get the number of available processors
+Platform="$(uname)"
+if [[ "$Platform" == "FreeBSD" ]]; then
+    NumProc=$(sysctl -n hw.ncpu)
+elif [[ "$Platform" == "NetBSD" || "$Platform" == "SunOS" ]]; then
+    NumProc=$(getconf NPROCESSORS_ONLN)
+elif [[ "$Platform" == "Darwin" ]]; then
+    NumProc=$(getconf _NPROCESSORS_ONLN)
+else
+    NumProc=$(nproc --all)
+fi
+
+MaxJobs=$((NumProc+1))
+
+echo "Executing cmake --build \"build/$TargetArch\" --config \"$BuildType\" --target objwriter -j \"$MaxJobs\""
+cmake --build "build/$TargetArch" --config "$BuildType" --target objwriter -j "$MaxJobs" || exit 1

--- a/src/coreclr/tools/aot/ObjWriter/toolchain.cmake
+++ b/src/coreclr/tools/aot/ObjWriter/toolchain.cmake
@@ -1,4 +1,10 @@
 if (WIN32)
+  # Use static CRT
+  set(LLVM_USE_CRT_DEBUG MTd)
+  set(LLVM_USE_CRT_RELEASE MT)
+  set(LLVM_USE_CRT_MINSIZEREL MT)
+  set(LLVM_USE_CRT_RELWITHDEBINFO MT)
+
   # Enable debug information for Release builds
   set(CMAKE_CXX_FLAGS_RELEASE_INIT /Zi)
   set(CMAKE_C_FLAGS_RELEASE_INIT /Zi)


### PR DESCRIPTION
Use the static CRT for `objwriter.dll` (fixes #795).  That increases the ARM64 library size by about 1.2%.

The `-j 10` CMake argument has been copy-pasted without giving a thought and it is probably not a good setting for our CI machines.  On my quad-core Windows machine with HT enabled, parallelism factor 5 gave the best release build time (times for factors 4 to 10 were pretty close though); however, passing `-m` to MSBuild was even better and that matches what we do for building native components in the Runtime repo.