### PR TITLE
Allow devirtualizing into unallocated types

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -412,6 +412,11 @@ namespace ILCompiler
                 if (_unsealedTypes.Contains(canonType))
                     return false;
 
+                // Don't report __Canon as sealed or it can cause trouble
+                // (E.g. RyuJIT might think it's okay to omit array element type checks for __Canon[].)
+                if (type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
+                    return false;
+
                 if (type is MetadataType metadataType)
                 {
                     // Due to how the compiler is structured, we might see "constructed" EETypes for things

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -407,21 +407,9 @@ namespace ILCompiler
 
             public override bool IsEffectivelySealed(TypeDesc type)
             {
-                // Valuetypes are sealed by design
-                if (type.IsValueType)
-                    return true;
-
                 // If we know we scanned a type that derives from this one, this for sure can't be reported as sealed.
                 TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
                 if (_unsealedTypes.Contains(canonType))
-                    return false;
-
-                // We don't want to report types that never got allocated as sealed because that would allow
-                // the codegen to do direct calls to the type's methods. That can potentially lead to codegen
-                // generating calls to methods we never scanned (consider a sealed type that never got allocated
-                // with a virtual method that can be devirtualized because the type is sealed).
-                // Codegen looking at code we didn't scan is never okay.
-                if (!_constructedTypes.Contains(canonType))
                     return false;
 
                 if (type is MetadataType metadataType)

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -739,12 +739,14 @@ namespace ILCompiler
                 // This could be a command line switch if we really wanted to.
                 builder.UseGenericDictionaryLayoutProvider(scanResults.GetDictionaryLayoutInfo());
 
-                // If we feed any outputs of the scanner into the compilation, it's essential
-                // we use scanner's devirtualization manager. It prevents optimizing codegens
-                // from accidentally devirtualizing cases that can never happen at runtime
-                // (e.g. devirtualizing a method on a type that never gets allocated).
+                // If we have a scanner, we can drive devirtualization using the information
+                // we collected at scanning time (effectively sealing unsealed types if possible).
+                // This could be a command line switch if we really wanted to.
                 builder.UseDevirtualizationManager(scanResults.GetDevirtualizationManager());
 
+                // If we use the scanner's result, we need to consult it to drive inlining.
+                // This prevents e.g. devirtualizing and inlining methods on types that were
+                // never actually allocated.
                 builder.UseInliningPolicy(scanResults.GetInliningPolicy());
             }
 


### PR DESCRIPTION
The purpose of this code was to prevent devirtualization on sealed types that were never seen as allocated (the devirtualization wouldn't be possible at runtime since the `this` would have to be null; and the compiler would crash before we get there because we would attempt to compile code that wasn't scanned).

This should not be needed after tentative instance methods were introduced in dotnet/runtimelab#643.