### PR TITLE
Cross-architecture publishing on Linux

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/BuildFrameworkNativeObjects.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/BuildFrameworkNativeObjects.proj
@@ -10,9 +10,8 @@
     <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
   </PropertyGroup>
 
-  <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
-  <Import Project="$(MSBuildThisFileDirectory)\Microsoft.DotNet.ILCompiler.targets" Condition="'$(IlcCalledViaPackage)' == 'true'"/>
-  <Import Project="Microsoft.NETCore.Native.targets" Condition="'$(IlcCalledViaPackage)' == ''"/>
+  <Import Project="$(MSBuildThisFileDirectory)\Microsoft.DotNet.ILCompiler.targets" Condition="'$(IlcCalledViaPackage)' == 'true'" />
+  <Import Project="Microsoft.NETCore.Native.targets" Condition="'$(IlcCalledViaPackage)' == ''" />
 
   <Target Name="BuildAllFrameworkLibraries"
     Inputs="@(DefaultFrameworkAssemblies)"
@@ -37,11 +36,11 @@
 
   <Target Name="BuildOneFrameworkLibrary">
     <PropertyGroup>
-        <IlcGenerateMetadataLog>true</IlcGenerateMetadataLog>
+      <IlcGenerateMetadataLog>true</IlcGenerateMetadataLog>
     </PropertyGroup>
     <ItemGroup>
-        <ManagedBinary Include="$(LibraryToCompile)" />
-        <IlcCompileInput Include="@(ManagedBinary)" />
+      <ManagedBinary Include="$(LibraryToCompile)" />
+      <IlcCompileInput Include="@(ManagedBinary)" />
     </ItemGroup>
   </Target>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
@@ -2,7 +2,6 @@
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
 
-    <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
     <!-- Define the name of the runtime specific compiler package to import -->
     <OSIdentifier Condition="$(RuntimeIdentifier.StartsWith('win'))">win</OSIdentifier>
     <OSIdentifier Condition="$(RuntimeIdentifier.StartsWith('osx'))">osx</OSIdentifier>
@@ -10,8 +9,14 @@
     <OSIdentifier Condition="'$(OSIdentifier)' == ''">linux</OSIdentifier>
 
     <RuntimeIlcPackageName>runtime.$(OSIdentifier)-$(PlatformTarget).Microsoft.DotNet.ILCompiler</RuntimeIlcPackageName>
-    <IlcHostArch Condition="'$(IlcHostArch)' == '' and ('$(PROCESSOR_ARCHITECTURE)' == 'ARM64' or '$(PROCESSOR_ARCHITEW6432)' == 'ARM64')">arm64</IlcHostArch>
-    <IlcHostArch Condition="'$(IlcHostArch)' == ''">x64</IlcHostArch>
+
+    <OSHostArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</OSHostArch>
+    <!-- OSArchitecture does not report the true OS architecture for x86 and x64 processes running on Windows ARM64. -->
+    <!-- The following condition checks those cases. -->
+    <OSHostArch Condition="$([MSBuild]::IsOSPlatform('Windows')) and
+        ('$(PROCESSOR_ARCHITEW6432)' == 'ARM64' or Exists('$(SystemRoot)\System32\xtajit64.dll'))">arm64</OSHostArch>
+
+    <IlcHostArch Condition="'$(IlcHostArch)' == ''">$(OSHostArch)</IlcHostArch>
     <IlcHostPackageName>runtime.$(OSIdentifier)-$(IlcHostArch).Microsoft.DotNet.ILCompiler</IlcHostPackageName>
     <IlcCalledViaPackage>true</IlcCalledViaPackage>
 
@@ -26,7 +31,6 @@
 
   </PropertyGroup>
 
-  <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
   <!-- Locate the runtime package according to the current target runtime -->
   <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' AND $(IlcCalledViaPackage) == 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
     <!-- CoreRT SDK and Framework Assemblies need to be defined to avoid CoreCLR implementations being set as compiler inputs -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -49,14 +49,23 @@
 
     <!-- Fail with descriptive error message for common mistake. -->
     <Error Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '5.0.0'))" Text=".NET SDK 5+ is required for native compilation." />
