### PR TITLE
Handle function pointers

### DIFF
--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/FunctionPointerTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/FunctionPointerTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Runtime.InteropServices;
+
+using Xunit;
+
+namespace DllImportGenerator.IntegrationTests
+{
+    partial class NativeExportsNE
+    {
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_after_gc")]
+        public static unsafe partial void InvokeAfterGC(delegate* <void> cb);
+
+        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_blittable_args")]
+        public static unsafe partial int InvokeWithBlittableArgument(delegate* <int, int, int> cb, int a, int b);
+    }
+
+    public class FunctionPointerTests
+    {
+        [Fact]
+        public void InvokedAfterGC()
+        {
+            bool wasCalled = false;
+            NativeExportsNE.InvokeAfterGC(Callback);
+            Assert.True(wasCalled);
+
+            void Callback()
+            {
+                wasCalled = true;
+            }
+        }
+
+        [Fact]
+        public void CalledWithArgumentsInOrder()
+        {
+            const int a = 100;
+            const int b = 50;
+            int result;
+
+            result = NativeExportsNE.InvokeWithBlittableArgument(Callback, a, b);
+            Assert.Equal(Callback(a, b), result);
+
+            result = NativeExportsNE.InvokeWithBlittableArgument(Callback, b, a);
+            Assert.Equal(Callback(b, a), result);
+
+            static int Callback(int a, int b)
+            {
+                // Use a noncommutative operation to validate passed in order.
+                return a - b;
+            }
+        }
+    }
+}

--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/FunctionPointerTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/FunctionPointerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 using Xunit;
 
@@ -6,45 +8,108 @@ namespace DllImportGenerator.IntegrationTests
 {
     partial class NativeExportsNE
     {
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_after_gc")]
-        public static unsafe partial void InvokeAfterGC(delegate* <void> cb);
+        public partial class FunctionPointer
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_after_gc")]
+            public static unsafe partial void InvokeAfterGC(delegate* <void> cb);
 
-        [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_blittable_args")]
-        public static unsafe partial int InvokeWithBlittableArgument(delegate* <int, int, int> cb, int a, int b);
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_after_gc")]
+            public static unsafe partial void InvokeAfterGC(delegate* unmanaged<void> cb);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_after_gc")]
+            public static unsafe partial void InvokeAfterGC(delegate* unmanaged[Stdcall]<void> cb);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_blittable_args")]
+            public static unsafe partial int InvokeWithBlittableArgument(delegate* <int, int, int> cb, int a, int b);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_blittable_args")]
+            public static unsafe partial int InvokeWithBlittableArgument(delegate* unmanaged<int, int, int> cb, int a, int b);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "invoke_callback_blittable_args")]
+            public static unsafe partial int InvokeWithBlittableArgument(delegate* unmanaged[Stdcall]<int, int, int> cb, int a, int b);
+        }
     }
 
     public class FunctionPointerTests
     {
+        private static bool wasCalled;
+
         [Fact]
-        public void InvokedAfterGC()
+        public unsafe void InvokedAfterGC()
         {
-            bool wasCalled = false;
-            NativeExportsNE.InvokeAfterGC(Callback);
+            wasCalled = false;
+            NativeExportsNE.FunctionPointer.InvokeAfterGC(&Callback);
             Assert.True(wasCalled);
 
-            void Callback()
+            wasCalled = false;
+            NativeExportsNE.FunctionPointer.InvokeAfterGC(&CallbackUnmanaged);
+            Assert.True(wasCalled);
+
+            wasCalled = false;
+            NativeExportsNE.FunctionPointer.InvokeAfterGC(&CallbackUnmanagedStdcall);
+            Assert.True(wasCalled);
+
+            static void Callback()
+            {
+                wasCalled = true;
+            }
+
+            [UnmanagedCallersOnly]
+            static void CallbackUnmanaged()
+            {
+                wasCalled = true;
+            }
+
+            [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+            static void CallbackUnmanagedStdcall()
             {
                 wasCalled = true;
             }
         }
 
         [Fact]
-        public void CalledWithArgumentsInOrder()
+        public unsafe void CalledWithArgumentsInOrder()
         {
             const int a = 100;
             const int b = 50;
             int result;
 
-            result = NativeExportsNE.InvokeWithBlittableArgument(Callback, a, b);
-            Assert.Equal(Callback(a, b), result);
+            int expected = Callback(a, b);
+            result = NativeExportsNE.FunctionPointer.InvokeWithBlittableArgument(&Callback, a, b);
+            Assert.Equal(expected, result);
 
-            result = NativeExportsNE.InvokeWithBlittableArgument(Callback, b, a);
-            Assert.Equal(Callback(b, a), result);
+            result = NativeExportsNE.FunctionPointer.InvokeWithBlittableArgument(&CallbackUnmanaged, a, b);
+            Assert.Equal(expected, result);
+
+            result = NativeExportsNE.FunctionPointer.InvokeWithBlittableArgument(&CallbackUnmanagedStdcall, a, b);
+            Assert.Equal(expected, result);
+
+            expected = Callback(b, a);
+            result = NativeExportsNE.FunctionPointer.InvokeWithBlittableArgument(&Callback, b, a);
+            Assert.Equal(expected, result);
+
+            result = NativeExportsNE.FunctionPointer.InvokeWithBlittableArgument(&CallbackUnmanaged, b, a);
+            Assert.Equal(expected, result);
+
+            result = NativeExportsNE.FunctionPointer.InvokeWithBlittableArgument(&CallbackUnmanagedStdcall, b, a);
+            Assert.Equal(expected, result);
 
             static int Callback(int a, int b)
             {
                 // Use a noncommutative operation to validate passed in order.
                 return a - b;
+            }
+
+            [UnmanagedCallersOnly]
+            static int CallbackUnmanaged(int a, int b)
+            {
+                return Callback(a, b);
+            }
+
+            [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+            static int CallbackUnmanagedStdcall(int a, int b)
+            {
+                return Callback(a, b);
             }
         }
     }

--- a/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -365,6 +365,21 @@ partial class Test
         out {typeName} pOut);
 }}";
 
