### PR TITLE
Align Module.Name behavior with .NET 5 single file

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/NativeFormat/NativeFormatRuntimeModule.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/NativeFormat/NativeFormatRuntimeModule.cs
@@ -32,19 +32,6 @@ namespace System.Reflection.Runtime.Modules.NativeFormat
             }
         }
 
-        public sealed override string Name
-        {
-            get
-            {
-                QScopeDefinition scope = _assembly.Scope;
-                MetadataReader reader = scope.Reader;
-                string name = scope.ScopeDefinition.ModuleName.GetConstantStringValue(reader).Value;
-                if (name == null)
-                    return _assembly.GetName().Name + ".dll"; // Workaround for TFS 441076 - Module data not emitted for facade assemblies.
-                return name;
-            }
-        }
-
         public sealed override int MetadataToken
         {
             get

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/RuntimeModule.cs
@@ -33,7 +33,13 @@ namespace System.Reflection.Runtime.Modules
             }
         }
 
-        public abstract override string Name { get; }
+        public sealed override string Name
+        {
+            get
+            {
+                return "<Unknown>";
+            }
+        }
 
         public sealed override bool Equals(object obj)
         {


### PR DESCRIPTION
We were returning the `ScopeName`. Single-file .NET apps are documented to return `<Unknown>`.