### PR TITLE
Support implicit blittability for structs declared in and not exposed outside of the current compilation.

### DIFF
--- a/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -499,14 +499,6 @@ struct MyStruct
     private int i;
     private short s;
 }";
-        public static string GenericBlittableStructParametersAndModifiers = BasicParametersAndModifiers("MyStruct<int>") + @"
-#pragma warning disable CS0169
-[BlittableType]
-struct MyStruct<T>
-{
-    private T t;
-    private short s;
-}";
 
         public static string ArrayParametersAndModifiers(string elementType) => $@"
 using System.Runtime.InteropServices;
@@ -1028,5 +1020,56 @@ partial class Test
 #endif
     public static int Foo() => throw null;
 }}";
+
+        public static string MaybeBlittableGenericTypeParametersAndModifiers(string typeArgument) => BasicParametersAndModifiers($"Generic<{typeArgument}>") + @"
+[BlittableType]
+struct Generic<T>
+{
+#pragma warning disable CS0649
+    public T field;
+}
+";
+
+        public static string MaybeBlittableGenericTypeParametersAndModifiers<T>() =>
+            MaybeBlittableGenericTypeParametersAndModifiers(typeof(T).ToString());
+
+        public static string ImplicitlyBlittableStructParametersAndModifiers(string visibility = "") => BasicParametersAndModifiers("ImplicitBlittable") + $@"
+#pragma warning disable CS0649
+#pragma warning disable CS0169
+{visibility} struct ImplicitBlittable
+{{
+    int i;
+}}";
+
+        public static string ImplicitlyBlittableGenericTypeParametersAndModifiers(string typeArgument, string visibility = "") => BasicParametersAndModifiers($"Generic<{typeArgument}>") + $@"
+{visibility} struct Generic<T>
+{{
+#pragma warning disable CS0649
+#pragma warning disable CS0169
+    public T field;
+}}
+";
+
+        public static string ImplicitlyBlittableGenericTypeParametersAndModifiers<T>(string visibility = "") =>
+            ImplicitlyBlittableGenericTypeParametersAndModifiers(typeof(T).ToString(), visibility);
+
+        public static string RecursiveImplicitlyBlittableStruct => BasicParametersAndModifiers("RecursiveStruct") + @"
+struct RecursiveStruct
+{
+    RecursiveStruct s;
+    int i;
+}";
+        public static string MutuallyRecursiveImplicitlyBlittableStruct => BasicParametersAndModifiers("RecursiveStruct1") + @"
+struct RecursiveStruct1
+{
+    RecursiveStruct2 s;
+    int i;
+}
+
+struct RecursiveStruct2
+{
+    RecursiveStruct1 s;
+    int i;
+}";
     }
 }

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -131,7 +131,6 @@ namespace DllImportGenerator.UnitTests
 
             // Structs
             yield return new[] { CodeSnippets.BlittableStructParametersAndModifiers };
-            yield return new[] { CodeSnippets.GenericBlittableStructParametersAndModifiers };
 
             // SafeHandle
             yield return new[] { CodeSnippets.BasicParametersAndModifiers("Microsoft.Win32.SafeHandles.SafeFileHandle") };
@@ -179,6 +178,26 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CustomStructMarshallingNativeTypePinnable };
             yield return new[] { CodeSnippets.CustomStructMarshallingMarshalUsingParametersAndModifiers };
             yield return new[] { CodeSnippets.ArrayMarshallingWithCustomStructElement };
+
+            // Generics
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<byte>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<sbyte>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<short>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<ushort>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<int>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<uint>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<long>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<ulong>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<float>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<double>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<IntPtr>() };
+            yield return new[] { CodeSnippets.MaybeBlittableGenericTypeParametersAndModifiers<UIntPtr>() };
+
+            // Implicit blittable types
+            yield return new[] { CodeSnippets.ImplicitlyBlittableStructParametersAndModifiers() };
+            yield return new[] { CodeSnippets.ImplicitlyBlittableStructParametersAndModifiers("internal") };
+            yield return new[] { CodeSnippets.ImplicitlyBlittableGenericTypeParametersAndModifiers<int>() };
+            yield return new[] { CodeSnippets.ImplicitlyBlittableGenericTypeParametersAndModifiers<int>("internal") };
         }
 
         [Theory]

