### PR TITLE
Fix scanning error in debug ILC targeting ARM64

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
@@ -14,7 +14,7 @@
     <!-- OSArchitecture does not report the true OS architecture for x86 and x64 processes running on Windows ARM64. -->
     <!-- The following condition checks those cases. -->
     <OSHostArch Condition="$([MSBuild]::IsOSPlatform('Windows')) and
-        ('$(PROCESSOR_ARCHITEW6432)' == 'ARM64' or Exists('$(SystemRoot)\System32\xtajit64.dll'))">arm64</OSHostArch>
+        $([System.Environment]::GetEnvironmentVariable('PROCESSOR_ARCHITECTURE', EnvironmentVariableTarget.Machine)) == 'ARM64'">arm64</OSHostArch>
 
     <IlcHostArch Condition="'$(IlcHostArch)' == ''">$(OSHostArch)</IlcHostArch>
     <IlcHostPackageName>runtime.$(OSIdentifier)-$(IlcHostArch).Microsoft.DotNet.ILCompiler</IlcHostPackageName>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -35,7 +35,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
       <TargetTriple />
       <TargetTriple Condition="'$(CrossCompileArch)' != ''">$(CrossCompileArch)-linux-gnu</TargetTriple>
-      <TargetTriple Condition="'$(CrossCompileArch)' != '' and $(CrossCompileRid.Contains('-musl-'))">$(CrossCompileArch)-alpine-linux-musl</TargetTriple>
+      <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('linux-musl')) or $(CrossCompileRid.StartsWith('alpine')))">$(CrossCompileArch)-alpine-linux-musl</TargetTriple>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -1049,6 +1049,14 @@ namespace Internal.IL
                 case ILOpcode.sub_ovf_un:
                     _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.Overflow), "_ovf");
                     break;
+
+                case ILOpcode.div:
+                case ILOpcode.div_un:
+                case ILOpcode.rem:
+                case ILOpcode.rem_un:
+                    // Required for ARM64
+                    _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.ThrowDivZero), "_divbyzero");
+                    break;
             }
         }
 


### PR DESCRIPTION
The debug version of ILC reports the following error when targeting ARM64 with optimizations enabled (in release mode):
```
*** Methods compiled but not scanned:
[S.P.CoreLib]Internal.Runtime.CompilerHelpers.ThrowHelpers.ThrowDivideByZeroException()
Unhandled exception. System.Exception: Scanning failure
```
This PR includes @MichalStrehovsky's fix for this issue that adds the `ThrowDivZero` helper to the scanning list and also minor changes to cross-compilation.