### PR TITLE
Support for default interface methods on generic interfaces

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SharedCodeHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SharedCodeHelpers.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    /// <summary>
+    /// These methods are used to implement shared generic code.
+    /// </summary>
+    internal static class SharedCodeHelpers
+    {
+        public static unsafe EEType* GetOrdinalInterface(EEType* pType, ushort interfaceIndex)
+        {
+            Debug.Assert(interfaceIndex <= pType->NumInterfaces);
+            return pType->InterfaceMap[interfaceIndex].InterfaceType;
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Internal\Runtime\CompilerHelpers\DelegateHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\LibraryInitializer.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\ReflectionHelpers.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\SharedCodeHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\ThreadingHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\StartupCodeHelpers.Reflection.cs" />
   </ItemGroup>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.IntefaceThunks.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.IntefaceThunks.cs
@@ -1,0 +1,287 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Internal.TypeSystem;
+using Internal.IL;
+using Internal.IL.Stubs;
+
+using Debug = System.Diagnostics.Debug;
+
+// Default interface method implementation thunks
+//
+// The problem with default interface methods and shared generic code is that for:
+//
+// interface IFoo<T>
+// {
+//     Type GetTheType() => typeof(T);
+// }
+//
+// The actual generated code when instantiated over a shareable instance (like object) is
+// just IFoo<__Canon>.GetTheType, for any shareable argument (there's no unique code
+// generated for IFoo<Object>/IFoo<string>/... - we just have IFoo<__Canon>).
+//
+// For the canonical code to know what the actual T is, we need to provide the instantiation
+// context somehow. We can't easily get it from `this` like we do for reference types
+// since the type might implement multiple instantiations of IFoo (`class Abc : IFoo<object>, IFoo<string> { }`)
+// and we wouldn't know which one we are executing for within the method body.
+//
+// So we end up passing the context same as for shared valuetype code (that also cannot
+// determine context from just `this`) - by adding an extra instantiation
+// argument. The actual code for IFoo<__Canon>.GetTheType looks something like this:
+//
+// Type IFoo__Canon__GetTheType(IFoo<__Canon> instance, EEType* context)
+// {
+//     return Type.GetTypeFromHandle(GetTypeHandleOfTInIFooCanon(context));
+// }
+//
+// Now we have a problem because this method expects an extra `context` argument
+// that will not be provided at the callsite, since the callsite doesn't know
+// where it will dispatch to (could be a non-default-interface-method).
+//
+// We solve this with an instantiating thunk. The instantiating thunk is the thing
+// we place in the vtable of the implementing type. The thunk looks like this:
+//
+// Type Abc_IFoo__Canon__GetTheType_Thunk(IFoo<__Canon> instance)
+// {
+//     return IFoo__Canon__GetTheType(instance, GetOrdinalInterface(instance.m_pEEType, 0));
+// }
+//
+// Notice the thunk now has the expected signature, and some code to compute the context.
+//
+// The GetOrdinalInterface method retrieves the specified interface EEType off the EEType's interface list.
+// The thunks are per-type (since the position in the inteface list is different).
+//
+// We hardcode the position in the interface list instead of just hardcoding the interface type
+// itself so that we don't require runtime code generation when a new type is loaded
+// (e.g. "class Abc<T> : IFoo<T> { }" and we MakeGenericType's a new Abc at runtime) -
+// the instantiating thunk in this shape can be shared.
+namespace ILCompiler
+{
+    // Contains functionality related to instantiating thunks for default interface methods
+    partial class CompilerTypeSystemContext
+    {
+        /// <summary>
+        /// For a shared (canonical) default interface method, gets a method that can be used to call the
+        /// method on a specific implementing class.
+        /// </summary>
+        public MethodDesc GetDefaultInterfaceMethodImplementationThunk(MethodDesc targetMethod, TypeDesc implementingClass, DefType interfaceOnDefinition)
+        {
+            Debug.Assert(targetMethod.IsSharedByGenericInstantiations);
+            Debug.Assert(!targetMethod.Signature.IsStatic);
+            Debug.Assert(!targetMethod.HasInstantiation);
+            Debug.Assert(interfaceOnDefinition.GetTypeDefinition() == targetMethod.OwningType.GetTypeDefinition());
+            Debug.Assert(targetMethod.OwningType.IsInterface);
+
+            int interfaceIndex = Array.IndexOf(implementingClass.GetTypeDefinition().RuntimeInterfaces, interfaceOnDefinition);
+            Debug.Assert(interfaceIndex >= 0);
+
+            // Get a method that will inject the appropriate instantiation context to the
+            // target default interface method.
+            var methodKey = new DefaultInterfaceMethodImplementationInstantiationThunkHashtableKey(targetMethod, interfaceIndex);
+            MethodDesc thunk = _dimThunkHashtable.GetOrCreateValue(methodKey);
+            
+            return thunk;
+        }
+
+        /// <summary>
+        /// Returns true of <paramref name="method"/> is a standin method for instantiating thunk target.
+        /// </summary>
+        public bool IsDefaultInterfaceMethodImplementationThunkTargetMethod(MethodDesc method)
+        {
+            return method.GetTypicalMethodDefinition().GetType() == typeof(DefaultInterfaceMethodImplementationWithHiddenParameter);
+        }
+
+        /// <summary>
+        /// Returns the real target method of an instantiating thunk.
+        /// </summary>
+        public MethodDesc GetRealDefaultInterfaceMethodImplementationThunkTargetMethod(MethodDesc method)
+        {
+            MethodDesc typicalMethod = method.GetTypicalMethodDefinition();
+            return ((DefaultInterfaceMethodImplementationWithHiddenParameter)typicalMethod).MethodRepresented;
+        }
+
+        private struct DefaultInterfaceMethodImplementationInstantiationThunkHashtableKey
+        {
+            public readonly MethodDesc TargetMethod;
+            public readonly int InterfaceIndex;
+
+            public DefaultInterfaceMethodImplementationInstantiationThunkHashtableKey(MethodDesc targetMethod, int interfaceIndex)
+            {
+                TargetMethod = targetMethod;
+                InterfaceIndex = interfaceIndex;
+            }
+        }
+
+        private class DefaultInterfaceMethodImplementationInstantiationThunkHashtable : LockFreeReaderHashtable<DefaultInterfaceMethodImplementationInstantiationThunkHashtableKey, DefaultInterfaceMethodImplementationInstantiationThunk>
+        {
+            protected override int GetKeyHashCode(DefaultInterfaceMethodImplementationInstantiationThunkHashtableKey key)
+            {
+                return key.TargetMethod.GetHashCode() ^ key.InterfaceIndex;
+            }
+            protected override int GetValueHashCode(DefaultInterfaceMethodImplementationInstantiationThunk value)
+            {
+                return value.TargetMethod.GetHashCode() ^ value.InterfaceIndex;
+            }
+            protected override bool CompareKeyToValue(DefaultInterfaceMethodImplementationInstantiationThunkHashtableKey key, DefaultInterfaceMethodImplementationInstantiationThunk value)
+            {
+                return Object.ReferenceEquals(key.TargetMethod, value.TargetMethod) &&
+                    key.InterfaceIndex == value.InterfaceIndex;
+            }
+            protected override bool CompareValueToValue(DefaultInterfaceMethodImplementationInstantiationThunk value1, DefaultInterfaceMethodImplementationInstantiationThunk value2)
+            {
+                return Object.ReferenceEquals(value1.TargetMethod, value2.TargetMethod) &&
+                    value1.InterfaceIndex == value2.InterfaceIndex;
+            }
+            protected override DefaultInterfaceMethodImplementationInstantiationThunk CreateValueFromKey(DefaultInterfaceMethodImplementationInstantiationThunkHashtableKey key)
+            {
+                TypeDesc owningTypeOfThunks = key.TargetMethod.Context.GeneratedAssembly.GetGlobalModuleType();
+                return new DefaultInterfaceMethodImplementationInstantiationThunk(owningTypeOfThunks, key.TargetMethod, key.InterfaceIndex);
+            }
+        }
+        private DefaultInterfaceMethodImplementationInstantiationThunkHashtable _dimThunkHashtable = new DefaultInterfaceMethodImplementationInstantiationThunkHashtable();
+
+        /// <summary>
+        /// Represents a thunk to call shared instance method on generic interfaces.
+        /// </summary>
+        private partial class DefaultInterfaceMethodImplementationInstantiationThunk : ILStubMethod, IPrefixMangledMethod
+        {
+            private readonly MethodDesc _targetMethod;
+            private readonly DefaultInterfaceMethodImplementationWithHiddenParameter _nakedTargetMethod;
+            private readonly TypeDesc _owningType;
+            private readonly int _interfaceIndex;
+
+            public DefaultInterfaceMethodImplementationInstantiationThunk(TypeDesc owningType, MethodDesc targetMethod, int interfaceIndex)
+            {
+                Debug.Assert(targetMethod.OwningType.IsInterface);
+                Debug.Assert(!targetMethod.Signature.IsStatic);
+
+                _owningType = owningType;
+                _targetMethod = targetMethod;
+                _nakedTargetMethod = new DefaultInterfaceMethodImplementationWithHiddenParameter(targetMethod, owningType);
+                _interfaceIndex = interfaceIndex;
+            }
+
+            public override TypeSystemContext Context => _targetMethod.Context;
+
+            public override TypeDesc OwningType => _owningType;
+
+            public int InterfaceIndex => _interfaceIndex;
+
+            public override MethodSignature Signature => _targetMethod.Signature;
+
+            public MethodDesc TargetMethod => _targetMethod;
+
+            public override string Name
+            {
+                get
+                {
+                    return _targetMethod.Name;
+                }
+            }
+
+            public MethodDesc BaseMethod => _targetMethod;
+
+            public string Prefix => $"__InstantiatingStub_{_interfaceIndex}_";
+
+            public override MethodIL EmitIL()
+            {
+                // Generate the instantiating stub. This loosely corresponds to following C#:
+                // return Interface.Method(this, GetOrdinalInterface(this.m_pEEType, Index), [rest of parameters])
+
+                ILEmitter emit = new ILEmitter();
+                ILCodeStream codeStream = emit.NewCodeStream();
+
+                FieldDesc eeTypeField = Context.GetWellKnownType(WellKnownType.Object).GetKnownField("m_pEEType");
+                MethodDesc getOrdinalInterfaceMethod = Context.GetHelperEntryPoint("SharedCodeHelpers", "GetOrdinalInterface");
+
+                // Load "this"
+                codeStream.EmitLdArg(0);
+
+                // Load the instantiating argument.
+                codeStream.EmitLdArg(0);
+                codeStream.Emit(ILOpcode.ldfld, emit.NewToken(eeTypeField));
+                codeStream.EmitLdc(_interfaceIndex);
+                codeStream.Emit(ILOpcode.call, emit.NewToken(getOrdinalInterfaceMethod));
+
+                // Load rest of the arguments
+                for (int i = 0; i < _targetMethod.Signature.Length; i++)
+                {
+                    codeStream.EmitLdArg(i + 1);
+                }
+
+                // Call an instance method on the target interface that has a fake instantiation parameter
+                // in it's signature. This will be swapped by the actual instance method after codegen is done.
+                codeStream.Emit(ILOpcode.tail);
+                codeStream.Emit(ILOpcode.call, emit.NewToken(_nakedTargetMethod));
+                codeStream.Emit(ILOpcode.ret);
+
+                return emit.Link(this);
+            }
+        }
+
+        /// <summary>
+        /// Represents an instance method on a generic interface with an explicit instantiation parameter in the
+        /// signature. This is so that we can refer to the parameter from IL. References to this method will
+        /// be replaced by the actual instance method after codegen is done.
+        /// </summary>
+        internal partial class DefaultInterfaceMethodImplementationWithHiddenParameter : MethodDesc
+        {
+            private readonly MethodDesc _methodRepresented;
+            private readonly TypeDesc _owningType;
+            private MethodSignature _signature;
+
+            public DefaultInterfaceMethodImplementationWithHiddenParameter(MethodDesc methodRepresented, TypeDesc owningType)
+            {
+                Debug.Assert(methodRepresented.OwningType.IsInterface);
+                Debug.Assert(!methodRepresented.Signature.IsStatic);
+
+                _methodRepresented = methodRepresented;
+                _owningType = owningType;
+            }
+
+            public MethodDesc MethodRepresented => _methodRepresented;
+
+            // We really don't want this method to be inlined.
+            public override bool IsNoInlining => true;
+
+            public override bool IsInternalCall => true;
+
+            public override bool IsIntrinsic => true;
+
+            public override TypeSystemContext Context => _methodRepresented.Context;
+            public override TypeDesc OwningType => _owningType;
+
+            public override string Name => _methodRepresented.Name;
+
+            public override MethodSignature Signature
+            {
+                get
+                {
+                    if (_signature == null)
+                    {
+                        TypeDesc[] parameters = new TypeDesc[_methodRepresented.Signature.Length + 1];
+
+                        // Shared instance methods on generic interfaces have a hidden parameter with the generic context.
+                        // We add it to the signature so that we can refer to it from IL.
+                        parameters[0] = Context.GetWellKnownType(WellKnownType.IntPtr);
+                        for (int i = 0; i < _methodRepresented.Signature.Length; i++)
+                            parameters[i + 1] = _methodRepresented.Signature[i];
+
+                        _signature = new MethodSignature(_methodRepresented.Signature.Flags,
+                            _methodRepresented.Signature.GenericParameterCount,
+                            _methodRepresented.Signature.ReturnType,
+                            parameters);
+                    }
+
+                    return _signature;
+                }
+            }
+
+            public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => false;
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Sorting.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Sorting.cs
@@ -50,5 +50,32 @@ namespace ILCompiler
                 return comparer.Compare(_methodRepresented, otherMethod._methodRepresented);
             }
         }
+
+        partial class DefaultInterfaceMethodImplementationInstantiationThunk
+        {
+            protected override int ClassCode => -789598;
+
+            protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+            {
+                var otherMethod = (DefaultInterfaceMethodImplementationInstantiationThunk)other;
+
+                int result = System.Collections.Generic.Comparer<int>.Default.Compare(_interfaceIndex, otherMethod._interfaceIndex);
+                if (result != 0)
+                    return result;
+
+                return comparer.Compare(_targetMethod, otherMethod._targetMethod);
+            }
+        }
+
+        partial class DefaultInterfaceMethodImplementationWithHiddenParameter
+        {
+            protected override int ClassCode => 4903209;
+
+            protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
+            {
+                var otherMethod = (DefaultInterfaceMethodImplementationWithHiddenParameter)other;
+                return comparer.Compare(_methodRepresented, otherMethod._methodRepresented);
+            }
+        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -299,9 +299,10 @@ namespace ILCompiler.DependencyAnalysis
                 // Add conditional dependencies for interface methods the type implements. For example, if the type T implements
                 // interface IFoo which has a method M1, add a dependency on T.M1 dependent on IFoo.M1 being called, since it's
                 // possible for any IFoo object to actually be an instance of T.
-                for (int interfaceIndex = 0; interfaceIndex < defType.RuntimeInterfaces.Length; interfaceIndex++)
+                DefType[] defTypeRuntimeInterfaces = defType.RuntimeInterfaces;
+                for (int interfaceIndex = 0; interfaceIndex < defTypeRuntimeInterfaces.Length; interfaceIndex++)
                 {
-                    DefType interfaceType = defType.RuntimeInterfaces[interfaceIndex];
+                    DefType interfaceType = defTypeRuntimeInterfaces[interfaceIndex];
 
                     Debug.Assert(interfaceType.IsInterface);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ILScanNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ILScanNodeFactory.cs
@@ -28,6 +28,10 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     return MethodEntrypoint(TypeSystemContext.GetRealSpecialUnboxingThunkTargetMethod(method));
                 }
+                else if (TypeSystemContext.IsDefaultInterfaceMethodImplementationThunkTargetMethod(method))
+                {
+                    return MethodEntrypoint(TypeSystemContext.GetRealDefaultInterfaceMethodImplementationThunkTargetMethod(method));
+                }
                 else if (method.IsArrayAddressMethod())
                 {
                     return new ScannedMethodNode(((ArrayType)method.OwningType).GetArrayMethod(ArrayMethodKind.AddressWithHiddenArg));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -133,14 +133,16 @@ namespace ILCompiler.DependencyAnalysis
 
             TypeDesc declType = _type.GetClosestDefType();
             TypeDesc declTypeDefinition = declType.GetTypeDefinition();
+            DefType[] declTypeRuntimeInterfaces = declType.RuntimeInterfaces;
+            DefType[] declTypeDefinitionRuntimeInterfaces = declTypeDefinition.RuntimeInterfaces;
 
             // Catch any runtime interface collapsing. We shouldn't have any
-            Debug.Assert(declType.RuntimeInterfaces.Length == declTypeDefinition.RuntimeInterfaces.Length);
+            Debug.Assert(declTypeRuntimeInterfaces.Length == declTypeDefinitionRuntimeInterfaces.Length);
 
-            for (int interfaceIndex = 0; interfaceIndex < declType.RuntimeInterfaces.Length; interfaceIndex++)
+            for (int interfaceIndex = 0; interfaceIndex < declTypeRuntimeInterfaces.Length; interfaceIndex++)
             {
-                var interfaceType = declType.RuntimeInterfaces[interfaceIndex];
-                var interfaceDefinitionType = declTypeDefinition.RuntimeInterfaces[interfaceIndex];
+                var interfaceType = declTypeRuntimeInterfaces[interfaceIndex];
+                var interfaceDefinitionType = declTypeDefinitionRuntimeInterfaces[interfaceIndex];
                 Debug.Assert(interfaceType.IsInterface);
 
                 IReadOnlyList<MethodDesc> virtualSlots = factory.VTable(interfaceType).Slots;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -14,7 +14,7 @@ namespace ILCompiler.DependencyAnalysis
     public class SealedVTableNode : ObjectNode, ISymbolDefinitionNode
     {
         private readonly TypeDesc _type;
-        private List<MethodDesc> _sealedVTableEntries;
+        private List<SealedVTableEntry> _sealedVTableEntries;
 
         public SealedVTableNode(TypeDesc type)
         {
@@ -67,7 +67,21 @@ namespace ILCompiler.DependencyAnalysis
 
             for (int i = 0; i < _sealedVTableEntries.Count; i++)
             {
-                if (_sealedVTableEntries[i] == method)
+                if (_sealedVTableEntries[i].Matches(method))
+                    return i;
+            }
+
+            return -1;
+        }
+
+        public int ComputeDefaultInterfaceMethodSlot(MethodDesc method, DefType interfaceOnDefinition)
+        {
+            if (_sealedVTableEntries == null)
+                throw new NotSupportedException();
+
+            for (int i = 0; i < _sealedVTableEntries.Count; i++)
+            {
+                if (_sealedVTableEntries[i].Matches(method, interfaceOnDefinition))
                     return i;
             }
 
@@ -87,7 +101,7 @@ namespace ILCompiler.DependencyAnalysis
             if (relocsOnly && !factory.VTable(declType).HasFixedSlots)
                 return false;
 
-            _sealedVTableEntries = new List<MethodDesc>();
+            _sealedVTableEntries = new List<SealedVTableEntry>();
 
             // If this is an interface, we're done. They don't have any slots.
             if (_type.IsInterface)
@@ -100,26 +114,28 @@ namespace ILCompiler.DependencyAnalysis
                 MethodDesc implMethod = declType.FindVirtualFunctionTargetMethodOnObjectType(virtualSlots[i]);
 
                 if (implMethod.CanMethodBeInSealedVTable())
-                    _sealedVTableEntries.Add(implMethod);
+                    _sealedVTableEntries.Add(SealedVTableEntry.FromVirtualMethod(implMethod));
             }
 
+            TypeDesc declTypeDefinition = declType.GetTypeDefinition();
+
             // Catch any runtime interface collapsing. We shouldn't have any
-            Debug.Assert(declType.RuntimeInterfaces.Length == declType.GetTypeDefinition().RuntimeInterfaces.Length);
+            Debug.Assert(declType.RuntimeInterfaces.Length == declTypeDefinition.RuntimeInterfaces.Length);
 
             for (int interfaceIndex = 0; interfaceIndex < declType.RuntimeInterfaces.Length; interfaceIndex++)
             {
                 var interfaceType = declType.RuntimeInterfaces[interfaceIndex];
-                var interfaceDefinitionType = declType.GetTypeDefinition().RuntimeInterfaces[interfaceIndex];
+                var interfaceDefinitionType = declTypeDefinition.RuntimeInterfaces[interfaceIndex];
 
                 virtualSlots = factory.VTable(interfaceType).Slots;
 
                 for (int interfaceMethodSlot = 0; interfaceMethodSlot < virtualSlots.Count; interfaceMethodSlot++)
                 {
                     MethodDesc declMethod = virtualSlots[interfaceMethodSlot];
-                    if (!interfaceType.IsTypeDefinition)
+                    if  (!interfaceType.IsTypeDefinition)
                         declMethod = factory.TypeSystemContext.GetMethodForInstantiatedType(declMethod.GetTypicalMethodDefinition(), (InstantiatedType)interfaceDefinitionType);
 
-                    var implMethod = declType.GetTypeDefinition().ResolveInterfaceMethodToVirtualMethodOnType(declMethod);
+                    var implMethod = declTypeDefinition.ResolveInterfaceMethodToVirtualMethodOnType(declMethod);
 
                     // Interface methods first implemented by a base type in the hierarchy will return null for the implMethod (runtime interface
                     // dispatch will walk the inheritance chain).
@@ -135,17 +151,21 @@ namespace ILCompiler.DependencyAnalysis
                             if (!implType.IsTypeDefinition)
                                 targetMethod = factory.TypeSystemContext.GetMethodForInstantiatedType(implMethod.GetTypicalMethodDefinition(), (InstantiatedType)implType);
 
-                            _sealedVTableEntries.Add(targetMethod);
+                            _sealedVTableEntries.Add(SealedVTableEntry.FromVirtualMethod(targetMethod));
                         }
                     }
                     else
                     {
                         // If the interface method is provided by a default implementation, add the default implementation
                         // to the sealed vtable.
-                        var resolution = declType.ResolveInterfaceMethodToDefaultImplementationOnType(virtualSlots[interfaceMethodSlot], out implMethod);
+                        var resolution = declTypeDefinition.ResolveInterfaceMethodToDefaultImplementationOnType(declMethod, out implMethod);
                         if (resolution == DefaultInterfaceMethodResolution.DefaultImplementation)
                         {
-                            _sealedVTableEntries.Add(implMethod);
+                            DefType providingInterfaceDefinitionType = (DefType)implMethod.OwningType;
+                            if (interfaceType != interfaceDefinitionType)
+                                implMethod = implMethod.InstantiateSignature(declType.Instantiation, Instantiation.Empty);
+
+                            _sealedVTableEntries.Add(SealedVTableEntry.FromDefaultInterfaceMethod(implMethod, providingInterfaceDefinitionType));
                         }
                     }
                 }
@@ -178,8 +198,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 for (int i = 0; i < _sealedVTableEntries.Count; i++)
                 {
-                    MethodDesc canonImplMethod = _sealedVTableEntries[i].GetCanonMethodTarget(CanonicalFormKind.Specific);
-                    IMethodNode relocTarget = factory.MethodEntrypoint(canonImplMethod, _sealedVTableEntries[i].OwningType.IsValueType);
+                    IMethodNode relocTarget = _sealedVTableEntries[i].GetTarget(factory, _type);
 
                     if (factory.Target.SupportsRelativePointers)
                         objData.EmitReloc(relocTarget, RelocType.IMAGE_REL_BASED_RELPTR32);
@@ -195,6 +214,69 @@ namespace ILCompiler.DependencyAnalysis
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             return comparer.Compare(_type, ((SealedVTableNode)other)._type);
+        }
+
+        private readonly struct SealedVTableEntry
+        {
+            private readonly MethodDesc _method;
+            private readonly DefType _interfaceDefinition;
+
+            private SealedVTableEntry(MethodDesc method, DefType interfaceDefinition)
+            {
+                Debug.Assert(interfaceDefinition == null || method.GetTypicalMethodDefinition().OwningType == interfaceDefinition.GetTypeDefinition());
+                (_method, _interfaceDefinition) = (method, interfaceDefinition);
+            }
+
+            public static SealedVTableEntry FromVirtualMethod(MethodDesc method)
+                => new SealedVTableEntry(method, null);
+
+            public static SealedVTableEntry FromDefaultInterfaceMethod(MethodDesc method, DefType interfaceOnDefinition)
+                => new SealedVTableEntry(method, interfaceOnDefinition);
+
+            public IMethodNode GetTarget(NodeFactory factory, TypeDesc implementingClass)
+            {
+                MethodDesc implMethod = _method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                if (_interfaceDefinition != null && implMethod.IsCanonicalMethod(CanonicalFormKind.Any))
+                {
+                    implMethod = factory.TypeSystemContext.GetDefaultInterfaceMethodImplementationThunk(implMethod, implementingClass.ConvertToCanonForm(CanonicalFormKind.Specific), _interfaceDefinition);
+                }
+                return factory.MethodEntrypoint(implMethod, _method.OwningType.IsValueType);
+            }
+
+            public bool Matches(MethodDesc method)
+            {
+                if (_method == method)
+                {
+                    // It is not valid to ask for slots of default implementations of interfaces on canonical version of the type.
+                    //
+                    // Consider:
+                    //
+                    // interface IFoo<T> { void Frob() => Console.WriteLine(typeof(T)) }
+                    // class Base<T> : IFoo<T> { }
+                    // class Derived<T, U> : Base<T>, IFoo<U> { }
+                    //
+                    // If we ask what's the slot of IFoo<__Canon>.Frob on Derived<__Canon, __Canon>, the answer is actually
+                    // "two slots". We need extra data (the interface implementation on the definition of the type -
+                    // e.g. "IFace<!0>") to disambiguate. Use the other overload.
+                    Debug.Assert(_interfaceDefinition == null || !method.IsCanonicalMethod(CanonicalFormKind.Any));
+                    return true;
+                }
+
+                return false;
+            }
+
+            public bool Matches(MethodDesc method, DefType interfaceDefinition)
+            {
+                Debug.Assert(method.GetTypicalMethodDefinition().OwningType == interfaceDefinition.GetTypeDefinition());
+                Debug.Assert(interfaceDefinition.IsInterface);
+
+                if (_method == method && _interfaceDefinition == interfaceDefinition)
+                {
+                    return true;
+                }
+
+                return false;
+            }
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -119,13 +119,16 @@ namespace ILCompiler.DependencyAnalysis
 
             TypeDesc declTypeDefinition = declType.GetTypeDefinition();
 
-            // Catch any runtime interface collapsing. We shouldn't have any
-            Debug.Assert(declType.RuntimeInterfaces.Length == declTypeDefinition.RuntimeInterfaces.Length);
+            DefType[] declTypeRuntimeInterfaces = declType.RuntimeInterfaces;
+            DefType[] declTypeDefinitionRuntimeInterfaces = declTypeDefinition.RuntimeInterfaces;
 
-            for (int interfaceIndex = 0; interfaceIndex < declType.RuntimeInterfaces.Length; interfaceIndex++)
+            // Catch any runtime interface collapsing. We shouldn't have any
+            Debug.Assert(declTypeRuntimeInterfaces.Length == declTypeDefinitionRuntimeInterfaces.Length);
+
+            for (int interfaceIndex = 0; interfaceIndex < declTypeRuntimeInterfaces.Length; interfaceIndex++)
             {
-                var interfaceType = declType.RuntimeInterfaces[interfaceIndex];
-                var interfaceDefinitionType = declTypeDefinition.RuntimeInterfaces[interfaceIndex];
+                var interfaceType = declTypeRuntimeInterfaces[interfaceIndex];
+                var interfaceDefinitionType = declTypeDefinitionRuntimeInterfaces[interfaceIndex];
 
                 virtualSlots = factory.VTable(interfaceType).Slots;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MethodExtensions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MethodExtensions.cs
@@ -160,6 +160,7 @@ namespace ILCompiler
             return !method.Signature.IsStatic && /* Static methods don't have this */
                 !owningType.IsValueType && /* Value type instance methods take a ref to data */
                 !owningType.IsArrayTypeWithoutGenericInterfaces() && /* Type loader can make these at runtime */
+                (owningType is not MetadataType mdType || !mdType.IsModuleType) && /* Compiler parks some instance methods on the <Module> type */
                 !method.IsSharedByGenericInstantiations; /* Current impl limitation; can be lifted */
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Compiler\CompilationModuleGroup.Aot.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.Aot.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.BoxedTypes.cs" />
+    <Compile Include="Compiler\CompilerTypeSystemContext.IntefaceThunks.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.Mangling.cs" />
     <Compile Include="Compiler\CompilerTypeSystemContext.Sorting.cs" />
     <Compile Include="Compiler\CompilerGeneratedInteropStubManager.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/RyuJitNodeFactory.cs
@@ -25,6 +25,10 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     return MethodEntrypoint(TypeSystemContext.GetRealSpecialUnboxingThunkTargetMethod(method));
                 }
+                else if (TypeSystemContext.IsDefaultInterfaceMethodImplementationThunkTargetMethod(method))
+                {
+                    return MethodEntrypoint(TypeSystemContext.GetRealDefaultInterfaceMethodImplementationThunkTargetMethod(method));
+                }
                 else if (method.IsArrayAddressMethod())
                 {
                     return MethodEntrypoint(((ArrayType)method.OwningType).GetArrayMethod(ArrayMethodKind.AddressWithHiddenArg));


### PR DESCRIPTION
Add support for generating instantiating stubs. The implementation strategy is similar to how we do instantiating stubs on generic structs. Adds two kind of methods - the actual instantiating stub, and a fake method that is necessary so that we can access the instantiation argument from IL. The fake method is replaced with the real entrypoint when we ask for the reloc for it.