### PR TITLE
Fix casting

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/EcmaExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/EcmaExtensions.cs
@@ -67,7 +67,7 @@ namespace ILCompiler.Dataflow
         public static PropertyPseudoDesc GetPropertyForAccessor(this MethodDesc accessor)
         {
             var ecmaAccessor = (EcmaMethod)accessor.GetTypicalMethodDefinition();
-            var type = (EcmaType)accessor.OwningType;
+            var type = (EcmaType)accessor.OwningType.GetTypeDefinition();
             var reader = type.MetadataReader;
             var module = type.EcmaModule;
             foreach (var propertyHandle in reader.GetTypeDefinition(type.Handle).GetProperties())

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/EcmaExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/EcmaExtensions.cs
@@ -67,7 +67,7 @@ namespace ILCompiler.Dataflow
         public static PropertyPseudoDesc GetPropertyForAccessor(this MethodDesc accessor)
         {
             var ecmaAccessor = (EcmaMethod)accessor.GetTypicalMethodDefinition();
-            var type = (EcmaType)accessor.OwningType.GetTypeDefinition();
+            var type = (EcmaType)ecmaAccessor.OwningType;
             var reader = type.MetadataReader;
             var module = type.EcmaModule;
             foreach (var propertyHandle in reader.GetTypeDefinition(type.Handle).GetProperties())


### PR DESCRIPTION
On the method `[linq2db]LinqToDB.Linq.Expressions+<>c.<.cctor>b__88_838()`
During attempt to compile accessor for property
`[S.P.CoreLib]System.Nullable``1<float64>.get_Value()`

I receive following error `An unhandled exception of type 'System.InvalidCastException' occurred in System.Private.CoreLib.dll
Unable to cast object of type 'Internal.TypeSystem.InstantiatedType' to type 'Internal.TypeSystem.Ecma.EcmaType'.`

Offending code looks approximately this way.
```
class Sql {
	public static double? Truncate(double? value)
	{
		if (value.HasValue)
		{
			return Math.Truncate(value.Value);
		}
		return null;
	}
}

public static LambdaExpression L<T1, TR>(Expression<Func<T1, TR>> func)
{
	return func;
}

internal LambdaExpression SomeFunction()
{
	return L((double p) => Sql.Truncate(p).Value);
}
```