### PR TITLE
fixed two fairly significant srm performance bugs

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
@@ -66,7 +66,7 @@ namespace System.Text.RegularExpressions.SRM
             var regex = new Regex(rootNode, options);
 //#if DEBUG
 //            //test the serialization roundtrip
-//            //effectively, all tests in DEBUG mode are run with deserialized matchers, not the original ones
+//            //effectively, here all tests in DEBUG mode are run with deserialized matchers, not the original ones
 //            StringBuilder sb = new();
 //            regex.Serialize(sb);
 //            regex = Regex.Deserialize(sb.ToString());
@@ -97,7 +97,7 @@ namespace System.Text.RegularExpressions.SRM
             input.Split(s_top_level_separator);
             //trim also whitespace from entries -- this implies for example that \r is removed if present in line endings
             string[] fragments = input.Split(s_top_level_separator, StringSplitOptions.TrimEntries);
-            if (fragments.Length != 12)
+            if (fragments.Length != 13)
                 throw new ArgumentException($"{nameof(Regex.Deserialize)} error", nameof(input));
 
             try

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/Base64.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/Base64.cs
@@ -152,6 +152,24 @@ namespace System.Text.RegularExpressions.SRM
         }
 
         /// <summary>
+        /// Custom Base64 encoder for char[].
+        /// Calls Encode for each character code. Numbers are separated by '.'.
+        /// Appends the serialized output to sb.
+        /// </summary>
+        public static void Encode(char[] arr, StringBuilder sb)
+        {
+            if (arr.Length == 0)
+                return;
+
+            sb.Append(Encode(arr[0]));
+            for (int i = 1; i < arr.Length; i++)
+            {
+                sb.Append('.');
+                sb.Append(Encode(arr[i]));
+            }
+        }
+
+        /// <summary>
         /// Custom Base64 encoder for string.
         /// Calls Encode for each character code. Numbers are separated by '.'.
         /// Appends the serialized output to sb.
@@ -205,6 +223,17 @@ namespace System.Text.RegularExpressions.SRM
         }
 
         /// <summary>
+        /// Custom Base64 deserializer for char.
+        /// </summary>
+        public static char DecodeChar(string s)
+        {
+            uint res = 0;
+            for (int i = 0; i < s.Length; i++)
+                res = (res << 6) | s_customBase64decoding[s[i] & 0x7F];
+            return (char)res;
+        }
+
+        /// <summary>
         /// Custom Base64 deserializer for long.
         /// </summary>
         public static long DecodeInt64(string s)
@@ -247,5 +276,10 @@ namespace System.Text.RegularExpressions.SRM
         /// Custom Base64 deserializer for ulong[].
         /// </summary>
         public static ulong[] DecodeUInt64Array(string s) => (s == string.Empty ? Array.Empty<ulong>() : Array.ConvertAll(s.Split('.'), DecodeUInt64));
+
+        /// <summary>
+        /// Custom Base64 deserializer for char[].
+        /// </summary>
+        public static char[] DecodeCharArray(string s) => (s == string.Empty ? Array.Empty<char>() : Array.ConvertAll(s.Split('.'), DecodeChar));
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -56,52 +56,80 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Contains(".*a+", str);
         }
 
-        //[Fact]
-        private void Test()
+        [Fact]
+        public void TestWordBoundary()
         {
-            //var re = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA);
-            //var re = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
-            //var re = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
-            //var re = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
-            //var re = new Regex(@"\b\w+nn\b", DFA);
-            //var re = new Regex(@"abracadabra\z", DFA | RegexOptions.Multiline);
-            //var re = new Regex("^.{5}", DFA);
-            //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
-            //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
-            //var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
-            //var re = new Regex(@"(([a-z])+.)+[A-Z]([a-z])+", DFA | RegexOptions.Singleline);
-            //var re = new Regex("ab+c$", DFA);
-            //ViewDGML(regex: re);
-            //ViewDGML(regex: re, addDotStar: true);
-            //ViewDGML(regex: re, inReverse: true);
-            //var match = re.Match("_.@[0.0.0.aaaaaaaaaa]");
-            string[] rawregexes = File.ReadAllLines("c:/tmp/VS19preview/cortana.txt");
-            HashSet<int> notsupported = new();
-            HashSet<string> set = new();
-            Regex QsizeMatcher = new Regex(@"\|Q\|=[0-9]+", DFA);
-            Regex DsizeMatcher = new Regex(@"\|&#x0394;\|=[0-9]+", DFA);
-            Regex AsizeMatcher = new Regex(@"\|&#x03A3;\|=[0-9]+", DFA);
-            Func<string, int> NrOfStates = (s) => int.Parse(QsizeMatcher.Match(s).Value.Substring(4));
-            Func<string, int> NrOfMoves = (s) => int.Parse(DsizeMatcher.Match(s).Value.Substring(11));
-            Func<string, int> NrOfSymbols = (s) => int.Parse(AsizeMatcher.Match(s).Value.Substring(11));
-            HashSet<int> stateSizes = new();
-            HashSet<int> moveSizes = new();
-            HashSet<int> alphSizes = new();
-            for (int i = 0; i < rawregexes.Length; i++)
-            {
-                var re = new Regex(rawregexes[i], DFA);
-                StringWriter sw = new StringWriter();
-                SaveDGML(re, sw, onlyDFAinfo: true);
-                ViewDGML(re);
-                int n = NrOfStates(sw.ToString());
-                int m = NrOfMoves(sw.ToString());
-                int k = NrOfSymbols(sw.ToString());
-                stateSizes.Add(n);
-                moveSizes.Add(m);
-                alphSizes.Add(k);
-            }
-            Console.WriteLine(stateSizes.Count);
+            var re = new Regex(@"\b\w+nn\b", DFA);
+            var match = re.Match("both Anne and Ann are names that contain nn");
+            Assert.True(match.Success);
+            Assert.Equal<int>(14, match.Index);
+            Assert.Equal<int>(3, match.Length);
+            var match2 = match.NextMatch();
+            Assert.False(match2.Success);
         }
