### PR TITLE
Skip RemoveAttributeInstances with arguments

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessLinkerXmlBase.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ProcessLinkerXmlBase.cs
@@ -47,6 +47,11 @@ namespace ILCompiler
             return _reader.GetAttribute(attribute);
         }
 
+        protected bool IsEmpty()
+        {
+            return _reader.IsEmptyElement;
+        }
+
         private void ProcessAssemblies()
         {
             while (_reader.IsStartElement())

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -797,7 +797,7 @@ namespace ILCompiler
             protected override void ProcessAttribute(TypeDesc type)
             {
                 string internalValue = GetAttribute("internal");
-                if (internalValue == "RemoveAttributeInstances" && !IsEmpty())
+                if (internalValue == "RemoveAttributeInstances" && IsEmpty())
                 {
                     _removedAttributes.Add(type);
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -797,7 +797,7 @@ namespace ILCompiler
             protected override void ProcessAttribute(TypeDesc type)
             {
                 string internalValue = GetAttribute("internal");
-                if (internalValue == "RemoveAttributeInstances")
+                if (internalValue == "RemoveAttributeInstances" && !IsEmpty())
                 {
                     _removedAttributes.Add(type);
                 }


### PR DESCRIPTION
ILLinkTrim.Attributes format received support for removing attribute instances with specific values of their arguments.

The support for this in illink equals to almost 1000 lines of code. There was no data on how much size savings this can actually provide when it was introduced. My spider-sense says "miniscule savings" (possibly somewhere around 0.1%).

We have plenty of other possible sources of savings with a smaller implementation complexity. This code will make sure to ignore such entries.