### PR TITLE
Update files shared with illink

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -187,12 +187,6 @@ namespace ILCompiler.Dataflow
             }
         }
 
-        public struct ValueBasicBlockPair
-        {
-            public ValueNode Value;
-            public int BasicBlockIndex;
-        }
-
         private static void StoreMethodLocalValue(
             ValueBasicBlockPair[] valueCollection,
             ValueNode valueToStore,
@@ -217,6 +211,41 @@ namespace ILCompiler.Dataflow
                 newValue.Value = MergePointValue.MergeValues(existingValue.Value, valueToStore);
             }
             valueCollection[index] = newValue;
+        }
+
+        private static void StoreMethodLocalValue<KeyType>(
+            Dictionary<KeyType, ValueBasicBlockPair> valueCollection,
+            ValueNode valueToStore,
+            KeyType collectionKey,
+            int curBasicBlock,
+            int? maxTrackedValues = null)
+        {
+            ValueBasicBlockPair newValue = new ValueBasicBlockPair { BasicBlockIndex = curBasicBlock };
+
+            ValueBasicBlockPair existingValue;
+            if (valueCollection.TryGetValue(collectionKey, out existingValue))
+            {
+                if (existingValue.BasicBlockIndex == curBasicBlock)
+                {
+                    // If the previous value was stored in the current basic block, then we can safely 
+                    // overwrite the previous value with the new one.
+                    newValue.Value = valueToStore;
+                }
+                else
+                {
+                    // If the previous value came from a previous basic block, then some other use of 
+                    // the local could see the previous value, so we must merge the new value with the 
+                    // old value.
+                    newValue.Value = MergePointValue.MergeValues(existingValue.Value, valueToStore);
+                }
+                valueCollection[collectionKey] = newValue;
+            }
+            else if (maxTrackedValues == null || valueCollection.Count < maxTrackedValues)
+            {
+                // We're not currently tracking a value a this index, so store the value now.
+                newValue.Value = valueToStore;
+                valueCollection[collectionKey] = newValue;
+            }
         }
 
         public void Scan(MethodIL methodBody)
@@ -281,22 +310,9 @@ namespace ILCompiler.Dataflow
                     case ILOpcode.cgt_un:
                     case ILOpcode.clt:
                     case ILOpcode.clt_un:
-                    case ILOpcode.ldelem_i:
-                    case ILOpcode.ldelem_i1:
-                    case ILOpcode.ldelem_i2:
-                    case ILOpcode.ldelem_i4:
-                    case ILOpcode.ldelem_i8:
-                    case ILOpcode.ldelem_r4:
-                    case ILOpcode.ldelem_r8:
-                    case ILOpcode.ldelem_u1:
-                    case ILOpcode.ldelem_u2:
-                    case ILOpcode.ldelem_u4:
                     case ILOpcode.shl:
                     case ILOpcode.shr:
                     case ILOpcode.shr_un:
-                    case ILOpcode.ldelem:
-                    case ILOpcode.ldelem_ref:
-                    case ILOpcode.ldelema:
                     case ILOpcode.ceq:
                         PopUnknown(currentStack, 2, methodBody, offset);
                         PushUnknown(currentStack);
@@ -492,13 +508,11 @@ namespace ILCompiler.Dataflow
                     case ILOpcode.newarr:
                         {
                             StackSlot count = PopUnknown(currentStack, 1, methodBody, offset);
-                            currentStack.Push(new StackSlot(new ArrayValue(count.Value)));
-                            reader.Skip(opcode);
+                            var arrayElement = (TypeDesc)methodBody.GetObject(reader.ReadILToken());
+                            currentStack.Push(new StackSlot(new ArrayValue(count.Value, arrayElement)));
                         }
                         break;
 
-                    case ILOpcode.cpblk:
-                    case ILOpcode.initblk:
                     case ILOpcode.stelem_i:
                     case ILOpcode.stelem_i1:
                     case ILOpcode.stelem_i2:
@@ -508,6 +522,29 @@ namespace ILCompiler.Dataflow
                     case ILOpcode.stelem_r8:
                     case ILOpcode.stelem:
                     case ILOpcode.stelem_ref:
+                        ScanStelem(offset, currentStack, methodBody, curBasicBlock);
+                        reader.Skip(opcode);
+                        break;
+
+                    case ILOpcode.ldelem_i:
+                    case ILOpcode.ldelem_i1:
+                    case ILOpcode.ldelem_i2:
+                    case ILOpcode.ldelem_i4:
+                    case ILOpcode.ldelem_i8:
+                    case ILOpcode.ldelem_r4:
+                    case ILOpcode.ldelem_r8:
+                    case ILOpcode.ldelem_u1:
+                    case ILOpcode.ldelem_u2:
+                    case ILOpcode.ldelem_u4:
+                    case ILOpcode.ldelem:
+                    case ILOpcode.ldelem_ref:
+                    case ILOpcode.ldelema:
+                        ScanLdelem(opcode, offset, currentStack, methodBody, curBasicBlock);
+                        reader.Skip(opcode);
+                        break;
+
+                    case ILOpcode.cpblk:
+                    case ILOpcode.initblk:
                         PopUnknown(currentStack, 3, methodBody, offset);
                         reader.Skip(opcode);
                         break;
