### PR TITLE
Define the inner P/Invokes as local functions instead of externally.

### DIFF
--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/ArrayTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/ArrayTests.cs
@@ -16,6 +16,9 @@ namespace DllImportGenerator.IntegrationTests
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array")]
             public static partial int Sum(int[] values, int numValues);
 
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array")]
+            public static partial int Sum(ref int values, int numValues);
+
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array_ref")]
             public static partial int SumInArray(in int[] values, int numValues);
 
@@ -69,6 +72,13 @@ namespace DllImportGenerator.IntegrationTests
         {
             var array = new[] { 1, 5, 79, 165, 32, 3 };
             Assert.Equal(array.Sum(), NativeExportsNE.Arrays.Sum(array, array.Length));
+        }
+
+        [Fact]
+        public void IntArrayRefToFirstElementMarshalledToNativeAsExpected()
+        {
+            var array = new[] { 1, 5, 79, 165, 32, 3 };
+            Assert.Equal(array.Sum(), NativeExportsNE.Arrays.Sum(ref array[0], array.Length));
         }
 
         [Fact]

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -279,5 +279,26 @@ namespace DllImportGenerator.UnitTests
                 Assert.StartsWith("'Marshal' does not contain a definition for ", diag.GetMessage());
             });
         }
+
+        public static IEnumerable<object[]> CodeSnippetsToCompileMultipleSources()
+        {
+            yield return new object[] { new[] { CodeSnippets.BasicParametersAndModifiers<int>(), CodeSnippets.MarshalAsParametersAndModifiers<bool>(UnmanagedType.Bool) } };
+            yield return new object[] { new[] { CodeSnippets.BasicParametersAndModifiersWithCharSet<int>(CharSet.Unicode), CodeSnippets.MarshalAsParametersAndModifiers<bool>(UnmanagedType.Bool) } };
+            yield return new object[] { new[] { CodeSnippets.BasicParameterByValue("int[]"), CodeSnippets.BasicParameterWithByRefModifier("ref", "int") } };
+        }
+
+        [Theory]
+        [MemberData(nameof(CodeSnippetsToCompileMultipleSources))]
+        public async Task ValidateSnippetsWithMultipleSources(string[] sources)
+        {
+            Compilation comp = await TestUtils.CreateCompilation(sources);
+            TestUtils.AssertPreSourceGeneratorCompilation(comp);
+
+            var newComp = TestUtils.RunGenerators(comp, out var generatorDiags, new Microsoft.Interop.DllImportGenerator());
+            Assert.Empty(generatorDiags);
+
+            var newCompDiags = newComp.GetDiagnostics();
+            Assert.Empty(newCompDiags);
+        }
     }
 }

--- a/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
@@ -55,6 +55,24 @@ namespace DllImportGenerator.UnitTests
         }
 
         /// <summary>
+        /// Create a compilation given sources
+        /// </summary>
+        /// <param name="sources">Sources to compile</param>
+        /// <param name="outputKind">Output type</param>
+        /// <param name="allowUnsafe">Whether or not use of the unsafe keyword should be allowed</param>
+        /// <returns>The resulting compilation</returns>
+        public static async Task<Compilation> CreateCompilation(string[] sources, OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary, bool allowUnsafe = true, IEnumerable<string>? preprocessorSymbols = null)
+        {
+            var (mdRefs, ancillary) = GetReferenceAssemblies();
+
+            return CSharpCompilation.Create("compilation",
+                sources.Select(source =>
+                    CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview, preprocessorSymbols: preprocessorSymbols))).ToArray(),
+                (await mdRefs.ResolveAsync(LanguageNames.CSharp, CancellationToken.None)).Add(ancillary),
+                new CSharpCompilationOptions(outputKind, allowUnsafe: allowUnsafe));
+        }
+
+        /// <summary>
         /// Create a compilation given source and reference assemblies
         /// </summary>
         /// <param name="source">Source to compile</param>

--- a/DllImportGenerator/DllImportGenerator/DllImportStub.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportStub.cs
@@ -56,8 +56,6 @@ namespace Microsoft.Interop
 
         public BlockSyntax StubCode { get; init; }
 
-        public MethodDeclarationSyntax DllImportDeclaration { get; init; }
-
         public AttributeListSyntax[] AdditionalAttributes { get; init; }
 
         /// <summary>
@@ -210,7 +208,7 @@ namespace Microsoft.Interop
 
             // Generate stub code
             var stubGenerator = new StubCodeGenerator(method, dllImportData, paramsTypeInfo, retTypeInfo, diagnostics, env.Options);
