### PR TITLE
Fix support for BStr marshalling

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -543,6 +543,7 @@ namespace Internal.TypeSystem.Interop
                         }
 
                     case NativeTypeKind.TBStr:
+                    case NativeTypeKind.BStr:
                         return MarshallerKind.BSTRString;
 
                     case NativeTypeKind.Default:

--- a/src/coreclr/tools/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
@@ -19,6 +19,7 @@ namespace Internal.TypeSystem
         U8 = 0xa,
         R4 = 0xb,
         R8 = 0xc,
+        BStr = 0x13,
         LPStr = 0x14,
         LPWStr = 0x15,
         LPTStr = 0x16,        // Ptr to OS preferred (SBCS/Unicode) string


### PR DESCRIPTION
Previously I incorrectly assume that TBStr is same as BStr.
I have plans to address that after #1061 since TBStr require to switch between BStr or AnsiBStr implementation most likely.