### PR TITLE
srm serialization updates

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
+++ b/src/libraries/System.Text.RegularExpressions/src/ILLink/ILLink.Descriptors.LibraryBuild.xml
@@ -1,0 +1,10 @@
+<linker>
+  <assembly fullname="System.Text.RegularExpressions">
+    <type fullname="System.Text.RegularExpressions.Regex">
+      <!-- called via reflection from System.Text.RegularExpressions.Tests -->
+      <method name="Serialize" />
+      <method name="Deserialize" />
+      <method name="SaveDGML" />
+    </type>
+  </assembly>
+</linker>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
@@ -57,6 +57,29 @@ namespace System.Text.RegularExpressions
             _srm.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, onlyDFAinfo, maxLabelLength);
         }
 
+        internal string Serialize()
+        {
+            if (!_useSRM)
+                throw new NotSupportedException();
+
+            StringBuilder sb = new StringBuilder();
+            _srm.Serialize(sb);
+            return sb.ToString();
+        }
+
+        internal static Regex Deserialize(string s)
+        {
+            var srm = SRM.Regex.Deserialize(s);
+            Regex r = new(srm);
+            return r;
+        }
+
+        private Regex(SRM.Regex srm)
+        {
+            _useSRM = true;
+            _srm = srm;
+        }
+
 #if DEBUG
         /// <summary>
         /// Generates two files IgnoreCaseRelation.cs and UnicodeCategoryRanges.cs for the namespace System.Text.RegularExpressions.SRM.Unicode

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -123,7 +123,7 @@ namespace System.Text.RegularExpressions
             _useSRM = (options & RegexOptions.DFA) != 0;
             if (_useSRM)
                 // remove the DFA flag because it is undefined in SRM
-                _srm = InitializeSRM(tree.Root, options & ~RegexOptions.DFA);
+                _srm = InitializeSRM(tree.Root, options & ~RegexOptions.DFA, matchTimeout);
 
             InitializeReferences();
         }
@@ -132,7 +132,7 @@ namespace System.Text.RegularExpressions
         /// Checks that the options are supported and creates a DFA matcher.
         /// The method throws NotSuppportedException if the regex uses constructs not compatible with the DFA option.
         /// </summary>
-        private static SRM.Regex InitializeSRM(RegexNode rootNode, RegexOptions options)
+        private static SRM.Regex InitializeSRM(RegexNode rootNode, RegexOptions options, TimeSpan matchTimeout)
         {
             // TBD: this could potentially be supported quite easily but is not of priority
             // it essentially affects how the iput string is being processed  -- characters are read backwards --
@@ -143,7 +143,7 @@ namespace System.Text.RegularExpressions
             if ((options & RegexOptions.ECMAScript) != 0)
                 throw new NotSupportedException(SRM.Regex._DFA_incompatible_with + RegexOptions.ECMAScript);
 
-            return SRM.Regex.Create(rootNode, options);
+            return SRM.Regex.Create(rootNode, options, matchTimeout);
         }
 
         internal static void ValidatePattern(string pattern)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
@@ -85,9 +85,9 @@ namespace System.Text.RegularExpressions.SRM
         /// </summary>
         public void Serialize(StringBuilder sb) => _matcher.Serialize(sb);
 
-        //the separator char could potentially also be \something other than '\n'
-        //it must not be a character used to serialize the fragments: 0-9A-Za-z/\+*()[].,;-^$?
-        internal const char s_top_level_separator = '\n';
+        //it must not be '\n' or a character used to serialize the fragments: 0-9A-Za-z/\+*()[].,-^$;?
+        //avoiding '\n' so that multiple serializations can be stored one per line in an ascii text file
+        internal const char s_top_level_separator = '#';
 
         /// <summary>
         /// Deserializes the matcher from the given input string created with Serialize.
