### PR TITLE
Cache the ThrowInstanceBodyRemoved helper

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -937,6 +937,22 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        private MethodDesc _instanceMethodRemovedHelper;
+        public MethodDesc InstanceMethodRemovedHelper
+        {
+            get
+            {
+                if (_instanceMethodRemovedHelper == null)
+                {
+                    // This helper is optional, but it's fine for this cache to be ineffective if that happens.
+                    // Those scenarios are rare and typically deal with small compilations.
+                    _instanceMethodRemovedHelper = TypeSystemContext.GetOptionalHelperEntryPoint("ThrowHelpers", "ThrowInstanceBodyRemoved");
+                }
+
+                return _instanceMethodRemovedHelper;
+            }
+        }
+
         private NodeCache<MethodDesc, VirtualMethodUseNode> _virtMethods;
 
         public DependencyNodeCore<NodeFactory> VirtualMethodUse(MethodDesc decl)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TentativeInstanceMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TentativeInstanceMethodNode.cs
@@ -38,7 +38,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override ISymbolNode GetTarget(NodeFactory factory)
         {
             // If the class library doesn't provide this helper, the optimization is disabled.
-            MethodDesc helper = factory.TypeSystemContext.GetOptionalHelperEntryPoint("ThrowHelpers", "ThrowInstanceBodyRemoved");
+            MethodDesc helper = factory.InstanceMethodRemovedHelper;
             return helper == null ? RealBody: factory.MethodEntrypoint(helper);
         }
 


### PR DESCRIPTION
Improves wallclock time for compilation of a Hello World by ~3%. Looking up things by name is not exactly cheap and we do it a lot here.