### PR TITLE
improved dgml generation and related pretty printing in srm

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -1291,6 +1291,8 @@ namespace System.Text.RegularExpressions.SRM
                             return left.ToStringForLoop() + "*" + (IsLazy ? "?" : "");
                         else if (IsPlus)
                             return left.ToStringForLoop() + "+" + (IsLazy ? "?" : "");
+                        else if (lower == 0 && upper == 0)
+                            return "()";
                         else if (IsBoundedLoop)
                             return left.ToStringForLoop() + "{" + lower + "," + upper + "}" + (IsLazy ? "?" : "");
                         else

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/IAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/IAutomaton.cs
@@ -42,6 +42,11 @@ namespace System.Text.RegularExpressions.SRM.DGML
         int InitialState { get; }
 
         /// <summary>
+        /// The number of states of the automaton.
+        /// </summary>
+        int StateCount { get; }
+
+        /// <summary>
         /// Returns true iff the state is a final state.
         /// </summary>
         bool IsFinalState(int state);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -1414,9 +1414,9 @@ namespace System.Text.RegularExpressions.SRM
 
         public void SaveDGML(TextWriter writer, int bound = 0, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 500)
         {
-            var graph = new DGML.RegexDFA<S>(this, bound, hideDerivatives, addDotStar);
-            var dgml = new DGML.DgmlWriter(writer, maxLabelLength);
-            dgml.Write<S>(graph, builder.solver.PrettyPrint);
+            var graph = new DGML.RegexDFA<S>(this, bound, addDotStar);
+            var dgml = new DGML.DgmlWriter(writer, hideDerivatives, maxLabelLength);
+            dgml.Write<S>(graph);
         }
 
 #if UNSAFE

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/IgnoreCaseRelationGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/IgnoreCaseRelationGenerator.cs
@@ -40,7 +40,6 @@ internal static class " + classname + @"
             sw.WriteLine(prefix);
 
             CreateUlongArray(sw);
-            //CreateStringArray(sw);
 
             sw.WriteLine(suffix);
             sw.Close();
@@ -121,35 +120,6 @@ internal static class " + classname + @"
                 }
             }
             return ignoreCase;
-        }
-
-        private static void CreateStringArray(StreamWriter sw)
-        {
-            sw.WriteLine("/// <summary>");
-            sw.WriteLine("/// Each string correponds to an equivalence class of characters when case is ignored.");
-            sw.WriteLine("/// </summary>");
-            sw.WriteLine("public static string[] ignorecase = new string[]{");
-            CharSetSolver solver = new CharSetSolver();
-
-            Dictionary<char, BDD> ignoreCase = ComputeIgnoreCaseDistionary(solver);
-
-            HashSet<BDD> done = new HashSet<BDD>();
-            foreach (var kv in ignoreCase)
-                if (done.Add(kv.Value))
-                {
-                    var ranges = solver.ToRanges(kv.Value);
-                    List<char> s = new List<char>();
-                    for (int i = 0; i < ranges.Length; i++)
-                    {
-                        var l = (int)ranges[i].Item1;
-                        var h = (int)ranges[i].Item2;
-                        for (int j = l; j <= h; j++)
-                            s.Add((char)j);
-                    }
-                    var str = StringUtility.Escape(new string(s.ToArray()));
-                    sw.WriteLine(@"{0},", str);
-                }
-            sw.WriteLine("};"); //end of array
         }
     };
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/StringUtility.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/StringUtility.cs
@@ -40,23 +40,45 @@ namespace System.Text.RegularExpressions.SRM
                     return string.Format("\\u{0:X}", code);
             }
 
