### PR TITLE
Consistently mark reflectable generics

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -259,7 +259,7 @@ namespace ILCompiler.Dataflow
 
             while (type != null)
             {
-                if (type is not EcmaType ecmaType)
+                if (type.GetTypeDefinition() is not EcmaType ecmaType)
                 {
                     yield break;
                 }
@@ -324,7 +324,7 @@ namespace ILCompiler.Dataflow
             
             while (type != null)
             {
-                if (type is not EcmaType ecmaType)
+                if (type.GetTypeDefinition() is not EcmaType ecmaType)
                 {
                     yield break;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -10,6 +10,7 @@ using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.DependencyAnalysis;
 
 using DependencyList=ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+using CombinedDependencyList=System.Collections.Generic.List<ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.CombinedDependencyListEntry>;
 using DependencyListEntry=ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyListEntry;
 
 namespace ILCompiler.DependencyAnalysis
@@ -104,6 +105,17 @@ namespace ILCompiler.DependencyAnalysis
                     }
                 }
             }
+        }
+
+        public static bool HasConditionalDependenciesDueToMethodCodePresence(MethodDesc method)
+        {
+            // NICE: would be nice if the metadata managed could decide this but we don't have a way to get at it
+            return method.HasInstantiation || method.OwningType.HasInstantiation;
+        }
+
+        public static void AddConditionalDependenciesDueToMethodCodePresence(ref CombinedDependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            factory.MetadataManager.GetConditionalDependenciesDueToMethodCodePresence(ref dependencies, factory, method);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
@@ -39,6 +39,15 @@ namespace ILCompiler.DependencyAnalysis
                 return dependencies;
             }
 
+            // Ensure we consistently apply reflectability to all methods sharing the same definition.
+            // Different instantiations of the method have a conditional dependency on the definition node that
+            // brings a ReflectableMethod of the instantiated method if it's necessary for it to be reflectable.
+            MethodDesc typicalMethod = _method.GetTypicalMethodDefinition();
+            if (typicalMethod != _method)
+            {
+                dependencies.Add(factory.ReflectableMethod(typicalMethod), "Definition of the reflectable method");
+            }
+
             MethodDesc canonMethod = _method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             if (canonMethod != _method)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ScannedMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ScannedMethodNode.cs
@@ -9,6 +9,7 @@ using ILCompiler.DependencyAnalysisFramework;
 using Internal.Text;
 using Internal.TypeSystem;
 
+using CombinedDependencyList = System.Collections.Generic.List<ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.CombinedDependencyListEntry>;
 using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler.DependencyAnalysis
@@ -65,11 +66,17 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
-        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
+        {
+            CombinedDependencyList dependencies = null;
+            CodeBasedDependencyAlgorithm.AddConditionalDependenciesDueToMethodCodePresence(ref dependencies, factory, _method);
+            return dependencies ?? (IEnumerable<CombinedDependencyListEntry>)Array.Empty<CombinedDependencyListEntry>();
+        }
+
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool HasDynamicDependencies => false;
-        public override bool HasConditionalStaticDependencies => false;
+        public override bool HasConditionalStaticDependencies => CodeBasedDependencyAlgorithm.HasConditionalDependenciesDueToMethodCodePresence(_method);
 
         int ISortableNode.ClassCode => -1381809560;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -13,6 +13,7 @@ using Debug = System.Diagnostics.Debug;
 using ReadyToRunSectionType = Internal.Runtime.ReadyToRunSectionType;
 using ReflectionMapBlob = Internal.Runtime.ReflectionMapBlob;
 using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+using CombinedDependencyList = System.Collections.Generic.List<ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.CombinedDependencyListEntry>;
 using MethodIL = Internal.IL.MethodIL;
 using CustomAttributeValue = System.Reflection.Metadata.CustomAttributeValue<Internal.TypeSystem.TypeDesc>;
 
@@ -415,6 +416,12 @@ namespace ILCompiler
 
             GetDependenciesDueToTemplateTypeLoader(ref dependencies, factory, method);
             GetDependenciesDueToMethodCodePresenceInternal(ref dependencies, factory, method, methodIL);
+        }
+
+        public virtual void GetConditionalDependenciesDueToMethodCodePresence(ref CombinedDependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            // MetadataManagers can override this to provide additional dependencies caused by the presence of
+            // method code.
         }
 
         private void GetDependenciesDueToTemplateTypeLoader(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -10,6 +10,8 @@ using Internal.IL;
 using Internal.Text;
 using Internal.TypeSystem;
 
+using CombinedDependencyList = System.Collections.Generic.List<ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.CombinedDependencyListEntry>;
+
 namespace ILCompiler.DependencyAnalysis
 {
     [DebuggerTypeProxy(typeof(MethodCodeNodeDebugView))]
@@ -64,6 +66,15 @@ namespace ILCompiler.DependencyAnalysis
         }
         public int Offset => 0;
         public override bool IsShareable => _method is InstantiatedMethod || EETypeNode.IsTypeNodeShareable(_method.OwningType);
+
+        public override bool HasConditionalStaticDependencies => CodeBasedDependencyAlgorithm.HasConditionalDependenciesDueToMethodCodePresence(_method);
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
+        {
+            CombinedDependencyList dependencies = null;
+            CodeBasedDependencyAlgorithm.AddConditionalDependenciesDueToMethodCodePresence(ref dependencies, factory, _method);
+            return dependencies ?? (IEnumerable<CombinedDependencyListEntry>)Array.Empty<CombinedDependencyListEntry>();
+        }
 
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection_ReflectedOnly.csproj
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection_ReflectedOnly.csproj
@@ -4,7 +4,6 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>$(DefineConstants);REFLECTION_FROM_USAGE</DefineConstants>
 
     <!-- Look for MULTIMODULE_BUILD #define for the more specific incompatible parts -->
     <NativeAotMultimoduleIncompatible>true</NativeAotMultimoduleIncompatible>
@@ -12,4 +11,14 @@
   <ItemGroup>
     <Compile Include="Reflection.cs" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <NativeAotProjectLines>
+      <![CDATA[
+  <ItemGroup>
+    <IlcArg Include="--reflectedonly" />
+  </ItemGroup>
+      ]]>
+    </NativeAotProjectLines>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
In the `--reflectedonly` mode that only generates reflection metadata for things that were seen as reflected, ensure that generic things get consistent reflectability information (i.e. if we decide `Foo<int>.Blah()` needs to be available for reflection, but we also compiled `Foo<double>.Blah()`, make sure that we have the reflection mapping for `Foo<double>.Blah()` too).

This is because we often don't know the exact generic instantiation involved - the dataflow analysis operates on definitions only and one can just `object.GetType()` something that already exists in the system and reflect on its members without dataflow analysis objecting.