@@ -600,7 +637,7 @@ namespace ILCompiler.Dataflow
                     case ILOpcode.call:
                     case ILOpcode.callvirt:
                     case ILOpcode.newobj:
-                        HandleCall(methodBody, opcode, offset, (MethodDesc)methodBody.GetObject(reader.ReadILToken()), currentStack);
+                        HandleCall(methodBody, opcode, offset, (MethodDesc)methodBody.GetObject(reader.ReadILToken()), currentStack, curBasicBlock);
                         break;
 
                     case ILOpcode.jmp:
@@ -895,7 +932,8 @@ namespace ILCompiler.Dataflow
             ILOpcode opcode,
             int offset,
             MethodDesc calledMethod,
-            Stack<StackSlot> currentStack)
+            Stack<StackSlot> currentStack,
+            int curBasicBlock)
         {
             bool isNewObj = opcode == ILOpcode.newobj;
 
@@ -933,6 +971,14 @@ namespace ILCompiler.Dataflow
 
             if (methodReturnValue != null)
                 currentStack.Push(new StackSlot(methodReturnValue, calledMethod.Signature.ReturnType.IsByRefOrPointer()));
+
+            foreach (var param in methodParams)
+            {
+                if (param is ArrayValue arr)
+                {
+                    MarkArrayValuesAsUnknown(arr, curBasicBlock);
+                }
+            }
         }
 
         public abstract bool HandleCall(
@@ -942,5 +988,87 @@ namespace ILCompiler.Dataflow
             int offset,
             ValueNodeList methodParams,
             out ValueNode methodReturnValue);
+
+        // Limit tracking array values to 32 values for performance reasons. There are many arrays much longer than 32 elements in .NET, but the interesting ones for the linker are nearly always less than 32 elements.
+        private const int MaxTrackedArrayValues = 32;
+
+        private static void MarkArrayValuesAsUnknown(ArrayValue arrValue, int curBasicBlock)
+        {
+            // Since we can't know the current index we're storing the value at, clear all indices.
+            // That way we won't accidentally think we know the value at a given index when we cannot.
+            foreach (var knownIndex in arrValue.IndexValues.Keys)
+            {
+                // Don't pass MaxTrackedArrayValues since we are only looking at keys we've already seen.
+                StoreMethodLocalValue(arrValue.IndexValues, UnknownValue.Instance, knownIndex, curBasicBlock);
+            }
+        }
+
+        private void ScanStelem(
+            int offset,
+            Stack<StackSlot> currentStack,
+            MethodIL methodBody,
+            int curBasicBlock)
+        {
+            StackSlot valueToStore = PopUnknown(currentStack, 1, methodBody, offset);
+            StackSlot indexToStoreAt = PopUnknown(currentStack, 1, methodBody, offset);
+            StackSlot arrayToStoreIn = PopUnknown(currentStack, 1, methodBody, offset);
+            int? indexToStoreAtInt = indexToStoreAt.Value.AsConstInt();
+            foreach (var array in arrayToStoreIn.Value.UniqueValues())
+            {
+                if (array is ArrayValue arrValue)
+                {
+                    if (indexToStoreAtInt == null)
+                    {
+                        MarkArrayValuesAsUnknown(arrValue, curBasicBlock);
+                    }
+                    else
+                    {
+                        // When we know the index, we can record the value at that index.
+                        StoreMethodLocalValue(arrValue.IndexValues, valueToStore.Value, indexToStoreAtInt.Value, curBasicBlock, MaxTrackedArrayValues);
+                    }
+                }
+            }
+        }
+
+        private void ScanLdelem(
+            ILOpcode opcode,
+            int offset,
+            Stack<StackSlot> currentStack,
+            MethodIL methodBody,
+            int curBasicBlock)
+        {
+            StackSlot indexToLoadFrom = PopUnknown(currentStack, 1, methodBody, offset);
+            StackSlot arrayToLoadFrom = PopUnknown(currentStack, 1, methodBody, offset);
+            if (arrayToLoadFrom.Value is not ArrayValue arr)
+            {
+                PushUnknown(currentStack);
+                return;
+            }
+            bool isByRef = opcode == ILOpcode.ldelema;
+
+            int? index = indexToLoadFrom.Value.AsConstInt();
+            if (index == null)
+            {
+                PushUnknown(currentStack);
+                if (isByRef)
+                {
+                    MarkArrayValuesAsUnknown(arr, curBasicBlock);
+                }
+                return;
+            }
+
+
+            ValueBasicBlockPair arrayIndexValue;
+            arr.IndexValues.TryGetValue(index.Value, out arrayIndexValue);
+            if (arrayIndexValue.Value != null)
+            {
+                ValueNode valueToPush = arrayIndexValue.Value;
+                currentStack.Push(new StackSlot(valueToPush, isByRef));
+            }
+            else
+            {
+                currentStack.Push(new StackSlot(null, isByRef));
+            }
+        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/Origin.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/Origin.cs
@@ -60,6 +60,18 @@ namespace ILCompiler.Dataflow
         public string GetDisplayName() => Field.GetDisplayName();
     }
 
