### PR TITLE
Don't allow canonical instantiations when reflection-rooting

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
@@ -113,7 +113,7 @@ namespace ILCompiler
             if (method.OwningType.IsGenericDefinition || method.OwningType.ContainsSignatureVariables(treatGenericParameterLikeSignatureVariable: true))
             {
                 TypeDesc owningType = method.OwningType.GetTypeDefinition();
-                Instantiation inst = TypeExtensions.GetInstantiationThatMeetsConstraints(owningType.Instantiation, allowCanon: method.Instantiation.Length == 0);
+                Instantiation inst = TypeExtensions.GetInstantiationThatMeetsConstraints(owningType.Instantiation, allowCanon: false);
                 if (inst.IsNull)
                 {
                     return false;


### PR DESCRIPTION
When the compiler sees a MakeGenericType/MakeGenericMethod call, it will try to come up with a shared instantiation so that things can at least work if instantiated with reference types at runtime.

We were allowing instantiations over `__Canon`, but this breaks places that use generic dictionaries to identify generic methods (we don't have one for `__Canon` instantiations). Instantiate over a concrete reference type instead.

Fixes #929.