### PR TITLE
Generate metadata for what should be reflectable only

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
@@ -197,14 +197,7 @@ namespace ILCompiler
                 if ((pair.Value & MetadataCategory.RuntimeMapping) != 0)
                 {
                     MethodDesc method = pair.Key;
-
-                    // We need to root virtual methods as if they were called virtually.
-                    // This will possibly trigger the generation of other overrides too.
-                    if (method.IsVirtual)
-                        rootProvider.RootVirtualMethodForReflection(method, reason);
-
-                    if (!method.IsAbstract)
-                        rootProvider.AddCompilationRoot(pair.Key, reason);
+                    rootProvider.AddReflectionRoot(method, reason);
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -65,7 +65,7 @@ namespace ILCompiler.DependencyAnalysis
             if (defaultCtor != null)
             {
                 dependencyList.Add(new DependencyListEntry(
-                    factory.MethodEntrypoint(defaultCtor, closestDefType.IsValueType),
+                    factory.ReflectableMethod(defaultCtor),
                     "DefaultConstructorNode"));
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public static void AddDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)
         {
-            factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencies, factory, method, methodIL);
+            factory.MetadataManager.GetDependenciesDueToMethodCodePresence(ref dependencies, factory, method, methodIL);
 
             factory.InteropStubManager.AddDependeciesDueToPInvoke(ref dependencies, factory, method);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -147,7 +147,7 @@ namespace ILCompiler.DependencyAnalysis
             if (defaultCtor != null)
             {
                 dependencyList.Add(new DependencyListEntry(
-                    factory.MethodEntrypoint(defaultCtor.GetCanonMethodTarget(CanonicalFormKind.Specific), closestDefType.IsValueType), 
+                    factory.ReflectableMethod(defaultCtor), 
                     "DefaultConstructorNode"));
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CustomAttributeBasedDependencyAlgorithm.cs
@@ -113,7 +113,7 @@ namespace ILCompiler.DependencyAnalysis
                     // Make a new list in case we need to abort.
                     var caDependencies = factory.MetadataManager.GetDependenciesForCustomAttribute(factory, constructor, decodedValue) ?? new DependencyList();
 
-                    caDependencies.Add(factory.CanonicalEntrypoint(constructor), "Attribute constructor");
+                    caDependencies.Add(factory.ReflectableMethod(constructor), "Attribute constructor");
                     caDependencies.Add(factory.ConstructedTypeSymbol(constructor.OwningType), "Attribute type");
 
                     if (AddDependenciesFromCustomAttributeBlob(caDependencies, factory, constructor.OwningType, decodedValue))
@@ -197,8 +197,7 @@ namespace ILCompiler.DependencyAnalysis
                             setterMethod = factory.TypeSystemContext.GetMethodForInstantiatedType(setterMethod, (InstantiatedType)attributeType);
                         }
 
-                        // TODO: what if the setter is virtual/abstract?
-                        dependencies.Add(factory.CanonicalEntrypoint(setterMethod), "Custom attribute blob");
+                        dependencies.Add(factory.ReflectableMethod(setterMethod), "Custom attribute blob");
                     }
 
                     return true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
@@ -33,6 +33,12 @@ namespace ILCompiler.DependencyAnalysis
             DependencyList dependencies = new DependencyList();
             factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencies, factory, _method);
 
+            // No runtime artifacts needed if this is a generic definition
+            if (_method.IsGenericMethodDefinition || _method.OwningType.IsGenericDefinition)
+            {
+                return dependencies;
+            }
+
             MethodDesc canonMethod = _method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             if (canonMethod != _method)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StringAllocatorMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/StringAllocatorMethodNode.cs
@@ -57,7 +57,7 @@ namespace ILCompiler.DependencyAnalysis
                 factory.MethodEntrypoint(_allocationMethod),
                 "String constructor call");
 
-            factory.MetadataManager.GetDependenciesDueToReflectability(ref result, factory, _constructorMethod, methodIL: null);
+            factory.MetadataManager.GetDependenciesDueToMethodCodePresence(ref result, factory, _constructorMethod, methodIL: null);
 
             return result;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/GeneratingMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/GeneratingMetadataManager.cs
@@ -131,7 +131,7 @@ namespace ILCompiler
             }
 
             HashSet<MethodDesc> canonicalGenericMethods = new HashSet<MethodDesc>();
