### PR TITLE
srm performance bug fixes and updated dgml support

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
@@ -46,14 +46,15 @@ namespace System.Text.RegularExpressions
         /// <param name="hideStateInfo">if true then hide state info</param>
         /// <param name="addDotStar">if true then pretend that there is a .* at the beginning</param>
         /// <param name="inReverse">if true then unwind the regex backwards (addDotStar is then ignored)</param>
+        /// <param name="onlyDFAinfo">if true then compute and save only genral DFA info</param>
         /// <param name="writer">dgml output is written here</param>
         /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
-        internal void SaveDGML(TextWriter writer, int bound, bool hideStateInfo,  bool addDotStar, bool inReverse, int maxLabelLength)
+        internal void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength)
         {
             if (!_useSRM)
                 throw new NotSupportedException();
 
-            _srm.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, maxLabelLength);
+            _srm.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, onlyDFAinfo, maxLabelLength);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
@@ -43,16 +43,17 @@ namespace System.Text.RegularExpressions
         /// Unwind the regex and save the resulting state graph in DGML
         /// </summary>
         /// <param name="bound">roughly the maximum number of states, 0 means no bound</param>
-        /// <param name="hideDerivatives">if true then hide derivatives in state labels</param>
+        /// <param name="hideStateInfo">if true then hide state info</param>
         /// <param name="addDotStar">if true then pretend that there is a .* at the beginning</param>
+        /// <param name="inReverse">if true then unwind the regex backwards (addDotStar is then ignored)</param>
         /// <param name="writer">dgml output is written here</param>
-        /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with ... </param>
-        internal void SaveDGML(TextWriter writer, int bound, bool hideDerivatives,  bool addDotStar, int maxLabelLength)
+        /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
+        internal void SaveDGML(TextWriter writer, int bound, bool hideStateInfo,  bool addDotStar, bool inReverse, int maxLabelLength)
         {
             if (!_useSRM)
                 throw new NotSupportedException();
 
-            _srm.SaveDGML(writer, bound, hideDerivatives, addDotStar, maxLabelLength);
+            _srm.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, maxLabelLength);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
@@ -121,9 +121,9 @@ namespace System.Text.RegularExpressions.SRM
             return sb.ToString();
         }
 
-        public void SaveDGML(TextWriter writer, int bound, bool hideDerivatives, bool addDotStar, int maxLabelLength)
+        public void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, int maxLabelLength)
         {
-            _matcher.SaveDGML(writer, bound, hideDerivatives, addDotStar, maxLabelLength);
+            _matcher.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, maxLabelLength);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
@@ -121,9 +121,9 @@ namespace System.Text.RegularExpressions.SRM
             return sb.ToString();
         }
 
-        public void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, int maxLabelLength)
+        public void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength)
         {
-            _matcher.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, maxLabelLength);
+            _matcher.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, onlyDFAinfo, maxLabelLength);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
@@ -61,6 +61,19 @@ namespace System.Text.RegularExpressions.SRM
                 default: return 0;
             }
         }
+
+        internal static string PrettyPrint(CharKindId id)
+        {
+            switch (id)
+            {
+                case CharKindId.Start: return @"\A";
+                case CharKindId.End: return @"\z";
+                case CharKindId.WordLetter: return @"\w";
+                case CharKindId.Newline: return @"\n";
+                case CharKindId.NewLineZ: return @"\n\z";
+                default: return "";
+            }
+        }
     }
     /// <summary>
     /// Captures a state of a DFA explored during matching.
@@ -117,6 +130,9 @@ namespace System.Text.RegularExpressions.SRM
             uint context = (CharKind.From(nextCharKindId) << 4) | PrevCharKind;
             // compute the derivative of the node for the given context
             SymbolicRegexNode<S> derivative = Node.MkDerivative(atom, context);
