### PR TITLE
Infer target architecture from RID

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
@@ -8,7 +8,15 @@
     <OSIdentifier Condition="$(RuntimeIdentifier.StartsWith('linux-musl')) OR $(RuntimeIdentifier.StartsWith('alpine'))">linux-musl</OSIdentifier>
     <OSIdentifier Condition="'$(OSIdentifier)' == ''">linux</OSIdentifier>
 
-    <RuntimeIlcPackageName>runtime.$(OSIdentifier)-$(PlatformTarget).Microsoft.DotNet.ILCompiler</RuntimeIlcPackageName>
+    <!-- Determine TargetArchitecture from RuntimeIdentifier -->
+    <RidWithHyphen>$(RuntimeIdentifier)-</RidWithHyphen>
+    <TargetArchitecture Condition="$(RidWithHyphen.Contains('-x86-'))">x86</TargetArchitecture>
+    <TargetArchitecture Condition="$(RidWithHyphen.Contains('-x64-'))">x64</TargetArchitecture>
+    <TargetArchitecture Condition="$(RidWithHyphen.Contains('-arm-'))">arm</TargetArchitecture>
+    <TargetArchitecture Condition="$(RidWithHyphen.Contains('-arm64-'))">arm64</TargetArchitecture>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">unknown</TargetArchitecture>
+
+    <RuntimeIlcPackageName>runtime.$(OSIdentifier)-$(TargetArchitecture).Microsoft.DotNet.ILCompiler</RuntimeIlcPackageName>
 
     <OSHostArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</OSHostArch>
     <!-- OSArchitecture does not report the true OS architecture for x86 and x64 processes running on Windows ARM64. -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -69,7 +69,7 @@
       Text="Native compilation can run on x64 and arm64 hosts only." />
 
     <Error Condition="'$(IlcHostPackagePath)' == '' and '$(RuntimePackagePath)' != '' and ('$(IlcHostArch)' == 'x64' or '$(IlcHostArch)' == 'arm64')"
-      Text="Add a PackageReference for '$(IlcHostPackageName)' to allow cross-compilation for $(PlatformTarget)" />
+      Text="Add a PackageReference for '$(IlcHostPackageName)' to allow cross-compilation for $(TargetArchitecture)" />
 
     <!-- CoreRT SDK and Framework Assemblies need to be defined to avoid CoreCLR implementations being set as compiler inputs -->
     <Error Condition="'@(PrivateSdkAssemblies)' == ''" Text="The PrivateSdkAssemblies ItemGroup is required for _ComputeAssembliesToCompileToNative" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -89,7 +89,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <Message Condition="'$(_WhereCppTools)' != '0'" Text="Tools '$(CppCompiler)' and '$(CppLinker)' not found on PATH. Attempting to autodetect." />
 
-    <Exec Condition="'$(_WhereCppTools)' != '0'" Command="&quot;$(MSBuildThisFileDirectory)findvcvarsall.bat&quot; $(PlatformTarget)"
+    <Exec Condition="'$(_WhereCppTools)' != '0'" Command="&quot;$(MSBuildThisFileDirectory)findvcvarsall.bat&quot; $(TargetArchitecture)"
       IgnoreExitCode="true" ConsoleToMSBuild="true" StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="_FindVCVarsallOutput" />
       <Output TaskParameter="ExitCode" PropertyName="_VCVarsAllFound" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -170,7 +170,7 @@ The .NET Foundation licenses this file to you under the MIT license.
           FrameworkObjPath=$(FrameworkObjPath);
           RuntimePackagePath=$(RuntimePackagePath);
           IlcHostPackagePath=$(IlcHostPackagePath);
-          PlatformTarget=$(PlatformTarget);
+          TargetArchitecture=$(TargetArchitecture);
         </AdditionalProperties>
       </ProjectToBuild>
     </ItemGroup>
@@ -230,7 +230,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(IlcReference->'-r:%(Identity)')" />
       <IlcArg Include="@(MibcFile->'--mibc:%(Identity)')" />
       <IlcArg Condition="$(IlcGenerateMetadataLog) == 'true'" Include="--metadatalog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).metadata.csv" />
-      <IlcArg Condition="$(PlatformTarget) != ''" Include="--targetarch:$(PlatformTarget)" />
+      <IlcArg Condition="$(TargetArchitecture) != ''" Include="--targetarch:$(TargetArchitecture)" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
       <IlcArg Condition="$(NativeDebugSymbols) == 'true'" Include="-g" />

--- a/src/tests/Common/CLRTest.NativeAot.targets
+++ b/src/tests/Common/CLRTest.NativeAot.targets
@@ -152,7 +152,7 @@ if defined RunNativeAot (
     <OutputType>Exe</OutputType>
     <OutputPath>%24(MSBuildProjectDirectory)\</OutputPath>
     <IntermediateOutputPath>%24(MSBuildProjectDirectory)\</IntermediateOutputPath>
-    <PlatformTarget>$(TargetArchitecture)</PlatformTarget>
+    <TargetArchitecture>$(TargetArchitecture)</TargetArchitecture>
     <Optimize>$(Optimize)</Optimize>
     <DebugSymbols>true</DebugSymbols>
     <NETCoreSdkVersion>$(NETCoreSdkVersion)</NETCoreSdkVersion>


### PR DESCRIPTION
`dotnet publish` should not use `PlatformTarget` as it may be set to `AnyCPU`. Fixes #1013.