### PR TITLE
Establish way for options instances to receive metadata from context

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -247,7 +247,8 @@ namespace System.Text.Json
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
         public System.Text.Json.Serialization.ReferenceHandler? ReferenceHandler { get { throw null; } set { } }
         public bool WriteIndented { get { throw null; } set { } }
-        public System.Text.Json.Serialization.JsonConverter? GetConverter(System.Type typeToConvert) { throw null; }
+        public System.Text.Json.Serialization.JsonConverter GetConverter(System.Type typeToConvert) { throw null; }
+        public void SetContext(System.Text.Json.Serialization.SourceGeneration.JsonSerializerContext context) { }
     }
     public enum JsonTokenType : byte
     {
@@ -753,7 +754,6 @@ namespace System.Text.Json.Serialization.SourceGeneration
     public abstract partial class JsonTypeInfo<T> : System.Text.Json.Serialization.SourceGeneration.JsonTypeInfo
     {
         internal JsonTypeInfo() { }
-        public void RegisterToOptions() { }
         public System.Text.Json.Serialization.SourceGeneration.MetadataServices.SerializeObjectDelegate<T>? SerializeObject { get; }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -558,6 +558,6 @@
     <value>The converter '{0}' cannot return an instance of JsonConverterFactory.</value>
   </data>
   <data name="SerializerContextOptionsImmutable" xml:space="preserve">
-    <value>Serializer options associated with a context cannot be changed once the context has been instantiated. To specify custom options, please use 'JsonContext.From'.</value>
+    <value>'JsonSerializerOptions' associated with a 'JsonSerializerOptions' cannot be changed once the context has been instantiated.</value>
   </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverterFactory.cs
@@ -20,7 +20,7 @@ namespace System.Text.Json.Serialization.Converters
 
             Type valueTypeToConvert = typeToConvert.GetGenericArguments()[0];
 
-            JsonConverter valueConverter = options.GetConverterInternal(valueTypeToConvert)!;
+            JsonConverter valueConverter = options.GetConverter(valueTypeToConvert)!;
             Debug.Assert(valueConverter != null);
 
             // If the value type has an interface or object converter, just return that converter directly.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ObjectConverter.cs
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state)
         {
             Type runtimeType = value.GetType();
-            JsonConverter runtimeConverter = options.GetConverterInternal(runtimeType)!;
+            JsonConverter runtimeConverter = options.GetConverter(runtimeType)!;
             if (runtimeConverter == this)
             {
                 ThrowHelper.ThrowNotSupportedException_DictionaryKeyTypeNotSupported(runtimeType!, this);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/JsonPropertyInfo.cs
@@ -440,7 +440,7 @@ namespace System.Text.Json.Serialization.SourceGeneration
                 }
                 else
                 {
-                    JsonConverter<object> converter = (JsonConverter<object>)Options.GetConverterInternal(JsonTypeInfo.ObjectType)!;
+                    JsonConverter<object> converter = (JsonConverter<object>)Options.GetConverter(JsonTypeInfo.ObjectType)!;
                     Debug.Assert(converter != null);
 
                     if (!converter.TryRead(ref reader, typeof(JsonElement), Options, ref state, out object? value))
@@ -458,7 +458,7 @@ namespace System.Text.Json.Serialization.SourceGeneration
                 Debug.Assert(propValue is IDictionary<string, JsonElement>);
                 IDictionary<string, JsonElement> dictionaryJsonElement = (IDictionary<string, JsonElement>)propValue;
 
-                JsonConverter<JsonElement> converter = (JsonConverter<JsonElement>)Options.GetConverterInternal(typeof(JsonElement))!;
+                JsonConverter<JsonElement> converter = (JsonConverter<JsonElement>)Options.GetConverter(typeof(JsonElement))!;
                 Debug.Assert(converter != null);
 
                 if (!converter.TryRead(ref reader, typeof(JsonElement), Options, ref state, out JsonElement value))
@@ -486,7 +486,7 @@ namespace System.Text.Json.Serialization.SourceGeneration
                 return true;
             }
 
-            JsonConverter<JsonElement> converter = (JsonConverter<JsonElement>)Options.GetConverterInternal(typeof(JsonElement))!;
+            JsonConverter<JsonElement> converter = (JsonConverter<JsonElement>)Options.GetConverter(typeof(JsonElement))!;
             Debug.Assert(converter != null);
             if (!converter.TryRead(ref reader, typeof(JsonElement), Options, ref state, out JsonElement jsonElement))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/JsonSerializerContext.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/JsonSerializerContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization.SourceGeneration
 {
@@ -11,20 +12,22 @@ namespace System.Text.Json.Serialization.SourceGeneration
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract partial class JsonSerializerContext
     {
-        internal readonly JsonSerializerOptions _options;
+        internal JsonSerializerOptions? _options;
 
         /// <summary>
         /// Gets the runtime options of the context. Can be modified until the first serialization or deserialization
         /// call using the context instances.
         /// </summary>
-        public JsonSerializerOptions Options => _options;
-
+        public JsonSerializerOptions? Options
+        {
+            get => _options;
+            internal set => _options = value;
+        }
         /// <summary>
         /// todo
         /// </summary>
         protected JsonSerializerContext()
         {
-            _options = new JsonSerializerOptions(JsonSerializerOptions.DefaultOptions, this);
         }
 
         /// <summary>
@@ -33,7 +36,8 @@ namespace System.Text.Json.Serialization.SourceGeneration
         /// <param name="options"></param>
         protected JsonSerializerContext(JsonSerializerOptions options)
         {
-            _options = new JsonSerializerOptions(options ?? throw new ArgumentNullException(nameof(options)), this);
+            options.SetContext(this);
+            Debug.Assert(_options == options);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/JsonTypeInfo.cs
@@ -419,12 +419,10 @@ namespace System.Text.Json.Serialization.SourceGeneration
 
         internal void InitializeSerializePropCache()
         {
-            JsonSerializerContext? context = Options._context;
-
-            Debug.Assert(context != null);
             Debug.Assert(PropInitFunc != null);
+            Debug.Assert(Options._context != null);
 
-            PropertyCacheArray = PropInitFunc(context);
+            PropertyCacheArray = PropInitFunc(Options._context);
         }
 
         internal void InitializeDeserializePropCache()
@@ -597,7 +595,7 @@ namespace System.Text.Json.Serialization.SourceGeneration
                 if (typeof(IDictionary<string, object>).IsAssignableFrom(declaredPropertyType) ||
                     typeof(IDictionary<string, JsonElement>).IsAssignableFrom(declaredPropertyType))
                 {
-                    JsonConverter converter = Options.GetConverterInternal(declaredPropertyType)!;
+                    JsonConverter converter = Options.GetConverter(declaredPropertyType)!;
                     Debug.Assert(converter != null);
                 }
                 else
@@ -719,6 +717,7 @@ namespace System.Text.Json.Serialization.SourceGeneration
 
             return converter;
         }
+
         private static void ValidateType(Type type, Type? parentClassType, MemberInfo? memberInfo, JsonSerializerOptions options)
         {
             if (!options.TypeIsCached(type) && IsInvalidForSerialization(type))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/JsonTypeInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/JsonTypeInfoOfT.cs
@@ -21,15 +21,6 @@ namespace System.Text.Json.Serialization.SourceGeneration
         { }
 
         /// <summary>
-        /// todo
-        /// </summary>
-        // TODO: remove this and perform this action based on Create methods/ctors on derived classes.
-        public void RegisterToOptions()
-        {
-            Options.AddJsonTypeInfoToCompleteInitialization(this);
-        }
-
-        /// <summary>
         /// TODO
         /// </summary>
         public MetadataServices.SerializeObjectDelegate<T>? SerializeObject { get; internal set; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/MetadataServices.Collections.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/SourceGeneration/MetadataServices.Collections.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Text.Json.Serialization.Converters;
 
 namespace System.Text.Json.Serialization.SourceGeneration


### PR DESCRIPTION
This helps existing code take advantage of new source-gen benefits.

Before:
```cs
JsonSerializerOptions options = new() { ... };
JsonSerializer.Serialize(instance, options);
```

After:
```cs
JsonSerializerOptions options = new() { ... };
options.SetContext(new JsonContext());
JsonSerializer.Serialize(instance, options);
```