-            var (code, dllImport) = stubGenerator.GenerateSyntax();
+            var code = stubGenerator.GenerateSyntax();
 
             var additionalAttrs = new List<AttributeListSyntax>();
 
@@ -235,7 +233,6 @@ namespace Microsoft.Interop
                 StubTypeNamespace = stubTypeNamespace,
                 StubContainingTypes = containingTypes,
                 StubCode = code,
-                DllImportDeclaration = dllImport,
                 AdditionalAttributes = additionalAttrs.ToArray(),
             };
         }

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -115,7 +115,7 @@ namespace Microsoft.Interop
             }
         }
 
-        public (BlockSyntax Code, MethodDeclarationSyntax DllImport) GenerateSyntax()
+        public BlockSyntax GenerateSyntax()
         {
             string dllImportName = stubMethod.Name + "__PInvoke__";
             var setupStatements = new List<StatementSyntax>();
@@ -340,20 +340,22 @@ namespace Microsoft.Interop
             var codeBlock = Block(UnsafeStatement(Block(allStatements)));
 
             // Define P/Invoke declaration
-            var dllImport = MethodDeclaration(retMarshaller.Generator.AsNativeType(retMarshaller.TypeInfo), dllImportName)
+            var dllImport = LocalFunctionStatement(retMarshaller.Generator.AsNativeType(retMarshaller.TypeInfo), dllImportName)
                 .AddModifiers(
                     Token(SyntaxKind.ExternKeyword),
-                    Token(SyntaxKind.PrivateKeyword),
                     Token(SyntaxKind.StaticKeyword),
                     Token(SyntaxKind.UnsafeKeyword))
-                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+                .WithAttributeLists(
+                    SingletonList(AttributeList(
+                        SingletonSeparatedList(CreateDllImportAttributeForTarget(GetTargetDllImportDataFromStubData())))));
             foreach (var marshaller in paramMarshallers)
             {
                 ParameterSyntax paramSyntax = marshaller.Generator.AsParameter(marshaller.TypeInfo);
                 dllImport = dllImport.AddParameterListParameters(paramSyntax);
             }
 
-            return (codeBlock, dllImport);
+            return codeBlock.AddStatements(dllImport);
 
             List<StatementSyntax> GetStatements(Stage stage)
             {
@@ -398,6 +400,132 @@ namespace Microsoft.Interop
                     generator.AsNativeType(info),
                     native));
             }