@@ -95,8 +95,7 @@ namespace System.Text.RegularExpressions.SRM
         public static Regex Deserialize(string input)
         {
             input.Split(s_top_level_separator);
-            //trim also whitespace from entries -- this implies for example that \r is removed if present in line endings
-            string[] fragments = input.Split(s_top_level_separator, StringSplitOptions.TrimEntries);
+            string[] fragments = input.Split(s_top_level_separator);
             if (fragments.Length != 13)
                 throw new ArgumentException($"{nameof(Regex.Deserialize)} error", nameof(input));
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
@@ -20,7 +20,7 @@ namespace System.Text.RegularExpressions.SRM
 
         internal IMatcher _matcher;
 
-        private Regex(RegexNode rootNode, System.Text.RegularExpressions.RegexOptions options)
+        private Regex(RegexNode rootNode, System.Text.RegularExpressions.RegexOptions options, TimeSpan matchTimeout)
         {
             RegexToAutomatonConverter<BDD> converter = new RegexToAutomatonConverter<BDD>(s_unicode);
             CharSetSolver solver = (CharSetSolver)s_unicode.solver;
@@ -42,7 +42,7 @@ namespace System.Text.RegularExpressions.SRM
                 builderBV.newLinePredicate = algBV.ConvertFromCharSet(solver, converter.srBuilder.newLinePredicate);
                 //convert the BDD based AST to BV based AST
                 SymbolicRegexNode<BV> rootBV = converter.srBuilder.Transform(root, builderBV, bdd => builderBV.solver.ConvertFromCharSet(solver, bdd));
-                SymbolicRegexMatcher<BV> matcherBV = new(rootBV, solver, partition, options);
+                SymbolicRegexMatcher<BV> matcherBV = new(rootBV, solver, partition, options, matchTimeout);
                 _matcher = matcherBV;
             }
             else
@@ -56,14 +56,14 @@ namespace System.Text.RegularExpressions.SRM
                 builder64.newLinePredicate = alg64.ConvertFromCharSet(solver, converter.srBuilder.newLinePredicate);
                 //convert the BDD based AST to ulong based AST
                 SymbolicRegexNode<ulong> root64 = converter.srBuilder.Transform(root, builder64, bdd => builder64.solver.ConvertFromCharSet(solver, bdd));
-                SymbolicRegexMatcher<ulong> matcher64 = new(root64, solver, partition, options);
+                SymbolicRegexMatcher<ulong> matcher64 = new(root64, solver, partition, options, matchTimeout);
                 _matcher = matcher64;
             }
         }
 
-        public static Regex Create(RegexNode rootNode, System.Text.RegularExpressions.RegexOptions options)
+        public static Regex Create(RegexNode rootNode, System.Text.RegularExpressions.RegexOptions options, TimeSpan matchTimeout)
         {
-            var regex = new Regex(rootNode, options);
+            var regex = new Regex(rootNode, options, matchTimeout);
 //#if DEBUG
 //            //test the serialization roundtrip
 //            //effectively, here all tests in DEBUG mode are run with deserialized matchers, not the original ones
@@ -96,7 +96,7 @@ namespace System.Text.RegularExpressions.SRM
         {
             input.Split(s_top_level_separator);
             string[] fragments = input.Split(s_top_level_separator);
-            if (fragments.Length != 13)
+            if (fragments.Length != 14)
                 throw new ArgumentException($"{nameof(Regex.Deserialize)} error", nameof(input));
 
             try

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
@@ -884,9 +884,9 @@ namespace System.Text.RegularExpressions.SRM
                         return this.eolAnchor;
                         #endregion
                     }
-                case '#':
+                case 'W':
                     {
-                        #region end of sequence anchor
+                        #region end of sequence/watchdog anchor
                         int j = s.IndexOf(')', i + 2);
                         int length = int.Parse(s.Substring(i + 2, j - (i + 2)));
                         i_next = j + 1;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -196,7 +196,7 @@ namespace System.Text.RegularExpressions.SRM
                         }
                     case SymbolicRegexKind.WatchDog:
                         {
-                            sb.Append("#(" + node.lower + ")");
+                            sb.Append("W(" + node.lower + ")");
                             return;
                         }
                     case SymbolicRegexKind.WBAnchor:

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -44,8 +44,8 @@ namespace System.Text.RegularExpressions.Tests
             saveDgml.Invoke(regex, new object[] { writer, bound, hideStateInfo, addDotStar, inReverse, onlyDFAinfo, maxLabelLength });
         }
 
