### PR TITLE
Throw BadImageFormat on calls to abstract methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -497,7 +497,7 @@ namespace Internal.IL
 
             if (directCall && targetMethod.IsAbstract)
             {
-                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramCallAbstractMethod);
+                ThrowHelper.ThrowBadImageFormatException();
             }
 
             bool allowInstParam = opcode != ILOpcode.ldvirtftn && opcode != ILOpcode.ldftn;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1062,7 +1062,7 @@ namespace Internal.JitInterface
 
             if (directCall && targetMethod.IsAbstract)
             {
-                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramCallAbstractMethod);
+                ThrowHelper.ThrowBadImageFormatException();
             }
 
             if (directCall && !allowInstParam && targetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific).RequiresInstArg())


### PR DESCRIPTION
We have a test for this. Also, the string ID doesn't actually have an exception string associated so this was failing to throw in the first place.