### PR TITLE
Prepend identifiers with @ symbol since the Roslyn Symbol API strips the @ from the name.

### DIFF
--- a/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -397,6 +397,18 @@ partial class Test
         public static string ByValueParameterWithModifier<T>(string attributeName) => ByValueParameterWithModifier(typeof(T).ToString(), attributeName);
 
         /// <summary>
+        /// Declaration with by-value parameter with custom name.
+        /// </summary>
+        public static string ByValueParameterWithName(string methodName, string paramName) => @$"
+using System.Runtime.InteropServices;
+partial class Test
+{{
+    [GeneratedDllImport(""DoesNotExist"")]
+    public static partial void {methodName}(
+        int {paramName});
+}}";
+
+        /// <summary>
         /// Declaration with parameters with MarshalAs.
         /// </summary>
         public static string MarshalAsParametersAndModifiers(string typeName, UnmanagedType unmanagedType) => @$"

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -179,6 +179,11 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CustomStructMarshallingNativeTypePinnable };
             yield return new[] { CodeSnippets.CustomStructMarshallingMarshalUsingParametersAndModifiers };
             yield return new[] { CodeSnippets.ArrayMarshallingWithCustomStructElement };
+
+            // Escaped C# keyword identifiers
+            yield return new[] { CodeSnippets.ByValueParameterWithName("Method", "@event") };
+            yield return new[] { CodeSnippets.ByValueParameterWithName("Method", "@var") };
+            yield return new[] { CodeSnippets.ByValueParameterWithName("@params", "i") };
         }
 
         [Theory]

--- a/DllImportGenerator/DllImportGenerator/TypePositionInfo.cs
+++ b/DllImportGenerator/DllImportGenerator/TypePositionInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Interop
 {
@@ -88,7 +88,7 @@ namespace Microsoft.Interop
             var typeInfo = new TypePositionInfo()
             {
                 ManagedType = paramSymbol.Type,
-                InstanceIdentifier = paramSymbol.Name,
+                InstanceIdentifier = ParseToken(paramSymbol.Name).IsReservedKeyword() ? $"@{paramSymbol.Name}" : paramSymbol.Name,
                 RefKind = paramSymbol.RefKind,
                 RefKindSyntax = RefKindToSyntax(paramSymbol.RefKind),
                 MarshallingAttributeInfo = marshallingInfo,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtimelab/issues/1096