### PR TITLE
Add DLLIMPORTGENERATOR_ENABLED when DllImportGenerator package is referenced

### DIFF
--- a/DllImportGenerator/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/ConvertToGeneratedDllImportFixerTests.cs
@@ -28,7 +28,7 @@ partial class Test
 using System.Runtime.InteropServices;
 partial class Test
 {{
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [GeneratedDllImport(""DoesNotExist"")]
     public static partial int {{|CS8795:Method|}}(out int ret);
 #else
@@ -74,7 +74,7 @@ using System.Runtime.InteropServices;
 partial class Test
 {{
     // P/Invoke
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [GeneratedDllImport(/*name*/""DoesNotExist"")] // comment
     public static partial int {{|CS8795:Method1|}}(out int ret);
 #else
@@ -83,7 +83,7 @@ partial class Test
 #endif
 
     /** P/Invoke **/
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [GeneratedDllImport(""DoesNotExist"") /*name*/]
     // < ... >
     public static partial int {{|CS8795:Method2|}}(out int ret);
@@ -135,7 +135,7 @@ partial class Test
 using System.Runtime.InteropServices;
 partial class Test
 {{
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [System.ComponentModel.Description(""Test""), GeneratedDllImport(""DoesNotExist"")]
     public static partial int {{|CS8795:Method1|}}(out int ret);
 #else
@@ -143,7 +143,7 @@ partial class Test
     public static extern int Method1(out int ret);
 #endif
 
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [System.ComponentModel.Description(""Test"")]
     [GeneratedDllImport(""DoesNotExist"")]
     [return: MarshalAs(UnmanagedType.I4)]
@@ -194,7 +194,7 @@ partial class Test
 using System.Runtime.InteropServices;
 partial class Test
 {{
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"")]
     public static partial int {{|CS8795:Method1|}}(out int ret);
 #else
@@ -202,7 +202,7 @@ partial class Test
     public static extern int Method1(out int ret);
 #endif
 
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"", CharSet = CharSet.Unicode)]
     public static partial int {{|CS8795:Method2|}}(out int ret);
 #else
@@ -246,7 +246,7 @@ partial class Test
 using System.Runtime.InteropServices;
 partial class Test
 {{
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [GeneratedDllImport(""DoesNotExist"", EntryPoint = ""Entry"")]
     public static partial int {{|CS8795:Method1|}}(out int ret);
 #else
@@ -254,7 +254,7 @@ partial class Test
     public static extern int Method1(out int ret);
 #endif
 
-#if NET
+#if DLLIMPORTGENERATOR_ENABLED
     [GeneratedDllImport(""DoesNotExist"")]
     public static partial int {{|CS8795:Method2|}}(out int ret);
 #else

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Verifiers/CSharpCodeFixVerifier.cs
@@ -113,7 +113,7 @@ namespace DllImportGenerator.UnitTests.Verifiers
             }
 
             protected override ParseOptions CreateParseOptions()
-                => ((CSharpParseOptions)base.CreateParseOptions()).WithPreprocessorSymbols("NET");
+                => ((CSharpParseOptions)base.CreateParseOptions()).WithPreprocessorSymbols("DLLIMPORTGENERATOR_ENABLED");
         }
     }
 }

--- a/DllImportGenerator/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportFixer.cs
+++ b/DllImportGenerator/DllImportGenerator/Analyzers/ConvertToGeneratedDllImportFixer.cs
@@ -127,11 +127,11 @@ namespace Microsoft.Interop.Analyzers
             }
             else
             {
-                // #if NET
+                // #if DLLIMPORTGENERATOR_ENABLED
                 generatedDeclaration = generatedDeclaration.WithLeadingTrivia(
                     generatedDeclaration.GetLeadingTrivia()
                         .AddRange(new[] {
-                            SyntaxFactory.Trivia(SyntaxFactory.IfDirectiveTrivia(SyntaxFactory.IdentifierName("NET"), isActive: true, branchTaken: true, conditionValue: true)),
+                            SyntaxFactory.Trivia(SyntaxFactory.IfDirectiveTrivia(SyntaxFactory.IdentifierName("DLLIMPORTGENERATOR_ENABLED"), isActive: true, branchTaken: true, conditionValue: true)),
                             SyntaxFactory.ElasticMarker
                         }));
 

--- a/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Interop
                 // .NET Standard
                 "netstandard" => false,
                 // .NET Core (when version < 5.0) or .NET
-                "System.Runtime" => version >= MinimumSupportedFrameworkVersion,
+                "System.Runtime" or "System.Private.CoreLib" => version >= MinimumSupportedFrameworkVersion,
                 _ => false,
             };
         }

--- a/DllImportGenerator/DllImportGenerator/Microsoft.Interop.DllImportGenerator.props
+++ b/DllImportGenerator/DllImportGenerator/Microsoft.Interop.DllImportGenerator.props
@@ -16,4 +16,7 @@
       -->
       <CompilerVisibleProperty Include="DllImportGenerator_GenerateForwarders" />
   </ItemGroup>
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);DLLIMPORTGENERATOR_ENABLED</DefineConstants>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Use a targeted define (`DLLIMPORTGENERATOR_ENABLED`) when the DllImportGenerator package is referenced. Makes it a bit easier to share code across projects that do and don't use the generator.

cc @AaronRobinsonMSFT @jkoritzinsky