+            //transitioning from the initial state with no prior input
+            if (PrevCharKindId == CharKindId.Start)
+                derivative = derivative.ReplaceStartAnchorByBottom();
             // nextCharKind will be the PrevCharKind of the target state
             // use an existing state instead if one exists already
             // otherwise create a new new id for it --- keep the reverse bit set

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
@@ -430,6 +430,8 @@ namespace System.Text.RegularExpressions.SRM
                 BDD W = MkNot(w);
                 BDD d = Regex.s_unicode.CategoryCondition(8);
                 BDD D = MkNot(d);
+                BDD asciiDigit = MkCharSetFromRange('0', '9');
+                BDD nonasciiDigit = MkAnd(d, MkNot(asciiDigit));
                 BDD s = Regex.s_unicode.WhiteSpaceCondition;
                 BDD S = MkNot(s);
                 BDD wD = MkAnd(w, D);
@@ -486,7 +488,13 @@ namespace System.Text.RegularExpressions.SRM
                 if (pred == s_or_d)
                     return "[\\s\\d]";
                 if (MkOr(s_or_d, pred) == s_or_d)
-                    return RepresentSetInPattern("[\\s\\d-[{0}]]", MkAnd(s_or_d, MkNot(pred)));
+                {
+                    //check first if this is purely ascii range
+                    if (MkAnd(pred, nonasciiDigit).IsEmpty)
+                        return string.Format("[\\s{0}]", RepresentRanges(ToRanges(MkAnd(pred, asciiDigit)), false));
+                    else
+                        return RepresentSetInPattern("[\\s\\d-[{0}]]", MkAnd(s_or_d, MkNot(pred)));
+                }
                 //---
                 // s|wD
                 BDD s_or_wD = MkOr(s, wD);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
@@ -489,8 +489,8 @@ namespace System.Text.RegularExpressions.SRM
                     return "[\\s\\d]";
                 if (MkOr(s_or_d, pred) == s_or_d)
                 {
-                    //check first if this is purely ascii range
-                    if (MkAnd(pred, nonasciiDigit).IsEmpty)
+                    //check first if this is purely ascii range for digits
+                    if (MkAnd(pred, s).Equals(s) && MkAnd(pred, nonasciiDigit).IsEmpty)
                         return string.Format("[\\s{0}]", RepresentRanges(ToRanges(MkAnd(pred, asciiDigit)), false));
                     else
                         return RepresentSetInPattern("[\\s\\d-[{0}]]", MkAnd(s_or_d, MkNot(pred)));

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/IMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/IMatcher.cs
@@ -26,8 +26,20 @@ namespace System.Text.RegularExpressions.SRM
         /// <param name="endat">end position in the input, -1 means that the value is unspecified and taken to be input.Length-1</param>
         public Match FindMatch(bool isMatch, string input, int startat = 0, int endat = -1);
 
+        /// <summary>
+        /// Custom serialization of the matcher as text in visible ASCII range.
+        /// </summary>
         public void Serialize(StringBuilder sb);
 
-        public void SaveDGML(TextWriter writer, int bound, bool hideDerivatives, bool addDotStar, int maxLabelLength);
+        /// <summary>
+        /// Unwind the regex of the matcher and save the resulting state graph in DGML
+        /// </summary>
+        /// <param name="bound">roughly the maximum number of states, 0 means no bound</param>
+        /// <param name="hideStateInfo">if true then hide state info</param>
+        /// <param name="addDotStar">if true then pretend that there is a .* at the beginning</param>
+        /// <param name="inReverse">if true then unwind the regex backwards (addDotStar is then ignored)</param>
+        /// <param name="writer">dgml output is written here</param>
+        /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
+        public void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, int maxLabelLength);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/IMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/IMatcher.cs
@@ -38,8 +38,9 @@ namespace System.Text.RegularExpressions.SRM
         /// <param name="hideStateInfo">if true then hide state info</param>
         /// <param name="addDotStar">if true then pretend that there is a .* at the beginning</param>
         /// <param name="inReverse">if true then unwind the regex backwards (addDotStar is then ignored)</param>