-            foreach (var method in GetCompiledMethods())
+            foreach (var method in GetReflectableMethods())
             {
                 if ((method.HasInstantiation && method.IsCanonicalMethod(CanonicalFormKind.Specific))
                     || (!method.HasInstantiation && method.GetCanonMethodTarget(CanonicalFormKind.Specific) != method))
@@ -204,38 +204,6 @@ namespace ILCompiler
             MethodDesc thunk = _typeSystemContext.GetDynamicInvokeThunk(lookupSig);
 
             return InstantiateCanonicalDynamicInvokeMethodForMethod(thunk, method);
-        }
-
-        protected sealed override void GetDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)
-        {
-            GetDependenciesDueToTemplateTypeLoader(ref dependencies, factory, method);
-            GetDependenciesDueToMethodCodePresenceInternal(ref dependencies, factory, method, methodIL);
-        }
-
-        protected virtual void GetDependenciesDueToMethodCodePresenceInternal(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)
-        {
-        }
-
-        protected virtual void GetDependenciesDueToTemplateTypeLoader(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
-        {
-            // TODO-SIZE: this is overly generous in the templates we create
-            if (_blockingPolicy is FullyBlockedMetadataBlockingPolicy)
-                return;
-
-            if (method.HasInstantiation)
-            {
-                GenericMethodsTemplateMap.GetTemplateMethodDependencies(ref dependencies, factory, method);
-            }
-            else
-            {
-                TypeDesc owningTemplateType = method.OwningType;
-
-                // Unboxing and Instantiating stubs use a different type as their template
-                if (factory.TypeSystemContext.IsSpecialUnboxingThunk(method))
-                    owningTemplateType = factory.TypeSystemContext.GetTargetOfSpecialUnboxingThunk(method).OwningType;
-
-                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningTemplateType);
-            }
         }
 
         protected override void GetDependenciesDueToEETypePresence(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/GeneratingMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/GeneratingMetadataManager.cs
@@ -133,6 +133,12 @@ namespace ILCompiler
             HashSet<MethodDesc> canonicalGenericMethods = new HashSet<MethodDesc>();
             foreach (var method in GetReflectableMethods())
             {
+                if (method.IsGenericMethodDefinition || method.OwningType.IsGenericDefinition)
+                {
+                    // Generic definitions don't have runtime artifacts we would need to map to.
+                    continue;
+                }
+
                 if ((method.HasInstantiation && method.IsCanonicalMethod(CanonicalFormKind.Specific))
                     || (!method.HasInstantiation && method.GetCanonMethodTarget(CanonicalFormKind.Specific) != method))
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
@@ -12,10 +12,10 @@ namespace ILCompiler
     {
         void AddCompilationRoot(MethodDesc method, string reason, string exportName = null);
         void AddCompilationRoot(TypeDesc type, string reason);
+        void AddReflectionRoot(MethodDesc method, string reason);
         void RootThreadStaticBaseForType(TypeDesc type, string reason);
         void RootGCStaticBaseForType(TypeDesc type, string reason);
         void RootNonGCStaticBaseForType(TypeDesc type, string reason);
-        void RootVirtualMethodForReflection(MethodDesc method, string reason);
         void RootModuleMetadata(ModuleDesc module, string reason);
         void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName);
         void RootDelegateMarshallingData(DefType type, string reason);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -50,6 +50,7 @@ namespace ILCompiler
         private readonly HashSet<TypeDesc> _typesWithEETypesGenerated = new HashSet<TypeDesc>();
         private readonly HashSet<TypeDesc> _typesWithConstructedEETypesGenerated = new HashSet<TypeDesc>();
         private HashSet<MethodDesc> _methodsGenerated = new HashSet<MethodDesc>();
+        private HashSet<MethodDesc> _reflectableMethods = new HashSet<MethodDesc>();
         private HashSet<GenericDictionaryNode> _genericDictionariesGenerated = new HashSet<GenericDictionaryNode>();
         private HashSet<IMethodBodyNode> _methodBodiesGenerated = new HashSet<IMethodBodyNode>();
         private List<TypeGVMEntriesNode> _typeGVMEntries = new List<TypeGVMEntriesNode>();
@@ -186,13 +187,17 @@ namespace ILCompiler
             if (methodNode != null)
             {
                 _methodsGenerated.Add(methodNode.Method);
+
+                if (AllMethodsCanBeReflectable)
+                    _reflectableMethods.Add(methodNode.Method);
+
                 return;
             }
 
             var reflectableMethodNode = obj as ReflectableMethodNode;
             if (reflectableMethodNode != null)
             {
-                _methodsGenerated.Add(reflectableMethodNode.Method);
+                _reflectableMethods.Add(reflectableMethodNode.Method);
             }
 
             var nonGcStaticSectionNode = obj as NonGCStaticsNode;
@@ -228,6 +233,8 @@ namespace ILCompiler
                 _dynamicInvokeTemplates.Add(dynamicInvokeTemplate.Method);
             }
         }
