### PR TITLE
cleanup of experiment code

### DIFF
--- a/eng/testing/.runsettings
+++ b/eng/testing/.runsettings
@@ -2,7 +2,7 @@
 <RunSettings>
   <RunConfiguration>
     <!-- Timeout in ms, 5 minutes -->
-    <TestSessionTimeout>300000</TestSessionTimeout>
+    <TestSessionTimeout>3000000</TestSessionTimeout>
     <!-- Directory for test run reports. E.g. trx, coverage etc. -->
     <ResultsDirectory>.\TestResults\</ResultsDirectory>
     <!-- Working directory for test invocation. Results directory can be relative to this. Used by IDEs. -->


### PR DESCRIPTION
Added method as a "unit test" TestRun() for experimenting with performance and correctness measurements.
This method is commented out but lives in the RegexExperiment class/file.
Currently assuming use of local path 'c:\tmp\runtimelab\' for the experimental data, this can be configured in a cleaner way.
The intent is that, while the code is public, the data and even the regexes are not.

Changed the global .runsettings test timeout limit to 50min, adding a local experiment.runsettings file did not work for some reason. 
Timeout was not updated and tests were still timing out after 5min, making the use of TestRun() impossible.