-        //[Fact]
-        private void TestDGMLGeneration()
+        [Fact]
+        public void TestDGMLGeneration()
         {
             StringWriter sw = new StringWriter();
             var re = new Regex(".*a+", DFA | RegexOptions.Singleline);
@@ -91,72 +91,205 @@ namespace System.Text.RegularExpressions.Tests
             Assert.False(match3.Success);
         }
 
+        /*
+         * misc stuff:
+        //var re = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA);
+        //var re = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
+        //var re = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
+        //var re = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
+        //var re = new Regex(@"\b\w+nn\b", DFA);
+        //var re = new Regex(@"abracadabra\z", DFA | RegexOptions.Multiline);
+        //var re = new Regex("^.{5}", DFA);
+        //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
+        //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
+        //var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
+        //var re = new Regex(@"(([a-z])+.)+[A-Z]([a-z])+", DFA | RegexOptions.Singleline);
+        //var re = new Regex("ab+c$", DFA);
+        //ViewDGML(regex: re);
+        //ViewDGML(regex: re, addDotStar: true);
+        //ViewDGML(regex: re, inReverse: true);
+        //var match = re.Match("_.@[0.0.0.aaaaaaaaaa]");
+        //string[] rawregexes = File.ReadAllLines("c:/tmp/VS19preview/cortana.txt");
+        //HashSet<int> notsupported = new();
+        //HashSet<string> set = new();
+        //Regex QsizeMatcher = new Regex(@"\|Q\|=[0-9]+", DFA);
+        //Regex DsizeMatcher = new Regex(@"\|&#x0394;\|=[0-9]+", DFA);
+        //Regex AsizeMatcher = new Regex(@"\|&#x03A3;\|=[0-9]+", DFA);
+        //Func<string, int> NrOfStates = (s) => int.Parse(QsizeMatcher.Match(s).Value.Substring(4));
+        //Func<string, int> NrOfMoves = (s) => int.Parse(DsizeMatcher.Match(s).Value.Substring(11));
+        //Func<string, int> NrOfSymbols = (s) => int.Parse(AsizeMatcher.Match(s).Value.Substring(11));
+        //HashSet<int> stateSizes = new();
+        //HashSet<int> moveSizes = new();
+        //HashSet<int> alphSizes = new();
+        //for (int i = 0; i < rawregexes.Length; i++)
+        //{
+        //    var re = new Regex(rawregexes[i], DFA);
+        //    StringWriter sw = new StringWriter();
+        //    SaveDGML(re, sw, onlyDFAinfo: true);
+        //    ViewDGML(re);
+        //    int n = NrOfStates(sw.ToString());
+        //    int m = NrOfMoves(sw.ToString());
+        //    int k = NrOfSymbols(sw.ToString());
+        //    stateSizes.Add(n);
+        //    moveSizes.Add(m);
+        //    alphSizes.Add(k);
+        //}
+        //Console.WriteLine(stateSizes.Count);
+        //string rawregex = @"((decryptionKey|validationKey)=""[a-zA-Z0-9]+"")";
+        //string rawregex = @"(?<Part0>(\b(10|11|12|[1-9])\b))\s*(?<Part1>(:)\s*(?<Part2>([0-5][0-9]))){0,1}\s*(?<Part3>(\b([Tt]he day before yesterday|day before yesterday|[Tt]he day after tomorrow|day after tomorrow|[Yy]esterday|[Tt]oday|[Tt]ommorrow|[Tt]omorrow|[Tt]ommorow|[Tt]mrw)\b))";
+        //string rawregex = @"(?<Part0>(tonight))\s*(?<Part1>(at)){0,1}\s*(?<Part2>(midnight))";
+        */
+
+        private const string inputfile = @"c:\tmp\vsinput.txt";
+        private const string outputfile = @"c:\tmp\vsoutput.txt";
+        private const string regexesfile = @"c:\tmp\vsregexes.txt";
+
+        /// <summary>
+        /// The intent is that this method is run in realease build for lightweight performance testing.
+        /// One can e.g. open the outputfile in emacs with AUTO-REVERT-ON in order to follow the progress in real time.
+        /// It will print timing info and match info for both DFA and Compiled option.
+        /// Place sample regexes in the regexesfile (one per line) and sample input in inputfile.
+        /// </summary>
         //[Fact]