+
+        protected virtual bool AllMethodsCanBeReflectable => false;
 
         /// <summary>
         /// Is a method that is reflectable a method which should be placed into the invoke map as invokable?
@@ -303,15 +310,8 @@ namespace ILCompiler
         /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies to compiled method bodies.
         /// </summary>
-        public void GetDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)
+        public void GetDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            if (method.HasInstantiation)
-            {
-                ExactMethodInstantiationsNode.GetExactMethodInstantiationDependenciesForMethod(ref dependencies, factory, method);
-            }
-
-            GetDependenciesDueToMethodCodePresence(ref dependencies, factory, method, methodIL);
-
             MetadataCategory category = GetMetadataCategory(method);
 
             if ((category & MetadataCategory.Description) != 0)
@@ -332,16 +332,8 @@ namespace ILCompiler
         /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies on a virtual method.
         /// </summary>
-        public void GetDependenciesDueToVirtualMethodReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        public virtual void GetDependenciesDueToVirtualMethodReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            // If we have a use of an abstract method, GetDependenciesDueToReflectability is not going to see the method
-            // as being used since there's no body. We inject a dependency on a new node that serves as a logical method body
-            // for the metadata manager. Metadata manager treats that node the same as a body.
-            if (method.IsAbstract && GetMetadataCategory(method) != 0)
-            {
-                dependencies = dependencies ?? new DependencyList();
-                dependencies.Add(factory.ReflectableMethod(method), "Abstract reflectable method");
-            }
         }
 
         protected virtual void GetMetadataDependenciesDueToReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
@@ -414,7 +406,40 @@ namespace ILCompiler
         /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies to generated method bodies.
         /// </summary>
-        protected virtual void GetDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)
+        public void GetDependenciesDueToMethodCodePresence(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)
+        {
+            if (method.HasInstantiation)
+            {
+                ExactMethodInstantiationsNode.GetExactMethodInstantiationDependenciesForMethod(ref dependencies, factory, method);
+            }
+
+            GetDependenciesDueToTemplateTypeLoader(ref dependencies, factory, method);
+            GetDependenciesDueToMethodCodePresenceInternal(ref dependencies, factory, method, methodIL);
+        }
+
+        private void GetDependenciesDueToTemplateTypeLoader(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            // TODO-SIZE: this is overly generous in the templates we create
+            if (_blockingPolicy is FullyBlockedMetadataBlockingPolicy)
+                return;
+
+            if (method.HasInstantiation)
+            {
+                GenericMethodsTemplateMap.GetTemplateMethodDependencies(ref dependencies, factory, method);
+            }
+            else
+            {
+                TypeDesc owningTemplateType = method.OwningType;
+
+                // Unboxing and Instantiating stubs use a different type as their template
+                if (factory.TypeSystemContext.IsSpecialUnboxingThunk(method))
+                    owningTemplateType = factory.TypeSystemContext.GetTargetOfSpecialUnboxingThunk(method).OwningType;
+
+                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref dependencies, factory, owningTemplateType);
+            }
+        }
+
+        protected virtual void GetDependenciesDueToMethodCodePresenceInternal(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)
         {
             // MetadataManagers can override this to provide additional dependencies caused by the presence of a
             // compiled method body.
@@ -627,6 +652,11 @@ namespace ILCompiler
         public IEnumerable<MethodDesc> GetCompiledMethods()
         {
             return _methodsGenerated;
+        }
+
+        public IEnumerable<MethodDesc> GetReflectableMethods()
+        {
+            return _reflectableMethods;
         }
 
         internal IEnumerable<IMethodBodyNode> GetCompiledMethodBodies()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
@@ -40,6 +40,11 @@ namespace ILCompiler
             _rootAdder(_factory.MaximallyConstructableType(type), reason);
         }
 
