### PR TITLE
Synchronize logging with IL Linker

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -182,6 +182,35 @@ The .NET Foundation licenses this file to you under the MIT license.
       Outputs="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
+    <!-- Set up default properties that have their defaults in the 6.0 SDK (Can be dropped once we drop 5.0 support) -->
+    <PropertyGroup Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '6.0.0'))">
+      <TrimmerSingleWarn Condition="'$(TrimmerSingleWarn)' == ''">true</TrimmerSingleWarn>
+    </PropertyGroup>
+
+    <!-- Set up single warn trimming like in the 6.0 SDK (Can be dropped once we drop 5.0 support) -->
+    <ItemGroup Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '6.0.0'))">
+      <!-- Don't collapse to a single warning for the intermediate assembly.
+           This just sets metadata on the items in ManagedAssemblyToLink that came from IntermediateAssembly. -->
+      <!-- Find ManagedAssemblyToLink _except_ IntermediateAssembly -->
+      <__SingleWarnIntermediateAssembly Include="@(ManagedAssemblyToLink)" />
+      <__SingleWarnIntermediateAssembly Remove="@(IntermediateAssembly)" />
+      <!-- Subtract these from ManagedAssemblyToLink, to get the intersection. -->
+      <_SingleWarnIntermediateAssembly Include="@(ManagedAssemblyToLink)" />
+      <_SingleWarnIntermediateAssembly Remove="@(__SingleWarnIntermediateAssembly)" />
+      <!-- Set metadata on the intersection. -->
+      <_SingleWarnIntermediateAssembly>
+        <TrimmerSingleWarn Condition=" '%(_SingleWarnIntermediateAssembly.TrimmerSingleWarn)' == '' ">false</TrimmerSingleWarn>
+      </_SingleWarnIntermediateAssembly>
+      <!-- Replace these items in ManagedAssemblyToLink. -->
+      <ManagedAssemblyToLink Remove="@(_SingleWarnIntermediateAssembly)" />
+      <ManagedAssemblyToLink Include="@(_SingleWarnIntermediateAssembly)" />
+
+      <!-- Don't collapse to a single warning for project references -->
+      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.ProjectReferenceOriginalItemSpec)' != '' ">
+        <TrimmerSingleWarn Condition=" '%(ManagedAssemblyToLink.TrimmerSingleWarn)' == '' ">false</TrimmerSingleWarn>
+      </ManagedAssemblyToLink>
+    </ItemGroup>
+
     <!-- Propagate the global TrimMode to all the assembly that don't have it yet -->
     <ItemGroup>
       <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.TrimMode)' == '' ">
@@ -192,6 +221,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup>
       <_IlcRootedAssemblies Include="@(TrimmerRootAssembly)" />
       <_IlcConditionallyRootedAssemblies Include="@(ManagedAssemblyToLink)" Condition="%(ManagedAssemblyToLink.TrimMode) == 'copyused'" />
+      <_IlcNoSingleWarnAssemblies Include="@(ManagedAssemblyToLink)" Condition="%(ManagedAssemblyToLink.TrimmerSingleWarn) == 'false'" />
     </ItemGroup>
 
     <ItemGroup>
@@ -228,8 +258,10 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcSystemModule) != ''" Include="--systemmodule:$(IlcSystemModule)" />
       <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
       <IlcArg Condition="$(NoWarn) != ''" Include='--nowarn:"$([MSBuild]::Escape($(NoWarn)))"' />
+      <IlcArg Condition="$(TrimmerSingleWarn) == 'true'" Include="--singlewarn" />
       <IlcArg Include="@(_IlcRootedAssemblies->'--root:%(Identity)')" />
       <IlcArg Include="@(_IlcConditionallyRootedAssemblies->'--conditionalroot:%(Identity)')" />
+      <IlcArg Include="@(_IlcNoSingleWarnAssemblies->'--nosinglewarnassembly:%(Filename)')" />
 
       <!-- The Emit-based DataContractSerializer won't work -->
       <IlcArg Include="--feature:System.Runtime.Serialization.DataContractSerializer.IsReflectionOnly=true" />