--- a/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
@@ -13,9 +13,7 @@ namespace Microsoft.Interop
 {
     static class TypeSymbolExtensions
     {
-#pragma warning disable RS1024 // Compare symbols correctly. We are using the correct comparer, but the analyzer doesn't see it correctly.
         public static bool HasOnlyBlittableFields(this ITypeSymbol type) => HasOnlyBlittableFields(type, new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
-#pragma warning restore RS1024 // Compare symbols correctly
 
         private static bool HasOnlyBlittableFields(this ITypeSymbol type, HashSet<ITypeSymbol> seenTypes)
         {
@@ -74,9 +72,7 @@ namespace Microsoft.Interop
             _ => false
          };
 
-#pragma warning disable RS1024 // Compare symbols correctly. We are using the correct comparer, but the analyzer doesn't see it correctly.
         public static bool IsConsideredBlittable(this ITypeSymbol type) => IsConsideredBlittable(type, new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
-#pragma warning restore RS1024 // Compare symbols correctly
 
         private static bool IsConsideredBlittable(this ITypeSymbol type, HashSet<ITypeSymbol> seenTypes)
         {

--- a/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Interop
                 return IsSpecialTypeBlittable(type.SpecialType);
             }
 
-            if (type.TypeKind == TypeKind.FunctionPointer)
+            if (type.TypeKind is TypeKind.FunctionPointer or TypeKind.Pointer)
             {
                 return true;
             }
@@ -93,11 +93,6 @@ namespace Microsoft.Interop
             if (!type.IsValueType || type.IsReferenceType)
             {
                 return false;
-            }
-
-            if (type is IPointerTypeSymbol)
-            {
-                return true;
             }
 
             if (type is INamedTypeSymbol { TypeKind: TypeKind.Enum, EnumUnderlyingType: ITypeSymbol underlyingType })

--- a/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
@@ -13,26 +13,34 @@ namespace Microsoft.Interop
 {
     static class TypeSymbolExtensions
     {
-        public static bool HasOnlyBlittableFields(this ITypeSymbol type)
+#pragma warning disable RS1024 // Compare symbols correctly. We are using the correct comparer, but the analyzer doesn't see it correctly.
+        public static bool HasOnlyBlittableFields(this ITypeSymbol type) => HasOnlyBlittableFields(type, new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+#pragma warning restore RS1024 // Compare symbols correctly
+
+        private static bool HasOnlyBlittableFields(this ITypeSymbol type, HashSet<ITypeSymbol> seenTypes)
         {
+            if (seenTypes.Contains(type))
+            {
+                // A recursive struct type isn't blittable.
+                // It's also illegal in C#, but I believe that source generators run
+                // before that is detected, so we check here to avoid a stack overflow.
+                return false;
+            }
+            seenTypes.Add(type);
             foreach (var field in type.GetMembers().OfType<IFieldSymbol>())
             {
                 bool? fieldBlittable = field switch
                 {
-                    { IsStatic : true } => null,
-                    { Type : { IsReferenceType : true }} => false,
-                    { Type : IPointerTypeSymbol ptr } => IsConsideredBlittable(ptr.PointedAtType),
-                    { Type : IFunctionPointerTypeSymbol } => true,
-                    not { Type : { SpecialType : SpecialType.None }} => IsSpecialTypeBlittable(field.Type.SpecialType),
+                    { IsStatic: true } => null,
+                    { Type: { IsReferenceType: true } } => false,
+                    { Type: IPointerTypeSymbol ptr } => IsConsideredBlittable(ptr.PointedAtType),
+                    { Type: IFunctionPointerTypeSymbol } => true,
+                    not { Type: { SpecialType: SpecialType.None } } => IsSpecialTypeBlittable(field.Type.SpecialType),
                     // Assume that type parameters that can be blittable are blittable.
                     // We'll re-evaluate blittability for generic fields of generic types at instantation time.
-                    { Type : ITypeParameterSymbol } => true,
-                    { Type : { IsValueType : false }} => false,
-                    // A recursive struct type isn't blittable.
-                    // It's also illegal in C#, but I believe that source generators run
-                    // before that is detected, so we check here to avoid a stack overflow.
-                    // [TODO]: Handle mutual recursion.
-                    _ => !SymbolEqualityComparer.Default.Equals(field.Type, type) && IsConsideredBlittable(field.Type)
+                    { Type: ITypeParameterSymbol } => true,
+                    { Type: { IsValueType: false } } => false,
+                    _ => IsConsideredBlittable(field.Type, seenTypes)
                 };
 
                 if (fieldBlittable is false)
@@ -62,7 +70,11 @@ namespace Microsoft.Interop
             _ => false
          };
 
-        public static bool IsConsideredBlittable(this ITypeSymbol type)
+#pragma warning disable RS1024 // Compare symbols correctly. We are using the correct comparer, but the analyzer doesn't see it correctly.
+        public static bool IsConsideredBlittable(this ITypeSymbol type) => IsConsideredBlittable(type, new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default));
+#pragma warning restore RS1024 // Compare symbols correctly
+
+        private static bool IsConsideredBlittable(this ITypeSymbol type, HashSet<ITypeSymbol> seenTypes)
         {
             if (type.SpecialType != SpecialType.None)
             {
@@ -79,14 +91,14 @@ namespace Microsoft.Interop
                 return false;
             }
 
-            if (type is IPointerTypeSymbol { PointedAtType: ITypeSymbol pointedAtType })
+            if (type is IPointerTypeSymbol)
             {
-                return pointedAtType.IsConsideredBlittable();
+                return true;
             }
 
             if (type is INamedTypeSymbol { TypeKind: TypeKind.Enum, EnumUnderlyingType: ITypeSymbol underlyingType })
             {
-                return underlyingType!.IsConsideredBlittable();
+                return underlyingType!.IsConsideredBlittable(seenTypes);
             }
 
             bool hasNativeMarshallingAttribute = false;
@@ -107,7 +119,7 @@ namespace Microsoft.Interop
                         // since we are guaranteed that if a type has generic fields,
                         // they will be present in the contract assembly to ensure
                         // that recursive structs can be identified at build time.
-                        return generic.HasOnlyBlittableFields();
+                        return generic.HasOnlyBlittableFields(seenTypes);
                     }
                     return true;
                 }
@@ -126,7 +138,16 @@ namespace Microsoft.Interop
                 // The struct type has generated marshalling via a source generator.
                 // We can't guarantee that we can see the results of the struct source generator,
                 // so we re-calculate if the type is blittable here.
-                return type.HasOnlyBlittableFields();
+                return type.HasOnlyBlittableFields(seenTypes);
+            }
+
+            if (type is INamedTypeSymbol namedType
+                && namedType.DeclaringSyntaxReferences.Length != 0
+                && !namedType.IsExposedOutsideOfCurrentCompilation())
+            {
+                // If a type is declared in the current compilation and not exposed outside of it,
+                // we will allow it to be considered blittable if its fields are considered blittable.
+                return type.HasOnlyBlittableFields(seenTypes);
             }
             return false;
         }
@@ -164,6 +185,20 @@ namespace Microsoft.Interop
                 or SpecialType.System_UIntPtr => true,
                 _ => false
             };
+        }
+
+        public static bool IsExposedOutsideOfCurrentCompilation(this INamedTypeSymbol type)
+        {
+            for (; type is not null; type = type.ContainingType)
+            {
+                Accessibility accessibility = type.DeclaredAccessibility;
+
+                if (accessibility is Accessibility.Internal or Accessibility.ProtectedAndInternal or Accessibility.Private or Accessibility.Friend or Accessibility.ProtectedAndFriend)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,7 +21,7 @@
     <!-- Roslyn dependencies -->
     <CompilerPlatformVersion>3.10.0-3.21229.26</CompilerPlatformVersion>
     <CompilerPlatformTestingVersion>1.0.1-beta1.20478.1</CompilerPlatformTestingVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3-beta1.21268.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <!-- Package dependencies -->
     <SystemCommandLineVersion>2.0.0-beta1.21118.1</SystemCommandLineVersion>
     <IcedVersion>1.8.0</IcedVersion>


### PR DESCRIPTION
Also significantly increase our test coverage for generic blittable types as they're another area nearby and something I hadn't added a ton of tests for originally.

Fixes #1125 