### PR TITLE
DFA to DGML support for debugging SRM, fixed a performance bug

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -10,6 +10,10 @@
     <Compile Include="System\Text\RegularExpressions\Regex.Match.SRM.cs" />
     <Compile Include="System\Text\RegularExpressions\srm\BooleanClassifier.cs" />
     <Compile Include="System\Text\RegularExpressions\srm\Classifier.cs" />
+    <Compile Include="System\Text\RegularExpressions\srm\dgml\DgmlWriter.cs" />
+    <Compile Include="System\Text\RegularExpressions\srm\dgml\IAutomaton.cs" />
+    <Compile Include="System\Text\RegularExpressions\srm\dgml\Move.cs" />
+    <Compile Include="System\Text\RegularExpressions\srm\dgml\RegexDFA.cs" />
     <Compile Include="System\Text\RegularExpressions\srm\State.cs" />
     <Compile Include="System\Text\RegularExpressions\srm\SymbolicRegexInfo.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.MappingTable.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Runtime.CompilerServices;
+using System.IO;
 
 namespace System.Text.RegularExpressions
 {
@@ -36,6 +37,22 @@ namespace System.Text.RegularExpressions
             }
             else
                 return System.Text.RegularExpressions.Match.Empty;
+        }
+
+        /// <summary>
+        /// Unwind the regex and save the resulting state graph in DGML
+        /// </summary>
+        /// <param name="bound">roughly the maximum number of states, 0 means no bound</param>
+        /// <param name="hideDerivatives">if true then hide derivatives in state labels</param>
+        /// <param name="addDotStar">if true then pretend that there is a .* at the beginning</param>
+        /// <param name="writer">dgml output is written here</param>
+        /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with ... </param>
+        internal void SaveDGML(TextWriter writer, int bound, bool hideDerivatives,  bool addDotStar, int maxLabelLength)
+        {
+            if (!_useSRM)
+                throw new NotSupportedException();
+
+            _srm.SaveDGML(writer, bound, hideDerivatives, addDotStar, maxLabelLength);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
@@ -14,7 +14,7 @@ namespace System.Text.RegularExpressions.SRM
         /// <summary>
         /// The unicode component includes the BDD algebra. It is being shared as a static member for efficiency.
         /// </summary>
-        private static readonly UnicodeCategoryTheory<BDD> s_unicode = new UnicodeCategoryTheory<BDD>(new CharSetSolver());
+        internal static readonly UnicodeCategoryTheory<BDD> s_unicode = new UnicodeCategoryTheory<BDD>(new CharSetSolver());
 
         internal const string _DFA_incompatible_with = "DFA option is incompatible with ";
 
@@ -64,13 +64,13 @@ namespace System.Text.RegularExpressions.SRM
         public static Regex Create(RegexNode rootNode, System.Text.RegularExpressions.RegexOptions options)
         {
             var regex = new Regex(rootNode, options);
-#if DEBUG
-            //test the serialization roundtrip
-            //effectively, all tests in DEBUG mode are run with deserialized matchers, not the original ones
-            StringBuilder sb = new();
-            regex.Serialize(sb);
-            regex = Regex.Deserialize(sb.ToString());
-#endif
+//#if DEBUG
+//            //test the serialization roundtrip
+//            //effectively, all tests in DEBUG mode are run with deserialized matchers, not the original ones
+//            StringBuilder sb = new();
+//            regex.Serialize(sb);
+//            regex = Regex.Deserialize(sb.ToString());
+//#endif
             return regex;
         }
 
@@ -119,6 +119,11 @@ namespace System.Text.RegularExpressions.SRM
             StringBuilder sb = new();
             Serialize(sb);
             return sb.ToString();
+        }
+
+        public void SaveDGML(TextWriter writer, int bound, bool hideDerivatives, bool addDotStar, int maxLabelLength)
+        {
+            _matcher.SaveDGML(writer, bound, hideDerivatives, addDotStar, maxLabelLength);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
@@ -100,7 +100,8 @@ namespace System.Text.RegularExpressions.SRM
         }
 
         /// <summary>
-        /// Compute the target state for the given input atom
+        /// Compute the target state for the given input atom.
+        /// If atom is False this means that this is \n and it is the last character of the input.
         /// </summary>
         /// <param name="atom">minterm corresponding to some input character or False corresponding to last \n</param>
         public State<S> Next(S atom)
@@ -130,7 +131,7 @@ namespace System.Text.RegularExpressions.SRM
         /// <summary>
         /// Make a new state with given node and previous character context
         /// </summary>