-            if (code > 255)
-                return ToUnicodeRepr(code);
-
-            if (code <= 255 && code > 126)
-                return string.Format("\\x{0:X}", code);
-
-            if (code >= 32 && code <= 126)
-                return c.ToString();
-
+            //special characters
             switch (c)
             {
+                case '.':
+                    return @"\.";
+                case '[':
+                    return @"\[";
+                case ']':
+                    return @"\]";
+                case '(':
+                    return @"\(";
+                case ')':
+                    return @"\)";
+                case '{':
+                    return @"\{";
+                case '}':
+                    return @"\}";
+                case '?':
+                    return @"\?";
+                case '+':
+                    return @"\+";
+                case '*':
+                    return @"\*";
+                case '|':
+                    return @"\|";
+                case '\\':
+                    return @"\\";
+                case '^':
+                    return @"\^";
+                case '$':
+                    return @"\$";
+                case '-':
+                    return @"\-";
+                case ':':
+                    return @"\:";
+                case '\"':
+                    return "\\\"";
                 case '\0':
                     return @"\0";
-                //case '\a':
-                //    return @"\a";
-                //case '\b':
-                //    return @"\b";
                 case '\t':
                     return @"\t";
                 case '\r':
@@ -68,11 +90,22 @@ namespace System.Text.RegularExpressions.SRM
                 case '\n':
                     return @"\n";
                 default:
-                    if (code <= 15)
-                        return string.Format("\\x0{0:X}", code);
-                    else
-                        return string.Format("\\x{0:X}", code);
+                    break;
             }
+
+            if (code > 255)
+                return ToUnicodeRepr(code);
+
+            if (code <= 255 && code > 126)
+                return string.Format("\\x{0:X}", code);
+
+            if (code >= 32 && code <= 126)
+                return c.ToString();
+
+            if (code <= 15)
+                return string.Format("\\x0{0:X}", code);
+            else
+                return string.Format("\\x{0:X}", code);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -27,11 +27,11 @@ namespace System.Text.RegularExpressions.Tests
         /// View the regex as a DFA in DGML format in VS.
         /// </summary>
         /// <param name="r"></param>
-        private static void ViewDGML(Regex regex, int bound = 10, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 1000)
+        private static void ViewDGML(Regex regex, int bound = 500, bool hideDerivatives = false, bool addDotStar = false, string name = "DFA", int maxLabelLength = 50)
         {
-            System.IO.StreamWriter sw = new StreamWriter("C:/tmp/DFA.dgml");
+            StringWriter sw = new StringWriter();
             SaveDGML(regex, sw, bound, hideDerivatives, addDotStar, maxLabelLength);
-            sw.Close();
+            File.WriteAllText(string.Format("C:/tmp/dgml/{0}.dgml", name), sw.ToString());
         }
 
         /// <summary>
@@ -59,10 +59,22 @@ namespace System.Text.RegularExpressions.Tests
         //[Fact]
         private void TestDGML()
         {
+            var email = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA | RegexOptions.Singleline);
+            var date = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
+            var ip = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
+            var uri = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
             //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
             //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
-            var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
-            ViewDGML(regex: re, addDotStar: true);
+            //var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
+            //var re = new Regex(@"(([a-z])+.)+[A-Z]([a-z])+", DFA | RegexOptions.Singleline);
+            ViewDGML(regex: email, name:"email");
+            ViewDGML(regex: email, addDotStar: true, name: "dots_email");
+            ViewDGML(regex: date, name:"date");
+            ViewDGML(regex: date, addDotStar: true, name: "dots_date");
+            ViewDGML(regex: ip, name:"ip");
+            ViewDGML(regex: ip, addDotStar: true, name: "dots_ip");
+            ViewDGML(regex: uri, name: "uri");
+            ViewDGML(regex: uri, addDotStar: true, name: "dots_uri");
         }
 
         [Fact]


### PR DESCRIPTION
Updated visualization of large sets of intervals in the generated dgml when typical regex character classes \w, \s, \d are used. These exploded the representation earlier and made debugging hard. DGML generation can be used to store the DFA of a regex in a dgml file that can then be viewed/inspected/validated in VS. I've found this as a very useful debugging feature that has helped expose bugs more efficiently.