### PR TITLE
Fix rpath for macOS

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -72,7 +72,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="--target=$(TargetTriple)" Condition="'$(TargetTriple)' != ''" />
       <LinkerArg Include="-g" Condition="$(NativeDebugSymbols) == 'true'" />
       <LinkerArg Include="-Wl,--strip-debug" Condition="$(NativeDebugSymbols) != 'true' and '$(TargetOS)' != 'OSX'" />
-      <LinkerArg Include="-Wl,-rpath,'$ORIGIN'" />
+      <LinkerArg Include="-Wl,-rpath,'$ORIGIN'" Condition="'$(TargetOS)' != 'OSX'" />
+      <LinkerArg Include="-Wl,-rpath,'@executable_path'" Condition="'$(TargetOS)' == 'OSX'" />
       <LinkerArg Include="-Wl,--as-needed" Condition="'$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-pthread" Condition="'$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-lstdc++" />

--- a/src/tests/Common/CLRTest.NativeAot.targets
+++ b/src/tests/Common/CLRTest.NativeAot.targets
@@ -61,13 +61,11 @@ if [ ! -z ${RunNativeAot+x} ]%3B then
       exit 1
     fi
 
-    # In OSX we copy the native component to the directory where the exectuable resides.
-    # However, in Linux dlopen doesn't seem to look for current directory to resolve the dynamic library.
-    # So instead we point LD_LIBRARY_PATH to the directory where the native component is.
+    # Copy the native component to the directory where the executable resides.
     if [[ "$OSTYPE" == "darwin"* ]]; then
         cp *.dylib  native/ 2>/dev/null
     else
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PWD}
+        cp *.so  native/ 2>/dev/null
     fi
 
     ExePath=native/$(MSBuildProjectName)


### PR DESCRIPTION
macOS uses different macro for application directory

Unify test setup between OSX and Linux. No need to set env variables for PInvoke smoke test on Linux anymore.

Fixes / related to #1055