+    class TypeOrigin : Origin
+    {
+        public MetadataType Type { get; }
+
+        public TypeOrigin(MetadataType type)
+        {
+            Type = type;
+        }
+
+        public string GetDisplayName() => Type.GetDisplayName();
+    }
+
     class GenericParameterOrigin : Origin
     {
         public GenericParameterDesc GenericParameter { get; }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/README.md
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/README.md
@@ -1,1 +1,1 @@
-Sources taken from https://github.com/mono/linker/tree/dd7d70118b7146125781c830bbff47a8cb953f39/src/linker/Linker.Dataflow.
+Sources taken from https://github.com/mono/linker/tree/6a82d56a9e95858005aca83891f2992edf665eb6/src/linker/Linker.Dataflow.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/ValueNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/ValueNode.cs
@@ -69,6 +69,12 @@ namespace Mono.Linker.Dataflow
 		public ValueNodeKind Kind { get; protected set; }
 
 		/// <summary>
+		/// The IL type of the value, represented as closely as possible, but not always exact.  It can be null, for
+		/// example, when the analysis is imprecise or operating on malformed IL.
+		/// </summary>
+		public TypeDefinition StaticType { get; protected set; }
+
+		/// <summary>
 		/// Allows the enumeration of the direct children of this node.  The ChildCollection struct returned here
 		/// supports 'foreach' without allocation.
 		/// </summary>
@@ -116,7 +122,10 @@ namespace Mono.Linker.Dataflow
 		protected abstract int NumChildren { get; }
 		protected abstract ValueNode ChildAt (int index);
 
-		public abstract bool Equals (ValueNode other);
+		public virtual bool Equals (ValueNode other)
+		{
+			return other != null && this.Kind == other.Kind && this.StaticType == other.StaticType;
+		}
 
 		public abstract override int GetHashCode ();
 
@@ -405,6 +414,9 @@ namespace Mono.Linker.Dataflow
 			case ValueNodeKind.Array:
 				ArrayValue av = (ArrayValue) node;
 				foundCycle = av.Size.DetectCycle (seenNodes, allNodesSeen);
+				foreach (ValueBasicBlockPair pair in av.IndexValues.Values) {
+					foundCycle |= pair.Value.DetectCycle (seenNodes, allNodesSeen);
+				}
 				break;
 
 			default:
@@ -486,18 +498,14 @@ namespace Mono.Linker.Dataflow
 		private UnknownValue ()
 		{
 			Kind = ValueNodeKind.Unknown;
+			StaticType = null;
 		}
 
 		public static UnknownValue Instance { get; } = new UnknownValue ();
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
-				return false;
-
-			return true;
+			return base.Equals (other);
 		}
 
 		public override int GetHashCode ()
@@ -518,16 +526,12 @@ namespace Mono.Linker.Dataflow
 		private NullValue ()
 		{
 			Kind = ValueNodeKind.Null;
+			StaticType = null;
 		}
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
-				return false;
-
-			return true;
+			return base.Equals (other);
 		}
 
 		public static NullValue Instance { get; } = new NullValue ();
@@ -553,6 +557,10 @@ namespace Mono.Linker.Dataflow
 		public SystemTypeValue (TypeDefinition typeRepresented)
 		{
 			Kind = ValueNodeKind.SystemType;
+
+			// Should be System.Type - but we don't have any use case where tracking it like that would matter
+			StaticType = null;
+
 			TypeRepresented = typeRepresented;
 		}
 
@@ -560,9 +568,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			return Equals (this.TypeRepresented, ((SystemTypeValue) other).TypeRepresented);
@@ -587,6 +593,10 @@ namespace Mono.Linker.Dataflow
 		public RuntimeTypeHandleValue (TypeDefinition typeRepresented)
 		{
 			Kind = ValueNodeKind.RuntimeTypeHandle;
+
+			// Should be System.RuntimeTypeHandle, but we don't have a use case for it like that
+			StaticType = null;
+
 			TypeRepresented = typeRepresented;
 		}
 
