### PR TITLE
Build ObjWriter with Ninja on Windows

### DIFF
--- a/src/coreclr/tools/aot/ObjWriter/build.cmd
+++ b/src/coreclr/tools/aot/ObjWriter/build.cmd
@@ -95,10 +95,11 @@ set "ExtraCMakeArgs=%~3"
     -DLLVM_TARGETS_TO_BUILD="AArch64;ARM;X86" ^
     -DLLVM_EXTERNAL_OBJWRITER_SOURCE_DIR="%ScriptDir%\" ^
     -DCORECLR_INCLUDE_DIR="%RepoRoot%src\coreclr\inc" ^
+    -G Ninja ^
     || goto Error
 
-echo Executing "%CMakePath%" --build "build\%Arch%" --config %BuildType% --target %Target% -- -m
-"%CMakePath%" --build "build\%Arch%" --config %BuildType% --target %Target% -- -m || goto Error
+echo Executing "%CMakePath%" --build "build\%Arch%" --config %BuildType% --target %Target%
+"%CMakePath%" --build "build\%Arch%" --config %BuildType% --target %Target% || goto Error
 exit /b 0
 
 :Error


### PR DESCRIPTION
Per https://github.com/dotnet/runtime/issues/50794 Ninja is the default generator for building the runtime repo on Windows, so people should have it. Piping through the fallback for MSBuild doesn't seem worth the trouble. I might do it along with the `-vs` option for `build.cmd` next time I need to do an ObjWriter change (I use VS, so not having a vcxproj is going to be annoying).

```
build.cmd nativeaot.objwriter
```

Before: Time Elapsed 00:19:29.02
After: Time Elapsed 00:17:04.22