-    <Error Condition="'$(RuntimeIdentifier)' == ''" Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
+    <Error Condition="'$(RuntimeIdentifier)' == ''"
+      Text="RuntimeIdentifier is required for native compilation. Try running dotnet publish with the -r option value specified." />
     <Error Condition="'$(GeneratePackageOnBuild)' == 'true'" Text="GeneratePackageOnBuild is not supported for native compilation." />
     <Error Condition="'$(OutputType)' != 'Library' and '$(NativeLib)' != ''" Text="NativeLib requires OutputType=Library." />
 
     <!-- Fail with descriptive error message for common unsupported cases. -->
-    <Error Condition="'$(DisableUnsupportedError)' != 'true' and '$(OS)' == 'Windows_NT' and !$(RuntimeIdentifier.StartsWith('win'))" Text="Cross-compilation is not supported yet. https://github.com/dotnet/corert/issues/5458" />
-    <Error Condition="'$(DisableUnsupportedError)' != 'true' and '$(OS)' != 'Windows_NT' and $(RuntimeIdentifier.StartsWith('win'))" Text="Cross-compilation is not supported yet. https://github.com/dotnet/corert/issues/5458" />
-    <Error Condition="'$(DisableUnsupportedError)' != 'true' and !$(RuntimeIdentifier.EndsWith('x64'))" Text="$(RuntimeIdentifier) not supported yet. https://github.com/dotnet/corert/issues/4589" />
+    <Error Condition="'$(DisableUnsupportedError)' != 'true' and '$(OS)' == 'Windows_NT' and !$(RuntimeIdentifier.StartsWith('win'))"
+      Text="Cross-OS native compilation is not supported. https://github.com/dotnet/corert/issues/5458" />
+
+    <Error Condition="'$(DisableUnsupportedError)' != 'true' and '$(OS)' != 'Windows_NT' and $(RuntimeIdentifier.StartsWith('win'))"
+      Text="Cross-OS native compilation is not supported. https://github.com/dotnet/corert/issues/5458" />
+
+    <Error Condition="'$(DisableUnsupportedError)' != 'true' and !$(RuntimeIdentifier.EndsWith('x64'))"
+      Text="Native compilation does not support targeting $(RuntimeIdentifier) yet. https://github.com/dotnet/corert/issues/4589" />
+
+    <Error Condition="'$(DisableUnsupportedError)' != 'true' and !('$(IlcHostArch)' == 'x64' or '$(IlcHostArch)' == 'arm64')"
+      Text="Native compilation can run on x64 and arm64 hosts only." />
 
     <Error Condition="'$(IlcHostPackagePath)' == '' and '$(RuntimePackagePath)' != '' and ('$(IlcHostArch)' == 'x64' or '$(IlcHostArch)' == 'arm64')"
       Text="Add a PackageReference for '$(IlcHostPackageName)' to allow cross-compilation for $(PlatformTarget)" />
@@ -65,9 +74,14 @@
     <Error Condition="'@(PrivateSdkAssemblies)' == ''" Text="The PrivateSdkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
     <Error Condition="'@(FrameworkAssemblies)' == ''" Text="The FrameworkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />
 
-    <ComputeManagedAssembliesToCompileToNative Assemblies="@(ResolvedAssembliesToPublish);@(_ResolvedCopyLocalPublishAssets)"
-    DotNetAppHostExecutableName="$(_DotNetAppHostExecutableName)" DotNetHostFxrLibraryName="$(_DotNetHostFxrLibraryName)" DotNetHostPolicyLibraryName="$(_DotNetHostPolicyLibraryName)"
-    SdkAssemblies="@(PrivateSdkAssemblies)" FrameworkAssemblies="@(FrameworkAssemblies)">
+    <ComputeManagedAssembliesToCompileToNative
+      Assemblies="@(ResolvedAssembliesToPublish);@(_ResolvedCopyLocalPublishAssets)"
+      DotNetAppHostExecutableName="$(_DotNetAppHostExecutableName)"
+      DotNetHostFxrLibraryName="$(_DotNetHostFxrLibraryName)"
+      DotNetHostPolicyLibraryName="$(_DotNetHostPolicyLibraryName)"
+      SdkAssemblies="@(PrivateSdkAssemblies)"
+      FrameworkAssemblies="@(FrameworkAssemblies)">
+
       <Output TaskParameter="ManagedAssemblies" ItemName="_ManagedResolvedAssembliesToPublish" />
       <Output TaskParameter="AssembliesToSkipPublish" ItemName="_AssembliesToSkipPublish" />
     </ComputeManagedAssembliesToCompileToNative>