+
+        [Fact]
+        public void TestStartSet()
+        {
+            var re = new Regex(@"\u221E|\u2713", DFA);
+            var match = re.Match("infinity \u221E and checkmark \u2713 are contained here");
+            Assert.True(match.Success);
+            Assert.Equal<int>(9, match.Index);
+            Assert.Equal<int>(1, match.Length);
+            var match2 = match.NextMatch();
+            Assert.True(match2.Success);
+            Assert.Equal<int>(25, match2.Index);
+            Assert.Equal<int>(1, match2.Length);
+            var match3 = match2.NextMatch();
+            Assert.False(match3.Success);
+        }
+
+        //[Fact]
+        //public void Test()
+        //{
+        //var re = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA);
+        //var re = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
+        //var re = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
+        //var re = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
+        //var re = new Regex(@"\b\w+nn\b", DFA);
+        //var re = new Regex(@"abracadabra\z", DFA | RegexOptions.Multiline);
+        //var re = new Regex("^.{5}", DFA);
+        //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
+        //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
+        //var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
+        //var re = new Regex(@"(([a-z])+.)+[A-Z]([a-z])+", DFA | RegexOptions.Singleline);
+        //var re = new Regex("ab+c$", DFA);
+        //ViewDGML(regex: re);
+        //ViewDGML(regex: re, addDotStar: true);
+        //ViewDGML(regex: re, inReverse: true);
+        //var match = re.Match("_.@[0.0.0.aaaaaaaaaa]");
+        //string[] rawregexes = File.ReadAllLines("c:/tmp/VS19preview/cortana.txt");
+        //HashSet<int> notsupported = new();
+        //HashSet<string> set = new();
+        //Regex QsizeMatcher = new Regex(@"\|Q\|=[0-9]+", DFA);
+        //Regex DsizeMatcher = new Regex(@"\|&#x0394;\|=[0-9]+", DFA);
+        //Regex AsizeMatcher = new Regex(@"\|&#x03A3;\|=[0-9]+", DFA);
+        //Func<string, int> NrOfStates = (s) => int.Parse(QsizeMatcher.Match(s).Value.Substring(4));
+        //Func<string, int> NrOfMoves = (s) => int.Parse(DsizeMatcher.Match(s).Value.Substring(11));
+        //Func<string, int> NrOfSymbols = (s) => int.Parse(AsizeMatcher.Match(s).Value.Substring(11));
+        //HashSet<int> stateSizes = new();
+        //HashSet<int> moveSizes = new();
+        //HashSet<int> alphSizes = new();
+        //for (int i = 0; i < rawregexes.Length; i++)
+        //{
+        //    var re = new Regex(rawregexes[i], DFA);
+        //    StringWriter sw = new StringWriter();
+        //    SaveDGML(re, sw, onlyDFAinfo: true);
+        //    ViewDGML(re);
+        //    int n = NrOfStates(sw.ToString());
+        //    int m = NrOfMoves(sw.ToString());
+        //    int k = NrOfSymbols(sw.ToString());
+        //    stateSizes.Add(n);
+        //    moveSizes.Add(m);
+        //    alphSizes.Add(k);
+        //}
+        //Console.WriteLine(stateSizes.Count);
+        //}
 
         [Fact]
         public void SRMPrefixBugFixTest()


### PR DESCRIPTION
In regexes such as (a|b): enabled use of startset for small startsets using string.IndexOfAny that was not being utilized although startset had been computed. Added also calculation of startset in form of a character array for fast access, this was also missing in deserialization code that was fixed (that was a correctness bug).

In the case of regexes starting with anchors (such as \b) fixed detection of nullability that was being precomputed over and over causing bad performance for fairly simple regexes. In particular the 'CanBeNullable' info was not used at all (a clear performance bug). Also cached (per node) context dependent nullability info so that this info  is not recomputed each time (as a further optimization, but I don't think this was the main culprit).