@@ -594,9 +604,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			return Equals (this.TypeRepresented, ((RuntimeTypeHandleValue) other).TypeRepresented);
@@ -622,6 +630,10 @@ namespace Mono.Linker.Dataflow
 		public SystemTypeForGenericParameterValue (GenericParameter genericParameter, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.SystemTypeForGenericParameter;
+
+			// Should be System.Type, but we don't have a use case for it
+			StaticType = null;
+
 			GenericParameter = genericParameter;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = genericParameter;
@@ -631,9 +643,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			var otherValue = (SystemTypeForGenericParameterValue) other;
@@ -659,6 +669,10 @@ namespace Mono.Linker.Dataflow
 		public RuntimeTypeHandleForGenericParameterValue (GenericParameter genericParameter)
 		{
 			Kind = ValueNodeKind.RuntimeTypeHandleForGenericParameter;
+
+			// Should be System.RuntimeTypeHandle, but we don't have a use case for it
+			StaticType = null;
+
 			GenericParameter = genericParameter;
 		}
 
@@ -666,9 +680,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			return Equals (this.GenericParameter, ((RuntimeTypeHandleForGenericParameterValue) other).GenericParameter);
@@ -693,6 +705,10 @@ namespace Mono.Linker.Dataflow
 		public RuntimeMethodHandleValue (MethodDefinition methodRepresented)
 		{
 			Kind = ValueNodeKind.RuntimeMethodHandle;
+
+			// Should be System.RuntimeMethodHandle, but we don't have a use case for it
+			StaticType = null;
+
 			MethodRepresented = methodRepresented;
 		}
 
@@ -700,9 +716,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			return Equals (this.MethodRepresented, ((RuntimeMethodHandleValue) other).MethodRepresented);
@@ -727,6 +741,10 @@ namespace Mono.Linker.Dataflow
 		public SystemReflectionMethodBaseValue (MethodDefinition methodRepresented)
 		{
 			Kind = ValueNodeKind.SystemReflectionMethodBase;
+
+			// Should be System.Reflection.MethodBase, but we don't have a use case for it
+			StaticType = null;
+
 			MethodRepresented = methodRepresented;
 		}
 
@@ -734,9 +752,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			return Equals (this.MethodRepresented, ((SystemReflectionMethodBaseValue) other).MethodRepresented);
@@ -761,6 +777,10 @@ namespace Mono.Linker.Dataflow
 		public KnownStringValue (string contents)
 		{
 			Kind = ValueNodeKind.KnownString;
+
+			// Should be System.String, but we don't have a use case for it
+			StaticType = null;
+
 			Contents = contents;
 		}
 
@@ -768,9 +788,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			return this.Contents == ((KnownStringValue) other).Contents;
@@ -798,6 +816,16 @@ namespace Mono.Linker.Dataflow
 		/// The bitfield of dynamically accessed member types the node guarantees
 		/// </summary>
 		public DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes { get; protected set; }
+
+		public override bool Equals (ValueNode other)
+		{
+			if (!base.Equals (other))
+				return false;
+
+			var otherValue = (LeafValueWithDynamicallyAccessedMemberNode) other;
+			return SourceContext == otherValue.SourceContext
+				&& DynamicallyAccessedMemberTypes == otherValue.DynamicallyAccessedMemberTypes;
+		}
 	}
 
 	/// <summary>
@@ -805,9 +833,14 @@ namespace Mono.Linker.Dataflow
 	/// </summary>
 	class MethodParameterValue : LeafValueWithDynamicallyAccessedMemberNode
 	{
-		public MethodParameterValue (int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, IMetadataTokenProvider sourceContext)
+		public MethodParameterValue (MethodDefinition method, int parameterIndex, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes, IMetadataTokenProvider sourceContext)
 		{
 			Kind = ValueNodeKind.MethodParameter;
+			StaticType = method.HasImplicitThis ()
+				? (parameterIndex == 0
+					? method.DeclaringType
+					: method.Parameters[parameterIndex - 1].ParameterType.ResolveToMainTypeDefinition ())
+				: method.Parameters[parameterIndex].ParameterType.ResolveToMainTypeDefinition ();
 			ParameterIndex = parameterIndex;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = sourceContext;
@@ -817,13 +850,11 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			var otherValue = (MethodParameterValue) other;
-			return this.ParameterIndex == otherValue.ParameterIndex && this.DynamicallyAccessedMemberTypes == otherValue.DynamicallyAccessedMemberTypes;
+			return this.ParameterIndex == otherValue.ParameterIndex;
 		}
 
 		public override int GetHashCode ()
@@ -845,19 +876,17 @@ namespace Mono.Linker.Dataflow
 		public AnnotatedStringValue (IMetadataTokenProvider sourceContext, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.AnnotatedString;
+
+			// Should be System.String, but we don't have a use case for it
+			StaticType = null;
+
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = sourceContext;
 		}
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
-				return false;
-
-			var otherValue = (AnnotatedStringValue) other;
-			return this.DynamicallyAccessedMemberTypes == otherValue.DynamicallyAccessedMemberTypes;
+			return base.Equals (other);
 		}
 
 		public override int GetHashCode ()
@@ -879,19 +908,14 @@ namespace Mono.Linker.Dataflow
 		public MethodReturnValue (MethodReturnType methodReturnType, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.MethodReturn;
+			StaticType = methodReturnType.ReturnType.ResolveToMainTypeDefinition ();
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = methodReturnType;
 		}
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
-				return false;
-
-			var otherValue = (MethodReturnValue) other;
-			return this.DynamicallyAccessedMemberTypes == otherValue.DynamicallyAccessedMemberTypes;
+			return base.Equals (other);
 		}
 
 		public override int GetHashCode ()
