### PR TITLE
Fix stresslog lifetime problem

### DIFF
--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -156,8 +156,8 @@ private:
 
 public:
 
-
-    void Destroy();
+    void Detach(); // First phase of thread destructor, executed with thread store lock taken
+    void Destroy(); // Second phase of thread destructor, executed without thread store lock taken
 
     bool                IsInitialized();
 


### PR DESCRIPTION
The thread-local StressLog was used even after it was detached.