### PR TITLE
Enable ARM64 → x64 publishing

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
@@ -10,7 +10,8 @@
     <OSIdentifier Condition="'$(OSIdentifier)' == ''">linux</OSIdentifier>
 
     <RuntimeIlcPackageName>runtime.$(OSIdentifier)-$(PlatformTarget).Microsoft.DotNet.ILCompiler</RuntimeIlcPackageName>
-    <IlcHostArch Condition="'$(IlcHostArch)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</IlcHostArch>
+    <IlcHostArch Condition="'$(IlcHostArch)' == '' and ('$(PROCESSOR_ARCHITECTURE)' == 'ARM64' or '$(PROCESSOR_ARCHITEW6432)' == 'ARM64')">arm64</IlcHostArch>
+    <IlcHostArch Condition="'$(IlcHostArch)' == ''">x64</IlcHostArch>
     <IlcHostPackageName>runtime.$(OSIdentifier)-$(IlcHostArch).Microsoft.DotNet.ILCompiler</IlcHostPackageName>
     <IlcCalledViaPackage>true</IlcCalledViaPackage>
 

--- a/src/coreclr/nativeaot/BuildIntegration/findvcvarsall.bat
+++ b/src/coreclr/nativeaot/BuildIntegration/findvcvarsall.bat
@@ -24,6 +24,10 @@ SET procArch=%PROCESSOR_ARCHITEW6432%
 IF "%procArch%"=="" SET procArch=%PROCESSOR_ARCHITECTURE%
 
 SET vcEnvironment=%~1
+IF /I "%~1"=="x64" (
+    SET vcEnvironment=x86_amd64
+    IF /I "%procArch%"=="AMD64" SET vcEnvironment=amd64
+)
 IF /I "%~1"=="arm64" (
     SET vcEnvironment=x86_arm64
     IF /I "%procArch%"=="AMD64" SET vcEnvironment=amd64_arm64


### PR DESCRIPTION
Enable ARM64 → x64 publishing and also fix #933. We cannot trust `RuntimeInformation.ProcessArchitecture` as it returns the `dotnet` binary's architecture. Nor can we trust `RuntimeInformation.OSArchitecture` as it may return `Architecture.X86` when running in x86 emulation mode on ARM64.