+        /// <param name="onlyDFAinfo">if true then compute and save only genral DFA info</param>
         /// <param name="writer">dgml output is written here</param>
         /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
-        public void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, int maxLabelLength);
+        public void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -1404,10 +1404,10 @@ namespace System.Text.RegularExpressions.SRM
             return (i == k ? -1 : i);
         }
 
-        public void SaveDGML(TextWriter writer, int bound = 0, bool hideStateInfo = false, bool addDotStar = false, bool inReverse = false, int maxLabelLength = 500)
+        public void SaveDGML(TextWriter writer, int bound = 0, bool hideStateInfo = false, bool addDotStar = false, bool inReverse = false, bool onlyDFAinfo = false, int maxLabelLength = 500)
         {
             var graph = new DGML.RegexDFA<S>(this, bound, addDotStar, inReverse);
-            var dgml = new DGML.DgmlWriter(writer, hideStateInfo, maxLabelLength);
+            var dgml = new DGML.DgmlWriter(writer, hideStateInfo, maxLabelLength, onlyDFAinfo);
             dgml.Write<S>(graph);
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -112,7 +112,7 @@ namespace System.Text.RegularExpressions.SRM
         /// <summary>
         /// Reverse(A).
         /// </summary>
-        private SymbolicRegexNode<S> Ar;
+        internal SymbolicRegexNode<S> Ar;
 
         ///// <summary>
         ///// if nonempty then Ar has that fixed prefix of predicates
@@ -160,7 +160,7 @@ namespace System.Text.RegularExpressions.SRM
         private int K;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private State<S> GetState(int stateId)
+        internal State<S> GetState(int stateId)
         {
             // the builder maintains a mapping
             // from stateIds to states
@@ -650,6 +650,11 @@ namespace System.Text.RegularExpressions.SRM
             while (i >= match_start_boundary)
             {
                 q = Delta(input, i, q);
+
+                //reached a deadend state,
+                //thus the earliest match start point must have occurred already
+                if (q.IsNothing)
+                    break;
 
                 if (q.IsNullable(GetCharKind(input, i-1)))
                 {
@@ -1399,10 +1404,10 @@ namespace System.Text.RegularExpressions.SRM
             return (i == k ? -1 : i);
         }
 
-        public void SaveDGML(TextWriter writer, int bound = 0, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = 500)
+        public void SaveDGML(TextWriter writer, int bound = 0, bool hideStateInfo = false, bool addDotStar = false, bool inReverse = false, int maxLabelLength = 500)
         {
-            var graph = new DGML.RegexDFA<S>(this, bound, addDotStar);
-            var dgml = new DGML.DgmlWriter(writer, hideDerivatives, maxLabelLength);
+            var graph = new DGML.RegexDFA<S>(this, bound, addDotStar, inReverse);
+            var dgml = new DGML.DgmlWriter(writer, hideStateInfo, maxLabelLength);
             dgml.Write<S>(graph);
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -27,21 +27,21 @@ namespace System.Text.RegularExpressions.Tests
         /// View the regex as a DFA in DGML format in VS.
         /// </summary>
         /// <param name="r"></param>
-        private static void ViewDGML(Regex regex, int bound = 500, bool hideDerivatives = false, bool addDotStar = false, string name = "DFA", int maxLabelLength = 50)
+        private static void ViewDGML(Regex regex, int bound = 500, bool hideStateInfo = true, bool addDotStar = false, bool inReverse = false, string name = "DFA", int maxLabelLength = 50)
         {
             StringWriter sw = new StringWriter();
-            SaveDGML(regex, sw, bound, hideDerivatives, addDotStar, maxLabelLength);
-            File.WriteAllText(string.Format("C:/tmp/dgml/{0}.dgml", name), sw.ToString());
+            SaveDGML(regex, sw, bound, hideStateInfo, addDotStar, inReverse, maxLabelLength);
+            File.WriteAllText(string.Format("C:/tmp/dgml/{0}.dgml", inReverse ? name + "r" : (addDotStar ? name + "1" : name)), sw.ToString());
         }
 
         /// <summary>
         /// Save the regex as a DFA in DGML format in the textwriter.
         /// </summary>
         /// <param name="r"></param>
-        private static void SaveDGML(Regex regex, TextWriter writer, int bound = -1, bool hideDerivatives = false, bool addDotStar = false, int maxLabelLength = -1)
+        private static void SaveDGML(Regex regex, TextWriter writer, int bound = -1, bool hideStateInfo = false, bool addDotStar = false, bool inReverse = false, int maxLabelLength = -1)
         {
             MethodInfo saveDgml = regex.GetType().GetMethod("SaveDGML", BindingFlags.NonPublic | BindingFlags.Instance);
-            saveDgml.Invoke(regex, new object[] { writer, bound, hideDerivatives, addDotStar, maxLabelLength });
+            saveDgml.Invoke(regex, new object[] { writer, bound, hideStateInfo, addDotStar, inReverse, maxLabelLength });
         }
 
         //[Fact]
@@ -59,27 +59,24 @@ namespace System.Text.RegularExpressions.Tests
         //[Fact]
         private void Test()
         {
-            //var email = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA | RegexOptions.Singleline);
-            //var date = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
-            //var ip = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
-            //var uri = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
-            //var nn = new Regex(@"\b\w+nn\b", DFA);
-            var ab = new Regex("abracadabra$", DFA | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+            var re = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA);
+            //var re = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
+            //var re = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
+            //var re = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
+            //var re = new Regex(@"\b\w+nn\b", DFA);
+            //var re = new Regex(@"abracadabra\z", DFA | RegexOptions.Multiline);
+            //var re = new Regex("^.{5}", DFA);
             //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
             //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
             //var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
             //var re = new Regex(@"(([a-z])+.)+[A-Z]([a-z])+", DFA | RegexOptions.Singleline);
-            //ViewDGML(regex: email, name:"email");
-            //ViewDGML(regex: email, addDotStar: true, name: "dots_email");
-            //ViewDGML(regex: date, name:"date");
-            //ViewDGML(regex: date, addDotStar: true, name: "dots_date");
-            //ViewDGML(regex: ip, name:"ip");
-            //ViewDGML(regex: ip, addDotStar: true, name: "dots_ip");
-            //ViewDGML(regex: uri, name: "uri");
-            //ViewDGML(regex: uri, addDotStar: true, name: "dots_uri");
-            ViewDGML(regex: ab, addDotStar: true); 
-            var match = ab.Match("abracadabraCAdabra\nabc");
-            Assert.True(match.Success);
+            //var re = new Regex("ab+c$", DFA);
+            ViewDGML(regex: re);
+            ViewDGML(regex: re, addDotStar: true);
+            ViewDGML(regex: re, inReverse: true);
+            //var match = re.Match("_.@[0.0.0.aaaaaaaaaa]");
+            var match = re.Match("xxxabbc");
+
         }
 
         [Fact]


### PR DESCRIPTION
Fixed several (I believe critical) performance bugs in srm, in particular the following two:
1) when handling start anchor in a regex like .*^ab+c it was not detected that this is bottom ([]) after start, thus caused unnecessary search until end of input, in particular when the input did not match and this was clear early on.
2) when finding earliest match start index (walking backwards in the input) there was a missing case to detect bottom ([]) that caused performance degradation for long inputs in regexes such as "ab+c$" in an input such as "xxxx...xxxxabbbc" where the match occurs at the end 

Updated dgml support to also view the DFA arising from the reverse of a regex. This helped in overall debugging and validation of expected behavior. Also did some other minor improvements in some pretty printing routines (mainly to help debugging).
