### PR TITLE
Mark Array.CreateInstance and Type.MakeArrayType AOT unsafe

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Extensions/NonPortable/CustomAttributeInstantiator.cs
@@ -126,6 +126,8 @@ namespace Internal.Reflection.Extensions.NonPortable
         //
         // Convert the argument value reported by Reflection into an actual object.
         //
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The AOT compiler ensures array types required by custom attribute blobs are generated.")]
         private static object Convert(this CustomAttributeTypedArgument typedArgument)
         {
             Type argumentType = typedArgument.ArgumentType;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/EnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/EnumInfo.cs
@@ -50,7 +50,18 @@ namespace Internal.Runtime.Augments
             // declaring "rawValues" as "Array" would prevent us from using the generic overload of Array.Sort()).
             //
             // The array element type is the underlying type, not the enum type. (The enum type could be an open generic.)
-            ValuesAsUnderlyingType = Array.CreateInstance(UnderlyingType, numValues);
+            ValuesAsUnderlyingType = Type.GetTypeCode(UnderlyingType) switch
+            {
+                TypeCode.Byte => new byte[numValues],
+                TypeCode.SByte => new sbyte[numValues],
+                TypeCode.UInt16 => new ushort[numValues],
+                TypeCode.Int16 => new short[numValues],
+                TypeCode.UInt32 => new uint[numValues],
+                TypeCode.Int32 => new int[numValues],
+                TypeCode.UInt64 => new ulong[numValues],
+                TypeCode.Int64 => new long[numValues],
+                _ => throw new NotSupportedException(),
+            };
             Array.Copy(rawValues, ValuesAsUnderlyingType, numValues);
 
             HasFlagsAttribute = isFlags;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Runtime;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
@@ -122,6 +123,8 @@ namespace Internal.Runtime.Augments
         // As a concession to the fact that we don't actually support non-zero lower bounds, "lowerBounds" accepts "null"
         // to avoid unnecessary array allocations by the caller.
         //
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures that if we have a TypeHandle of a Rank-1 MdArray, we also generated the SzArray.")]
         public static unsafe Array NewMultiDimArray(RuntimeTypeHandle typeHandleForArrayType, int[] lengths, int[] lowerBounds)
         {
             Debug.Assert(lengths != null);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ArrayHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ArrayHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime;
+using System.Diagnostics.CodeAnalysis;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -17,6 +18,8 @@ namespace Internal.Runtime.CompilerHelpers
         /// Helper for array allocations via `newobj` IL instruction. Dimensions are passed in as block of integers.
         /// The content of the dimensions block may be modified by the helper.
         /// </summary>
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures that if we have a TypeHandle of a Rank-1 MdArray, we also generated the SzArray.")]
         public static unsafe Array NewObjArray(IntPtr pEEType, int nDimensions, int* pDimensions)
         {
             EETypePtr eeType = new EETypePtr(pEEType);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.CoreRT.cs
@@ -5,6 +5,7 @@ using System.Runtime;
 using System.Threading;
 using System.Collections;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
@@ -62,6 +63,7 @@ namespace System
             return EETypePtr.EETypePtrOf<Array>().ToPointer();
         }
 
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         public static Array CreateInstance(Type elementType, int length)
         {
             if (elementType is null)
@@ -70,6 +72,8 @@ namespace System
             return CreateSzArray(elementType, length);
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "MDArrays of Rank != 1 can be created because they don't implement generic interfaces.")]
         public static unsafe Array CreateInstance(Type elementType, int length1, int length2)
         {
             if (elementType is null)
@@ -86,6 +90,8 @@ namespace System
             return NewMultiDimArray(arrayType.TypeHandle.ToEETypePtr(), pLengths, 2);
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "MDArrays of Rank != 1 can be created because they don't implement generic interfaces.")]
         public static unsafe Array CreateInstance(Type elementType, int length1, int length2, int length3)
         {
             if (elementType is null)
@@ -105,6 +111,7 @@ namespace System
             return NewMultiDimArray(arrayType.TypeHandle.ToEETypePtr(), pLengths, 3);
         }
 
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         public static Array CreateInstance(Type elementType, params int[] lengths)
         {
             if (elementType is null)
@@ -133,6 +140,7 @@ namespace System
             }
         }
 
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         public static Array CreateInstance(Type elementType, int[] lengths, int[] lowerBounds)
         {
             if (elementType is null)
@@ -149,6 +157,7 @@ namespace System
             return CreateMultiDimArray(elementType, lengths, lowerBounds);
         }
 
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         private static Array CreateSzArray(Type elementType, int length)
         {
             // Though our callers already validated length once, this parameter is passed via arrays, so we must check it again
@@ -160,6 +169,7 @@ namespace System
             return RuntimeImports.RhNewArray(arrayType.TypeHandle.ToEETypePtr(), length);
         }
 
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         private static Array CreateMultiDimArray(Type elementType, int[] lengths, int[] lowerBounds)
         {
             Debug.Assert(lengths != null);
@@ -176,6 +186,7 @@ namespace System
             return RuntimeAugments.NewMultiDimArray(arrayType.TypeHandle, lengths, lowerBounds);
         }
 
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         private static Type GetArrayTypeFromElementType(Type elementType, bool multiDim, int rank)
         {
             elementType = elementType.UnderlyingSystemType;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/CustomAttributeExtensions.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/CustomAttributeExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -334,6 +335,8 @@ namespace System.Reflection
         // There are known store apps that cast the results of apis and expect the cast to work. The implementation of Attribute.GetCustomAttribute()
         // also relies on this (it performs an unsafe cast to Attribute[] and does not re-copy the array.)
         //==============================================================================================================================
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "Arrays of reference types are safe to create.")]
         private static IEnumerable<Attribute> Instantiate(this IEnumerable<CustomAttributeData> cads, Type actualElementType)
         {
             LowLevelList<Attribute> attributes = new LowLevelList<Attribute>();

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/Helpers.cs
@@ -185,6 +185,8 @@ namespace System.Reflection.Runtime.General
         // Helper for ICustomAttributeProvider.GetCustomAttributes(). The result of this helper is returned directly to apps
         // so it must always return a newly allocated array. Unlike most of the newer custom attribute apis, the attribute type
         // need not derive from System.Attribute. (In particular, it can be an interface or System.Object.)
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "Array.CreateInstance is only used with reference types here and is therefore safe.")]
         public static object[] InstantiateAsArray(this IEnumerable<CustomAttributeData> cads, Type actualElementType)
         {
             LowLevelList<object> attributes = new LowLevelList<object>();

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using System.Reflection;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection.Runtime.Assemblies;
@@ -793,6 +794,8 @@ namespace System.Reflection.Runtime.General
             return result;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures we have array types referenced from custom attribute blobs")]
         public static byte[] ToArray(this ByteCollection collection, Type enumType = null)
         {
             int count = collection.Count;
@@ -815,6 +818,8 @@ namespace System.Reflection.Runtime.General
             return result;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures we have array types referenced from custom attribute blobs")]
         public static sbyte[] ToArray(this SByteCollection collection, Type enumType = null)
         {
             int count = collection.Count;
@@ -837,6 +842,8 @@ namespace System.Reflection.Runtime.General
             return result;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures we have array types referenced from custom attribute blobs")]
         public static ushort[] ToArray(this UInt16Collection collection, Type enumType = null)
         {
             int count = collection.Count;
@@ -859,6 +866,8 @@ namespace System.Reflection.Runtime.General
             return result;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures we have array types referenced from custom attribute blobs")]
         public static short[] ToArray(this Int16Collection collection, Type enumType = null)
         {
             int count = collection.Count;
@@ -881,6 +890,8 @@ namespace System.Reflection.Runtime.General
             return result;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures we have array types referenced from custom attribute blobs")]
         public static uint[] ToArray(this UInt32Collection collection, Type enumType = null)
         {
             int count = collection.Count;
@@ -903,6 +914,8 @@ namespace System.Reflection.Runtime.General
             return result;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures we have array types referenced from custom attribute blobs")]
         public static int[] ToArray(this Int32Collection collection, Type enumType = null)
         {
             int count = collection.Count;
@@ -925,6 +938,8 @@ namespace System.Reflection.Runtime.General
             return result;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures we have array types referenced from custom attribute blobs")]
         public static ulong[] ToArray(this UInt64Collection collection, Type enumType = null)
         {
             int count = collection.Count;
@@ -947,6 +962,8 @@ namespace System.Reflection.Runtime.General
             return result;
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "The compiler ensures we have array types referenced from custom attribute blobs")]
         public static long[] ToArray(this Int64Collection collection, Type enumType = null)
         {
             int count = collection.Count;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/NativeFormat/NativeFormatRuntimeModule.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/Modules/NativeFormat/NativeFormatRuntimeModule.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Runtime.Assemblies;
 using System.Reflection.Runtime.General;
 using System.Reflection.Runtime.CustomAttributes;
@@ -60,6 +60,7 @@ namespace System.Reflection.Runtime.Modules.NativeFormat
             }
         }
 
+        [RequiresUnreferencedCode("Fields might be removed")]
         public sealed override FieldInfo GetField(string name, BindingFlags bindingAttr)
         {
             QScopeDefinition scope = _assembly.Scope;
@@ -67,6 +68,7 @@ namespace System.Reflection.Runtime.Modules.NativeFormat
             return scope.ScopeDefinition.GlobalModuleType.GetNamedType(reader).GetField(name, bindingAttr);
         }
 
+        [RequiresUnreferencedCode("Fields might be removed")]
         public sealed override FieldInfo[] GetFields(BindingFlags bindingFlags)
         {
             QScopeDefinition scope = _assembly.Scope;
@@ -74,6 +76,7 @@ namespace System.Reflection.Runtime.Modules.NativeFormat
             return scope.ScopeDefinition.GlobalModuleType.GetNamedType(reader).GetFields(bindingFlags);
         }
 
+        [RequiresUnreferencedCode("Methods might be removed")]
         protected sealed override MethodInfo GetMethodImpl(string name, BindingFlags bindingAttr, Binder binder, CallingConventions callConvention, Type[] types, ParameterModifier[] modifiers)
         {
             QScopeDefinition scope = _assembly.Scope;
@@ -90,6 +93,7 @@ namespace System.Reflection.Runtime.Modules.NativeFormat
             }
         }
 
+        [RequiresUnreferencedCode("Methods might be removed")]
         public sealed override MethodInfo[] GetMethods(BindingFlags bindingFlags)
         {
             QScopeDefinition scope = _assembly.Scope;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeName.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeParsing/TypeName.cs
@@ -190,6 +190,8 @@ namespace System.Reflection.Runtime.TypeParsing
             return ElementTypeName + "[]";
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:AotUnfriendlyApi",
+            Justification = "Used to implement resolving types from strings.")]
         public sealed override Type ResolveType(Assembly containingAssemblyIfAny, GetTypeOptions getTypeOptions)
         {
             return ElementTypeName.ResolveType(containingAssemblyIfAny, getTypeOptions)?.MakeArrayType();
@@ -212,6 +214,8 @@ namespace System.Reflection.Runtime.TypeParsing
             return ElementTypeName + "[" + (_rank == 1 ? "*" : new string(',', _rank - 1)) + "]";
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:AotUnfriendlyApi",
+            Justification = "Used to implement resolving types from strings.")]
         public sealed override Type ResolveType(Assembly containingAssemblyIfAny, GetTypeOptions getTypeOptions)
         {
             return ElementTypeName.ResolveType(containingAssemblyIfAny, getTypeOptions)?.MakeArrayType(_rank);

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -68,6 +68,7 @@ namespace System
             Debug.Assert(array != null);
         }
 
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         public static Array CreateInstance(Type elementType, params long[] lengths)
         {
             if (lengths == null)

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
@@ -12,6 +12,7 @@
 ===========================================================*/
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Collections
 {
@@ -716,6 +717,7 @@ namespace System.Collections
         // downcasting all elements.  This copy may fail and is an O(n) operation.
         // Internally, this implementation calls Array.Copy.
         //
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         public virtual Array ToArray(Type type)
         {
             if (type == null)
@@ -1099,6 +1101,7 @@ namespace System.Collections
                 return array;
             }
 
+            [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
             public override Array ToArray(Type type)
             {
                 if (type == null)
@@ -1492,6 +1495,7 @@ namespace System.Collections
                 }
             }
 
+            [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
             public override Array ToArray(Type type)
             {
                 lock (_root)
@@ -1874,6 +1878,7 @@ namespace System.Collections
                 return _list.ToArray();
             }
 
+            [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
             public override Array ToArray(Type type)
             {
                 return _list.ToArray(type);
@@ -2125,6 +2130,7 @@ namespace System.Collections
                 return _list.ToArray();
             }
 
+            [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
             public override Array ToArray(Type type)
             {
                 return _list.ToArray(type);
@@ -2578,6 +2584,7 @@ namespace System.Collections
                 return array;
             }
 
+            [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
             public override Array ToArray(Type type)
             {
                 if (type == null)

--- a/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using CultureInfo = System.Globalization.CultureInfo;
 
 namespace System
@@ -27,6 +28,8 @@ namespace System
         //
         // The most specific match will be selected.
         //
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:RequiresDynamicCode",
+            Justification = "Known corner case bug https://github.com/dotnet/runtimelab/issues/1079.")]
         public sealed override MethodBase BindToMethod(
             BindingFlags bindingAttr, MethodBase[] match, ref object?[] args,
             ParameterModifier[]? modifiers, CultureInfo? cultureInfo, string[]? names, out object? state)

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureTypeExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/SignatureTypeExtensions.cs
@@ -166,6 +166,8 @@ namespace System.Reflection
             }
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:AotUnfriendlyApi",
+            Justification = "Used to find matching method overloads. Only used for assignability checks.")]
         private static Type? TryMakeArrayType(this Type type)
         {
             try
@@ -178,6 +180,8 @@ namespace System.Reflection
             }
         }
 
+        [UnconditionalSuppressMessage("AotAnalysis", "IL9700:AotUnfriendlyApi",
+            Justification = "Used to find matching method overloads. Only used for assignability checks.")]
         private static Type? TryMakeArrayType(this Type type, int rank)
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -497,7 +497,9 @@ namespace System
             throw NotImplemented.ByDesign;
         }
 
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         public virtual Type MakeArrayType() => throw new NotSupportedException();
+        [RequiresDynamicCode("The native code for the array might not be available at runtime.")]
         public virtual Type MakeArrayType(int rank) => throw new NotSupportedException();
         public virtual Type MakeByRefType() => throw new NotSupportedException();
         [RequiresDynamicCode("The native code for this instantiation might not be available at runtime.")]


### PR DESCRIPTION
These potentially require runtime code generation, same as MakeGenericType.