@@ -76,13 +90,13 @@
 
   <Target Name="CopyNativeBinary" AfterTargets="Publish">
     <!-- override apphost with binary we generated during native compilation -->
-    <Delete Files="$(PublishDir)\$(TargetName)$(NativeBinaryExt)"/>
+    <Delete Files="$(PublishDir)\$(TargetName)$(NativeBinaryExt)" />
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)" DestinationFolder="$(PublishDir)" />
   </Target>
 
   <Target Name="CopyNativePdb" Condition="'$(DebugType)' != 'None' and '$(TargetOS)' == 'windows' and '$(NativeLib)' != 'Static'" AfterTargets="Publish">
     <!-- dotnet CLI produces managed debug symbols - substitute with those we generated during native compilation -->
-    <Delete Files="$(PublishDir)\$(TargetName).pdb"/>
+    <Delete Files="$(PublishDir)\$(TargetName).pdb" />
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName).pdb" DestinationFolder="$(PublishDir)" />
   </Target>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -25,6 +25,17 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <FullRuntimeName>libRuntime</FullRuntimeName>
       <FullRuntimeName Condition="'$(ServerGarbageCollection)' != ''">libRuntime.ServerGC</FullRuntimeName>
+
+      <CrossCompileRid />
+      <CrossCompileRid Condition="'$(TargetOS)' != 'OSX' and !$(RuntimeIdentifier.EndsWith('-$(OSHostArch)'))">$(RuntimeIdentifier)</CrossCompileRid>
+
+      <CrossCompileArch />
+      <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-x64'))">x86_64</CrossCompileArch>
+      <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-arm64'))">aarch64</CrossCompileArch>
+
+      <TargetTriple />
+      <TargetTriple Condition="'$(CrossCompileArch)' != ''">$(CrossCompileArch)-linux-gnu</TargetTriple>
+      <TargetTriple Condition="'$(CrossCompileArch)' != '' and $(CrossCompileRid.Contains('-musl-'))">$(CrossCompileArch)-alpine-linux-musl</TargetTriple>
     </PropertyGroup>
 
     <ItemGroup>
@@ -39,8 +50,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <NetCoreAppNativeLibrary Include="System.Globalization.Native" />
       <NetCoreAppNativeLibrary Include="System.IO.Compression.Native" />
       <NetCoreAppNativeLibrary Include="System.Net.Security.Native" />
-      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Apple" Condition="'$(TargetOS)' == 'OSX'"/>
-      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.OpenSsl" Condition="'$(TargetOS)' != 'OSX'"/>
+      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.Apple" Condition="'$(TargetOS)' == 'OSX'" />
+      <NetCoreAppNativeLibrary Include="System.Security.Cryptography.Native.OpenSsl" Condition="'$(TargetOS)' != 'OSX'" />
     </ItemGroup>
 
     <ItemGroup>
@@ -57,6 +68,8 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup>
       <LinkerArg Include="@(NativeLibrary)" />
+      <LinkerArg Include="--sysroot=$(SysRoot)" Condition="'$(SysRoot)' != ''" />
+      <LinkerArg Include="--target=$(TargetTriple)" Condition="'$(TargetTriple)' != ''" />
       <LinkerArg Include="-g" Condition="$(NativeDebugSymbols) == 'true'" />
       <LinkerArg Include="-Wl,--strip-debug" Condition="$(NativeDebugSymbols) != 'true' and '$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-Wl,-rpath,'$ORIGIN'" />
