### PR TITLE
Check for invalid IL during static initialization of the field

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -2142,6 +2142,9 @@ namespace ILCompiler
 
             public void SetField(FieldDesc field, Value value)
             {
+                if (value is not ValueTypeValue)
+                    ThrowHelper.ThrowInvalidProgramException();
+
                 Debug.Assert(!field.IsStatic);
                 Debug.Assert(!field.FieldType.IsGCPointer);
                 int fieldOffset = field.Offset.AsInt;


### PR DESCRIPTION
Closes #1005 