--- a/src/coreclr/tools/Common/Compiler/Logger.cs
+++ b/src/coreclr/tools/Common/Compiler/Logger.cs
@@ -20,21 +20,30 @@ namespace ILCompiler
     {
         private readonly HashSet<int> _suppressedWarnings;
 
+        private readonly bool _isSingleWarn;
+        private readonly HashSet<string> _singleWarnEnabledAssemblies;
+        private readonly HashSet<string> _singleWarnDisabledAssemblies;
+        private readonly HashSet<string> _trimWarnedAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _aotWarnedAssemblies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
         public static Logger Null = new Logger(TextWriter.Null, false);
 
         public TextWriter Writer { get; }
 
         public bool IsVerbose { get; }
 
-        public Logger(TextWriter writer, bool isVerbose, IEnumerable<int> suppressedWarnings)
+        public Logger(TextWriter writer, bool isVerbose, IEnumerable<int> suppressedWarnings, bool singleWarn, IEnumerable<string> singleWarnEnabledModules, IEnumerable<string> singleWarnDisabledModules)
         {
             Writer = TextWriter.Synchronized(writer);
             IsVerbose = isVerbose;
             _suppressedWarnings = new HashSet<int>(suppressedWarnings);
+            _isSingleWarn = singleWarn;
+            _singleWarnEnabledAssemblies = new HashSet<string>(singleWarnEnabledModules, StringComparer.OrdinalIgnoreCase);
+            _singleWarnDisabledAssemblies = new HashSet<string>(singleWarnDisabledModules, StringComparer.OrdinalIgnoreCase);
         }
 
         public Logger(TextWriter writer, bool isVerbose)
-            : this(writer, isVerbose, Array.Empty<int>())
+            : this(writer, isVerbose, Array.Empty<int>(), singleWarn: false, Array.Empty<string>(), Array.Empty<string>())
         {
         }
 
@@ -73,6 +82,12 @@ namespace ILCompiler
 
             MessageOrigin messageOrigin = new MessageOrigin(origin.OwningMethod, document, lineNumber, null);
             LogWarning(text, code, messageOrigin, subcategory);
+        }
+
+        public void LogWarning(string text, int code, string origin, string subcategory = MessageSubCategory.None)
+        {
+            MessageOrigin _origin = new MessageOrigin(origin);
+            LogWarning(text, code, _origin, subcategory);
         }
 
         internal bool IsWarningSuppressed(int code, MessageOrigin origin)
@@ -119,6 +134,54 @@ namespace ILCompiler
         {
             // TODO: warnaserror
             return false;
+        }
+
+        internal bool IsSingleWarn(ModuleDesc owningModule, string messageSubcategory)
+        {
+            string assemblyName = owningModule.Assembly.GetName().Name;
+
+            bool result = false;
+
+            if ((_isSingleWarn || _singleWarnEnabledAssemblies.Contains(assemblyName))
+                && !_singleWarnDisabledAssemblies.Contains(assemblyName))
+            {
+                result = true;
+
+                if (messageSubcategory == MessageSubCategory.TrimAnalysis)
+                {
+                    lock (_trimWarnedAssemblies)
+                    {
+                        if (_trimWarnedAssemblies.Add(assemblyName))
+                        {
+                            LogWarning($"Assembly '{assemblyName}' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries", 2104, GetModuleFileName(owningModule));
+                        }
+                    }
+                }
+                else if (messageSubcategory == MessageSubCategory.AotAnalysis)
+                {
+                    lock (_aotWarnedAssemblies)
+                    {
+                        if (_aotWarnedAssemblies.Add(assemblyName))
+                        {
+                            LogWarning($"Assembly '{assemblyName}' produced AOT analysis warnings.", 9702, GetModuleFileName(owningModule));
+                        }
+                    }
+                }
+            }
+            
+            return result;
+        }
+
+        private static string GetModuleFileName(ModuleDesc module)
+        {
+            string assemblyName = module.Assembly.GetName().Name;
+            var context = (CompilerTypeSystemContext)module.Context;
+            if (context.ReferenceFilePaths.TryGetValue(assemblyName, out string result)
+                || context.InputFilePaths.TryGetValue(assemblyName, out result))
+            {
+                return result;
+            }
+            return assemblyName;
         }
     }
 

--- a/src/coreclr/tools/Common/Compiler/Logging/MessageContainer.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/MessageContainer.cs
@@ -5,6 +5,8 @@ using System;
 using System.Text;
 using Internal.TypeSystem;
 
