### PR TITLE
Fix stack traces when framework resources are stripped

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2932,8 +2932,8 @@
   <data name="NotSupported_ByRefLikeArray" xml:space="preserve">
     <value>Cannot create arrays of ByRef-like values.</value>
   </data>
-  <data name="StackTrace_AtWord" xml:space="preserve">
-    <value>   at </value>
+  <data name="Word_At" xml:space="preserve">
+    <value>at</value>
   </data>
   <data name="StackTrace_EndStackTraceFromPreviousThrow" xml:space="preserve">
     <value>--- End of stack trace from previous location where exception was thrown ---</value>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.CoreRT.cs
@@ -138,7 +138,10 @@ namespace System.Diagnostics
         {
             if (_ipAddress != StackTraceHelper.SpecialIP.EdiSeparator)
             {
-                builder.Append(SR.StackTrace_AtWord);
+                // Passing a default string for "at" in case SR.UsingResourceKeys() is true
+                // as this is a special case and we don't want to have "Word_At" on stack traces.
+                string word_At = SR.GetResourceString(nameof(SR.Word_At), defaultString: "at");
+                builder.AppendFormat("   {0} ", word_At);
                 builder.AppendLine(DeveloperExperience.Default.CreateStackTraceString(_ipAddress, _needFileInfo));
             }
             if (_isLastFrameFromForeignExceptionStackTrace)


### PR DESCRIPTION
Got tired of seeing

```
Unhandled Exception: EETypeRva:0x0011A0D0: TypeInitialization_Type_NoTypeAvailable
StackTrace_AtWordProgram!+0x754cd
StackTrace_AtWordProgram!+0x755be
StackTrace_AtWordProgram!+0xdf7e7
```

in new issues.

This is actually how CoreCLR also does this, so I just stole the code.