### PR TITLE
fixed regex fixed prefix computation bug in SRM

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -1768,7 +1768,7 @@ namespace System.Text.RegularExpressions.SRM
                                 var prefix_length = alts_prefix.TakeWhile((x, i) => i < p.Count && x.Equals(p[i])).Count();
                                 alts_prefix = alts_prefix.RemoveRange(prefix_length, alts_prefix.Count - prefix_length);
                             }
-                            return alts_prefix;
+                            return pref.AddRange(alts_prefix);
                         }
                     default:
                         {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -23,6 +23,26 @@ namespace System.Text.RegularExpressions.Tests
         internal static RegexOptions DFA = (RegexOptions)0x400;
 
         [Fact]
+        public void SRMPrefixBugFixTest()
+        {
+            var re1 = new Regex("(a|ba)c", DFA);
+            var match1 = re1.Match("bac");
+            Assert.True(match1.Success);
+            Assert.Equal(0, match1.Index);
+            Assert.Equal(3, match1.Length);
+            //---
+            var match2 = re1.Match("ac");
+            Assert.True(match2.Success);
+            Assert.Equal(0, match2.Index);
+            Assert.Equal(2, match2.Length);
+            //---
+            var match3 = re1.Match("baacd");
+            Assert.True(match3.Success);
+            Assert.Equal(2, match3.Index);
+            Assert.Equal(2, match3.Length);
+        }
+
+        [Fact]
         public void BasicSRMTestBorderAnchors()
         {
             var re1 = new Regex(@"\B x", DFA);


### PR DESCRIPTION
Fixed a bug in regex prefix computation in SRM that caused wrong prefix to be computed in some cases.