### PR TITLE
A couple native layout fixes

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/ExecutionEnvironmentImplementation.MappingTables.cs
@@ -498,11 +498,10 @@ namespace Internal.Reflection.Execution
 
             // This is either a constructor ("returns" void) or an instance method
             MethodInfo reflectionMethodInfo = reflectionMethodBase as MethodInfo;
-            Type returnType = reflectionMethodInfo != null ? reflectionMethodInfo.ReturnType : typeof(void);
 
             // Only use the return type if it's not void
-            if (returnType != typeof(void))
-                dynamicInvokeMethodGenArguments.Add(returnType.TypeHandle);
+            if (reflectionMethodInfo != null && reflectionMethodInfo.ReturnType != typeof(void))
+                dynamicInvokeMethodGenArguments.Add(methodParamsInfo.ReturnTypeHandle);
 
             for (int i = 0; i < dynamicInvokeMethodGenArguments.Count; i++)
             {
@@ -1510,18 +1509,24 @@ namespace Internal.Reflection.Execution
                 }
             }
 
+            public RuntimeTypeHandle ReturnTypeHandle
+            {
+                get
+                {
+                    MethodInfo reflectionMethodInfo = _methodBase as MethodInfo;
+                    Type returnType = reflectionMethodInfo != null ? reflectionMethodInfo.ReturnType : typeof(void);
+                    if (returnType.IsByRef)
+                        returnType = returnType.GetElementType();
+                    return returnType.TypeHandle;
+                }
+            }
+
             public LowLevelList<RuntimeTypeHandle> ReturnTypeAndParameterTypeHandles
             {
                 get
                 {
                     LowLevelList<RuntimeTypeHandle> result = ParameterTypeHandles;
-
-                    MethodInfo reflectionMethodInfo = _methodBase as MethodInfo;
-                    Type returnType = reflectionMethodInfo != null ? reflectionMethodInfo.ReturnType : typeof(void);
-                    if (returnType.IsByRef)
-                        returnType = returnType.GetElementType();
-                    result.Insert(0, returnType.TypeHandle);
-
+                    result.Insert(0, ReturnTypeHandle);
                     return result;
                 }
             }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -449,11 +449,15 @@ namespace Internal.Runtime.TypeLoader
 
                 if (templateMethod == null)
                 {
+#if SUPPORTS_NATIVE_METADATA_TYPE_LOADING
                     // In this case we were looking for the r2r template to create the dictionary, but
                     // there isn't one. This implies that we don't need a Canon specific dictionary
                     // so just generate something empty
                     method.SetGenericDictionary(new GenericMethodDictionary(Array.Empty<GenericDictionaryCell>()));
                     return;
+#else
+                    throw new TypeBuilder.MissingTemplateException();
+#endif
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayMapNode.cs
@@ -57,7 +57,11 @@ namespace ILCompiler.DependencyAnalysis
 
                 var arrayType = (ArrayType)type;
 
-                if (!arrayType.ElementType.IsValueType)
+                // If we're generating a template for this type, we can skip generating the hashtable entry
+                // since the type loader can just create this type at runtime if something needs it. It's
+                // okay to have multiple EETypes for the same array type.
+                var canonArrayType = arrayType.ConvertToCanonForm(CanonicalFormKind.Specific);
+                if (arrayType != canonArrayType && factory.NativeLayout.TemplateTypeLayout(canonArrayType).Marked)
                     continue;
 
                 // Look at the constructed type symbol. If a constructed type wasn't emitted, then the array map entry isn't valid for use

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DynamicInvokeTemplateDataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DynamicInvokeTemplateDataNode.cs
@@ -81,7 +81,9 @@ namespace ILCompiler.DependencyAnalysis
             {
                 new DependencyListEntry(factory.MethodEntrypoint(method), "Dynamic invoke stub"),
                 new DependencyListEntry(factory.NativeLayout.PlacedSignatureVertex(factory.NativeLayout.MethodNameAndSignatureVertex(method)), "Dynamic invoke stub"),
-                new DependencyListEntry(factory.NecessaryTypeSymbol(method.OwningType), "Dynamic invoke stub containing type")
+                new DependencyListEntry(factory.NecessaryTypeSymbol(method.OwningType), "Dynamic invoke stub containing type"),
+                new DependencyListEntry(factory.NativeLayout.TemplateMethodLayout(method), "Template"),
+                new DependencyListEntry(factory.NativeLayout.TemplateMethodEntry(method), "Template"),
             };
         }
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -993,6 +993,18 @@ internal class ReflectionTest
             public static unsafe ref ByRefLike ByRefLikeRefReturningMethod(ByRefLike* a) => ref *a;
         }
 
+        private sealed class TestClass2<T>
+        {
+            private T _value;
+
+            public TestClass2(T value) { _value = value; }
+
+#if OPTIMIZED_MODE_WITHOUT_SCANNER
+            [MethodImpl(MethodImplOptions.NoInlining)]
+#endif
+            public ref T RefReturningMethod(T someArgument) => ref _value;
+        }
+
         private sealed unsafe class TestClassIntPointer
         {
             private int* _value;
@@ -1031,6 +1043,10 @@ internal class ReflectionTest
             TestRefReturnInvoke(new BigStruct { X = 123, D = 456 }, (p, t) => p.GetGetMethod().Invoke(t, Array.Empty<object>()));
             TestRefReturnInvoke(new object(), (p, t) => p.GetGetMethod().Invoke(t, Array.Empty<object>()));
             TestRefReturnInvoke((object)null, (p, t) => p.GetGetMethod().Invoke(t, Array.Empty<object>()));
+
+            // Regression test
+            MethodInfo mi = typeof(TestClass2<string>).GetMethod(nameof(TestClass2<string>.RefReturningMethod));
+            mi.Invoke(new TestClass2<string>("Hello"), new object[] { "Hello" });
         }
 
         public static void TestRefReturnNullable()


### PR DESCRIPTION
I was looking at generating fewer type loader templates in the compiler this weekend (we currently generate a template for everything we compile, but we don't have to). The full fix might be more involved but I stumbled on a couple smaller bugs. See individual commits.