### PR TITLE
Require that methods marked with GeneratedDllImport are in types that are marked partial and any parents of their containing types are also marked partial.

### DIFF
--- a/DllImportGenerator/DllImportGenerator/AnalyzerReleases.Unshipped.md
+++ b/DllImportGenerator/DllImportGenerator/AnalyzerReleases.Unshipped.md
@@ -21,3 +21,4 @@ DLLIMPORTGENANALYZER013 | Usage            | Warning  | GeneratedDllImportMissin
 DLLIMPORTGENANALYZER014 | Usage            | Error    | RefValuePropertyUnsupported
 DLLIMPORTGENANALYZER015 | Interoperability | Disabled | ConvertToGeneratedDllImportAnalyzer
 DLLIMPORTGENANALYZER016 | Usage            | Error    | GenericTypeMustBeClosed
+DLLIMPORTGENANALYZER017 | Usage            | Warning  | GeneratedDllImportContainingTypeMissingModifiers

--- a/DllImportGenerator/DllImportGenerator/Analyzers/AnalyzerDiagnostics.cs
+++ b/DllImportGenerator/DllImportGenerator/Analyzers/AnalyzerDiagnostics.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Interop.Analyzers
 
             // GeneratedDllImport
             public const string GeneratedDllImportMissingRequiredModifiers = Prefix + "013";
+            public const string GeneratedDllImportContaiingTypeMissingRequiredModifiers = Prefix + "017";
 
             // Migration from DllImport to GeneratedDllImport
             public const string ConvertToGeneratedDllImport = Prefix + "015";

--- a/DllImportGenerator/DllImportGenerator/Analyzers/GeneratedDllImportAnalyzer.cs
+++ b/DllImportGenerator/DllImportGenerator/Analyzers/GeneratedDllImportAnalyzer.cs
@@ -74,10 +74,7 @@ namespace Microsoft.Interop.Analyzers
                 foreach (var reference in methodSymbol.DeclaringSyntaxReferences)
                 {
                     var syntax = reference.GetSyntax(context.CancellationToken);
-                    if (syntax is not MethodDeclarationSyntax methodSyntax)
-                        continue;
-
-                    if (!methodSyntax.Modifiers.Any(SyntaxKind.PartialKeyword))
+                    if (syntax is MethodDeclarationSyntax methodSyntax && !methodSyntax.Modifiers.Any(SyntaxKind.PartialKeyword))
                     {
                         // Must be marked partial
                         context.ReportDiagnostic(methodSymbol.CreateDiagnostic(GeneratedDllImportMissingModifiers, methodSymbol.Name));
@@ -90,10 +87,7 @@ namespace Microsoft.Interop.Analyzers
                     foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
                     {
                         var syntax = reference.GetSyntax(context.CancellationToken);
-                        if (syntax is not TypeDeclarationSyntax typeSyntax)
-                            continue;
-
-                        if (!typeSyntax.Modifiers.Any(SyntaxKind.PartialKeyword))
+                        if (syntax is TypeDeclarationSyntax typeSyntax && !typeSyntax.Modifiers.Any(SyntaxKind.PartialKeyword))
                         {
                             // Must be marked partial
                             context.ReportDiagnostic(typeSymbol.CreateDiagnostic(GeneratedDllImportContainingTypeMissingModifiers, typeSymbol.Name));

--- a/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
@@ -445,6 +445,15 @@ namespace Microsoft.Interop
                     return;
                 }
 
+                // Verify that the types the method is declared in are marked partial.
+                for (SyntaxNode? parentNode = methodSyntax.Parent; parentNode is TypeDeclarationSyntax typeDecl; parentNode = parentNode.Parent)
+                {
+                    if (!typeDecl.Modifiers.Any(SyntaxKind.PartialKeyword))
+                    {
+                        return;
+                    }
+                }
+
                 // Check if the method is marked with the GeneratedDllImport attribute.
                 foreach (AttributeListSyntax listSyntax in methodSyntax.AttributeLists)
                 {

--- a/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
+++ b/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
@@ -250,6 +250,33 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Types that contain methods marked with &apos;GeneratedDllImportAttribute&apos; must be &apos;partial&apos;. P/Invoke source generation will ignore methods contained within non-partial types..
+        /// </summary>
+        internal static string GeneratedDllImportContainingTypeMissingModifiersDescription {
+            get {
+                return ResourceManager.GetString("GeneratedDllImportContainingTypeMissingModifiersDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type &apos;{0}&apos; contains methods marked with &apos;GeneratedDllImportAttribute&apos; and should be &apos;partial&apos;. P/Invoke source generation will ignore methods contained within non-partial types..
+        /// </summary>
+        internal static string GeneratedDllImportContainingTypeMissingModifiersMessage {
+            get {
+                return ResourceManager.GetString("GeneratedDllImportContainingTypeMissingModifiersMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Types that contain methods marked with &apos;GeneratedDllImportAttribute&apos; must be &apos;partial&apos;..
+        /// </summary>
+        internal static string GeneratedDllImportContainingTypeMissingModifiersTitle {
+            get {
+                return ResourceManager.GetString("GeneratedDllImportContainingTypeMissingModifiersTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Methods marked with &apos;GeneratedDllImportAttribute&apos; should be &apos;static&apos; and &apos;partial&apos;. P/Invoke source generation will ignore methods that are not &apos;static&apos; and &apos;partial&apos;..
         /// </summary>
         internal static string GeneratedDllImportMissingModifiersDescription {

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -181,6 +181,15 @@
   <data name="CustomTypeMarshallingNativeToManagedUnsupported" xml:space="preserve">
     <value>The specified parameter needs to be marshalled from native to managed, but the native type '{0}' does not support it.</value>
   </data>
+  <data name="GeneratedDllImportContainingTypeMissingModifiersDescription" xml:space="preserve">
+    <value>Types that contain methods marked with 'GeneratedDllImportAttribute' must be 'partial'. P/Invoke source generation will ignore methods contained within non-partial types.</value>
+  </data>
+  <data name="GeneratedDllImportContainingTypeMissingModifiersMessage" xml:space="preserve">
+    <value>Type '{0}' contains methods marked with 'GeneratedDllImportAttribute' and should be 'partial'. P/Invoke source generation will ignore methods contained within non-partial types.</value>
+  </data>
+  <data name="GeneratedDllImportContainingTypeMissingModifiersTitle" xml:space="preserve">
+    <value>Types that contain methods marked with 'GeneratedDllImportAttribute' must be 'partial'.</value>
+  </data>
   <data name="GeneratedDllImportMissingModifiersDescription" xml:space="preserve">
     <value>Methods marked with 'GeneratedDllImportAttribute' should be 'static' and 'partial'. P/Invoke source generation will ignore methods that are not 'static' and 'partial'.</value>
   </data>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtimelab/issues/1088