+        public void AddReflectionRoot(MethodDesc method, string reason)
+        {
+            _rootAdder(_factory.ReflectableMethod(method), reason);
+        }
+
         public void RootThreadStaticBaseForType(TypeDesc type, string reason)
         {
             Debug.Assert(!type.IsGenericDefinition);
@@ -78,28 +83,6 @@ namespace ILCompiler
             if (metadataType != null && (metadataType.NonGCStaticFieldSize.AsInt > 0 || _factory.PreinitializationManager.HasLazyStaticConstructor(type)))
             {
                 _rootAdder(_factory.TypeNonGCStaticsSymbol(metadataType), reason);
-            }
-        }
-
-        public void RootVirtualMethodForReflection(MethodDesc method, string reason)
-        {
-            Debug.Assert(method.IsVirtual);
-
-            if (method.HasInstantiation)
-            {
-                _rootAdder(_factory.GVMDependencies(method), reason);
-            }
-            else
-            {
-                // Virtual method use is tracked on the slot defining method only.
-                MethodDesc slotDefiningMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
-                if (!_factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
-                    _rootAdder(_factory.VirtualMethodUse(slotDefiningMethod), reason);
-            }
-
-            if (method.IsAbstract)
-            {
-                _rootAdder(_factory.ReflectableMethod(method), reason);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -136,9 +136,11 @@ namespace ILCompiler
         {
             MetadataCategory category = 0;
 
-            if (!IsReflectionBlocked(method) && !method.IsGenericMethodDefinition && !method.OwningType.IsGenericDefinition)
+            if (!IsReflectionBlocked(method))
             {
-                category = MetadataCategory.RuntimeMapping;
+                // Can't do mapping for uninstantiated things
+                if (!method.IsGenericMethodDefinition && !method.OwningType.IsGenericDefinition)
+                    category = MetadataCategory.RuntimeMapping;
 
                 if (_compilationModuleGroup.ContainsType(method.GetTypicalMethodDefinition().OwningType))
                     category |= MetadataCategory.Description;
@@ -569,6 +571,9 @@ namespace ILCompiler
 
             foreach (var method in GetReflectableMethods())
             {
+                if (method.IsGenericMethodDefinition || method.OwningType.IsGenericDefinition)
+                    continue;
+
                 if (!IsReflectionBlocked(method))
                 {
                     if ((reflectableTypes[method.OwningType] & MetadataCategory.RuntimeMapping) != 0)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -121,7 +121,7 @@ namespace ILCompiler
         {
             MetadataCategory category = 0;
 
-            if (!IsReflectionBlocked(field))
+            if (!IsReflectionBlocked(field) && !field.OwningType.IsGenericDefinition)
             {
                 category = MetadataCategory.RuntimeMapping;
 
@@ -136,7 +136,7 @@ namespace ILCompiler
         {
             MetadataCategory category = 0;
 
-            if (!IsReflectionBlocked(method))
+            if (!IsReflectionBlocked(method) && !method.IsGenericMethodDefinition && !method.OwningType.IsGenericDefinition)
             {
                 category = MetadataCategory.RuntimeMapping;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -121,9 +121,11 @@ namespace ILCompiler
         {
             MetadataCategory category = 0;
 
-            if (!IsReflectionBlocked(field) && !field.OwningType.IsGenericDefinition)
+            if (!IsReflectionBlocked(field))
             {
-                category = MetadataCategory.RuntimeMapping;
+                // Can't do mapping for uninstantiated things
+                if (!field.OwningType.IsGenericDefinition)
+                    category = MetadataCategory.RuntimeMapping;
 
                 if (_compilationModuleGroup.ContainsType(field.GetTypicalFieldDefinition().OwningType))
                     category |= MetadataCategory.Description;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -162,6 +162,8 @@ namespace ILCompiler
             return category;
         }
 
+        protected override bool AllMethodsCanBeReflectable => (_generationOptions & UsageBasedMetadataGenerationOptions.ReflectedMembersOnly) == 0;
+
         protected override void ComputeMetadata(NodeFactory factory,
             out byte[] metadataBlob,
             out List<MetadataMapping<MetadataType>> typeMappings,
@@ -315,25 +317,8 @@ namespace ILCompiler
 
         public override void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            // In order for the RuntimeMethodHandle data structure to be usable at runtime, ensure the method
-            // is generating metadata.
-            if ((GetMetadataCategory(method) & MetadataCategory.Description) == MetadataCategory.Description)
-            {
-                dependencies = dependencies ?? new DependencyList();
-                dependencies.Add(factory.MethodMetadata(method.GetTypicalMethodDefinition()), "LDTOKEN method");
-            }
-
-            // Since this is typically used for LINQ expressions, let's also make sure there's runnable code
-            // for this available, unless this is ldtoken of something we can't generate code for
-            // (ldtoken of an uninstantiated generic method - F# makes this).
-            if (!method.IsGenericMethodDefinition)
-            {
-                var deps = dependencies ?? new DependencyList();
-                RootingHelpers.TryRootMethod(
-                    new RootingServiceProvider(
-                        factory, (o, reason) => deps.Add((DependencyNodeCore<NodeFactory>)o, reason)), method, "LDTOKEN method");
-                dependencies = deps;
-            }
+            dependencies = dependencies ?? new DependencyList();
+            dependencies.Add(factory.ReflectableMethod(method), "LDTOKEN method");
         }
 
         public override bool ShouldConsiderLdTokenReferenceAConstruction(TypeDesc type)
@@ -389,6 +374,27 @@ namespace ILCompiler
             if (method.GetTypicalMethodDefinition() is Internal.TypeSystem.Ecma.EcmaMethod ecmaMethod)
             {
                 DynamicDependencyAttributeAlgorithm.AddDependenciesDueToDynamicDependencyAttribute(ref dependencies, factory, ecmaMethod);
+            }
+
+            // Presence of code might trigger the reflectability dependencies.
+            if ((_generationOptions & UsageBasedMetadataGenerationOptions.ReflectedMembersOnly) == 0)
+            {
+                GetDependenciesDueToReflectability(ref dependencies, factory, method);
+            }
+        }
+
+        public override void GetDependenciesDueToVirtualMethodReflectability(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            if ((_generationOptions & UsageBasedMetadataGenerationOptions.ReflectedMembersOnly) == 0)
+            {
+                // If we have a use of an abstract method, GetDependenciesDueToReflectability is not going to see the method
+                // as being used since there's no body. We inject a dependency on a new node that serves as a logical method body
+                // for the metadata manager. Metadata manager treats that node the same as a body.
+                if (method.IsAbstract && GetMetadataCategory(method) != 0)
+                {
+                    dependencies = dependencies ?? new DependencyList();
+                    dependencies.Add(factory.ReflectableMethod(method), "Abstract reflectable method");
+                }
             }
         }
 
@@ -561,7 +567,7 @@ namespace ILCompiler
                 reflectableMethods[methodWithMetadata] = MetadataCategory.Description;
             }
 
-            foreach (var method in GetCompiledMethods())
+            foreach (var method in GetReflectableMethods())
             {
                 if (!IsReflectionBlocked(method))
                 {
@@ -841,5 +847,10 @@ namespace ILCompiler
         /// Scan IL for common reflection patterns to find additional compilation roots.
         /// </summary>
         ReflectionILScanning = 4,
+
+        /// <summary>
+        /// Only members that were seen as reflected on will be reflectable.
+        /// </summary>
+        ReflectedMembersOnly = 8,
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -54,6 +54,7 @@ namespace ILCompiler
         private bool _noMetadataBlocking;
         private bool _disableReflection;
         private bool _completeTypesMetadata;
+        private bool _reflectedOnly;
         private bool _scanReflection;
         private bool _methodBodyFolding;
         private bool _singleThreaded;
@@ -184,6 +185,7 @@ namespace ILCompiler
                 syntax.DefineOption("nometadatablocking", ref _noMetadataBlocking, "Ignore metadata blocking for internal implementation details");
                 syntax.DefineOption("disablereflection", ref _disableReflection, "Disable generation of reflection metadata");
                 syntax.DefineOption("completetypemetadata", ref _completeTypesMetadata, "Generate complete metadata for types");
+                syntax.DefineOption("reflectedonly", ref _reflectedOnly, "Generate metadata only for reflected members");
                 syntax.DefineOption("scanreflection", ref _scanReflection, "Scan IL for reflection patterns");
                 syntax.DefineOption("scan", ref _useScanner, "Use IL scanner to generate optimized code (implied by -O)");
                 syntax.DefineOption("noscan", ref _noScanner, "Do not use IL scanner to generate optimized code");
@@ -627,6 +629,8 @@ namespace ILCompiler
                     metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.CompleteTypesOnly;
                 if (_scanReflection)
                     metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.ReflectionILScanning;
+                if (_reflectedOnly)
+                    metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.ReflectedMembersOnly;
             }
             else
             {


### PR DESCRIPTION
This adds a mode (not default for now) where we only generate metadata for things that were specificed as reflectable. I'm seeing 15-20% size on disk savings.

We only do this for methods for now. Fields can follow, although I don't expect this big savings.

The way to specify reflectable things is through the usual avenues:
* Dataflow analysis
* Reflection rooting entire assemblies though our default compat settings
* RD.XML
* Maybe I forgot some

I tested this with `dotnet new webapi` and surpsingly this already works, with ~16% size savings.

It still needs a bit of work so that some invariants can hold (address taken methods should be reflectable so that GetMethodInfo works, all generic instantiations should match reflectability of the definition, etc.).

I'm hoping this will let us get rid of the concept of reflection blocking in the future.

On a high level, this change updates all the places that assumed "I got a method entrypoint therefore the method is reflectable unless blocked" with "you need a ReflectedMethod node to make things reflectable".

Using ReflectedMethodNode simplified reflection rooting in general.