@@ -916,6 +940,7 @@ namespace Mono.Linker.Dataflow
 		private MergePointValue (ValueNode one, ValueNode two)
 		{
 			Kind = ValueNodeKind.MergePoint;
+			StaticType = null;
 			m_values = new ValueNodeHashSet ();
 
 			if (one.Kind == ValueNodeKind.MergePoint) {
@@ -993,9 +1018,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			MergePointValue otherMpv = (MergePointValue) other;
@@ -1036,6 +1059,10 @@ namespace Mono.Linker.Dataflow
 		{
 			_resolver = resolver;
 			Kind = ValueNodeKind.GetTypeFromString;
+
+			// Should be System.Type, but we don't have a use case for it
+			StaticType = null;
+
 			AssemblyIdentity = assemblyIdentity;
 			NameString = nameString;
 		}
@@ -1091,9 +1118,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			GetTypeFromStringValue otherGtfs = (GetTypeFromStringValue) other;
@@ -1122,6 +1147,7 @@ namespace Mono.Linker.Dataflow
 		public LoadFieldValue (FieldDefinition fieldToLoad, DynamicallyAccessedMemberTypes dynamicallyAccessedMemberTypes)
 		{
 			Kind = ValueNodeKind.LoadField;
+			StaticType = fieldToLoad.FieldType.ResolveToMainTypeDefinition ();
 			Field = fieldToLoad;
 			DynamicallyAccessedMemberTypes = dynamicallyAccessedMemberTypes;
 			SourceContext = fieldToLoad;
@@ -1131,16 +1157,11 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			LoadFieldValue otherLfv = (LoadFieldValue) other;
-			if (!Equals (this.Field, otherLfv.Field))
-				return false;
-
-			return this.DynamicallyAccessedMemberTypes == otherLfv.DynamicallyAccessedMemberTypes;
+			return Equals (this.Field, otherLfv.Field);
 		}
 
 		public override int GetHashCode ()
@@ -1162,6 +1183,10 @@ namespace Mono.Linker.Dataflow
 		public ConstIntValue (int value)
 		{
 			Kind = ValueNodeKind.ConstInt;
+
+			// Should be System.Int32, but we don't have a usecase for it right now
+			StaticType = null;
+
 			Value = value;
 		}
 
@@ -1174,9 +1199,7 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			ConstIntValue otherCiv = (ConstIntValue) other;
@@ -1191,18 +1214,32 @@ namespace Mono.Linker.Dataflow
 
 	class ArrayValue : ValueNode
 	{
-		protected override int NumChildren => 1;
+		protected override int NumChildren => 1 + IndexValues.Count;
 
 		/// <summary>
 		/// Constructs an array value of the given size
 		/// </summary>
-		public ArrayValue (ValueNode size)
+		public ArrayValue (ValueNode size, TypeReference elementType)
 		{
 			Kind = ValueNodeKind.Array;
+
+			// Should be System.Array (or similar), but we don't have a use case for it
+			StaticType = null;
+
 			Size = size ?? UnknownValue.Instance;
+			ElementType = elementType.ResolveToMainTypeDefinition ();
+			IndexValues = new Dictionary<int, ValueBasicBlockPair> ();
+		}
+
+		private ArrayValue (ValueNode size, TypeReference elementType, Dictionary<int, ValueBasicBlockPair> indexValues)
+			: this (size, elementType)
+		{
+			IndexValues = indexValues;
 		}
 
 		public ValueNode Size { get; }
+		public TypeReference ElementType { get; }
+		public Dictionary<int, ValueBasicBlockPair> IndexValues { get; }
 
 		public override int GetHashCode ()
 		{
@@ -1211,29 +1248,40 @@ namespace Mono.Linker.Dataflow
 
 		public override bool Equals (ValueNode other)
 		{
-			if (other == null)
-				return false;
-			if (this.Kind != other.Kind)
+			if (!base.Equals (other))
 				return false;
 
 			ArrayValue otherArr = (ArrayValue) other;
-			return Size.Equals (otherArr.Size);
+			bool equals = Size.Equals (otherArr.Size);
+			equals &= IndexValues.Count == otherArr.IndexValues.Count;
+			if (!equals)
+				return false;
+
+			// If both sets T and O are the same size and "T intersect O" is empty, then T == O.
+			HashSet<KeyValuePair<int, ValueBasicBlockPair>> thisValueSet = new (IndexValues);
+			HashSet<KeyValuePair<int, ValueBasicBlockPair>> otherValueSet = new (otherArr.IndexValues);
+			thisValueSet.ExceptWith (otherValueSet);
+			return thisValueSet.Count == 0;
 		}
 
 		protected override string NodeToString ()
 		{
-			return ValueNodeDump.ValueNodeToString (this, Size);
+			// TODO: Use StringBuilder and remove Linq usage.
+			return $"(Array Size:{ValueNodeDump.ValueNodeToString (this, Size)}, Values:({string.Join (',', IndexValues.Select (v => $"({v.Key},{ValueNodeDump.ValueNodeToString (v.Value.Value)})"))})";
 		}
 
 		protected override IEnumerable<ValueNode> EvaluateUniqueValues ()
 		{
 			foreach (var sizeConst in Size.UniqueValuesInternal)
-				yield return new ArrayValue (sizeConst);
+				yield return new ArrayValue (sizeConst, ElementType, IndexValues);
 		}
 
 		protected override ValueNode ChildAt (int index)
 		{
 			if (index == 0) return Size;
+			if (index - 1 <= IndexValues.Count)
+				return IndexValues.Values.ElementAt (index - 1).Value;
+
 			throw new InvalidOperationException ();
 		}
 	}
@@ -1314,5 +1362,11 @@ namespace Mono.Linker.Dataflow
 				hashCode.Add (item);
 			return hashCode.ToHashCode ();
 		}
+	}
+
+	public struct ValueBasicBlockPair
+	{
+		public ValueNode Value;
+		public int BasicBlockIndex;
 	}
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -1230,7 +1230,7 @@ namespace ILCompiler.Dataflow
                             foreach (var valueNode in methodParams[0].UniqueValues())
                             {
                                 TypeDesc staticType = valueNode.StaticType;
-                                if (staticType is null || staticType.IsGenericParameter)
+                                if (staticType is null || (!staticType.IsDefType && !staticType.IsArray))
                                 {
                                     // We don’t know anything about the type GetType was called on. Track this as a usual “result of a method call without any annotations”
                                     methodReturnValue = MergePointValue.MergeValues(methodReturnValue, new MethodReturnValue(calledMethod, DynamicallyAccessedMemberTypes.None));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -1230,7 +1230,7 @@ namespace ILCompiler.Dataflow
                             foreach (var valueNode in methodParams[0].UniqueValues())
                             {
                                 TypeDesc staticType = valueNode.StaticType;
-                                if (staticType is null)
+                                if (staticType is null || staticType.IsGenericParameter)
                                 {
                                     // We don’t know anything about the type GetType was called on. Track this as a usual “result of a method call without any annotations”
                                     methodReturnValue = MergePointValue.MergeValues(methodReturnValue, new MethodReturnValue(calledMethod, DynamicallyAccessedMemberTypes.None));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -297,6 +297,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new ReflectableMethodNode(method);
             });
 
+            _objectGetTypeFlowDependencies = new NodeCache<MetadataType, ObjectGetTypeFlowDependenciesNode>(type =>
+            {
+                return new ObjectGetTypeFlowDependenciesNode(type);
+            });
+
             _shadowConcreteMethods = new NodeCache<MethodKey, IMethodNode>(methodKey =>
             {
                 MethodDesc canonMethod = methodKey.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
@@ -855,6 +860,12 @@ namespace ILCompiler.DependencyAnalysis
         public ReflectableMethodNode ReflectableMethod(MethodDesc method)
         {
             return _reflectableMethods.GetOrAdd(method);
+        }
+
+        private NodeCache<MetadataType, ObjectGetTypeFlowDependenciesNode> _objectGetTypeFlowDependencies;
+        internal ObjectGetTypeFlowDependenciesNode ObjectGetTypeFlowDependencies(MetadataType type)
+        {
+            return _objectGetTypeFlowDependencies.GetOrAdd(type);
         }
 
         private NodeCache<MethodDesc, DynamicInvokeTemplateNode> _dynamicInvokeTemplates;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectGetTypeFlowDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectGetTypeFlowDependenciesNode.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents dataflow dependencies from a call to Object.GetType on an instance statically
+    /// typed as the given type.
+    /// </summary>
+    internal class ObjectGetTypeFlowDependenciesNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly MetadataType _type;
+
+        public ObjectGetTypeFlowDependenciesNode(MetadataType type)
+        {
+            _type = type;
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return $"Object.GetType dependencies called on {_type}";
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
+        {
+            var mdManager = (UsageBasedMetadataManager)factory.MetadataManager;
+            
+            // We don't mark any members on interfaces - these nodes are only used as conditional dependencies
+            // of other nodes. Calling `object.GetType()` on something typed as an interface will return
+            // something that implements the interface, not the interface itself. We're not reflecting on the
+            // interface.
+            if (_type.IsInterface)
+                return Array.Empty<DependencyListEntry>();
+
+            return Dataflow.ReflectionMethodBodyScanner.ProcessTypeGetTypeDataflow(factory, mdManager.FlowAnnotations, mdManager.Logger, _type);
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+        
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -386,6 +386,17 @@ namespace ILCompiler
             // MetadataManagers can override this to provide additional dependencies caused by the emission of an EEType.
         }
 
+        public virtual void GetConditionalDependenciesDueToEETypePresence(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+            // MetadataManagers can override this to provide additional dependencies caused by the presence of
+            // an EEType.
+        }
+
+        public virtual bool HasConditionalDependenciesDueToEETypePresence(TypeDesc type)
+        {
+            return false;
+        }
+
         /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies to generated RuntimeMethodHandles.
         /// </summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -309,6 +309,67 @@ namespace ILCompiler
             }
         }
 
+        public override bool HasConditionalDependenciesDueToEETypePresence(TypeDesc type)
+        {
+            // Note: duplicated with the check in GetConditionalDependenciesDueToEETypePresence
+            return type.IsDefType && !type.IsInterface && FlowAnnotations.GetTypeAnnotation(type) != default;
+        }
+
+        public override void GetConditionalDependenciesDueToEETypePresence(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc type)
+        {
+            // Check to see if we have any dataflow annotations on the type.
+            // The check below also covers flow annotations inherited through base classes and implemented interfaces.
+            if (type.IsDefType
+                && !type.IsInterface /* "IFoo x; x.GetType();" -> this doesn't actually return an interface type */
+                && FlowAnnotations.GetTypeAnnotation(type) != default)
+            {
+                // We have some flow annotations on this type.
+                //
+                // The flow annotations are supposed to ensure that should we call object.GetType on a location
+                // typed as one of the annotated subclasses of this type, this type is going to have the specified
+                // members kept. We don't keep them right away, but condition them on the object.GetType being called.
+                //
+                // Now we figure out where the annotations are coming from:
+
+                DefType baseType = type.BaseType;
+                if (baseType != null && FlowAnnotations.GetTypeAnnotation(baseType) != default)
+                {
+                    // There's an annotation on the base type. If object.GetType was called on something
+                    // statically typed as the base type, we might actually be calling it on this type.
+                    // Ensure we have the flow dependencies.
+                    dependencies ??= new CombinedDependencyList();
+                    dependencies.Add(new DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry(
+                        factory.ObjectGetTypeFlowDependencies((MetadataType)type),
+                        factory.ObjectGetTypeFlowDependencies((MetadataType)baseType),
+                        "GetType called on the base type"));
+
+                    // We don't have to follow all the bases since the base EEType will bubble this up
+                }
+
+                foreach (DefType interfaceType in type.RuntimeInterfaces)
+                {
+                    if (FlowAnnotations.GetTypeAnnotation(interfaceType) != default)
+                    {
+                        // There's an annotation on the interface type. If object.GetType was called on something
+                        // statically typed as the interface type, we might actually be calling it on this type.
+                        // Ensure we have the flow dependencies.
+                        dependencies ??= new CombinedDependencyList();
+                        dependencies.Add(new DependencyNodeCore<NodeFactory>.CombinedDependencyListEntry(
+                            factory.ObjectGetTypeFlowDependencies((MetadataType)type),
+                            factory.ObjectGetTypeFlowDependencies((MetadataType)interfaceType),
+                            "GetType called on the interface"));
+                    }
+
+                    // We don't have to recurse into the interface because we're inspecting runtime interfaces
+                    // and this list is already flattened.
+                }
+
+                // Note we don't add any conditional dependencies if this type itself was annotated and none
+                // of the bases/interfaces are annotated.
+                // ObjectGetTypeFlowDependencies don't need to be conditional in that case. They'll be added as needed.
+            }
+        }
+
         public override void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, FieldDesc field)
         {
             // In order for the RuntimeFieldHandle data structure to be usable at runtime, ensure the field

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Compiler\DependencyAnalysis\IndirectionExtensions.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellSectionNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodExceptionHandlingInfoNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ObjectGetTypeFlowDependenciesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionMethodBodyScanner.cs" />
     <Compile Include="Compiler\DependencyAnalysis\StructMarshallingDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_ARM64\ARM64TentativeMethodNode.cs" />

--- a/src/tests/nativeaot/SmokeTests/Dataflow/Dataflow.cs
+++ b/src/tests/nativeaot/SmokeTests/Dataflow/Dataflow.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using System.Diagnostics.CodeAnalysis;
 
 #pragma warning disable 649 // 'blah' is never assgined to
+#pragma warning disable 169 // 'blah' is never used
+#pragma warning disable 436 // conflicting type
 
 class Program
 {
@@ -20,6 +22,7 @@ class Program
         TestAllDataflow.Run();
         TestDynamicDependency.Run();
         TestDynamicDependencyWithGenerics.Run();
+        TestObjectGetTypeDataflow.Run();
 
         return 100;
     }
@@ -402,6 +405,114 @@ class Program
             Assert.Equal(1, typeof(TypeWithPublicPropertiesKept<>).CountProperties());
         }
     }
+
+    class TestObjectGetTypeDataflow
+    {
+        static TypeWithNonPublicMethodsKept s_typeWithNonpublicMethodsKept = new TypeWithNonPublicMethodsKeptThroughBase();
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods)]
+        class TypeWithNonPublicMethodsKept
+        {
+            private void Method1() { }
+            public void Method2() { }
+            private void Method3() { }
+        }
+
+        class TypeWithNonPublicMethodsKeptThroughBase : TypeWithNonPublicMethodsKept
+        {
+            private void Method4() { }
+            public void Method5() { }
+        }
+
+        static NeverAllocatedTypeAskingForNonPublicMethods s_neverAllocatedTypeAskingForNonPublicMethods = null;
+
+        class NeverAllocatedTypeAskingForNonPublicMethods : TypeWithNonPublicMethodsKept
+        {
+            private void Method4() { }
+        }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicMethods)]
+        interface IInterfaceWithNonPublicMethodsKept
+        {
+            public static void Method1() { }
+            private static void Method2() { }
+        }
+
+        interface IInterfaceWithNonPublicMethodsKeptIndirectly : IInterfaceWithNonPublicMethodsKept
+        {
+            public static void Method3() { }
+            private static void Method4() { }
+        }
+
+        static IInterfaceWithNonPublicMethodsKeptIndirectly s_interfaceWithNonPublicMethodsKeptIndirectly = new TypeWithNonPublicMethodsKeptThroughIndirectInterface();
+
+        class TypeWithNonPublicMethodsKeptThroughIndirectInterface : IInterfaceWithNonPublicMethodsKeptIndirectly
+        {
+            private void Method1() { }
+            public void Method2() { }
+        }
+
+        class TypeWithNonPublicMethodsKeptThroughIndirectInterfaceNeverAllocated : IInterfaceWithNonPublicMethodsKept
+        {
+            private void Method1() { }
+            public void Method2() { }
+        }
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        interface IKeepNonPublicCtors { }
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        interface IKeepPublicMethods { }
+
+        static BaseWithMixKept s_baseWithMixKept = new DerivedWithMixKept(123);
+
+        class BaseWithMixKept : IKeepNonPublicCtors, IKeepPublicMethods { }
+        class DerivedWithMixKept : BaseWithMixKept
+        {
+            public DerivedWithMixKept(int x) { }
+            public DerivedWithMixKept(double x) { }
+            private DerivedWithMixKept(string y) { }
+            public void PublicMethod() { }
+            private void PrivateMethod() { }
+        }
+
+        public static void Run()
+        {
+            Assert.Equal(1, s_typeWithNonpublicMethodsKept.GetType().CountMethods());
+            Assert.Equal(0, s_typeWithNonpublicMethodsKept.GetType().CountPublicMethods());
+
+            Assert.Equal(2, s_typeWithNonpublicMethodsKept.GetType().BaseType.CountMethods());
+            Assert.Equal(0, s_typeWithNonpublicMethodsKept.GetType().BaseType.CountPublicMethods());
+
+            if (s_neverAllocatedTypeAskingForNonPublicMethods != null)
+            {
+                // This should never be reached, but we need to trick analysis into seeing this
+                // so that we can tests this doesn't lead to keeping the type.
+                Assert.Equal(666, s_neverAllocatedTypeAskingForNonPublicMethods.GetType().CountMethods());
+            }
+            // This is not great - the GetType() call above "wished" NeverAllocatedTypeAskingForNonPublicMethods
+            // into existence, but it shouldn't have. We could do better here if this is a problem.
+            // If we do that, change this .NotNull to .Null.
+            Assert.NotNull(typeof(TestObjectGetTypeDataflow).GetNestedTypeSecretly(nameof(NeverAllocatedTypeAskingForNonPublicMethods)));
+            // Sanity check
+            Assert.NotNull(typeof(TestObjectGetTypeDataflow).GetNestedTypeSecretly(nameof(TypeWithNonPublicMethodsKept)));
+
+            // DAM doesn't apply to the interface since it only goes into effect with an object.GetType call.
+            Assert.Equal(0, typeof(IInterfaceWithNonPublicMethodsKept).CountMethods());
+            Assert.Equal(0, typeof(IInterfaceWithNonPublicMethodsKeptIndirectly).CountMethods());
+
+            Assert.Equal(1, s_interfaceWithNonPublicMethodsKeptIndirectly.GetType().CountMethods());
+            Assert.Equal(0, s_interfaceWithNonPublicMethodsKeptIndirectly.GetType().CountPublicMethods());
+
+            // Typeof shouldn't make the DAM annotation on the type to kick in.
+            Assert.Equal(0, typeof(TypeWithNonPublicMethodsKeptThroughIndirectInterfaceNeverAllocated).CountMethods());
+            Assert.Equal(0, typeof(TypeWithNonPublicMethodsKeptThroughIndirectInterfaceNeverAllocated).CountPublicMethods());
+
+            Assert.Equal(1, s_baseWithMixKept.GetType().CountMethods());
+            Assert.Equal(1, s_baseWithMixKept.GetType().CountPublicMethods());
+            Assert.Equal(2, s_baseWithMixKept.GetType().CountPublicConstructors());
+            Assert.Equal(2, s_baseWithMixKept.GetType().CountConstructors());
+        }
+    }
 }
 
 static class Assert
@@ -415,6 +526,12 @@ static class Assert
     public static void NotNull(object o)
     {
         if (o is null)
+            throw new Exception();
+    }
+
+    public static void Null(object o)
+    {
+        if (o is not null)
             throw new Exception();
     }
 }
@@ -445,4 +562,19 @@ static class Helpers
         Justification = "That's the point")]
     public static int CountProperties(this Type t)
         => t.GetProperties(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly).Length;
+
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "That's the point")]
+    public static Type GetNestedTypeSecretly(this Type t, string name)
+        => t.GetNestedType(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+        }
+    }
 }


### PR DESCRIPTION
This brings two major things:

* Ability to track contents of arrays in the dataflow analysis. We could later use this to model MakeGenericType and MakeGenericMethod.
* Support for DynamicallyAccessedMembersAttribute on classes and interfaces.

The semantic of DAMAttribute on classes and interface is: when a type has DAMAttribute, calls to `object.GetType` on locations statically typed as something having/inheriting the DAMAttribute return an annotated System.Type value.

The marking part of this required creating a new node in the dependency graph. The node represents "`object.GetType` could have been called on this annotated type". It brings the dependencies mandated by the DAMAttribute.