### PR TITLE
Require VS 2019 for linking the native image

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/findvcvarsall.bat
+++ b/src/coreclr/nativeaot/BuildIntegration/findvcvarsall.bat
@@ -15,7 +15,7 @@ IF /I "%~1"=="arm64" SET toolsSuffix=ARM64
 FOR /F "tokens=*" %%i IN (
     '"%vswherePath%" -latest -prerelease -products * ^
     -requires Microsoft.VisualStudio.Component.VC.Tools.%toolsSuffix% ^
-    -version [16,16] ^
+    -version [16,17) ^
     -property installationPath'
 ) DO SET vsBase=%%i
 

--- a/src/coreclr/nativeaot/BuildIntegration/findvcvarsall.bat
+++ b/src/coreclr/nativeaot/BuildIntegration/findvcvarsall.bat
@@ -15,7 +15,7 @@ IF /I "%~1"=="arm64" SET toolsSuffix=ARM64
 FOR /F "tokens=*" %%i IN (
     '"%vswherePath%" -latest -prerelease -products * ^
     -requires Microsoft.VisualStudio.Component.VC.Tools.%toolsSuffix% ^
-    -version [16,17) ^
+    -version [16^,17^) ^
     -property installationPath'
 ) DO SET vsBase=%%i
 

--- a/src/coreclr/nativeaot/BuildIntegration/findvcvarsall.bat
+++ b/src/coreclr/nativeaot/BuildIntegration/findvcvarsall.bat
@@ -15,6 +15,7 @@ IF /I "%~1"=="arm64" SET toolsSuffix=ARM64
 FOR /F "tokens=*" %%i IN (
     '"%vswherePath%" -latest -prerelease -products * ^
     -requires Microsoft.VisualStudio.Component.VC.Tools.%toolsSuffix% ^
+    -version [16,16] ^
     -property installationPath'
 ) DO SET vsBase=%%i
 


### PR DESCRIPTION
The runtime libraries are built using VS 2019