-        public static State<S> MkState(SymbolicRegexNode<S> node, CharKindId prevCharKindId, bool reverse)
+        public static State<S> MkState(SymbolicRegexNode<S> node, CharKindId prevCharKindId, bool reverse = false)
         {
             State<S> s = new State<S>(node, prevCharKindId, reverse);
             State<S> state;
@@ -238,7 +239,9 @@ namespace System.Text.RegularExpressions.SRM
 
         public override int GetHashCode() => (PrevCharKind, Node).GetHashCode();
 
-        public override string ToString() => (DescribeCharKind(PrevCharKind), Node).ToString();
+        public override string ToString() =>
+            PrevCharKind == (uint)CharKindId.None ? Node.ToString() :
+             (DescribeCharKind(PrevCharKind) + ':' + Node.ToString());
 
         private static string DescribeCharKind(uint i)
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
@@ -255,15 +255,15 @@ namespace System.Text.RegularExpressions.SRM
         {
             string res;
             if (i == CharKind.WordLetter)
-                res = "w";
+                res = @"\w";
             else if (i == CharKind.Start)
-                res = "A";
+                res = @"\A";
             else if (i == CharKind.Newline)
-                res = "n";
+                res = @"\n";
             else if (i == CharKind.NewLineZ)
-                res = "Z";
+                res = @"\Z";
             else if (i == CharKind.End)
-                res = "z";
+                res = @"\z";
             else
                 res = "";
             return res;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
@@ -208,20 +208,10 @@ namespace System.Text.RegularExpressions.SRM
 
             //exclude epsilons from the concatenation
             for (int i = regexes.Length - 1; i >= 0; i--)
-            {
                 if (regexes[i] == this.nothing)
-                {
                     return this.nothing;
-                }
-                else if (sr.IsEpsilon)
-                {
-                    sr = regexes[i];
-                }
-                else if (!regexes[i].IsEpsilon)
-                {
+                else
                     sr = SymbolicRegexNode<S>.MkConcat(this, regexes[i], sr);
-                }
-            }
             return sr;
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.IO;
 using System.Text;
 
 namespace System.Text.RegularExpressions.SRM
@@ -1213,7 +1214,7 @@ namespace System.Text.RegularExpressions.SRM
             }
             else
             {
-                if (this.kind != that.kind || this.info.Equals(that.info))
+                if (this.kind != that.kind || !this.info.Equals(that.info))
                     return false;
                 switch (this.kind)
                 {
@@ -1221,8 +1222,6 @@ namespace System.Text.RegularExpressions.SRM
                         return this.left.Equals(that.left) && this.right.Equals(that.right);
                     case SymbolicRegexKind.Singleton:
                         return object.Equals(this.set, that.set);
-                    //case SymbolicRegexKind.Sequence:
-                    //    return object.Equals(this.sequence, that.sequence);
                     case SymbolicRegexKind.Or:
                     case SymbolicRegexKind.And:
                         return this.alts.Equals(that.alts);
@@ -1286,8 +1285,12 @@ namespace System.Text.RegularExpressions.SRM
                     {
                         if (IsDotStar)
                             return ".*";
+                        else if (IsMaybe)
+                            return left.ToStringForLoop() + "?";
                         else if (IsStar)
                             return left.ToStringForLoop() + "*" + (IsLazy ? "?" : "");
+                        else if (IsPlus)
+                            return left.ToStringForLoop() + "+" + (IsLazy ? "?" : "");
                         else if (IsBoundedLoop)
                             return left.ToStringForLoop() + "{" + lower + "," + upper + "}" + (IsLazy ? "?" : "");
                         else
@@ -1298,9 +1301,9 @@ namespace System.Text.RegularExpressions.SRM
                 case SymbolicRegexKind.And:
                     return alts.ToString();
                 case SymbolicRegexKind.Concat:
-                    return "(" + left.ToString() + ")" + right.ToString();
+                    return left.ToString() + right.ToString();
                 case SymbolicRegexKind.Singleton:
-                    return builder.solver.SerializePredicate(set);
+                    return builder.solver.PrettyPrint(set);
                 default:
                     return "(TBD:if-then-else)";
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BV64Algebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BV64Algebra.cs
@@ -133,7 +133,7 @@ namespace System.Text.RegularExpressions.SRM
             return res;
         }
 
-        public BDD ConvertToCharSet(BDDAlgebra solver, ulong pred)
+        public BDD ConvertToCharSet(ICharAlgebra<BDD> solver, ulong pred)
         {
             if (_partition == null)
                 throw new NotImplementedException(nameof(ConvertToCharSet));
@@ -176,5 +176,21 @@ namespace System.Text.RegularExpressions.SRM
         #endregion
 
         public ulong MkCharPredicate(string name, ulong pred) => throw new NotImplementedException(nameof(MkCharPredicate));
+
+        /// <summary>
+        /// Pretty print the bitvector bv as the character set it represents.
+        /// </summary>
+        public string PrettyPrint(ulong bv)
+        {
+            //accesses the shared BDD solver
+            var bddalgebra = System.Text.RegularExpressions.SRM.Regex.s_unicode.solver;
+
+            if (_partition == null || bddalgebra == null)
+                return "[" + SerializePredicate(bv) + "]";
+
+            var bdd = ConvertToCharSet(bddalgebra, bv);
+            string str = bddalgebra.PrettyPrint(bdd);
+            return str;
+        }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BVAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BVAlgebra.cs
@@ -174,7 +174,7 @@ namespace System.Text.RegularExpressions.SRM
             return res;
         }
 
-        public BDD ConvertToCharSet(BDDAlgebra solver, BV pred)
+        public BDD ConvertToCharSet(ICharAlgebra<BDD> solver, BV pred)
         {
 #if DEBUG
             if (_partition == null)
@@ -204,5 +204,21 @@ namespace System.Text.RegularExpressions.SRM
         /// calls BV.Deserialize(s)
         /// </summary>
         public BV DeserializePredicate(string s) => BV.Deserialize(s);
+
+        /// <summary>
+        /// Pretty print the bitvector bv as the character set it represents.
+        /// </summary>
+        public string PrettyPrint(BV bv)
+        {
+            //accesses the shared BDD solver
+            var bddalgebra = System.Text.RegularExpressions.SRM.Regex.s_unicode.solver;
+
+            if (_partition == null || bddalgebra == null)
+                return "[" + bv.SerializeToString() + "]";
+
+            var bdd = ConvertToCharSet(bddalgebra, bv);
+            string str = bddalgebra.PrettyPrint(bdd);
+            return str;
+        }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
@@ -399,23 +399,23 @@ namespace System.Text.RegularExpressions.SRM
             //check if ranges represents a complement of a singleton
             if (ranges.Length == 2 && ranges[0].Item1 == 0 && ranges[1].Item2 == 0xFFFF &&
                 ranges[0].Item2 + 2 == ranges[1].Item1)
-                return "[^" + ((char)(ranges[0].Item2 + 1)) + "]";
+                return "[^" + (StringUtility.Escape((char)(ranges[0].Item2 + 1))) + "]";
 
             StringBuilder sb = new();
             for (int i = 0; i < ranges.Length; i++)
             {
                 if (ranges[i].Item1 == ranges[i].Item2)
-                    sb.Append((char)ranges[i].Item1);
+                    sb.Append(StringUtility.Escape((char)ranges[i].Item1));
                 else if (ranges[i].Item2 == ranges[i].Item1 + 1)
                 {
-                    sb.Append((char)ranges[i].Item1);
-                    sb.Append((char)ranges[i].Item2);
+                    sb.Append(StringUtility.Escape((char)ranges[i].Item1));
+                    sb.Append(StringUtility.Escape((char)ranges[i].Item2));
                 }
                 else
                 {
-                    sb.Append((char)ranges[i].Item1);
+                    sb.Append(StringUtility.Escape((char)ranges[i].Item1));
                     sb.Append('-');
-                    sb.Append((char)ranges[i].Item2);
+                    sb.Append(StringUtility.Escape((char)ranges[i].Item2));
                 }
             }
             if (ranges.Length > 1 || ranges[0].Item1 != ranges[0].Item2)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
@@ -380,7 +380,7 @@ namespace System.Text.RegularExpressions.SRM
             yield break;
         }
 
-        public BDD ConvertToCharSet(BDDAlgebra alg, BDD pred)
+        public BDD ConvertToCharSet(ICharAlgebra<BDD> _, BDD pred)
         {
             return pred;
         }
@@ -388,6 +388,40 @@ namespace System.Text.RegularExpressions.SRM
         public BDD[] GetPartition()
         {
             throw new NotSupportedException();
+        }
+
+        public string PrettyPrint(BDD pred)
+        {
+            if (pred.IsEmpty)
+                return "[]";
+
+            var ranges = ToRanges(pred);
+            //check if ranges represents a complement of a singleton
+            if (ranges.Length == 2 && ranges[0].Item1 == 0 && ranges[1].Item2 == 0xFFFF &&
+                ranges[0].Item2 + 2 == ranges[1].Item1)
+                return "[^" + ((char)(ranges[0].Item2 + 1)) + "]";
+
+            StringBuilder sb = new();
+            for (int i = 0; i < ranges.Length; i++)
+            {
+                if (ranges[i].Item1 == ranges[i].Item2)
+                    sb.Append((char)ranges[i].Item1);
+                else if (ranges[i].Item2 == ranges[i].Item1 + 1)
+                {
+                    sb.Append((char)ranges[i].Item1);
+                    sb.Append((char)ranges[i].Item2);
+                }
+                else
+                {
+                    sb.Append((char)ranges[i].Item1);
+                    sb.Append('-');
+                    sb.Append((char)ranges[i].Item2);
+                }
+            }
+            if (ranges.Length > 1 || ranges[0].Item1 != ranges[0].Item2)
+                return "[" + sb.ToString() + "]";
+            else
+                return sb.ToString();
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/ICharAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/ICharAlgebra.cs
@@ -47,7 +47,7 @@ namespace System.Text.RegularExpressions.SRM
         /// <summary>
         /// Convert a predicate into a set of characters.
         /// </summary>
-        BDD ConvertToCharSet(BDDAlgebra solver, PRED pred);
+        BDD ConvertToCharSet(ICharAlgebra<BDD> bddalg, PRED pred);
 
         /// <summary>
         /// Gets the underlying character set solver.
@@ -67,5 +67,10 @@ namespace System.Text.RegularExpressions.SRM
         /// Returns a partition of the full domain.
         /// </summary>
         PRED[] GetPartition();
+
+        /// <summary>
+        /// Pretty print the character predicate
+        /// </summary>
+        string PrettyPrint(PRED pred);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/DgmlWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/DgmlWriter.cs
@@ -1,0 +1,167 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace System.Text.RegularExpressions.SRM.DGML
+{
+    internal class DgmlWriter
+    {
+        private int _maxDgmlTransitionLabelLength;
+        private TextWriter _tw;
+
+        internal DgmlWriter(TextWriter tw, int maxDgmlTransitionLabelLength = 500)
+        {
+            _maxDgmlTransitionLabelLength = maxDgmlTransitionLabelLength;
+            _tw = tw;
+        }
+
+        /// <summary>
+        /// Write the automaton in dgml format into the textwriter.
+        /// </summary>
+        public void Write<S>(int k, IAutomaton<S> fa, Func<S, string> describeS = null)
+        {
+            var nonEpsilonMoves = new Dictionary<Tuple<int, int>, List<S>>();
+            var epsilonmoves = new List<Move<S>>();
+
+            var nonEpsilonStates = new HashSet<int>();
+            Func<int, bool> IsEpsilonState = (s => !nonEpsilonStates.Contains(s));
+
+            foreach (var move in fa.GetMoves())
+            {
+                if (move.IsEpsilon)
+                    epsilonmoves.Add(move);
+
+                else
+                {
+                    nonEpsilonStates.Add(move.SourceState);
+                    List<S> rules;
+                    var p = new Tuple<int, int>(move.SourceState, move.TargetState);
+                    if (!nonEpsilonMoves.TryGetValue(p, out rules))
+                    {
+                        rules = new List<S>();
+                        nonEpsilonMoves[p] = rules;
+                    }
+                    rules.Add(move.Label);
+                }
+            }
+
+            _tw.WriteLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+            _tw.WriteLine("<DirectedGraph xmlns=\"http://schemas.microsoft.com/vs/2009/dgml\" ZoomLevel=\"1.5\" GraphDirection=\"TopToBottom\" >");
+            _tw.WriteLine("<Nodes>");
+            _tw.WriteLine("<Node Id=\"init\" Label=\"{0}\" Stroke=\"white\" Background=\"white\"/>", " ");
+            foreach (int state in fa.GetStates())
+            {
+                _tw.WriteLine("<Node Id=\"{0}\" Label=\"{1}\" Category=\"State\" >", state, EncodeChars(fa.DescribeState(state)));
+                if (state == fa.InitialState)
+                    _tw.WriteLine("<Category Ref=\"InitialState\" />");
+                if (fa.IsFinalState(state))
+                    _tw.WriteLine("<Category Ref=\"FinalState\" />");
+                _tw.WriteLine("</Node>");
+            }
+            _tw.WriteLine("</Nodes>");
+            _tw.WriteLine("<Links>");
+            _tw.WriteLine("<Link Source=\"init\" Target=\"{0}\" Label=\"{1}\" Category=\"StartTransition\" />", fa.InitialState, EncodeChars(fa.DescribeStartLabel()));
+            foreach (var move in epsilonmoves)
+                _tw.WriteLine("<Link Source=\"{0}\" Target=\"{1}\" Category=\"EpsilonTransition\" />", move.SourceState, move.TargetState);
+
+            foreach (var move in nonEpsilonMoves)
+                _tw.WriteLine(GetNonFinalRuleInfo(k, fa, move.Key.Item1, move.Key.Item2, move.Value, describeS));
+
+            _tw.WriteLine("</Links>");
+            WriteCategoriesAndStyles();
+            _tw.WriteLine("</DirectedGraph>");
+        }
+
+        private string GetNonFinalRuleInfo<S>(int k, IAutomaton<S> aut, int source, int target, List<S> rules, Func<S, string> describeS = null)
+        {
+            if (describeS == null)
+                describeS = aut.DescribeLabel;
+
+            string lab = "";
+            string info = "";
+            for (int i = 0; i < rules.Count; i++)
+            {
+                lab += (lab == "" ? "" : ",\n ") + describeS(rules[i]);
+            }
+            if (k >= 0 && lab.Length > k)
+                lab = lab.Substring(0, k) + "...";
+            lab = EncodeChars(lab);
+            if (lab.Length > _maxDgmlTransitionLabelLength)
+            {
+                info += string.Format(" HiddenLabel = \"{0}\"", lab);
+                lab = "...";
+            }
+            return string.Format("<Link Source=\"{0}\" Target=\"{1}\" Label=\"{2}\" Category=\"NonepsilonTransition\" {3}/>", source, target, lab, info);
+        }
+
+        private static string EncodeChars(string s)
+        {
+            string s1 = SRM.StringUtility.Escape(s);
+            string s2 = s1.Replace("&", "&amp;").Replace("\"", "&quot;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\n", "&#13;");
+            return s2;
+        }
+
+        private void WriteCategoriesAndStyles()
+        {
+            _tw.WriteLine("<Categories>");
+            _tw.WriteLine("<Category Id=\"EpsilonTransition\" Label=\"Epsilon transition\" IsTag=\"True\" />");
+            _tw.WriteLine("<Category Id=\"StartTransition\" Label=\"Initial transition\" IsTag=\"True\" />");
+            _tw.WriteLine("<Category Id=\"FinalLabel\" Label=\"Final transition\" IsTag=\"True\" />");
+            _tw.WriteLine("<Category Id=\"FinalState\" Label=\"Final\" IsTag=\"True\" />");
+            _tw.WriteLine("<Category Id=\"SinkState\" Label=\"Sink state\" IsTag=\"True\" />");
+            _tw.WriteLine("<Category Id=\"EpsilonState\" Label=\"Epsilon state\" IsTag=\"True\" />");
+            _tw.WriteLine("<Category Id=\"InitialState\" Label=\"Initial\" IsTag=\"True\" />");
+            _tw.WriteLine("<Category Id=\"NonepsilonTransition\" Label=\"Nonepsilon transition\" IsTag=\"True\" />");
+            _tw.WriteLine("<Category Id=\"State\" Label=\"State\" IsTag=\"True\" />");
+            _tw.WriteLine("</Categories>");
+            _tw.WriteLine("<Styles>");
+            _tw.WriteLine("<Style TargetType=\"Node\" GroupLabel=\"InitialState\" ValueLabel=\"True\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('InitialState')\" />");
+            _tw.WriteLine("<Setter Property=\"Background\" Value=\"white\" />");
+            _tw.WriteLine("<Setter Property=\"MinWidth\" Value=\"0\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("<Style TargetType=\"Node\" GroupLabel=\"FinalState\" ValueLabel=\"True\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('FinalState')\" />");
+            //tw.WriteLine("<Setter Property=\"Background\" Value=\"lightgreen\" />");
+            _tw.WriteLine("<Setter Property=\"StrokeThickness\" Value=\"4\" />");
+            //tw.WriteLine("<Setter Property=\"Background\" Value=\"white\" />");
+            //tw.WriteLine("<Setter Property=\"MinWidth\" Value=\"0\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("<Style TargetType=\"Node\" GroupLabel=\"SinkState\" ValueLabel=\"True\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('SinkState')\" />");
+            _tw.WriteLine("<Setter Property=\"NodeRadius\" Value=\"0\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("<Style TargetType=\"Node\" GroupLabel=\"EpsilonState\" ValueLabel=\"True\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('EpsilonState')\" />");
+            _tw.WriteLine("<Setter Property=\"Background\" Value=\"tomato\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("<Style TargetType=\"Node\" GroupLabel=\"State\" ValueLabel=\"True\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('State')\" />");
+            _tw.WriteLine("<Setter Property=\"Stroke\" Value=\"black\" />");
+            _tw.WriteLine("<Setter Property=\"Background\" Value=\"white\" />");
+            _tw.WriteLine("<Setter Property=\"MinWidth\" Value=\"0\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("<Style TargetType=\"Link\" GroupLabel=\"NonepsilonTransition\" ValueLabel=\"True\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('NonepsilonTransition')\" />");
+            _tw.WriteLine("<Setter Property=\"Stroke\" Value=\"black\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("<Style TargetType=\"Link\" GroupLabel=\"StartTransition\" ValueLabel=\"True\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('StartTransition')\" />");
+            _tw.WriteLine("<Setter Property=\"Stroke\" Value=\"black\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("<Style TargetType=\"Link\" GroupLabel=\"EpsilonTransition\" ValueLabel=\"True\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('EpsilonTransition')\" />");
+            _tw.WriteLine("<Setter Property=\"Stroke\" Value=\"black\" />");
+            _tw.WriteLine("<Setter Property=\"StrokeDashArray\" Value=\"8 8\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("<Style TargetType=\"Link\" GroupLabel=\"FinalLabel\" ValueLabel=\"False\">");
+            _tw.WriteLine("<Condition Expression=\"HasCategory('FinalLabel')\" />");
+            _tw.WriteLine("<Setter Property=\"Stroke\" Value=\"black\" />");
+            _tw.WriteLine("<Setter Property=\"StrokeDashArray\" Value=\"8 8\" />");
+            _tw.WriteLine("</Style>");
+            _tw.WriteLine("</Styles>");
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/IAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/IAutomaton.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace System.Text.RegularExpressions.SRM.DGML
+{
+    /// <summary>
+    /// For accessing the key components of an automaton.
+    /// </summary>
+    /// <typeparam name="L">type of labels in moves</typeparam>
+    internal interface IAutomaton<L>
+    {
+        /// <summary>
+        /// Enumerates all moves of the automaton.
+        /// </summary>
+        IEnumerable<Move<L>> GetMoves();
+
+        /// <summary>
+        /// Enumerates all states of the automaton.
+        /// </summary>
+        IEnumerable<int> GetStates();
+
+        /// <summary>
+        /// Provides a description of the state for visualization purposes.
+        /// </summary>
+        string DescribeState(int state);
+
+        /// <summary>
+        /// Provides a description of the label for visualization purposes.
+        /// </summary>
+        string DescribeLabel(L lab);
+
+        /// <summary>
+        /// Provides a description of the start label for visualization purposes.
+        /// </summary>
+        string DescribeStartLabel();
+
+        /// <summary>
+        /// The initial state of the automaton.
+        /// </summary>
+        int InitialState { get; }
+
+        /// <summary>
+        /// Returns true iff the state is a final state.
+        /// </summary>
+        bool IsFinalState(int state);
+    }
+
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/Move.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/Move.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Text.RegularExpressions.SRM.DGML
+{
+    /// <summary>
+    /// Represents a move of a symbolic finite automaton.
+    /// The value default(L) is reserved to represent the label of an epsilon move.
+    /// Thus if S is a reference type the label of an epsilon move is null.
+    /// </summary>
+    /// <typeparam name="L">the type of the labels on moves</typeparam>
+    internal class Move<L>
+    {
+        /// <summary>
+        /// Source state of the move
+        /// </summary>
+        public readonly int SourceState;
+        /// <summary>
+        /// Target state of the move
+        /// </summary>
+        public readonly int TargetState;
+        /// <summary>
+        /// Label of the move
+        /// </summary>
+        public readonly L Label;
+
+        /// <summary>
+        /// Transition of an automaton.
+        /// </summary>
+        /// <param name="sourceState">source state of the transition</param>
+        /// <param name="targetState">target state of the transition</param>
+        /// <param name="lab">label of the transition</param>
+        public Move(int sourceState, int targetState, L lab)
+        {
+            this.SourceState = sourceState;
+            this.TargetState = targetState;
+            this.Label = lab;
+        }
+
+        /// <summary>
+        /// Creates a move. Creates an epsilon move if label is default(L).
+        /// </summary>
+        public static Move<L> Create(int sourceState, int targetState, L condition)
+        {
+            return new Move<L>(sourceState, targetState, condition);
+        }
+
+        /// <summary>
+        /// Creates an epsilon move. Same as Create(sourceState, targetState, default(L)).
+        /// </summary>
+        public static Move<L> Epsilon(int sourceState, int targetState)
+        {
+            return new Move<L>(sourceState, targetState, default(L));
+        }
+
+        /// <summary>
+        /// Returns true if label equals default(S).
+        /// </summary>
+        public bool IsEpsilon => object.Equals(Label, default(L));
+
+        /// <summary>
+        /// Returns true if the source state and the target state are identical
+        /// </summary>
+        public bool IsSelfLoop => SourceState == TargetState;
+
+        /// <summary>
+        /// Returns true if obj is a move with the same source state, target state, and label.
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Move<L>))
+                return false;
+            Move<L> t = (Move<L>)obj;
+            return (t.SourceState == SourceState && t.TargetState == TargetState &&
+                (object.Equals(t.Label, default(L)) ? object.Equals(Label, default(L))
+                : t.Label.Equals(Label)));
+        }
+
+        public override int GetHashCode() => (SourceState, Label, TargetState).GetHashCode();
+
+        public override string ToString()
+        {
+            return "(" + SourceState + "," + (object.Equals(Label, default(L)) ? "" : Label + ",") + TargetState + ")";
+        }
+    }
+
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
@@ -54,11 +54,11 @@ namespace System.Text.RegularExpressions.SRM.DGML
 
         public int InitialState => _q0.Id;
 
-        public string DescribeLabel(S lab) => _solver.PrettyPrint(lab);
+        public string DescribeLabel(S lab) => EncodeChars(_solver.PrettyPrint(lab));
 
         public string DescribeStartLabel() => "";
 
-        public string DescribeState(int state) => (_hideDerivatives ? state.ToString() : _states[state].ToString());
+        public string DescribeState(int state) => (_hideDerivatives ? state.ToString() : ViewState(_states[state]));
 
         public IEnumerable<int> GetStates() => _states.Keys;
 
@@ -68,6 +68,21 @@ namespace System.Text.RegularExpressions.SRM.DGML
         {
             foreach (var entry in _normalizedmoves)
                 yield return Move<S>.Create(entry.Key.Item1, entry.Key.Item2, entry.Value);
+        }
+
+        private static string EncodeChars(string s)
+        {
+            string s1 = SRM.StringUtility.Escape(s);
+            string s2 = s1.Replace("&", "&amp;").Replace("\"", "&quot;").Replace("<", "&lt;").Replace(">", "&gt;");
+            return s2;
+        }
+
+        private static string ViewState(State<S> state)
+        {
+            if (state.PrevCharKindId == CharKindId.None)
+                return EncodeChars(state.Node.ToString());
+            else
+                return string.Format("Prev:{0}&#13;{1}", state.PrevCharKindId, EncodeChars(state.Node.ToString()));
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace System.Text.RegularExpressions.SRM.DGML
+{
+    /// <summary>
+    /// Used by DgmlWriter to unwind a regex into a DFA up to a bound that limits the number of states
+    /// </summary>
+    internal class RegexDFA<S> : IAutomaton<S>
+    {
+        private State<S> _q0;
+        private Dictionary<int, State<S>> _states = new Dictionary<int, State<S>>();
+        private Dictionary<Tuple<int, int>, S> _normalizedmoves = new Dictionary<Tuple<int, int>, S>();
+        private ICharAlgebra<S> _solver;
+        private bool _hideDerivatives;
+
+        internal RegexDFA(SymbolicRegexMatcher<S> srm, int bound, bool hideDerivatives, bool addDotStar)
+        {
+            _solver = srm.builder.solver;
+            _hideDerivatives = hideDerivatives;
+            CharKindId startId = (srm.A.info.StartsWithSomeAnchor ? CharKindId.Start : CharKindId.None);
+            _q0 = State<S>.MkState(addDotStar ? srm.A1 : srm.A, startId);
+            var stack = new Stack<State<S>>();
+            stack.Push(_q0);
+            _states[_q0.Id] = _q0;
+            var partition = _solver.GetPartition();
+            //construct until the stack is empty or the bound has been reached
+            while (stack.Count > 0 && (bound <= 0 || _states.Count < bound))
+            {
+                var q = stack.Pop();
+                foreach (var c in partition)
+                {
+                    var p = q.Next(c);
+                    //check that p is not a dead-end
+                    if (!p.IsNothing)
+                    {
+                        if (!_states.ContainsKey(p.Id))
+                        {
+                            stack.Push(p);
+                            _states[p.Id] = p;
+                        }
+                        var qp = new Tuple<int, int>(q.Id, p.Id);
+                        if (_normalizedmoves.ContainsKey(qp))
+                            _normalizedmoves[qp] = _solver.MkOr(_normalizedmoves[qp], c);
+                        else
+                            _normalizedmoves[qp] = c;
+                    }
+                }
+            }
+        }
+
+        public int InitialState => _q0.Id;
+
+        public string DescribeLabel(S lab) => _solver.PrettyPrint(lab);
+
+        public string DescribeStartLabel() => "";
+
+        public string DescribeState(int state) => (_hideDerivatives ? state.ToString() : _states[state].ToString());
+
+        public IEnumerable<int> GetStates() => _states.Keys;
+
+        public bool IsFinalState(int state) => _states[state].IsNullable(0);
+
+        public IEnumerable<Move<S>> GetMoves()
+        {
+            foreach (var entry in _normalizedmoves)
+                yield return Move<S>.Create(entry.Key.Item1, entry.Key.Item2, entry.Value);
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/IMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/IMatcher.cs
@@ -27,5 +27,7 @@ namespace System.Text.RegularExpressions.SRM
         public Match FindMatch(bool isMatch, string input, int startat = 0, int endat = -1);
 
         public void Serialize(StringBuilder sb);
+
+        public void SaveDGML(TextWriter writer, int bound, bool hideDerivatives, bool addDotStar, int maxLabelLength);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -144,7 +144,7 @@ namespace System.Text.RegularExpressions.SRM
         /// <summary>
         /// .*A start regex
         /// </summary>
-        private SymbolicRegexNode<S> A1;
+        internal SymbolicRegexNode<S> A1;
 
         private State<S>[] _Aq0 = new State<S>[6];
 
@@ -1410,6 +1410,13 @@ namespace System.Text.RegularExpressions.SRM
             while (i < k && !pred[input[i]])
                 i += 1;
             return (i == k ? -1 : i);
+        }
+
+        public void SaveDGML(TextWriter writer, int bound = 0, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 500)
+        {
+            var graph = new DGML.RegexDFA<S>(this, bound, hideDerivatives, addDotStar);
+            var dgml = new DGML.DgmlWriter(writer, maxLabelLength);
+            dgml.Write<S>(bound, graph, builder.solver.PrettyPrint);
         }
 
 #if UNSAFE

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -1416,7 +1416,7 @@ namespace System.Text.RegularExpressions.SRM
         {
             var graph = new DGML.RegexDFA<S>(this, bound, hideDerivatives, addDotStar);
             var dgml = new DGML.DgmlWriter(writer, maxLabelLength);
-            dgml.Write<S>(bound, graph, builder.solver.PrettyPrint);
+            dgml.Write<S>(graph, builder.solver.PrettyPrint);
         }
 
 #if UNSAFE

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/StringUtility.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/StringUtility.cs
@@ -53,10 +53,10 @@ namespace System.Text.RegularExpressions.SRM
             {
                 case '\0':
                     return @"\0";
-                case '\a':
-                    return @"\a";
-                case '\b':
-                    return @"\b";
+                //case '\a':
+                //    return @"\a";
+                //case '\b':
+                //    return @"\b";
                 case '\t':
                     return @"\t";
                 case '\r':

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/StringUtility.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/StringUtility.cs
@@ -46,55 +46,32 @@ namespace System.Text.RegularExpressions.SRM
             if (code <= 255 && code > 126)
                 return string.Format("\\x{0:X}", code);
 
+            if (code >= 32 && code <= 126)
+                return c.ToString();
+
             switch (c)
             {
                 case '\0':
                     return @"\0";
-                //case '\a':
-                //    return @"\a";
-                //case '\b':
-                //    return @"\b";
-                //case '\t':
-                //    return @"\t";
-                //case '\r':
-                //    return @"\r";
-                //case '\v':
-                //    return @"\v";
-                //case '\f':
-                //    return @"\f";
+                case '\a':
+                    return @"\a";
+                case '\b':
+                    return @"\b";
+                case '\t':
+                    return @"\t";
+                case '\r':
+                    return @"\r";
+                case '\v':
+                    return @"\v";
+                case '\f':
+                    return @"\f";
                 case '\n':
                     return @"\n";
-                case '=':
-                    return "=";
-                case ';':
-                    return ";";
-                case '/':
-                    return "/";
-                case '!':
-                    return "!";
-                //case '>':
-                //    return ">";
-                //case '\"':
-                //    return "\\\"";
-                //case '\'':
-                //    return "\\\'";
-                //case ' ':
-                //    return " ";
-                //case '\\' :
-                //    return @"\\";
                 default:
                     if (code <= 15)
-                    {
                         return string.Format("\\x0{0:X}", code);
-                    }
-                    else if (!(((int)'a') <= code && code <= ((int)'z'))
-                         && !(((int)'A') <= code && code <= ((int)'Z'))
-                         && !(((int)'0') <= code && code <= ((int)'9')))
-                    {
-                        return string.Format("\\x{0:X}", code);
-                    }
                     else
-                        return c.ToString();
+                        return string.Format("\\x{0:X}", code);
             }
         }
 
@@ -126,46 +103,15 @@ namespace System.Text.RegularExpressions.SRM
 
         /// <summary>
         /// Makes an escaped string from a literal string s.
-        /// Appends '\"' at the start and end of the encoded string.
         /// </summary>
         public static string Escape(string s)
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append('"');
             foreach (char c in s)
-            {
                 sb.Append(Escape(c));
-            }
-            sb.Append('"');
             return sb.ToString();
         }
 
-        /// <summary>
-        /// Unescapes any escaped characters in in the input string.
-        /// (Same as System.Text.RegularExpressions.Regex.Unescape)
-        /// </summary>
-        public static string Unescape(string s)
-        {
-            return System.Text.RegularExpressions.Regex.Unescape(s);
-        }
         #endregion
-
-        internal static string SerializeStringToCharCodeSequence(string s)
-        {
-            if (string.IsNullOrEmpty(s))
-                return s;
-            var encodedChars = Array.ConvertAll(s.ToCharArray(), c => ((int)c).ToString());
-            var serialized = string.Join(",", encodedChars);
-            return serialized;
-        }
-
-        internal static string DeserializeStringFromCharCodeSequence(string s)
-        {
-            if (string.IsNullOrEmpty(s))
-                return s;
-            var encodedChars = s.Split(',');
-            var deserialized = new string(Array.ConvertAll(encodedChars, x => (char)(int.Parse(x))));
-            return deserialized;
-        }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -27,10 +27,10 @@ namespace System.Text.RegularExpressions.Tests
         /// View the regex as a DFA in DGML format in VS.
         /// </summary>
         /// <param name="r"></param>
-        private static void ViewDGML(Regex r, int bound = 10, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 1000)
+        private static void ViewDGML(Regex regex, int bound = 10, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 1000)
         {
             System.IO.StreamWriter sw = new StreamWriter("C:/tmp/DFA.dgml");
-            WriteDGML(r, sw, bound, hideDerivatives, addDotStar, maxLabelLength);
+            SaveDGML(regex, sw, bound, hideDerivatives, addDotStar, maxLabelLength);
             sw.Close();
         }
 
@@ -38,10 +38,10 @@ namespace System.Text.RegularExpressions.Tests
         /// Save the regex as a DFA in DGML format in the textwriter.
         /// </summary>
         /// <param name="r"></param>
-        private static void WriteDGML(Regex r, TextWriter writer, int bound = 10, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 1000)
+        private static void SaveDGML(Regex regex, TextWriter writer, int bound = -1, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = -1)
         {
-            MethodInfo saveDgml = r.GetType().GetMethod("SaveDGML", BindingFlags.NonPublic | BindingFlags.Instance);
-            saveDgml.Invoke(r, new object[] { writer, bound, hideDerivatives, addDotStar, maxLabelLength });
+            MethodInfo saveDgml = regex.GetType().GetMethod("SaveDGML", BindingFlags.NonPublic | BindingFlags.Instance);
+            saveDgml.Invoke(regex, new object[] { writer, bound, hideDerivatives, addDotStar, maxLabelLength });
         }
 
         [Fact]
@@ -49,19 +49,20 @@ namespace System.Text.RegularExpressions.Tests
         {
             StringWriter sw = new StringWriter();
             var re = new Regex(".*a+", DFA | RegexOptions.Singleline);
-            WriteDGML(re, sw);
+            SaveDGML(re, sw);
             string str = sw.ToString();
             Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", str);
             Assert.Contains("DirectedGraph", str);
             Assert.Contains(".*a+", str);
         }
 
-        [Fact]
-        public void TestDGML()
+        //[Fact]
+        private void TestDGML()
         {
-            var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
-            //var re = new Regex(@"\b[a-z]+nn\b", DFA);
-            ViewDGML(re, 20, false);
+            //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
+            //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
+            var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
+            ViewDGML(regex: re, addDotStar: true);
         }
 
         [Fact]

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 using Xunit.Abstractions;
 using System.Linq;
@@ -21,6 +22,47 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         internal static RegexOptions DFA = (RegexOptions)0x400;
+
+        /// <summary>
+        /// View the regex as a DFA in DGML format in VS.
+        /// </summary>
+        /// <param name="r"></param>
+        private static void ViewDGML(Regex r, int bound = 10, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 1000)
+        {
+            System.IO.StreamWriter sw = new StreamWriter("C:/tmp/DFA.dgml");
+            WriteDGML(r, sw, bound, hideDerivatives, addDotStar, maxLabelLength);
+            sw.Close();
+        }
+
+        /// <summary>
+        /// Save the regex as a DFA in DGML format in the textwriter.
+        /// </summary>
+        /// <param name="r"></param>
+        private static void WriteDGML(Regex r, TextWriter writer, int bound = 10, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 1000)
+        {
+            MethodInfo saveDgml = r.GetType().GetMethod("SaveDGML", BindingFlags.NonPublic | BindingFlags.Instance);
+            saveDgml.Invoke(r, new object[] { writer, bound, hideDerivatives, addDotStar, maxLabelLength });
+        }
+
+        [Fact]
+        public void TestDGMLGeneration()
+        {
+            StringWriter sw = new StringWriter();
+            var re = new Regex(".*a+", DFA | RegexOptions.Singleline);
+            WriteDGML(re, sw);
+            string str = sw.ToString();
+            Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", str);
+            Assert.Contains("DirectedGraph", str);
+            Assert.Contains(".*a+", str);
+        }
+
+        [Fact]
+        public void TestDGML()
+        {
+            var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
+            //var re = new Regex(@"\b[a-z]+nn\b", DFA);
+            ViewDGML(re, 20, false);
+        }
 
         [Fact]
         public void SRMPrefixBugFixTest()


### PR DESCRIPTION
DGML support allows generation of DFA saved in DGML format that then can be displayed as a directed graph in VS. DGML generation is exposed as an internal method of Regex. Added unit tests (through reflection) to illustrate and test usage.

Fixed a performance bug in SRM that was caused by states not being identified correctly by SymbolicRegexNode.Equals and the state space was exploding and caused slowdown in derivative computations, the bug was a one-character-bug (a missing negation sign '!' in one place). 