### PR TITLE
Add detection of managed C++

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -191,7 +191,7 @@ namespace ILCompiler
             {
                 PEReader peReader = OpenPEFile(filePath, out mappedViewAccessor);
 #if !READYTORUN
-                if ((peReader.PEHeaders.CorHeader.Flags & (CorFlags.ILLibrary | CorFlags.ILOnly)) == 0)
+                if (peReader.HasMetadata && (peReader.PEHeaders.CorHeader.Flags & (CorFlags.ILLibrary | CorFlags.ILOnly)) == 0)
                     throw new NotSupportedException($"Error: managed C++ is not supported: '{filePath}'");
 #endif
 

--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -190,6 +190,11 @@ namespace ILCompiler
             try
             {
                 PEReader peReader = OpenPEFile(filePath, out mappedViewAccessor);
+#if !READYTORUN
+                if ((peReader.PEHeaders.CorHeader.Flags & (CorFlags.ILLibrary | CorFlags.ILOnly)) == 0)
+                    throw new NotSupportedException($"Error: managed C++ is not supported: '{filePath}'");
+#endif
+
                 pdbReader = PortablePdbSymbolReader.TryOpenEmbedded(peReader, GetMetadataStringDecoder()) ?? OpenAssociatedSymbolFile(filePath, peReader);
 
                 EcmaModule module = EcmaModule.Create(this, peReader, containingAssembly: null, pdbReader);

--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -192,7 +192,7 @@ namespace ILCompiler
                 PEReader peReader = OpenPEFile(filePath, out mappedViewAccessor);
 #if !READYTORUN
                 if (peReader.HasMetadata && (peReader.PEHeaders.CorHeader.Flags & (CorFlags.ILLibrary | CorFlags.ILOnly)) == 0)
-                    throw new NotSupportedException($"Error: managed C++ is not supported: '{filePath}'");
+                    throw new NotSupportedException($"Error: C++/CLI is not supported: '{filePath}'");
 #endif
 
                 pdbReader = PortablePdbSymbolReader.TryOpenEmbedded(peReader, GetMetadataStringDecoder()) ?? OpenAssociatedSymbolFile(filePath, peReader);


### PR DESCRIPTION
Managed C++ is going to crash the compiler, so might as well have a better message for it. This is in a different spot than crossgen2: https://github.com/dotnet/runtime/pull/38113. Both approaches have their advantages and disadvantages. For us it's probably better to do this lazily.