### PR TITLE
Fix cases when preprocessor definitions are surrounding the method we are generating.

### DIFF
--- a/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -929,5 +929,73 @@ class MySafeHandle : SafeHandle
 
     protected override bool ReleaseHandle() => true;
 }}";
+
+        public static string PreprocessorIfAroundFullFunctionDefinition(string define) =>
+            @$"
+partial class Test
+{{
+#if {define}
+    [System.Runtime.InteropServices.GeneratedDllImport(""DoesNotExist"")]
+    public static partial int Method(
+        int p,
+        in int pIn,
+        out int pOut);
+#endif
+}}";
+
+        public static string PreprocessorIfAroundFullFunctionDefinitionWithFollowingFunction(string define) =>
+            @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+#if {define}
+    [GeneratedDllImport(""DoesNotExist"")]
+    public static partial int Method(
+        int p,
+        in int pIn,
+        out int pOut);
+#endif
+    public static int Method2(
+        SafeHandle p) => throw null;
+}}";
+
+        public static string PreprocessorIfAfterAttributeAroundFunction(string define) =>
+            @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+    [GeneratedDllImport(""DoesNotExist"")]
+#if {define}
+    public static partial int Method(
+        int p,
+        in int pIn,
+        out int pOut);
+#else
+    public static partial int Method2(
+        int p,
+        in int pIn,
+        out int pOut);
+#endif
+}}";
+
+        public static string PreprocessorIfAfterAttributeAroundFunctionAdditionalFunctionAfter(string define) =>
+            @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+    [GeneratedDllImport(""DoesNotExist"")]
+#if {define}
+    public static partial int Method(
+        int p,
+        in int pIn,
+        out int pOut);
+#else
+    public static partial int Method2(
+        int p,
+        in int pIn,
+        out int pOut);
+#endif
+    public static int Foo() => throw null;
+}}";
     }
 }

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -182,6 +182,32 @@ namespace DllImportGenerator.UnitTests
             var newCompDiags = newComp.GetDiagnostics();
             Assert.Empty(newCompDiags);
         }
+
+        public static IEnumerable<object[]> CodeSnippetsToCompileWithPreprocessorSymbols()
+        {
+            yield return new object[] { CodeSnippets.PreprocessorIfAroundFullFunctionDefinition("Foo"), new string[] { "Foo" } };
+            yield return new object[] { CodeSnippets.PreprocessorIfAroundFullFunctionDefinition("Foo"), Array.Empty<string>() };
+            yield return new object[] { CodeSnippets.PreprocessorIfAroundFullFunctionDefinitionWithFollowingFunction("Foo"), new string[] { "Foo" } };
+            yield return new object[] { CodeSnippets.PreprocessorIfAroundFullFunctionDefinitionWithFollowingFunction("Foo"), Array.Empty<string>() };
+            yield return new object[] { CodeSnippets.PreprocessorIfAfterAttributeAroundFunction("Foo"), new string[] { "Foo" } };
+            yield return new object[] { CodeSnippets.PreprocessorIfAfterAttributeAroundFunction("Foo"), Array.Empty<string>() };
+            yield return new object[] { CodeSnippets.PreprocessorIfAfterAttributeAroundFunctionAdditionalFunctionAfter("Foo"), new string[] { "Foo" } };
+            yield return new object[] { CodeSnippets.PreprocessorIfAfterAttributeAroundFunctionAdditionalFunctionAfter("Foo"), Array.Empty<string>() };
+        }
+
+        [Theory]
+        [MemberData(nameof(CodeSnippetsToCompileWithPreprocessorSymbols))]
+        public async Task ValidateSnippetsWithPreprocessorDefintions(string source, IEnumerable<string> preprocessorSymbols)
+        {
+            Compilation comp = await TestUtils.CreateCompilation(source, preprocessorSymbols: preprocessorSymbols);
+            TestUtils.AssertPreSourceGeneratorCompilation(comp);
+
+            var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.DllImportGenerator());
+            Assert.Empty(generatorDiags);
+
+            var newCompDiags = newComp.GetDiagnostics();
+            Assert.Empty(newCompDiags);
+        }
         
         public static IEnumerable<object[]> CodeSnippetsToCompileWithForwarder()
         {

--- a/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
@@ -43,12 +43,12 @@ namespace DllImportGenerator.UnitTests
         /// <param name="outputKind">Output type</param>
         /// <param name="allowUnsafe">Whether or not use of the unsafe keyword should be allowed</param>
         /// <returns>The resulting compilation</returns>
-        public static async Task<Compilation> CreateCompilation(string source, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true)
+        public static async Task<Compilation> CreateCompilation(string source, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true, IEnumerable<string>? preprocessorSymbols = null)
         {
             var (mdRefs, ancillary) = GetReferenceAssemblies();
 
             return CSharpCompilation.Create("compilation",
-                new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview)) },
+                new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview, preprocessorSymbols: preprocessorSymbols)) },
                 (await mdRefs.ResolveAsync(LanguageNames.CSharp, CancellationToken.None)).Add(ancillary),
                 new CSharpCompilationOptions(outputKind, allowUnsafe: allowUnsafe));
         }

--- a/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
@@ -128,9 +128,14 @@ namespace Microsoft.Interop
             context.RegisterForSyntaxNotifications(() => new SyntaxReceiver());
         }
 
-        private SyntaxTokenList StripLeadingTriviaFromTokenList(SyntaxTokenList tokenList)
+        private SyntaxTokenList StripTriviaFromModifiers(SyntaxTokenList tokenList)
         {
-            return tokenList.Replace(tokenList[0], tokenList[0].WithoutTrivia());
+            SyntaxToken[] strippedTokens = new SyntaxToken[tokenList.Count];
+            for (int i = 0; i < tokenList.Count; i++)
+            {
+                strippedTokens[i] = tokenList[i].WithoutTrivia();
+            }
+            return new SyntaxTokenList(strippedTokens);
         }
 
         private TypeDeclarationSyntax CreateTypeDeclarationWithoutTrivia(TypeDeclarationSyntax typeDeclaration)
@@ -151,7 +156,7 @@ namespace Microsoft.Interop
             // Create stub function
             var stubMethod = MethodDeclaration(stub.StubReturnType, userDeclaredMethod.Identifier)
                 .AddAttributeLists(stub.AdditionalAttributes)
-                .WithModifiers(StripLeadingTriviaFromTokenList(userDeclaredMethod.Modifiers))
+                .WithModifiers(StripTriviaFromModifiers(userDeclaredMethod.Modifiers))
                 .WithParameterList(ParameterList(SeparatedList(stub.StubParameters)))
                 .WithBody(stub.StubCode);
 

--- a/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Interop
             // Create the DllImport declaration.
             var dllImport = stub.DllImportDeclaration.AddAttributeLists(
                 AttributeList(
-                    SingletonSeparatedList<AttributeSyntax>(dllImportAttr)));
+                    SingletonSeparatedList(dllImportAttr)));
 
             // Stub should have at least one containing type
             Debug.Assert(stub.StubContainingTypes.Any());


### PR DESCRIPTION
Manually create more of the nodes from scratch and strip trivia directly when needed to avoid accidentally bringing along preprocessor defs from user code.

Fixes #938 