### PR TITLE
Add support for null arrays in the blittable array marshaller's pinning optimization.

### DIFF
--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/ArrayTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/ArrayTests.cs
@@ -67,8 +67,14 @@ namespace DllImportGenerator.IntegrationTests
         [Fact]
         public void IntArrayMarshalledToNativeAsExpected()
         {
-            var array = new [] { 1, 5, 79, 165, 32, 3 };
+            var array = new[] { 1, 5, 79, 165, 32, 3 };
             Assert.Equal(array.Sum(), NativeExportsNE.Arrays.Sum(array, array.Length));
+        }
+
+        [Fact]
+        public void NullIntArrayMarshalledToNativeAsExpected()
+        {
+            Assert.Equal(-1, NativeExportsNE.Arrays.Sum(null, 0));
         }
 
         [Fact]

--- a/DllImportGenerator/DllImportGenerator/Marshalling/BlittableArrayMarshaller.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/BlittableArrayMarshaller.cs
@@ -59,6 +59,14 @@ namespace Microsoft.Interop
                 string byRefIdentifier = $"__byref_{managedIdentifer}";
                 if (context.CurrentStage == StubCodeContext.Stage.Marshal)
                 {
+                    // [COMPAT] We use explicit byref calculations here instead of just using a fixed statement 
+                    // since a fixed statement converts a zero-length array to a null pointer.
+                    // Many native APIs, such as GDI+, ICU, etc. validate that an array parameter is non-null
+                    // even when the passed in array length is zero. To avoid breaking customers that want to move
+                    // to source-generated interop in subtle ways, we explicitly pass a reference to the 0-th element
+                    // of an array as long as it is non-null, matching the behavior of the built-in interop system
+                    // for single-dimensional zero-based arrays.
+
                     // ref <elementType> <byRefIdentifier> = <managedIdentifer> == null ? ref Unsafe.NullRef<<elementType>>() : ref MemoryMarshal.GetArrayDataReference(<managedIdentifer>);
                     var unsafeNullRef =
                         InvocationExpression(
@@ -96,7 +104,7 @@ namespace Microsoft.Interop
                 }
                 if (context.CurrentStage == StubCodeContext.Stage.Pin)
                 {
-                    // fixed (<nativeType> <nativeIdentifier> = &MemoryMarshal.GetArrayDataReference(<managedIdentifer>))
+                    // fixed (<nativeType> <nativeIdentifier> = &<byrefIdentifier>)
                     yield return FixedStatement(
                         VariableDeclaration(AsNativeType(info), SingletonSeparatedList(
                             VariableDeclarator(nativeIdentifier)

--- a/DllImportGenerator/DllImportGenerator/TypeNames.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeNames.cs
@@ -44,7 +44,9 @@ namespace Microsoft.Interop
         public const string System_Runtime_InteropServices_OutAttribute = "System.Runtime.InteropServices.OutAttribute";
 
         public const string System_Runtime_InteropServices_InAttribute = "System.Runtime.InteropServices.InAttribute";
-        
+
         public const string System_Runtime_CompilerServices_SkipLocalsInitAttribute = "System.Runtime.CompilerServices.SkipLocalsInitAttribute";
+
+        public const string System_Runtime_CompilerServices_Unsafe = "System.Runtime.CompilerServices.Unsafe";
     }
 }

--- a/DllImportGenerator/DllImportGenerator/TypeNames.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeNames.cs
@@ -46,7 +46,5 @@ namespace Microsoft.Interop
         public const string System_Runtime_InteropServices_InAttribute = "System.Runtime.InteropServices.InAttribute";
 
         public const string System_Runtime_CompilerServices_SkipLocalsInitAttribute = "System.Runtime.CompilerServices.SkipLocalsInitAttribute";
-
-        public const string System_Runtime_CompilerServices_Unsafe = "System.Runtime.CompilerServices.Unsafe";
     }
 }


### PR DESCRIPTION
Example generated code:

```csharp
void Foo(int[] p)
{
   ref int __byref_p = ref (p == null ? ref System.Runtime.CompilerServices.Unsafe.NullRef<int>() : ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(p));
   fixed (int* __p_gen_native= &p)
   {
        Foo__PInvoke__(__p_gen_native);
   }
}
```


Fixes #1051