+        /// <summary>
+        /// Declaration with parameters and unsafe.
+        /// </summary>
+        public static string BasicParametersAndModifiersUnsafe(string typeName) => @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+    [GeneratedDllImport(""DoesNotExist"")]
+    public static unsafe partial {typeName} Method(
+        {typeName} p,
+        in {typeName} pIn,
+        ref {typeName} pRef,
+        out {typeName} pOut);
+}}";
+
         public static string BasicParametersAndModifiers<T>() => BasicParametersAndModifiers(typeof(T).ToString());
 
         /// <summary>
@@ -425,17 +440,7 @@ partial class Test
         /// <summary>
         /// Declaration with pointer parameters.
         /// </summary>
-        public static string PointerParameters<T>() => @$"
-using System.Runtime.InteropServices;
-partial class Test
-{{
-    [GeneratedDllImport(""DoesNotExist"")]
-    public static unsafe partial {typeof(T)}* Method(
-        {typeof(T)}* p,
-        in {typeof(T)}* pIn,
-        ref {typeof(T)}* pRef,
-        out {typeof(T)}* pOut);
-}}";
+        public static string PointerParameters<T>() => BasicParametersAndModifiersUnsafe($"{typeof(T)}*");
 
         /// <summary>
         /// Declaration with PreserveSig = false.

--- a/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -413,6 +413,23 @@ partial class Test
 }}
 ";
 
+        /// <summary>
+        /// Declaration with parameters with MarshalAs.
+        /// </summary>
+        public static string MarshalAsParametersAndModifiersUnsafe(string typeName, UnmanagedType unmanagedType) => @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+    [GeneratedDllImport(""DoesNotExist"")]
+    [return: MarshalAs(UnmanagedType.{unmanagedType})]
+    public static unsafe partial {typeName} Method(
+        [MarshalAs(UnmanagedType.{unmanagedType})] {typeName} p,
+        [MarshalAs(UnmanagedType.{unmanagedType})] in {typeName} pIn,
+        [MarshalAs(UnmanagedType.{unmanagedType})] ref {typeName} pRef,
+        [MarshalAs(UnmanagedType.{unmanagedType})] out {typeName} pOut);
+}}
+";
+
         public static string MarshalAsParametersAndModifiers<T>(UnmanagedType unmanagedType) => MarshalAsParametersAndModifiers(typeof(T).ToString(), unmanagedType);
 
         /// <summary>

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -83,6 +83,8 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.MarshalAsParametersAndModifiers<bool>(UnmanagedType.I1) };
             yield return new[] { CodeSnippets.MarshalAsParametersAndModifiers<char>(UnmanagedType.I2) };
             yield return new[] { CodeSnippets.MarshalAsParametersAndModifiers<char>(UnmanagedType.U2) };
