### PR TITLE
Don't do guarded devirtualization for unallocated types

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DevirtualizationManager.cs
+++ b/src/coreclr/tools/Common/Compiler/DevirtualizationManager.cs
@@ -92,5 +92,16 @@ namespace ILCompiler
 
             return impl;
         }
+
+#if !READYTORUN
+        /// <summary>
+        /// Gets a value indicating whether it might be possible to obtain a constructed type data structure for the given type.
+        /// </summary>
+        /// <remarks>
+        /// This is a bit of a hack, but devirtualization manager has a global view of all allocated types
+        /// so it can answer this question.
+        /// </remarks>
+        public virtual bool CanConstructType(TypeDesc type) => true;
+#endif
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -96,6 +96,11 @@ namespace ILCompiler
             return _inliningPolicy.CanInline(caller, callee);
         }
 
+        public bool CanConstructType(TypeDesc type)
+        {
+            return _devirtualizationManager.CanConstructType(type);
+        }
+
         public DelegateCreationInfo GetDelegateCtor(TypeDesc delegateType, MethodDesc target, bool followVirtualDispatch)
         {
             // If we're creating a delegate to a virtual method that cannot be overriden, devirtualize.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -438,6 +438,8 @@ namespace ILCompiler
 
                 return base.IsEffectivelySealed(method);
             }
+
+            public override bool CanConstructType(TypeDesc type) => _constructedTypes.Contains(type);
         }
 
         private class ScannedInliningPolicy : IInliningPolicy


### PR DESCRIPTION
PGO data can refer to types we have not seen during scanning. There's no point to do guarded devirtualization for them since they were not allocated in the program. The only thing the guarded devirtualization would do is crash the compiler.