-        private void TestRun()
+        private void TestRunPerformance()
         {
-            //var re = new Regex(@"^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,12}|[0-9]{1,3})(\]?)$", DFA);
-            //var re = new Regex(@"\b\d{1,2}\/\d{1,2}\/\d{2,4}\b", DFA | RegexOptions.Singleline);
-            //var re = new Regex(@"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])", DFA | RegexOptions.Singleline);
-            //var re = new Regex(@"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?", DFA | RegexOptions.Singleline);
-            //var re = new Regex(@"\b\w+nn\b", DFA);
-            //var re = new Regex(@"abracadabra\z", DFA | RegexOptions.Multiline);
-            //var re = new Regex("^.{5}", DFA);
-            //var re = new Regex("^a(_?a?_?a?_?)+$", DFA);
-            //var re = new Regex(@"^\b[a-z]+(n|\n|@|_)n\b", DFA);
-            //var re = new Regex(@"^[a-z]+", DFA | RegexOptions.Multiline);
-            //var re = new Regex(@"(([a-z])+.)+[A-Z]([a-z])+", DFA | RegexOptions.Singleline);
-            //var re = new Regex("ab+c$", DFA);
-            //ViewDGML(regex: re);
-            //ViewDGML(regex: re, addDotStar: true);
-            //ViewDGML(regex: re, inReverse: true);
-            //var match = re.Match("_.@[0.0.0.aaaaaaaaaa]");
-            //string[] rawregexes = File.ReadAllLines("c:/tmp/VS19preview/cortana.txt");
-            //HashSet<int> notsupported = new();
-            //HashSet<string> set = new();
-            //Regex QsizeMatcher = new Regex(@"\|Q\|=[0-9]+", DFA);
-            //Regex DsizeMatcher = new Regex(@"\|&#x0394;\|=[0-9]+", DFA);
-            //Regex AsizeMatcher = new Regex(@"\|&#x03A3;\|=[0-9]+", DFA);
-            //Func<string, int> NrOfStates = (s) => int.Parse(QsizeMatcher.Match(s).Value.Substring(4));
-            //Func<string, int> NrOfMoves = (s) => int.Parse(DsizeMatcher.Match(s).Value.Substring(11));
-            //Func<string, int> NrOfSymbols = (s) => int.Parse(AsizeMatcher.Match(s).Value.Substring(11));
-            //HashSet<int> stateSizes = new();
-            //HashSet<int> moveSizes = new();
-            //HashSet<int> alphSizes = new();
-            //for (int i = 0; i < rawregexes.Length; i++)
-            //{
-            //    var re = new Regex(rawregexes[i], DFA);
-            //    StringWriter sw = new StringWriter();
-            //    SaveDGML(re, sw, onlyDFAinfo: true);
-            //    ViewDGML(re);
-            //    int n = NrOfStates(sw.ToString());
-            //    int m = NrOfMoves(sw.ToString());
-            //    int k = NrOfSymbols(sw.ToString());
-            //    stateSizes.Add(n);
-            //    moveSizes.Add(m);
-            //    alphSizes.Add(k);
-            //}
-            //Console.WriteLine(stateSizes.Count);
-            //string rawregex = @"((decryptionKey|validationKey)=""[a-zA-Z0-9]+"")";
-            //string rawregex = @"(?<Part0>(\b(10|11|12|[1-9])\b))\s*(?<Part1>(:)\s*(?<Part2>([0-5][0-9]))){0,1}\s*(?<Part3>(\b([Tt]he day before yesterday|day before yesterday|[Tt]he day after tomorrow|day after tomorrow|[Yy]esterday|[Tt]oday|[Tt]ommorrow|[Tt]omorrow|[Tt]ommorow|[Tt]mrw)\b))";
-            //string rawregex = @"(?<Part0>(tonight))\s*(?<Part1>(at)){0,1}\s*(?<Part2>(midnight))";
-            string s = File.ReadAllText(@"c:\tmp\largesemirandom.txt");
-            string[] rawregexes = File.ReadAllLines(@"c:\tmp\someregexes.txt");
+            string input = File.ReadAllText(inputfile);
+            string[] rawregexes = File.ReadAllLines(regexesfile);
+            File.AppendAllText(outputfile, string.Format("\n========= date:{0} =========\n", System.DateTime.Now));
+            int totDFA = 0;
+            int totCOM = 0;
+            int tDFA = 0;
+            int tCOM = 0;
             for (int i = 0; i < rawregexes.Length; i++)
             {
                 var rawregex = rawregexes[i];
-                Regex re = new(rawregex, DFA);
-                Regex reC = new(rawregex, RegexOptions.Compiled);
-                //ViewDGML(re);
-                //warmup
-                re.Match(s);
-                //now measure the time
+                Regex re = new(rawregex, DFA, new TimeSpan(0, 0, 10));
+                Regex reC = new(rawregex, RegexOptions.Compiled, new TimeSpan(0,0,10));
+                File.AppendAllText(outputfile, string.Format("\n--- Regex:{0}\n", i));
+                //-------------------
+                //-- measure DFA
+                //-------------------
+                tDFA = MeasureMatchTime(re, "DFA", input);
+                //-------------------
+                //-- measure COMPILED
+                //-------------------
+                tCOM = MeasureMatchTime(reC, "COM", input);
+                //ignore the cases when one times out
+                if (tDFA >= 0 && tCOM >= 0)
+                {
+                    totDFA += tDFA;
+                    totCOM += tCOM;
+                }
+            }
+            File.AppendAllText(outputfile, string.Format("\ntotal time: DFA:{0}ms, COM:{1}ms\n", totDFA, totCOM));
+        }
+
+        private static int MeasureMatchTime(Regex re, string tag, string input)
+        {
+            File.AppendAllText(outputfile, tag + ": warmup:...");
+            try
+            {
+                int t0 = System.Environment.TickCount;
+                re.Match(input);
+                t0 = System.Environment.TickCount - t0;
+                File.AppendAllText(outputfile, string.Format("{0}ms, run:...", t0));
                 int t1 = System.Environment.TickCount;
-                var match1 = re.Match(s);
+                var match1 = re.Match(input);
                 t1 = System.Environment.TickCount - t1;
-                int t2 = System.Environment.TickCount;
-                var match2 = reC.Match(s);
-                t2 = System.Environment.TickCount - t2;
-                File.AppendAllText(@"c:\tmp\vsoutput.txt", string.Format("\n--- Regex: {8}\n,DFA={0}ms, COMPILED={1}ms, ({3}/{6},at:{4}/{7}) match={2}({5})", t1, t2, match1.Value, match1.Success, match1.Success ? match1.Index : -1, match2.Value, match2.Success, match2.Success ? match2.Index : -1, rawregex));
+                File.AppendAllText(outputfile, string.Format("{0}ms, Match:{1} (Index:{2} Length:{3})\n", t1, match1.Success, match1.Index, match1.Length));
+                return t1;
+            }
+            catch (TimeoutException)
+            {
+                File.AppendAllText(outputfile, " TIMEOUT\n");
+                return -1;
+            }
+            catch (Exception)
+            {
+                File.AppendAllText(outputfile, " ERROR\n");
+                return -1;
+            }
+        }
+
+        private static MethodInfo _Deserialize = typeof(Regex).GetMethod("Deserialize", BindingFlags.NonPublic | BindingFlags.Static);
+        private static Regex Deserialize(string s) => _Deserialize.Invoke(null, new object[] { s }) as Regex;
+
+        private static MethodInfo _Serialize = typeof(Regex).GetMethod("Serialize", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static string Serialize(Regex r) => _Serialize.Invoke(r, null) as string;
+
+        private const string serializedout = @"c:\tmp\serialized.txt";
+        /// <summary>
+        /// Test serialization/deserialization and measure performance for all regexes in the regexesfile.
+        /// </summary>
+        //[Fact]
+        private void TestRunSerialization()
+        {
+            string[] rawregexes = File.ReadAllLines(regexesfile);
+            File.AppendAllText(outputfile, string.Format("\n========= TimeStamp:{0} =========\n", System.DateTime.Now));
+            int k = rawregexes.Length;
+            Regex[] rs = new Regex[k];
+            string[] ser = new string[k];
+            Regex[] drs = new Regex[k];
+            //construct
+            int totConstrTime = System.Environment.TickCount;
+            for (int i = 0; i < k; i++)
+                rs[i] = new Regex(rawregexes[i], DFA);
+            totConstrTime = System.Environment.TickCount - totConstrTime;
+            //serialize
+            int totSerTime = System.Environment.TickCount;
+            //repeat ten times
+            for (int j = 0; j < 10; j++)
+                for (int i = 0; i < k; i++)
+                    ser[i] = Serialize(rs[i]);
+            totSerTime = System.Environment.TickCount - totSerTime;
+            totSerTime = totSerTime / 10;
+            //save the serializations
+            File.WriteAllLines(serializedout, ser);
+            //deserialize
+            int totDeSerTime = System.Environment.TickCount;
+            //repeat ten times
+            for (int j = 0; j < 10; j++)
+                for (int i = 0; i < k; i++)
+                    drs[i] = Deserialize(ser[i]);
+            totDeSerTime = System.Environment.TickCount - totDeSerTime;
+            totDeSerTime = totDeSerTime / 10;
+            File.AppendAllText(outputfile, string.Format("\nconstr:{0}ms, serialization:{1}ms, deserialization:{2}ms\n", totConstrTime, totSerTime, totDeSerTime));
+        }
+
+        /// <summary>
+        /// Test serialization/deserialization of some sample regexes.
+        /// Verify correctness of all the deserialized regexes against the original ones.
+        /// Test also that serialization is idempotent.
+        /// </summary>
+        [Fact]
+        public void TestRegexSerialization()
+        {
+            string[] rawregexes = new string[] {@"\b\d\w+nn\b", "An+e", "^this", "(?i:Jaan$)", @"\p{Sm}+" };
+            int k = rawregexes.Length;
+            //DFA versions
+            var rs = Array.ConvertAll(rawregexes, s => new Regex(s, DFA));
+            //Compiled versions
+            var rsC = Array.ConvertAll(rawregexes, s => new Regex(s, RegexOptions.Compiled));
+            //serialize
+            var ser = Array.ConvertAll(rs, Serialize);
+            //deserialize
+            var drs = Array.ConvertAll(ser, Deserialize);
+            //repeat serialization on  the deserialized regexes
+            var ser2 = Array.ConvertAll(drs, Serialize);
+            //check idempotence
+            for (int i = 0; i < k; i++)
+                Assert.True(ser[i] == ser2[i], string.Format("idempotence of serialization of regex {0} fails", i));
+
+            string input = "this text contains math symbols +~<> and names like Ann and Anne and maku and jaan";
+            for (int i = 0; i < k; i++)
+            {
+                var match1 = rs[i].Match(input);
+                var match2 = drs[i].Match(input);
+                var matchExpected = rsC[i].Match(input);
+                Assert.Equal(matchExpected.Success, match1.Success);
+                Assert.Equal(matchExpected.Success, match2.Success);
+                Assert.Equal(matchExpected.Value, match1.Value);
+                Assert.Equal(matchExpected.Value, match2.Value);
             }
         }
 


### PR DESCRIPTION
Added internal methods Serialize and Deserialize to Regex to enable serialization and deserialization to/from a custom string representation (in visible/safe ascii).

Added ILLink file to declare internal Regex methods for release build, that are accessed from unit tests.

Updated slightly the format of output of serialization that now avoids '\n' so serialized DFA
regexes can be stored as single ascii text lines in a text file. 

Added unit tests to test basic serialization correctness (and also for dgml generation). Added also methods that can be used  to do lightweight performance testing when declared as facts and run as unit tests after the regex solution has been build in release mode.
 
Measured that for the 150 CredScan regexes the total size of the serialized regexes is roughly 
1KB per regex or 150KB in total. 
For these regexes the total construction time is 1.5sec (roughly 10ms per regex).
The total serialization time for them is roughly 15-20ms. (roughly 125 micro sec per regex)
The total deserialization time for them is roughly 35-40ms. (roughly 250 micro sec per regex)
The (de)serialization times seem acceptable and need not be further optimized I believe.