+        }
+
+        private static AttributeSyntax CreateDllImportAttributeForTarget(DllImportStub.GeneratedDllImportData targetDllImportData)
+        {
+            var newAttributeArgs = new List<AttributeArgumentSyntax>
+            {
+                AttributeArgument(LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    Literal(targetDllImportData.ModuleName))),
+                AttributeArgument(
+                    NameEquals(nameof(DllImportAttribute.EntryPoint)),
+                    null,
+                    CreateStringExpressionSyntax(targetDllImportData.EntryPoint))
+            };
+
+            if (targetDllImportData.IsUserDefined.HasFlag(DllImportStub.DllImportMember.BestFitMapping))
+            {
+                var name = NameEquals(nameof(DllImportAttribute.BestFitMapping));
+                var value = CreateBoolExpressionSyntax(targetDllImportData.BestFitMapping);
+                newAttributeArgs.Add(AttributeArgument(name, null, value));
+            }
+            if (targetDllImportData.IsUserDefined.HasFlag(DllImportStub.DllImportMember.CallingConvention))
+            {
+                var name = NameEquals(nameof(DllImportAttribute.CallingConvention));
+                var value = CreateEnumExpressionSyntax(targetDllImportData.CallingConvention);
+                newAttributeArgs.Add(AttributeArgument(name, null, value));
+            }
+            if (targetDllImportData.IsUserDefined.HasFlag(DllImportStub.DllImportMember.CharSet))
+            {
+                var name = NameEquals(nameof(DllImportAttribute.CharSet));
+                var value = CreateEnumExpressionSyntax(targetDllImportData.CharSet);
+                newAttributeArgs.Add(AttributeArgument(name, null, value));
+            }
+            if (targetDllImportData.IsUserDefined.HasFlag(DllImportStub.DllImportMember.ExactSpelling))
+            {
+                var name = NameEquals(nameof(DllImportAttribute.ExactSpelling));
+                var value = CreateBoolExpressionSyntax(targetDllImportData.ExactSpelling);
+                newAttributeArgs.Add(AttributeArgument(name, null, value));
+            }
+            if (targetDllImportData.IsUserDefined.HasFlag(DllImportStub.DllImportMember.PreserveSig))
+            {
+                var name = NameEquals(nameof(DllImportAttribute.PreserveSig));
+                var value = CreateBoolExpressionSyntax(targetDllImportData.PreserveSig);
+                newAttributeArgs.Add(AttributeArgument(name, null, value));
+            }
+            if (targetDllImportData.IsUserDefined.HasFlag(DllImportStub.DllImportMember.SetLastError))
+            {
+                var name = NameEquals(nameof(DllImportAttribute.SetLastError));
+                var value = CreateBoolExpressionSyntax(targetDllImportData.SetLastError);
+                newAttributeArgs.Add(AttributeArgument(name, null, value));
+            }
+            if (targetDllImportData.IsUserDefined.HasFlag(DllImportStub.DllImportMember.ThrowOnUnmappableChar))
+            {
+                var name = NameEquals(nameof(DllImportAttribute.ThrowOnUnmappableChar));
+                var value = CreateBoolExpressionSyntax(targetDllImportData.ThrowOnUnmappableChar);
+                newAttributeArgs.Add(AttributeArgument(name, null, value));
+            }
+
+            // Create new attribute
+            return Attribute(
+                ParseName(typeof(DllImportAttribute).FullName),
+                AttributeArgumentList(SeparatedList(newAttributeArgs)));
+
+            static ExpressionSyntax CreateBoolExpressionSyntax(bool trueOrFalse)
+            {
+                return LiteralExpression(
+                    trueOrFalse
+                        ? SyntaxKind.TrueLiteralExpression
+                        : SyntaxKind.FalseLiteralExpression);
+            }
+
+            static ExpressionSyntax CreateStringExpressionSyntax(string str)
+            {
+                return LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    Literal(str));
+            }
+
+            static ExpressionSyntax CreateEnumExpressionSyntax<T>(T value) where T : Enum
+            {
+                return MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    IdentifierName(typeof(T).FullName),
+                    IdentifierName(value.ToString()));
+            }
+        }
+
+        DllImportStub.GeneratedDllImportData GetTargetDllImportDataFromStubData()
+        {
+            DllImportStub.DllImportMember membersToForward = DllImportStub.DllImportMember.All
+                               // https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.dllimportattribute.preservesig
+                               // If PreserveSig=false (default is true), the P/Invoke stub checks/converts a returned HRESULT to an exception.
+                               & ~DllImportStub.DllImportMember.PreserveSig
+                               // https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.dllimportattribute.setlasterror
+                               // If SetLastError=true (default is false), the P/Invoke stub gets/caches the last error after invoking the native function.
+                               & ~DllImportStub.DllImportMember.SetLastError;
+            if (options.GenerateForwarders())
+            {
+                membersToForward = DllImportStub.DllImportMember.All;
+            }
+
+            var targetDllImportData = new DllImportStub.GeneratedDllImportData
+            {
+                CharSet = dllImportData.CharSet,
+                BestFitMapping = dllImportData.BestFitMapping,
+                CallingConvention = dllImportData.CallingConvention,
+                EntryPoint = dllImportData.EntryPoint,
+                ModuleName = dllImportData.ModuleName,
+                ExactSpelling = dllImportData.ExactSpelling,
+                SetLastError = dllImportData.SetLastError,
+                PreserveSig = dllImportData.PreserveSig,
+                ThrowOnUnmappableChar = dllImportData.ThrowOnUnmappableChar,
+                IsUserDefined = dllImportData.IsUserDefined & membersToForward
+            };
+
+            // If the EntryPoint property is not set, we will compute and
+            // add it based on existing semantics (i.e. method name).
+            //
+            // N.B. The export discovery logic is identical regardless of where
+            // the name is defined (i.e. method name vs EntryPoint property).
+            if (!targetDllImportData.IsUserDefined.HasFlag(DllImportStub.DllImportMember.EntryPoint))
+            {
+                targetDllImportData.EntryPoint = stubMethod.Name;
+            }
+
+            return targetDllImportData;
         }
     }
 }


### PR DESCRIPTION
My previous PR got auto-closed due to git shenanigans, so I'm reopening it here.

This is an alternative to https://github.com/dotnet/runtimelab/pull/1081.

This implementation makes the inner P/Invokes not conflict by making them completely internal instead of attempting reuse between the different methods. This way we won't need to track the DllImport info for the target in the same manner that #1081 does.

Fixes #1064