### PR TITLE
performance improvement for anchors in srm

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/IAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/IAutomaton.cs
@@ -22,6 +22,11 @@ namespace System.Text.RegularExpressions.SRM.DGML
         IEnumerable<int> GetStates();
 
         /// <summary>
+        /// Returns the minterm partition of the alphabet.
+        /// </summary>
+        L[] Alphabet { get; }
+
+        /// <summary>
         /// Provides a description of the state for visualization purposes.
         /// </summary>
         string DescribeState(int state);
@@ -45,6 +50,11 @@ namespace System.Text.RegularExpressions.SRM.DGML
         /// The number of states of the automaton.
         /// </summary>
         int StateCount { get; }
+
+        /// <summary>
+        /// The number of transitions of the automaton.
+        /// </summary>
+        int TransitionCount { get; }
 
         /// <summary>
         /// Returns true iff the state is a final state.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
@@ -68,7 +68,7 @@ namespace System.Text.RegularExpressions.SRM.DGML
 
         public IEnumerable<int> GetStates() => Array.ConvertAll(_states.ToArray(), state => _stateId[state]);
 
-        public bool IsFinalState(int state) => _states[state].IsNullable(0);
+        public bool IsFinalState(int state) => _states[state].IsNullable(CharKind.End);
 
         public IEnumerable<Move<S>> GetMoves()
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
@@ -56,9 +56,13 @@ namespace System.Text.RegularExpressions.SRM.DGML
             }
         }
 
+        public S[] Alphabet => _solver.GetPartition();
+
         public int InitialState => 0;
 
         public int StateCount => _states.Count;
+
+        public int TransitionCount => _normalizedmoves.Count;
 
         public string DescribeLabel(S lab) => HTMLEncodeChars(_solver.PrettyPrint(lab));
 

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -64,7 +64,7 @@ namespace System.Text.RegularExpressions.Tests
             //var ip = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
             //var uri = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
             //var nn = new Regex(@"\b\w+nn\b", DFA);
-            var ab = new Regex("abracadabra$", DFA | RegexOptions.Multiline);
+            var ab = new Regex("abracadabra$", DFA | RegexOptions.Multiline | RegexOptions.IgnoreCase);
             //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
             //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
             //var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
@@ -78,7 +78,7 @@ namespace System.Text.RegularExpressions.Tests
             //ViewDGML(regex: uri, name: "uri");
             //ViewDGML(regex: uri, addDotStar: true, name: "dots_uri");
             ViewDGML(regex: ab, addDotStar: true); 
-            var match = ab.Match("abracadabracadabra\nabc");
+            var match = ab.Match("abracadabraCAdabra\nabc");
             Assert.True(match.Success);
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -44,8 +44,8 @@ namespace System.Text.RegularExpressions.Tests
             saveDgml.Invoke(regex, new object[] { writer, bound, hideDerivatives, addDotStar, maxLabelLength });
         }
 
-        [Fact]
-        public void TestDGMLGeneration()
+        //[Fact]
+        private void TestDGMLGeneration()
         {
             StringWriter sw = new StringWriter();
             var re = new Regex(".*a+", DFA | RegexOptions.Singleline);
@@ -57,24 +57,29 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         //[Fact]
-        private void TestDGML()
+        private void Test()
         {
-            var email = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA | RegexOptions.Singleline);
-            var date = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
-            var ip = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
-            var uri = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
+            //var email = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA | RegexOptions.Singleline);
+            //var date = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
+            //var ip = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
+            //var uri = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
+            //var nn = new Regex(@"\b\w+nn\b", DFA);
+            var ab = new Regex("abracadabra$", DFA | RegexOptions.Multiline);
             //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
             //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
             //var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
             //var re = new Regex(@"(([a-z])+.)+[A-Z]([a-z])+", DFA | RegexOptions.Singleline);
-            ViewDGML(regex: email, name:"email");
-            ViewDGML(regex: email, addDotStar: true, name: "dots_email");
-            ViewDGML(regex: date, name:"date");
-            ViewDGML(regex: date, addDotStar: true, name: "dots_date");
-            ViewDGML(regex: ip, name:"ip");
-            ViewDGML(regex: ip, addDotStar: true, name: "dots_ip");
-            ViewDGML(regex: uri, name: "uri");
-            ViewDGML(regex: uri, addDotStar: true, name: "dots_uri");
+            //ViewDGML(regex: email, name:"email");
+            //ViewDGML(regex: email, addDotStar: true, name: "dots_email");
+            //ViewDGML(regex: date, name:"date");
+            //ViewDGML(regex: date, addDotStar: true, name: "dots_date");
+            //ViewDGML(regex: ip, name:"ip");
+            //ViewDGML(regex: ip, addDotStar: true, name: "dots_ip");
+            //ViewDGML(regex: uri, name: "uri");
+            //ViewDGML(regex: uri, addDotStar: true, name: "dots_uri");
+            ViewDGML(regex: ab, addDotStar: true); 
+            var match = ab.Match("abracadabracadabra\nabc");
+            Assert.True(match.Success);
         }
 
         [Fact]


### PR DESCRIPTION
Main changes should improve performance when dealing with \b and \B anchors.

Also did minor improvements in BDD pretty printing routines, that improved dgml output.

Removed DGML testcase (that uses reflection) for now.