+using Debug = System.Diagnostics.Debug;
+
 namespace ILCompiler.Logging
 {
     public enum MessageCategory
@@ -86,6 +88,26 @@ namespace ILCompiler.Logging
         {
             if (context.IsWarningSuppressed(code, origin))
                 return null;
+
+            if (subcategory == MessageSubCategory.AotAnalysis || subcategory == MessageSubCategory.TrimAnalysis)
+            {
+                var declaringType = origin.MemberDefinition switch
+                {
+                    TypeDesc type => type,
+                    MethodDesc method => method.OwningType,
+                    FieldDesc field => field.OwningType,
+                    PropertyPseudoDesc property => property.OwningType,
+                    EventPseudoDesc @event => @event.OwningType,
+                    _ => null,
+                };
+
+                ModuleDesc declaringAssembly = (declaringType as MetadataType)?.Module;
+                Debug.Assert(declaringAssembly != null);
+                if (declaringAssembly != null && context.IsSingleWarn(declaringAssembly, subcategory))
+                {
+                    return null;
+                }
+            }
 
             if (context.IsWarningAsError(code))
                 return new MessageContainer(MessageCategory.WarningAsError, text, code, subcategory, origin);

--- a/src/coreclr/tools/Common/Compiler/Logging/MessageOrigin.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/MessageOrigin.cs
@@ -19,7 +19,7 @@ namespace ILCompiler.Logging
         public int? SourceLine { get; }
         public int? SourceColumn { get; }
 
-        public MessageOrigin(string fileName, int sourceLine = 0, int sourceColumn = 0)
+        public MessageOrigin(string fileName, int? sourceLine = null, int? sourceColumn = null)
         {
             FileName = fileName;
             SourceLine = sourceLine;

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageContainer.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageContainer.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Diagnostics;
@@ -9,240 +10,244 @@ using Mono.Cecil;
 
 namespace Mono.Linker
 {
-    public readonly struct MessageContainer : IComparable<MessageContainer>, IEquatable<MessageContainer>
-    {
-        public static readonly MessageContainer Empty;
+	public readonly struct MessageContainer : IComparable<MessageContainer>, IEquatable<MessageContainer>
+	{
+		public static readonly MessageContainer Empty;
 
-        /// <summary>
-        /// Optional data with a filename, line and column that triggered the
-        /// linker to output an error (or warning) message.
-        /// </summary>
-        public MessageOrigin? Origin { get; }
+		/// <summary>
+		/// Optional data with a filename, line and column that triggered the
+		/// linker to output an error (or warning) message.
+		/// </summary>
+		public MessageOrigin? Origin { get; }
 
-        public MessageCategory Category { get; }
+		public MessageCategory Category { get; }
 
-        /// <summary>
-        /// Further categorize the message.
-        /// </summary>
-        public string SubCategory { get; }
+		/// <summary>
+		/// Further categorize the message.
+		/// </summary>
+		public string SubCategory { get; }
 
-        /// <summary>
-        /// Code identifier for errors and warnings reported by the IL linker.
-        /// </summary>
-        public int? Code { get; }
+		/// <summary>
+		/// Code identifier for errors and warnings reported by the IL linker.
+		/// </summary>
+		public int? Code { get; }
 
-        /// <summary>
-        /// User friendly text describing the error or warning.
-        /// </summary>
-        public string Text { get; }
+		/// <summary>
+		/// User friendly text describing the error or warning.
+		/// </summary>
+		public string Text { get; }
 
-        /// <summary>
-        /// Create an error message.
-        /// </summary>
-        /// <param name="text">Humanly readable message describing the error</param>
-        /// <param name="code">Unique error ID. Please see https://github.com/mono/linker/blob/main/doc/error-codes.md
-        /// for the list of errors and possibly add a new one</param>
-        /// <param name="subcategory">Optionally, further categorize this error</param>
-        /// <param name="origin">Filename, line, and column where the error was found</param>
-        /// <returns>New MessageContainer of 'Error' category</returns>
-        internal static MessageContainer CreateErrorMessage(string text, int code, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null)
-        {
-            if (!(code >= 1000 && code <= 2000))
-                throw new ArgumentOutOfRangeException(nameof(code), $"The provided code '{code}' does not fall into the error category, which is in the range of 1000 to 2000 (inclusive).");
+		/// <summary>
+		/// Create an error message.
+		/// </summary>
+		/// <param name="text">Humanly readable message describing the error</param>
+		/// <param name="code">Unique error ID. Please see https://github.com/mono/linker/blob/main/docs/error-codes.md
+		/// for the list of errors and possibly add a new one</param>
+		/// <param name="subcategory">Optionally, further categorize this error</param>
+		/// <param name="origin">Filename, line, and column where the error was found</param>
+		/// <returns>New MessageContainer of 'Error' category</returns>
+		internal static MessageContainer CreateErrorMessage (string text, int code, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null)
+		{
+			if (!(code >= 1000 && code <= 2000))
+				throw new ArgumentOutOfRangeException (nameof (code), $"The provided code '{code}' does not fall into the error category, which is in the range of 1000 to 2000 (inclusive).");
 
-            return new MessageContainer(MessageCategory.Error, text, code, subcategory, origin);
-        }
+			return new MessageContainer (MessageCategory.Error, text, code, subcategory, origin);
+		}
 
-        /// <summary>
-        /// Create a custom error message.
-        /// </summary>
-        /// <param name="text">Humanly readable message describing the error</param>
-        /// <param name="code">A custom error ID. This code should be greater than or equal to 6001
-        /// to avoid any collisions with existing and future linker errors</param>
-        /// <param name="subcategory">Optionally, further categorize this error</param>
-        /// <param name="origin">Filename or member where the error is coming from</param>
-        /// <returns>Custom MessageContainer of 'Error' category</returns>
-        public static MessageContainer CreateCustomErrorMessage(string text, int code, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null)
-        {
+		/// <summary>
+		/// Create a custom error message.
+		/// </summary>
+		/// <param name="text">Humanly readable message describing the error</param>
+		/// <param name="code">A custom error ID. This code should be greater than or equal to 6001
+		/// to avoid any collisions with existing and future linker errors</param>
+		/// <param name="subcategory">Optionally, further categorize this error</param>
+		/// <param name="origin">Filename or member where the error is coming from</param>
+		/// <returns>Custom MessageContainer of 'Error' category</returns>
+		public static MessageContainer CreateCustomErrorMessage (string text, int code, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null)
+		{
 #if DEBUG
 			Debug.Assert (Assembly.GetCallingAssembly () != typeof (MessageContainer).Assembly,
 				"'CreateCustomErrorMessage' is intended to be used by external assemblies only. Use 'CreateErrorMessage' instead.");
 #endif
-            if (code <= 6000)
-                throw new ArgumentOutOfRangeException(nameof(code), $"The provided code '{code}' does not fall into the permitted range for external errors. To avoid possible collisions " +
-                    "with existing and future {Constants.ILLink} errors, external messages should use codes starting from 6001.");
+			if (code <= 6000)
+				throw new ArgumentOutOfRangeException (nameof (code), $"The provided code '{code}' does not fall into the permitted range for external errors. To avoid possible collisions " +
+					"with existing and future {Constants.ILLink} errors, external messages should use codes starting from 6001.");
 
-            return new MessageContainer(MessageCategory.Error, text, code, subcategory, origin);
-        }
+			return new MessageContainer (MessageCategory.Error, text, code, subcategory, origin);
+		}
 
-        /// <summary>
-        /// Create a warning message.
-        /// </summary>
-        /// <param name="context">Context with the relevant warning suppression info.</param>
-        /// <param name="text">Humanly readable message describing the warning</param>
-        /// <param name="code">Unique warning ID. Please see https://github.com/mono/linker/blob/main/doc/error-codes.md
-        /// for the list of warnings and possibly add a new one</param>
-        /// /// <param name="origin">Filename or member where the warning is coming from</param>
-        /// <param name="subcategory">Optionally, further categorize this warning</param>
-        /// <param name="version">Optional warning version number. Versioned warnings can be controlled with the
-        /// warning wave option --warn VERSION. Unversioned warnings are unaffected by this option. </param>
-        /// <returns>New MessageContainer of 'Warning' category</returns>
-        internal static MessageContainer CreateWarningMessage(LinkContext context, string text, int code, MessageOrigin origin, WarnVersion version, string subcategory = MessageSubCategory.None)
-        {
-            if (!(code > 2000 && code <= 6000))
-                throw new ArgumentOutOfRangeException(nameof(code), $"The provided code '{code}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
+		/// <summary>
+		/// Create a warning message.
+		/// </summary>
+		/// <param name="context">Context with the relevant warning suppression info.</param>
+		/// <param name="text">Humanly readable message describing the warning</param>
+		/// <param name="code">Unique warning ID. Please see https://github.com/mono/linker/blob/main/docs/error-codes.md
+		/// for the list of warnings and possibly add a new one</param>
+		/// /// <param name="origin">Filename or member where the warning is coming from</param>
+		/// <param name="subcategory">Optionally, further categorize this warning</param>
+		/// <param name="version">Optional warning version number. Versioned warnings can be controlled with the
+		/// warning wave option --warn VERSION. Unversioned warnings are unaffected by this option. </param>
+		/// <returns>New MessageContainer of 'Warning' category</returns>
+		internal static MessageContainer CreateWarningMessage (LinkContext context, string text, int code, MessageOrigin origin, WarnVersion version, string subcategory = MessageSubCategory.None)
+		{
+			if (!(code > 2000 && code <= 6000))
+				throw new ArgumentOutOfRangeException (nameof (code), $"The provided code '{code}' does not fall into the warning category, which is in the range of 2001 to 6000 (inclusive).");
 
-            return CreateWarningMessageContainer(context, text, code, origin, version, subcategory);
-        }
+			return CreateWarningMessageContainer (context, text, code, origin, version, subcategory);
+		}
 
-        /// <summary>
-        /// Create a custom warning message.
-        /// </summary>
-        /// <param name="context">Context with the relevant warning suppression info.</param>
-        /// <param name="text">Humanly readable message describing the warning</param>
-        /// <param name="code">A custom warning ID. This code should be greater than or equal to 6001
-        /// to avoid any collisions with existing and future linker warnings</param>
-        /// <param name="origin">Filename or member where the warning is coming from</param>
-        /// <param name="version">Optional warning version number. Versioned warnings can be controlled with the
-        /// warning wave option --warn VERSION. Unversioned warnings are unaffected by this option</param>
-        /// <param name="subcategory"></param>
-        /// <returns>Custom MessageContainer of 'Warning' category</returns>
-        public static MessageContainer CreateCustomWarningMessage(LinkContext context, string text, int code, MessageOrigin origin, WarnVersion version, string subcategory = MessageSubCategory.None)
-        {
+		/// <summary>
+		/// Create a custom warning message.
+		/// </summary>
+		/// <param name="context">Context with the relevant warning suppression info.</param>
+		/// <param name="text">Humanly readable message describing the warning</param>
+		/// <param name="code">A custom warning ID. This code should be greater than or equal to 6001
+		/// to avoid any collisions with existing and future linker warnings</param>
+		/// <param name="origin">Filename or member where the warning is coming from</param>
+		/// <param name="version">Optional warning version number. Versioned warnings can be controlled with the
+		/// warning wave option --warn VERSION. Unversioned warnings are unaffected by this option</param>
+		/// <param name="subcategory"></param>
+		/// <returns>Custom MessageContainer of 'Warning' category</returns>
+		public static MessageContainer CreateCustomWarningMessage (LinkContext context, string text, int code, MessageOrigin origin, WarnVersion version, string subcategory = MessageSubCategory.None)
+		{
 #if DEBUG
 			Debug.Assert (Assembly.GetCallingAssembly () != typeof (MessageContainer).Assembly,
 				"'CreateCustomWarningMessage' is intended to be used by external assemblies only. Use 'CreateWarningMessage' instead.");
 #endif
-            if (code <= 6000)
-                throw new ArgumentOutOfRangeException(nameof(code), $"The provided code '{code}' does not fall into the permitted range for external warnings. To avoid possible collisions " +
-                    $"with existing and future {Constants.ILLink} warnings, external messages should use codes starting from 6001.");
+			if (code <= 6000)
+				throw new ArgumentOutOfRangeException (nameof (code), $"The provided code '{code}' does not fall into the permitted range for external warnings. To avoid possible collisions " +
+					$"with existing and future {Constants.ILLink} warnings, external messages should use codes starting from 6001.");
 
-            return CreateWarningMessageContainer(context, text, code, origin, version, subcategory);
-        }
+			return CreateWarningMessageContainer (context, text, code, origin, version, subcategory);
+		}
 
-        private static MessageContainer CreateWarningMessageContainer(LinkContext context, string text, int code, MessageOrigin origin, WarnVersion version, string subcategory = MessageSubCategory.None)
-        {
-            if (!(version >= WarnVersion.ILLink0 && version <= WarnVersion.Latest))
-                throw new ArgumentException($"The provided warning version '{version}' is invalid.");
+		private static MessageContainer CreateWarningMessageContainer (LinkContext context, string text, int code, MessageOrigin origin, WarnVersion version, string subcategory = MessageSubCategory.None)
+		{
+			if (!(version >= WarnVersion.ILLink0 && version <= WarnVersion.Latest))
+				throw new ArgumentException ($"The provided warning version '{version}' is invalid.");
 
-            if (context.IsWarningSuppressed(code, origin))
-                return Empty;
+			if (context.IsWarningSuppressed (code, origin))
+				return Empty;
 
-            if (version > context.WarnVersion)
-                return Empty;
+			if (version > context.WarnVersion)
+				return Empty;
 
-            if (context.IsWarningAsError(code))
-                return new MessageContainer(MessageCategory.WarningAsError, text, code, subcategory, origin);
+			if (subcategory == MessageSubCategory.TrimAnalysis) {
+				Debug.Assert (origin.MemberDefinition != null);
+				var declaringType = origin.MemberDefinition?.DeclaringType ?? (origin.MemberDefinition as TypeDefinition);
+				var assembly = declaringType.Module.Assembly;
+				var assemblyName = assembly?.Name.Name;
+				if (assemblyName != null && context.IsSingleWarn (assemblyName)) {
+					if (context.AssembliesWithGeneratedSingleWarning.Add (assemblyName))
+						context.LogWarning ($"Assembly '{assemblyName}' produced trim warnings. For more information see https://aka.ms/dotnet-illink/libraries", 2104, context.GetAssemblyLocation (assembly));
+					return Empty;
+				}
+			}
 
-            return new MessageContainer(MessageCategory.Warning, text, code, subcategory, origin);
-        }
+			if (context.IsWarningAsError (code))
+				return new MessageContainer (MessageCategory.WarningAsError, text, code, subcategory, origin);
 
-        /// <summary>
-        /// Create a info message.
-        /// </summary>
-        /// <param name="text">Humanly readable message</param>
-        /// <returns>New MessageContainer of 'Info' category</returns>
-        public static MessageContainer CreateInfoMessage(string text)
-        {
-            return new MessageContainer(MessageCategory.Info, text, null);
-        }
+			return new MessageContainer (MessageCategory.Warning, text, code, subcategory, origin);
+		}
 
-        /// <summary>
-        /// Create a diagnostics message.
-        /// </summary>
-        /// <param name="text">Humanly readable message</param>
-        /// <returns>New MessageContainer of 'Diagnostic' category</returns>
-        public static MessageContainer CreateDiagnosticMessage(string text)
-        {
-            return new MessageContainer(MessageCategory.Diagnostic, text, null);
-        }
+		/// <summary>
+		/// Create a info message.
+		/// </summary>
+		/// <param name="text">Humanly readable message</param>
+		/// <returns>New MessageContainer of 'Info' category</returns>
+		public static MessageContainer CreateInfoMessage (string text)
+		{
+			return new MessageContainer (MessageCategory.Info, text, null);
+		}
 
-        private MessageContainer(MessageCategory category, string text, int? code, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null)
-        {
-            Code = code;
-            Category = category;
-            Origin = origin;
-            SubCategory = subcategory;
-            Text = text;
-        }
+		/// <summary>
+		/// Create a diagnostics message.
+		/// </summary>
+		/// <param name="text">Humanly readable message</param>
+		/// <returns>New MessageContainer of 'Diagnostic' category</returns>
+		public static MessageContainer CreateDiagnosticMessage (string text)
+		{
+			return new MessageContainer (MessageCategory.Diagnostic, text, null);
+		}
 
-        public override string ToString() => ToMSBuildString();
+		private MessageContainer (MessageCategory category, string text, int? code, string subcategory = MessageSubCategory.None, MessageOrigin? origin = null)
+		{
+			Code = code;
+			Category = category;
+			Origin = origin;
+			SubCategory = subcategory;
+			Text = text;
+		}
 
-        public string ToMSBuildString()
-        {
-            const string originApp = Constants.ILLink;
-            string origin = Origin?.ToString() ?? originApp;
+		public override string ToString () => ToMSBuildString ();
 
-            StringBuilder sb = new StringBuilder();
-            sb.Append(origin).Append(":");
+		public string ToMSBuildString ()
+		{
+			const string originApp = Constants.ILLink;
+			string origin = Origin?.ToString () ?? originApp;
 
-            if (!string.IsNullOrEmpty(SubCategory))
-                sb.Append(" ").Append(SubCategory);
+			StringBuilder sb = new StringBuilder ();
+			sb.Append (origin).Append (":");
 
-            string cat;
-            switch (Category)
-            {
-                case MessageCategory.Error:
-                case MessageCategory.WarningAsError:
-                    cat = "error";
-                    break;
-                case MessageCategory.Warning:
-                    cat = "warning";
-                    break;
-                default:
-                    cat = "";
-                    break;
-            }
+			if (!string.IsNullOrEmpty (SubCategory))
+				sb.Append (" ").Append (SubCategory);
 
-            if (!string.IsNullOrEmpty(cat))
-            {
-                sb.Append(" ")
-                    .Append(cat)
-                    .Append(" IL")
-                    .Append(Code.Value.ToString("D4"))
-                    .Append(": ");
-            }
-            else
-            {
-                sb.Append(" ");
-            }
+			string cat;
+			switch (Category) {
+			case MessageCategory.Error:
+			case MessageCategory.WarningAsError:
+				cat = "error";
+				break;
+			case MessageCategory.Warning:
+				cat = "warning";
+				break;
+			default:
+				cat = "";
+				break;
+			}
 
-            if (Origin?.MemberDefinition != null)
-            {
-                if (Origin?.MemberDefinition is MethodDefinition method)
-                    sb.Append(method.GetDisplayName());
-                else
-                    sb.Append(Origin?.MemberDefinition.FullName);
+			if (!string.IsNullOrEmpty (cat)) {
+				sb.Append (" ")
+					.Append (cat)
+					.Append (" IL")
+					.Append (Code.Value.ToString ("D4"))
+					.Append (": ");
+			} else {
+				sb.Append (" ");
+			}
 
-                sb.Append(": ");
-            }
+			if (Origin?.MemberDefinition != null) {
+				if (Origin?.MemberDefinition is MethodDefinition method)
+					sb.Append (method.GetDisplayName ());
+				else
+					sb.Append (Origin?.MemberDefinition.FullName);
 
-            // Expected output $"{FileName(SourceLine, SourceColumn)}: {SubCategory}{Category} IL{Code}: ({MemberDisplayName}: ){Text}");
-            sb.Append(Text);
-            return sb.ToString();
-        }
+				sb.Append (": ");
+			}
 
-        public bool Equals(MessageContainer other) =>
-            (Category, Text, Code, SubCategory, Origin) == (other.Category, other.Text, other.Code, other.SubCategory, other.Origin);
+			// Expected output $"{FileName(SourceLine, SourceColumn)}: {SubCategory}{Category} IL{Code}: ({MemberDisplayName}: ){Text}");
+			sb.Append (Text);
+			return sb.ToString ();
+		}
 
-        public override bool Equals(object obj) => obj is MessageContainer messageContainer && Equals(messageContainer);
-        public override int GetHashCode() => (Category, Text, Code, SubCategory, Origin).GetHashCode();
+		public bool Equals (MessageContainer other) =>
+			(Category, Text, Code, SubCategory, Origin) == (other.Category, other.Text, other.Code, other.SubCategory, other.Origin);
 
-        public int CompareTo(MessageContainer other)
-        {
-            if (Origin != null && other.Origin != null)
-            {
-                return Origin.Value.CompareTo(other.Origin.Value);
-            }
-            else if (Origin == null && other.Origin == null)
-            {
-                return (Code < other.Code) ? -1 : 1;
-            }
+		public override bool Equals (object obj) => obj is MessageContainer messageContainer && Equals (messageContainer);
+		public override int GetHashCode () => (Category, Text, Code, SubCategory, Origin).GetHashCode ();
 
-            return (Origin == null) ? 1 : -1;
-        }
+		public int CompareTo (MessageContainer other)
+		{
+			if (Origin != null && other.Origin != null) {
+				return Origin.Value.CompareTo (other.Origin.Value);
+			} else if (Origin == null && other.Origin == null) {
+				return (Code < other.Code) ? -1 : 1;
+			}
 
-        public static bool operator ==(MessageContainer lhs, MessageContainer rhs) => lhs.Equals(rhs);
-        public static bool operator !=(MessageContainer lhs, MessageContainer rhs) => !lhs.Equals(rhs);
-    }
+			return (Origin == null) ? 1 : -1;
+		}
+
+		public static bool operator == (MessageContainer lhs, MessageContainer rhs) => lhs.Equals (rhs);
+		public static bool operator != (MessageContainer lhs, MessageContainer rhs) => !lhs.Equals (rhs);
+	}
 }

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageOrigin.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageOrigin.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Linq;
@@ -9,98 +10,89 @@ using Mono.Cecil.Cil;
 
 namespace Mono.Linker
 {
-    public readonly struct MessageOrigin : IComparable<MessageOrigin>, IEquatable<MessageOrigin>
-    {
+	public readonly struct MessageOrigin : IComparable<MessageOrigin>, IEquatable<MessageOrigin>
+	{
 #nullable enable
-        public string? FileName { get; }
-        public IMemberDefinition? MemberDefinition { get; }
+		public string? FileName { get; }
+		public IMemberDefinition? MemberDefinition { get; }
 #nullable disable
-        public int SourceLine { get; }
-        public int SourceColumn { get; }
-        public int? ILOffset { get; }
+		public int SourceLine { get; }
+		public int SourceColumn { get; }
+		public int? ILOffset { get; }
 
-        public MessageOrigin(string fileName, int sourceLine = 0, int sourceColumn = 0)
-        {
-            FileName = fileName;
-            SourceLine = sourceLine;
-            SourceColumn = sourceColumn;
-            MemberDefinition = null;
-            ILOffset = null;
-        }
+		public MessageOrigin (string fileName, int sourceLine = 0, int sourceColumn = 0)
+		{
+			FileName = fileName;
+			SourceLine = sourceLine;
+			SourceColumn = sourceColumn;
+			MemberDefinition = null;
+			ILOffset = null;
+		}
 
-        public MessageOrigin(IMemberDefinition memberDefinition, int? ilOffset = null)
-        {
-            FileName = null;
-            MemberDefinition = memberDefinition;
-            SourceLine = 0;
-            SourceColumn = 0;
-            ILOffset = ilOffset;
-        }
+		public MessageOrigin (IMemberDefinition memberDefinition, int? ilOffset = null)
+		{
+			FileName = null;
+			MemberDefinition = memberDefinition;
+			SourceLine = 0;
+			SourceColumn = 0;
+			ILOffset = ilOffset;
+		}
 
-        public override string ToString()
-        {
-            int sourceLine = SourceLine, sourceColumn = SourceColumn;
-            string fileName = FileName;
-            if (MemberDefinition is MethodDefinition method &&
-                method.DebugInformation.HasSequencePoints)
-            {
-                var offset = ILOffset ?? 0;
-                SequencePoint correspondingSequencePoint = method.DebugInformation.SequencePoints
-                    .Where(s => s.Offset <= offset)?.Last();
-                if (correspondingSequencePoint != null)
-                {
-                    fileName = correspondingSequencePoint.Document.Url;
-                    sourceLine = correspondingSequencePoint.StartLine;
-                    sourceColumn = correspondingSequencePoint.StartColumn;
-                }
-            }
+		public override string ToString ()
+		{
+			int sourceLine = SourceLine, sourceColumn = SourceColumn;
+			string fileName = FileName;
+			if (MemberDefinition is MethodDefinition method &&
+				method.DebugInformation.HasSequencePoints) {
+				var offset = ILOffset ?? 0;
+				SequencePoint correspondingSequencePoint = method.DebugInformation.SequencePoints
+					.Where (s => s.Offset <= offset)?.Last ();
+				if (correspondingSequencePoint != null) {
+					fileName = correspondingSequencePoint.Document.Url;
+					sourceLine = correspondingSequencePoint.StartLine;
+					sourceColumn = correspondingSequencePoint.StartColumn;
+				}
+			}
 
-            if (fileName == null)
-                return null;
+			if (fileName == null)
+				return null;
 
-            StringBuilder sb = new StringBuilder(fileName);
-            if (sourceLine != 0)
-            {
-                sb.Append("(").Append(sourceLine);
-                if (sourceColumn != 0)
-                    sb.Append(",").Append(sourceColumn);
+			StringBuilder sb = new StringBuilder (fileName);
+			if (sourceLine != 0) {
+				sb.Append ("(").Append (sourceLine);
+				if (sourceColumn != 0)
+					sb.Append (",").Append (sourceColumn);
 
-                sb.Append(")");
-            }
+				sb.Append (")");
+			}
 
-            return sb.ToString();
-        }
+			return sb.ToString ();
+		}
 
-        public bool Equals(MessageOrigin other) =>
-            (FileName, MemberDefinition, SourceLine, SourceColumn) == (other.FileName, other.MemberDefinition, other.SourceLine, other.SourceColumn);
+		public bool Equals (MessageOrigin other) =>
+			(FileName, MemberDefinition, SourceLine, SourceColumn) == (other.FileName, other.MemberDefinition, other.SourceLine, other.SourceColumn);
 
-        public override bool Equals(object obj) => obj is MessageOrigin messageOrigin && Equals(messageOrigin);
-        public override int GetHashCode() => (FileName, MemberDefinition, SourceLine, SourceColumn).GetHashCode();
-        public static bool operator ==(MessageOrigin lhs, MessageOrigin rhs) => lhs.Equals(rhs);
-        public static bool operator !=(MessageOrigin lhs, MessageOrigin rhs) => !lhs.Equals(rhs);
+		public override bool Equals (object obj) => obj is MessageOrigin messageOrigin && Equals (messageOrigin);
+		public override int GetHashCode () => (FileName, MemberDefinition, SourceLine, SourceColumn).GetHashCode ();
+		public static bool operator == (MessageOrigin lhs, MessageOrigin rhs) => lhs.Equals (rhs);
+		public static bool operator != (MessageOrigin lhs, MessageOrigin rhs) => !lhs.Equals (rhs);
 
-        public int CompareTo(MessageOrigin other)
-        {
-            if (MemberDefinition != null && other.MemberDefinition != null)
-            {
-                return (MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, MemberDefinition.DeclaringType?.Name, MemberDefinition?.Name).CompareTo
-                    ((other.MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, other.MemberDefinition.DeclaringType?.Name, other.MemberDefinition?.Name));
-            }
-            else if (MemberDefinition == null && other.MemberDefinition == null)
-            {
-                if (FileName != null && other.FileName != null)
-                {
-                    return string.Compare(FileName, other.FileName);
-                }
-                else if (FileName == null && other.FileName == null)
-                {
-                    return (SourceLine, SourceColumn).CompareTo((other.SourceLine, other.SourceColumn));
-                }
+		public int CompareTo (MessageOrigin other)
+		{
+			if (MemberDefinition != null && other.MemberDefinition != null) {
+				return (MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, MemberDefinition.DeclaringType?.Name, MemberDefinition?.Name).CompareTo
+					((other.MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, other.MemberDefinition.DeclaringType?.Name, other.MemberDefinition?.Name));
+			} else if (MemberDefinition == null && other.MemberDefinition == null) {
+				if (FileName != null && other.FileName != null) {
+					return string.Compare (FileName, other.FileName);
+				} else if (FileName == null && other.FileName == null) {
+					return (SourceLine, SourceColumn).CompareTo ((other.SourceLine, other.SourceColumn));
+				}
 
-                return (FileName == null) ? 1 : -1;
-            }
+				return (FileName == null) ? 1 : -1;
+			}
 
-            return (MemberDefinition == null) ? 1 : -1;
-        }
-    }
+			return (MemberDefinition == null) ? 1 : -1;
+		}
+	}
 }

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/README.md
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/README.md
@@ -1,1 +1,1 @@
-Sources from the mono/linker repo at commit 8ee2557ccbaf9e4cf243f15b8cb95da4eddb18aa.
+Sources from the mono/linker repo at commit 6a82d56a9e95858005aca83891f2992edf665eb6.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -2713,6 +2713,7 @@ namespace ILCompiler.Dataflow
                 // TODO: these are all unique to NativeAOT - mono/linker repo is not aware this error code is used.
                 public const string IL9700 = "Calling '{0}' which has `RequiresDynamicCodeAttribute` can break functionality when compiled fully ahead of time.";
                 // IL9701 - COM
+                // IL9702 - AOT analysis warnings
             }
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -87,6 +87,10 @@ namespace ILCompiler
 
         public IReadOnlyList<string> _mibcFilePaths = Array.Empty<string>();
 
+        private IReadOnlyList<string> _singleWarnEnabledAssemblies = Array.Empty<string>();
+        private IReadOnlyList<string> _singleWarnDisabledAssemblies = Array.Empty<string>();
+        private bool _singleWarn;
+
         private bool _help;
 
         private Program()
@@ -201,6 +205,9 @@ namespace ILCompiler
                 syntax.DefineOption("preinitstatics", ref _preinitStatics, "Interpret static constructors at compile time if possible (implied by -O)");
                 syntax.DefineOption("nopreinitstatics", ref _noPreinitStatics, "Do not interpret static constructors at compile time");
                 syntax.DefineOptionList("nowarn", ref _suppressedWarnings, "Disable specific warning messages");
+                syntax.DefineOption("singlewarn", ref _singleWarn, "Generate single AOT/trimming warning per assembly");
+                syntax.DefineOptionList("singlewarnassembly", ref _singleWarnEnabledAssemblies, "Generate single AOT/trimming warning for given assembly");
+                syntax.DefineOptionList("nosinglewarnassembly", ref _singleWarnDisabledAssemblies, "Expand AOT/trimming warnings for given assembly");
                 syntax.DefineOptionList("directpinvoke", ref _directPInvokes, "PInvoke to call directly");
                 syntax.DefineOptionList("directpinvokelist", ref _directPInvokeLists, "File with list of PInvokes to call directly");
 
@@ -608,7 +615,7 @@ namespace ILCompiler
             }
             ilProvider = new FeatureSwitchManager(ilProvider, featureSwitches);
 
-            var logger = new Logger(Console.Out, _isVerbose, ProcessWarningCodes(_suppressedWarnings));
+            var logger = new Logger(Console.Out, _isVerbose, ProcessWarningCodes(_suppressedWarnings), _singleWarn, _singleWarnEnabledAssemblies, _singleWarnDisabledAssemblies);
 
             var stackTracePolicy = _emitStackTraceData ?
                 (StackTraceEmissionPolicy)new EcmaMethodStackTraceEmissionPolicy() : new NoStackTraceEmissionPolicy();


### PR DESCRIPTION
Adds support for the `singlewarn` option that collapses all trimming (and for us, also AOT) warnings in an assembly into a single log entry.

Also includes MSBuild goo that turns on detailed warnings only for user assemblies. Most of that is copied from IL Link targets and can be deleted once we drop .NET 5.0 SDK support.