### PR TITLE
Fix stack overflow on ARM64 process startup

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionDomainSetupImplementation.cs
@@ -14,19 +14,12 @@ namespace Internal.Reflection.Execution
     //=========================================================================================================================
     internal sealed class ReflectionDomainSetupImplementation : ReflectionDomainSetup
     {
-        public ReflectionDomainSetupImplementation(ExecutionEnvironmentImplementation executionEnvironment)
+        public ReflectionDomainSetupImplementation()
         {
-            _executionEnvironment = executionEnvironment;
-            _assemblyBinder = AssemblyBinderImplementation.Instance;
         }
 
-        public sealed override AssemblyBinder AssemblyBinder
-        {
-            get
-            {
-                return _assemblyBinder;
-            }
-        }
+        // Obtain it lazily to avoid using RuntimeAugments.Callbacks before it is initialized
+        public sealed override AssemblyBinder AssemblyBinder => AssemblyBinderImplementation.Instance;
 
         public sealed override Exception CreateMissingMetadataException(TypeInfo pertainant)
         {
@@ -57,10 +50,9 @@ namespace Internal.Reflection.Execution
                         throw new PlatformNotSupportedException(SR.PlatformNotSupported_CannotInvokeDelegateCtor);
                 }
             }
+
             string pertainantString = MissingMetadataExceptionCreator.ComputeUsefulPertainantIfPossible(pertainant);
-            if (pertainantString == null)
-                pertainantString = "?";
-            return new MissingRuntimeArtifactException(SR.Format(resourceName, pertainantString));
+            return new MissingRuntimeArtifactException(SR.Format(resourceName, pertainantString ?? "?"));
         }
 
         public sealed override Exception CreateMissingArrayTypeException(Type elementType, bool isMultiDim, int rank)
@@ -72,8 +64,5 @@ namespace Internal.Reflection.Execution
         {
             return MissingMetadataExceptionCreator.CreateMissingConstructedGenericTypeException(genericTypeDefinition, genericTypeArguments);
         }
-
-        private AssemblyBinderImplementation _assemblyBinder;
-        private ExecutionEnvironmentImplementation _executionEnvironment;
     }
 }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ReflectionExecution.cs
@@ -47,13 +47,13 @@ namespace Internal.Reflection.Execution
         internal static void Initialize()
         {
             // Initialize Reflection.Core's one and only ExecutionDomain.
-            ExecutionEnvironmentImplementation executionEnvironment = new ExecutionEnvironmentImplementation();
-            ReflectionDomainSetupImplementation setup = new ReflectionDomainSetupImplementation(executionEnvironment);
+            var executionEnvironment = new ExecutionEnvironmentImplementation();
+            var setup = new ReflectionDomainSetupImplementation();
             ReflectionCoreExecution.InitializeExecutionDomain(setup, executionEnvironment);
 
-            // Initialize our two communication with System.Private.CoreLib.
+            // Initialize our two-way communication with System.Private.CoreLib.
             ExecutionDomain executionDomain = ReflectionCoreExecution.ExecutionDomain;
-            ReflectionExecutionDomainCallbacksImplementation runtimeCallbacks = new ReflectionExecutionDomainCallbacksImplementation(executionDomain, executionEnvironment);
+            var runtimeCallbacks = new ReflectionExecutionDomainCallbacksImplementation(executionDomain, executionEnvironment);
             RuntimeAugments.Initialize(runtimeCallbacks);
 
             ExecutionEnvironment = executionEnvironment;


### PR DESCRIPTION
Fixes #989 the way @MichalStrehovsky suggested in https://github.com/dotnet/runtimelab/issues/989#issuecomment-824018355. Also removes an unused parameter of the `ReflectionDomainSetupImplementation` constructor.