@@ -79,7 +92,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <Exec Command="command -v $(CppLinker)" IgnoreExitCode="true" StandardOutputImportance="Low">
-      <Output TaskParameter="ExitCode" PropertyName="_WhereLinker"/>
+      <Output TaskParameter="ExitCode" PropertyName="_WhereLinker" />
     </Exec>
     <Error Condition="'$(_WhereLinker)' != '0' and '$(TargetOS)' == 'OSX'" Text="Platform linker ('$(CppLinker)') not found. Try installing Xcode to resolve the problem." />
     <Error Condition="'$(_WhereLinker)' != '0' and '$(TargetOS)' != 'OSX'" Text="Platform linker ('$(CppLinker)') not found. Try installing $(CppLinker) or the appropriate package for your platform to resolve the problem." />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -24,7 +24,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     <LinkerSubsystem Condition="'$(OutputType)' == 'Exe' and '$(LinkerSubsystem)' == ''">CONSOLE</LinkerSubsystem>
   </PropertyGroup>
 
-  <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
   <!-- Ensure that runtime-specific paths have already been set -->
   <Target Name="SetupOSSpecificProps" DependsOnTargets="$(IlcDynamicBuildPropertyDependencies)">
 
@@ -75,7 +74,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="/INCREMENTAL:NO" />
       <LinkerArg Condition="'$(LinkerSubsystem)' != ''" Include="/SUBSYSTEM:$(LinkerSubsystem)" />
       <LinkerArg Condition="'$(OutputType)' == 'WinExe' or '$(OutputType)' == 'Exe'" Include="/ENTRY:$(EntryPointSymbol)" />
-      <LinkerArg Condition="$(NativeLib) == 'Shared'" Include="/INCLUDE:CoreRT_StaticInitialization"/>
+      <LinkerArg Condition="$(NativeLib) == 'Shared'" Include="/INCLUDE:CoreRT_StaticInitialization" />
       <LinkerArg Include="/NATVIS:&quot;$(MSBuildThisFileDirectory)CoreRTNatVis.natvis&quot;" />
     </ItemGroup>
 
@@ -85,15 +84,15 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <Exec Command="where /Q $(CppCompiler) &amp;&amp; where /Q $(CppLinker)" IgnoreExitCode="true">
-      <Output TaskParameter="ExitCode" PropertyName="_WhereCppTools"/>
+      <Output TaskParameter="ExitCode" PropertyName="_WhereCppTools" />
     </Exec>
 
     <Message Condition="'$(_WhereCppTools)' != '0'" Text="Tools '$(CppCompiler)' and '$(CppLinker)' not found on PATH. Attempting to autodetect." />
 
     <Exec Condition="'$(_WhereCppTools)' != '0'" Command="&quot;$(MSBuildThisFileDirectory)findvcvarsall.bat&quot; $(PlatformTarget)"
       IgnoreExitCode="true" ConsoleToMSBuild="true" StandardOutputImportance="Low">
-      <Output TaskParameter="ConsoleOutput" PropertyName="_FindVCVarsallOutput"/>
-      <Output TaskParameter="ExitCode" PropertyName="_VCVarsAllFound"/>
+      <Output TaskParameter="ConsoleOutput" PropertyName="_FindVCVarsallOutput" />
+      <Output TaskParameter="ExitCode" PropertyName="_VCVarsAllFound" />
     </Exec>
 
     <ItemGroup Condition="'$(_VCVarsAllFound)' == '0'">

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -93,7 +93,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
   <ItemGroup Condition="$(IlcSystemModule) == ''">
     <AutoInitializedAssemblies Include="System.Private.CoreLib" />
