### PR TITLE
Fix hanging in JIT for ARM64 release compilation

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VectorOfTFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VectorOfTFieldLayoutAlgorithm.cs
@@ -62,10 +62,17 @@ namespace ILCompiler
             return false;
         }
 
+        private static bool IsSupportedElementType(TypeDesc type)
+        {
+            return type.IsPrimitiveNumeric
+                || type.Category == TypeFlags.IntPtr
+                || type.Category == TypeFlags.UIntPtr;
+        }
+
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
             if (type.Context.Target.Architecture == TargetArchitecture.ARM64 &&
-                            type.Instantiation[0].IsPrimitiveNumeric)
+                IsSupportedElementType(type.Instantiation[0]))
             {
                 return type.InstanceFieldSize.AsInt switch
                 {


### PR DESCRIPTION
dotnet/runtime#50832 added support for `Vector<nint>` and `Vector<nuint>`, which caused release builds of JIT to hang while compiling `Vector<nuint>` methods.  Debug builds of JIT would fail the following assertion in `Compiler::raUpdateRegStateForArg`: https://github.com/dotnet/runtimelab/blob/fda312f08c26c6d75d693b2fe188a75db74763ee/src/coreclr/jit/regalloc.cpp#L180  The issue is caused by disagreement between JIT and ILCompiler on whether the aforementioned types are homogeneous vector aggregates (HVA).  The fix is to extend the HVA check in `VectorOfTFieldLayoutAlgorithm.ComputeValueTypeShapeCharacteristics` to include `IntPtr` and `UIntPtr` element types.

The introduced `IsSupportedElementType` method may be temporary.  When Runtime repo adds support for `nint` and `nuint` element types for `Vector64<T>`, `Vector128<T>`, and `Vector256<T>` types, they would have to extend similarly the `TypeDesc.IsPrimitiveNumeric` check here: https://github.com/dotnet/runtimelab/blob/fda312f08c26c6d75d693b2fe188a75db74763ee/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs#L95-L96

If they update/rename the `TypeDesc.IsPrimitiveNumeric` property, we will use the updated property in this class as well.