+            yield return new[] { CodeSnippets.MarshalAsParametersAndModifiers<IntPtr>(UnmanagedType.SysInt) };
+            yield return new[] { CodeSnippets.MarshalAsParametersAndModifiers<UIntPtr>(UnmanagedType.SysUInt) };
             yield return new[] { CodeSnippets.MarshalAsParametersAndModifiers<string>(UnmanagedType.LPWStr) };
             yield return new[] { CodeSnippets.MarshalAsParametersAndModifiers<string>(UnmanagedType.LPTStr) };
             yield return new[] { CodeSnippets.MarshalAsParametersAndModifiers<string>(UnmanagedType.LPUTF8Str) };
@@ -120,9 +122,12 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.DelegateMarshalAsParametersAndModifiers };
 
             // Function pointers
+            yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* <void>") };
             yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* unmanaged<void>") };
             yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* unmanaged<int, int>") };
             yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* unmanaged[Stdcall]<int, int>") };
+            yield return new[] { CodeSnippets.MarshalAsParametersAndModifiersUnsafe("delegate* <int>", UnmanagedType.FunctionPtr) };
+            yield return new[] { CodeSnippets.MarshalAsParametersAndModifiersUnsafe("delegate* unmanaged<int>", UnmanagedType.FunctionPtr) };
 
             // Structs
             yield return new[] { CodeSnippets.BlittableStructParametersAndModifiers };

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -113,10 +113,15 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.PointerParameters<bool>() };
             yield return new[] { CodeSnippets.PointerParameters<IntPtr>() };
             yield return new[] { CodeSnippets.PointerParameters<UIntPtr>() };
+            yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("void*") };
 
             // Delegates
             yield return new[] { CodeSnippets.DelegateParametersAndModifiers };
             yield return new[] { CodeSnippets.DelegateMarshalAsParametersAndModifiers };
+
+            // Function pointers
+            yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* unmanaged<void>") };
+            yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* unmanaged<int, int>") };
 
             // Structs
             yield return new[] { CodeSnippets.BlittableStructParametersAndModifiers };
@@ -208,12 +213,12 @@ namespace DllImportGenerator.UnitTests
             var newCompDiags = newComp.GetDiagnostics();
             Assert.Empty(newCompDiags);
         }
-        
+
         public static IEnumerable<object[]> CodeSnippetsToCompileWithForwarder()
         {
             yield return new[] { CodeSnippets.UserDefinedEntryPoint };
             yield return new[] { CodeSnippets.AllSupportedDllImportNamedArguments };
-            
+
             // Parameter / return types (supported in DllImportGenerator)
             yield return new[] { CodeSnippets.BasicParametersAndModifiers<byte>() };
             // Parameter / return types (not supported in DllImportGenerator)
@@ -243,7 +248,7 @@ namespace DllImportGenerator.UnitTests
         {
             // SetLastError
             yield return new[] { CodeSnippets.AllSupportedDllImportNamedArguments };
-            
+
             // SafeHandle
             yield return new[] { CodeSnippets.BasicParametersAndModifiers("Microsoft.Win32.SafeHandles.SafeFileHandle") };
         }

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -122,6 +122,7 @@ namespace DllImportGenerator.UnitTests
             // Function pointers
             yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* unmanaged<void>") };
             yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* unmanaged<int, int>") };
+            yield return new[] { CodeSnippets.BasicParametersAndModifiersUnsafe("delegate* unmanaged[Stdcall]<int, int>") };
 
             // Structs
             yield return new[] { CodeSnippets.BlittableStructParametersAndModifiers };

--- a/DllImportGenerator/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportAnalyzerTests.cs
@@ -28,6 +28,7 @@ namespace DllImportGenerator.UnitTests
             new object[] { typeof(int*) },
             new object[] { typeof(bool*) },
             new object[] { typeof(char*) },
+            new object[] { typeof(delegate* <void>) },
             new object[] { typeof(IntPtr) },
             new object[] { typeof(ConsoleKey) }, // enum
         };

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -216,6 +216,10 @@ namespace Microsoft.Interop
                 case { ManagedType: { TypeKind: TypeKind.Pointer }, MarshallingAttributeInfo: NoMarshallingInfo }:
                     return Blittable;
 
