### PR TITLE
Clean up native artifacts by default

### DIFF
--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -313,7 +313,7 @@ if defined RunCrossGen (
   call :ReleaseLock
 )
 if defined RunNativeAot (
-  if NOT "%CLRTestNoCleanup%" == "" (
+  if not defined CLRTestNoCleanup (
     IF EXIST native rmdir /s /q native
   )
 )


### PR DESCRIPTION
The condition was written incorrectly. We want to delete compilation artifacts by default.