### PR TITLE
Disable System.Collections test on macOS

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -400,7 +400,7 @@
   <ItemGroup Condition="'$(ClrNativeAot)' == 'true'">
     <!-- Run only a small randomly chosen set of passing test suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj" />
-    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" />
+    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" Condition="'$(TargetOS)' != 'OSX'" />
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" Condition="'$(__DistroRid)' != 'linux-musl-x64'"/>
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Threading\tests\System.Threading.Tests.csproj" />
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" Condition="'$(TargetOS)' != 'OSX'" />


### PR DESCRIPTION
Similar failure mode to System.IO.FileSystem (SIGSEGV happening very often).