+                // Function pointer with no marshalling info
+                case { ManagedType: { TypeKind: TypeKind.FunctionPointer }, MarshallingAttributeInfo: NoMarshallingInfo }:
+                    return Blittable;
+
                 case { ManagedType: { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: NoMarshallingInfo }:
                     return WinBool; // [Compat] Matching the default for the built-in runtime marshallers.
                 case { ManagedType: { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: MarshalAsInfo(UnmanagedType.I1 or UnmanagedType.U1, _) }:

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -196,8 +196,8 @@ namespace Microsoft.Interop
                     or { ManagedType: { SpecialType: SpecialType.System_UInt32 }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.U4, _) }
                     or { ManagedType: { SpecialType: SpecialType.System_Int64 }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.I8, _) }
                     or { ManagedType: { SpecialType: SpecialType.System_UInt64 }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.U8, _) }
-                    or { ManagedType: { SpecialType: SpecialType.System_IntPtr }, MarshallingAttributeInfo: NoMarshallingInfo }
-                    or { ManagedType: { SpecialType: SpecialType.System_UIntPtr }, MarshallingAttributeInfo: NoMarshallingInfo }
+                    or { ManagedType: { SpecialType: SpecialType.System_IntPtr }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.SysInt, _) }
+                    or { ManagedType: { SpecialType: SpecialType.System_UIntPtr }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.SysUInt, _) }
                     or { ManagedType: { SpecialType: SpecialType.System_Single }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.R4, _) }
                     or { ManagedType: { SpecialType: SpecialType.System_Double }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.R8, _) }:
                     return Blittable;
@@ -217,7 +217,7 @@ namespace Microsoft.Interop
                     return Blittable;
 
                 // Function pointer with no marshalling info
-                case { ManagedType: { TypeKind: TypeKind.FunctionPointer }, MarshallingAttributeInfo: NoMarshallingInfo }:
+                case { ManagedType: { TypeKind: TypeKind.FunctionPointer }, MarshallingAttributeInfo: NoMarshallingInfo or MarshalAsInfo(UnmanagedType.FunctionPtr, _) }:
                     return Blittable;
 
                 case { ManagedType: { SpecialType: SpecialType.System_Boolean }, MarshallingAttributeInfo: NoMarshallingInfo }:

--- a/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
@@ -69,6 +69,11 @@ namespace Microsoft.Interop
                 return IsSpecialTypeBlittable(type.SpecialType);
             }
 
+            if (type.TypeKind == TypeKind.FunctionPointer)
+            {
+                return true;
+            }
+
             if (!type.IsValueType || type.IsReferenceType)
             {
                 return false;

--- a/DllImportGenerator/TestAssets/NativeExports/DelegatesAndFunctionPointers.cs
+++ b/DllImportGenerator/TestAssets/NativeExports/DelegatesAndFunctionPointers.cs
@@ -10,12 +10,11 @@ namespace NativeExports
         {
             // We are at the mercy of the GC to verify our delegate has been retain
             // across the native function call. This is a best effort validation.
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
+            for (int i = 0; i < 5; ++i)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
 
             // If the corresponding Delegate was collected, the runtime will rudely abort.
             fptr();

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,9 +19,9 @@
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
     <!-- Roslyn dependencies -->
-    <CompilerPlatformVersion>3.8.0-3.final</CompilerPlatformVersion>
+    <CompilerPlatformVersion>3.10.0-3.21229.26</CompilerPlatformVersion>
     <CompilerPlatformTestingVersion>1.0.1-beta1.20478.1</CompilerPlatformTestingVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.0</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisAnalyzersVersion>
     <!-- Package dependencies -->
     <SystemCommandLineVersion>2.0.0-beta1.21118.1</SystemCommandLineVersion>
     <IcedVersion>1.8.0</IcedVersion>


### PR DESCRIPTION
- Handle function pointers (no marshalling info or `UnmanagedType.FunctionPtr`) using the `BlittableMarshaller`
- Move to latest Roslyn packages - needed to get the fix for https://github.com/dotnet/roslyn/issues/51222
- Update tests
- Treat `IntPtr`/`UIntPtr` with `UnmanagedType.SysInt`/`UnmanagedType.SysUInt` as blittable - fixes #226

cc @AaronRobinsonMSFT @jkoritzinsky 