### PR TITLE
Rename MarshalEx.SetLastWin32Error -> SetLastPInvokeError

### DIFF
--- a/DllImportGenerator/Ancillary.Interop/MarshalEx.cs
+++ b/DllImportGenerator/Ancillary.Interop/MarshalEx.cs
@@ -23,9 +23,15 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Set the last platform invoke error on the thread 
         /// </summary>
-        public static void SetLastWin32Error(int error)
+        public static void SetLastPInvokeError(int error)
         {
-            typeof(Marshal).GetMethod("SetLastWin32Error", BindingFlags.NonPublic | BindingFlags.Static)!.Invoke(null, new object[] { error });
+            MethodInfo? method = typeof(Marshal).GetMethod("SetLastWin32Error", BindingFlags.NonPublic | BindingFlags.Static);
+            if (method == null)
+            {
+                method = typeof(Marshal).GetMethod("SetLastPInvokeError", BindingFlags.Public | BindingFlags.Static);
+            }
+
+            method!.Invoke(null, new object[] { error });
         }
 
         /// <summary>

--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/SetLastErrorTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/SetLastErrorTests.cs
@@ -18,7 +18,7 @@ namespace DllImportGenerator.IntegrationTests
         public int ToManaged()
         {
             // Explicity set the last error to something else on unmarshalling
-            MarshalEx.SetLastWin32Error(val * 2);
+            MarshalEx.SetLastPInvokeError(val * 2);
             return val;
         }
     }
@@ -54,12 +54,12 @@ namespace DllImportGenerator.IntegrationTests
             Assert.Equal(errorString, ret);
 
             // Clear the last error
-            MarshalEx.SetLastWin32Error(0);
+            MarshalEx.SetLastPInvokeError(0);
 
             NativeExportsNE.SetLastError.SetError(error, shouldSetError: 1);
             Assert.Equal(error, Marshal.GetLastWin32Error());
 
-            MarshalEx.SetLastWin32Error(0);
+            MarshalEx.SetLastPInvokeError(0);
 
             // Custom marshalling sets the last error on unmarshalling.
             // Last error should reflect error from native call, not unmarshalling.
@@ -71,7 +71,7 @@ namespace DllImportGenerator.IntegrationTests
         public void ClearPreviousError()
         {
             int error = 100;
-            MarshalEx.SetLastWin32Error(error);
+            MarshalEx.SetLastPInvokeError(error);
 
             // Don't actually set the error in the native call. SetLastError=true should clear any existing error.
             string errorString = error.ToString();
@@ -79,7 +79,7 @@ namespace DllImportGenerator.IntegrationTests
             Assert.Equal(0, Marshal.GetLastWin32Error());
             Assert.Equal(errorString, ret);
 
-            MarshalEx.SetLastWin32Error(error);
+            MarshalEx.SetLastPInvokeError(error);
 
             // Don't actually set the error in the native call. SetLastError=true should clear any existing error.
             NativeExportsNE.SetLastError.SetError(error, shouldSetError: 0);

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -321,13 +321,13 @@ namespace Microsoft.Interop
 
             if (this.dllImportData.SetLastError && !options.GenerateForwarders())
             {
-                // Marshal.SetLastWin32Error(<lastError>);
+                // Marshal.SetLastPInvokeError(<lastError>);
                 allStatements.Add(ExpressionStatement(
                     InvocationExpression(
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             ParseName(TypeNames.MarshalEx(options)),
-                            IdentifierName("SetLastWin32Error")),
+                            IdentifierName("SetLastPInvokeError")),
                         ArgumentList(SingletonSeparatedList(
                             Argument(IdentifierName(LastErrorIdentifier)))))));
             }


### PR DESCRIPTION
Rename to match API added for .NET 6.0

cc @AaronRobinsonMSFT @jkoritzinsky 