### PR TITLE
Allow targeting Windows/Linux ARM64

### DIFF
--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -43,14 +43,6 @@ where `<Configuration>` is your project configuration (such as Debug or Release)
 
 If the compilation succeeds, the native executable will be placed under the `bin/<Configuration>/net5.0/<RID>/publish/` path relative to your project's root directory.
 
-## Targeting ARM64
-
-We are bringing up win-arm64 and linux-arm64 RID targets. Until we have better test coverage, publishing for those RIDs is disabled by default. You may override that on your own risk by setting the `DisableUnsupportedError` property:
-```bash
-> dotnet publish -r linux-arm64 -c Release -p:DisableUnsupportedError=true
-```
-Please be aware of possible bugs for those targets.
-
 ## Cross-architecture compilation
 
 Native AOT toolchain allows targeting ARM64 on an x64 host and vice versa for both Windows and Linux. Cross-OS compilation, such as targeting Linux on a Windows host, is not supported. To target win-arm64 on a Windows x64 host, in addition to the `Microsoft.DotNet.ILCompiler` package reference, also add the `runtime.win-x64.Microsoft.DotNet.ILCompiler` package reference to get the x64-hosted compiler:
@@ -60,7 +52,7 @@ Native AOT toolchain allows targeting ARM64 on an x64 host and vice versa for bo
 
 Note that it is important to use _the same version_ for both packages to avoid potential hard-to-debug issues (use the latest version from the [dotnet-experimental feed](https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=dotnet-experimental&package=Microsoft.DotNet.ILCompiler&protocolType=NuGet)). After adding the package reference, you may publish for win-arm64 as usual:
 ```bash
-> dotnet publish -r win-arm64 -c Release -p:DisableUnsupportedError=true
+> dotnet publish -r win-arm64 -c Release
 ```
 
 Similarly, to target linux-arm64 on a Linux x64 host, in addition to the `Microsoft.DotNet.ILCompiler` package reference, also add the `runtime.linux-x64.Microsoft.DotNet.ILCompiler` package reference to get the x64-hosted compiler:
@@ -70,7 +62,7 @@ Similarly, to target linux-arm64 on a Linux x64 host, in addition to the `Micros
 
 You also need to specify the sysroot directory for Clang using the `SysRoot` property. For example, assuming you are using one of ARM64-targeting [Docker images](../workflow/building/coreclr/linux-instructions.md#Docker-Images) employed for cross-compilation by this repo, you may publish for linux-arm64 with the following command:
 ```bash
-> dotnet publish -r linux-arm64 -c Release -p:DisableUnsupportedError=true -p:CppCompilerAndLinker=clang-9 -p:SysRoot=/crossrootfs/arm64
+> dotnet publish -r linux-arm64 -c Release -p:CppCompilerAndLinker=clang-9 -p:SysRoot=/crossrootfs/arm64
 ```
 
 You may also follow [cross-building instructions](../workflow/building/coreclr/cross-building.md) to create your own sysroot directory.

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -61,7 +61,8 @@
     <Error Condition="'$(DisableUnsupportedError)' != 'true' and '$(OS)' != 'Windows_NT' and $(RuntimeIdentifier.StartsWith('win'))"
       Text="Cross-OS native compilation is not supported. https://github.com/dotnet/corert/issues/5458" />
 
-    <Error Condition="'$(DisableUnsupportedError)' != 'true' and !$(RuntimeIdentifier.EndsWith('x64'))"
+    <Error Condition="'$(DisableUnsupportedError)' != 'true' and !($(RuntimeIdentifier.EndsWith('x64')) or
+      ($(RuntimeIdentifier.EndsWith('arm64')) and !$(RuntimeIdentifier.StartsWith('osx'))))"
       Text="Native compilation does not support targeting $(RuntimeIdentifier) yet. https://github.com/dotnet/corert/issues/4589" />
 
     <Error Condition="'$(DisableUnsupportedError)' != 'true' and !('$(IlcHostArch)' == 'x64' or '$(IlcHostArch)' == 'arm64')"

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ILCompilerVersion>6.0.0-preview.3.21155.4</ILCompilerVersion>
+    <ILCompilerVersion>6.0.0-preview.5.21222.2</ILCompilerVersion>
 
     <ObjWriterArtifactPath Condition="'$(TargetsWindows)' == 'true'">$(ArtifactsDir)llvm\build\$(TargetArchitecture)\bin\Release\$(LibPrefix)objwriter$(LibSuffix)</ObjWriterArtifactPath>
     <ObjWriterArtifactPath Condition="'$(TargetsWindows)' != 'true'">$(ArtifactsDir)llvm\build\$(TargetArchitecture)\lib\$(LibPrefix)objwriter$(LibSuffix)</ObjWriterArtifactPath>

--- a/src/tests/Common/CLRTest.NativeAot.targets
+++ b/src/tests/Common/CLRTest.NativeAot.targets
@@ -137,6 +137,7 @@ if defined RunNativeAot (
   </Target>
 
   <Target Name="CreateNativeAotBuildProjectFile"
+    Condition="'$(_WillCLRTestProjectBuild)' == 'true'"
     Inputs="$(MSBuildProjectFullPath)"
     Outputs="$(OutputPath)\nativebuild.proj"
     BeforeTargets="Build">

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/X64Baseline.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IlcDisableReflection>true</IlcDisableReflection>
     <DefineConstants>$(DefineConstants);BASELINE_INTRINSICS</DefineConstants>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64NonVex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64NonVex.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IlcDisableReflection>true</IlcDisableReflection>
     <DefineConstants>$(DefineConstants);NON_VEX_INTRINSICS</DefineConstants>

--- a/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
+++ b/src/tests/nativeaot/SmokeTests/HardwareIntrinsics/x64Vex.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64'">true</CLRTestTargetUnsupported>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IlcDisableReflection>true</IlcDisableReflection>
     <DefineConstants>$(DefineConstants);VEX_INTRINSICS</DefineConstants>


### PR DESCRIPTION
* Allow targeting Windows/Linux ARM64 without setting `DisableUnsupportedError=true`.
* Bump `objwriter` library version used for developer builds.
* Mark x64-specific tests to avoid building them for ARM64.
* Avoid generating the `nativebuild.proj` file for skipped tests.