-    <AutoInitializedAssemblies Include="System.Private.StackTraceMetadata" Condition="$(IlcDisableReflection) != 'true' or $(IlcGenerateStackTraceData) == 'true'"/>
+    <AutoInitializedAssemblies Include="System.Private.StackTraceMetadata" Condition="$(IlcDisableReflection) != 'true' or $(IlcGenerateStackTraceData) == 'true'" />
     <AutoInitializedAssemblies Include="System.Private.TypeLoader" />
     <AutoInitializedAssemblies Include="System.Private.Reflection.Execution" Condition="$(IlcDisableReflection) != 'true'" />
     <AutoInitializedAssemblies Include="System.Private.DisabledReflection" Condition="$(IlcDisableReflection) == 'true'" />
@@ -103,16 +103,12 @@ The .NET Foundation licenses this file to you under the MIT license.
 
   <ItemGroup>
     <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" />
-  </ItemGroup>
-  <ItemGroup>
+
     <!-- Exclude System.IO.Compression.Native.dll -->
     <FrameworkAssemblies Include="$(IlcPath)\framework\*.dll" Exclude="$(IlcPath)\framework\*.Native.dll" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(IlcPgoOptimize)' == 'true'">
-    <MibcFile Include="$(IlcPath)\mibc\*.mibc" />
-  </ItemGroup>
 
-  <ItemGroup>
+    <MibcFile Include="$(IlcPath)\mibc\*.mibc" Condition="'$(IlcPgoOptimize)' == 'true'" />
+
     <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
     <DefaultFrameworkAssemblies Include="@(PrivateSdkAssemblies)" />
   </ItemGroup>
@@ -130,7 +126,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
   </Target>
 
-  <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
   <!-- The properties below need to be defined only after we've found the correct runtime package reference -->
   <Target Name="SetupProperties" DependsOnTargets="$(IlcSetupPropertiesDependsOn)" BeforeTargets="Publish">
     <PropertyGroup>
@@ -142,16 +137,12 @@ The .NET Foundation licenses this file to you under the MIT license.
     <!-- If running from a package these values need to be set again with the resolved IlcPath -->
     <ItemGroup>
       <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" />
-    </ItemGroup>
-    <ItemGroup>
+
       <!-- Exclude System.IO.Compression.Native.dll -->
       <FrameworkAssemblies Include="$(IlcPath)\framework\*.dll" Exclude="$(IlcPath)\framework\*.Native.dll" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(IlcPgoOptimize)' == 'true'">
-      <MibcFile Include="$(IlcPath)\mibc\*.mibc" />
-    </ItemGroup>
 
-    <ItemGroup>
+      <MibcFile Include="$(IlcPath)\mibc\*.mibc" Condition="'$(IlcPgoOptimize)' == 'true'" />
+
       <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
       <DefaultFrameworkAssemblies Include="@(PrivateSdkAssemblies)" />
     </ItemGroup>
@@ -299,7 +290,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="/EXPORT:DotNetRuntimeDebugHeader,DATA" Condition="'$(TargetOS)' == 'windows' and '$(NativeDebugSymbols)' == 'true'" />
       <CustomLinkerArg Include="/LIBPATH:&quot;%(AdditionalNativeLibraryDirectories.Identity)&quot;" Condition="'$(TargetOS)' == 'windows' and '@(AdditionalNativeLibraryDirectories->Count())' &gt; 0" />
       <CustomLinkerArg Include="-exported_symbols_list &quot;$(ExportsFile)&quot;" Condition="'$(TargetOS)' == 'OSX' and $(ExportsFile) != ''" />
-      <CustomLinkerArg Include="-Wl,--version-script=$(ExportsFile)" Condition="'$(TargetOS)' != 'windows' and '$(TargetOS)' != 'OSX' and $(ExportsFile) != ''"/>
+      <CustomLinkerArg Include="-Wl,--version-script=$(ExportsFile)" Condition="'$(TargetOS)' != 'windows' and '$(TargetOS)' != 'OSX' and $(ExportsFile) != ''" />
       <CustomLinkerArg Condition="Exists('$(_Win32ResFile)')" Include="&quot;$(_Win32ResFile)&quot;" />
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>


### PR DESCRIPTION
Allow cross-architecture publishing on Linux by setting the `SysRoot` property. Includes some cleanup and formatting fixes.