### PR TITLE
Disable the test for the Marshal switch now that it currently is a no-op.

### DIFF
--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -253,14 +253,10 @@ namespace DllImportGenerator.UnitTests
 
         public static IEnumerable<object[]> CodeSnippetsToCompileWithMarshalType()
         {
-            // SetLastError
-            yield return new[] { CodeSnippets.AllSupportedDllImportNamedArguments };
-
-            // SafeHandle
-            yield return new[] { CodeSnippets.BasicParametersAndModifiers("Microsoft.Win32.SafeHandles.SafeFileHandle") };
+            yield break;
         }
 
-        [Theory]
+        [Theory(Skip = "No current scenarios to test.")]
         [MemberData(nameof(CodeSnippetsToCompileWithMarshalType))]
         public async Task ValidateSnippetsWithMarshalType(string source)
         {


### PR DESCRIPTION
 I've disabled the test so that we can re-enable it if we end up adding more APIs to the MarshalEx surface.