### PR TITLE
Don't pass PlatformTarget to libraries testing

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -22,7 +22,6 @@
 
   <PropertyGroup Condition="'$(ClrNativeAot)' == 'true'">
     <IlcPath>$(TestNativeAotCompilerRootPath)</IlcPath>
-    <PlatformTarget>$(TargetArchitecture)</PlatformTarget>
     <SelfContained>true</SelfContained>
     <NoWarn>$(NoWarn);IL9700;IL9701;IL1005</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Shouldn't be needed after #1072.