### PR TITLE
Add functionality to enumerate virtual methods only

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/ArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ArrayType.cs
@@ -119,6 +119,11 @@ namespace Internal.TypeSystem
             return _methods;
         }
 
+        public override IEnumerable<MethodDesc> GetVirtualMethods()
+        {
+            return MethodDesc.EmptyMethods;
+        }
+
         public MethodDesc GetArrayMethod(ArrayMethodKind kind)
         {
             if (_methods == null)

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
@@ -144,6 +144,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override IEnumerable<MethodDesc> GetVirtualMethods()
+        {
+            foreach (var typicalMethodDef in _typeDef.GetVirtualMethods())
+            {
+                yield return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);
+            }
+        }
+
         // TODO: Substitutions, generics, modopts, ...
         public override MethodDesc GetMethod(string name, MethodSignature signature, Instantiation substitution)
         {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -330,11 +330,8 @@ namespace Internal.TypeSystem
             MethodSignature sig = targetMethod.Signature;
 
             MethodDesc implMethod = null;
-            foreach (MethodDesc candidate in currentType.GetAllMethods())
+            foreach (MethodDesc candidate in currentType.GetAllVirtualMethods())
             {
-                if (!candidate.IsVirtual)
-                    continue;
-
                 if (candidate.Name == name)
                 {
                     if (candidate.Signature.Equals(sig))
@@ -810,11 +807,8 @@ namespace Internal.TypeSystem
             {
                 do
                 {
-                    foreach (MethodDesc m in type.GetAllMethods())
+                    foreach (MethodDesc m in type.GetAllVirtualMethods())
                     {
-                        if (!m.IsVirtual)
-                            continue;
-
                         MethodDesc possibleVirtual = FindSlotDefiningMethodForVirtualMethod(m);
                         if (!alreadyEnumerated.Contains(possibleVirtual))
                         {

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
@@ -511,6 +511,16 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
+        /// Gets a subset of methods returned by <see cref="GetMethods"/> that are virtual.
+        /// </summary>
+        public virtual IEnumerable<MethodDesc> GetVirtualMethods()
+        {
+            foreach (MethodDesc method in GetMethods())
+                if (method.IsVirtual)
+                    yield return method;
+        }
+
+        /// <summary>
         /// Gets a named method on the type. This method only looks at methods defined
         /// in type's metadata. The <paramref name="signature"/> parameter can be null.
         /// If signature is not specified and there are multiple matches, the first one

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemContext.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemContext.cs
@@ -677,6 +677,11 @@ namespace Internal.TypeSystem
             return type.GetMethods();
         }
 
+        protected internal virtual IEnumerable<MethodDesc> GetAllVirtualMethods(TypeDesc type)
+        {
+            return type.GetVirtualMethods();
+        }
+
         /// <summary>
         /// Abstraction to allow the type system context to affect the field layout
         /// algorithm used by types to lay themselves out.

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
@@ -261,6 +261,14 @@ namespace Internal.TypeSystem
             return type.Context.GetAllMethods(type);
         }
 
+        /// <summary>
+        /// Retrieves all virtual methods on a type, including the ones injected by the type system context.
+        /// </summary>
+        public static IEnumerable<MethodDesc> GetAllVirtualMethods(this TypeDesc type)
+        {
+            return type.Context.GetAllVirtualMethods(type);
+        }
+
         public static IEnumerable<MethodDesc> EnumAllVirtualSlots(this TypeDesc type)
         {
             return type.Context.GetVirtualMethodAlgorithmForType(type).ComputeAllVirtualSlots(type);

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -306,7 +306,18 @@ namespace Internal.TypeSystem.Ecma
         {
             foreach (var handle in _typeDefinition.GetMethods())
             {
-                yield return (MethodDesc)_module.GetObject(handle);
+                yield return (EcmaMethod)_module.GetObject(handle);
+            }
+        }
+
+        public override IEnumerable<MethodDesc> GetVirtualMethods()
+        {
+            MetadataReader reader = _module.MetadataReader;
+            foreach (var handle in _typeDefinition.GetMethods())
+            {
+                MethodDefinition methodDef = reader.GetMethodDefinition(handle);
+                if ((methodDef.Attributes & MethodAttributes.Virtual) != 0)
+                    yield return (EcmaMethod)_module.GetObject(handle);
             }
         }
 
@@ -319,7 +330,7 @@ namespace Internal.TypeSystem.Ecma
             {
                 if (stringComparer.Equals(metadataReader.GetMethodDefinition(handle).Name, name))
                 {
-                    MethodDesc method = (MethodDesc)_module.GetObject(handle);
+                    var method = (EcmaMethod)_module.GetObject(handle);
                     if (signature == null || signature.Equals(method.Signature.ApplySubstitution(substitution)))
                         return method;
                 }
@@ -339,7 +350,7 @@ namespace Internal.TypeSystem.Ecma
                 if (methodDefinition.Attributes.IsRuntimeSpecialName() &&
                     stringComparer.Equals(methodDefinition.Name, ".cctor"))
                 {
-                    MethodDesc method = (MethodDesc)_module.GetObject(handle);
+                    var method = (EcmaMethod)_module.GetObject(handle);
                     return method;
                 }
             }
@@ -362,7 +373,7 @@ namespace Internal.TypeSystem.Ecma
                 if (attributes.IsRuntimeSpecialName() && attributes.IsPublic()
                     && stringComparer.Equals(methodDefinition.Name, ".ctor"))
                 {
-                    MethodDesc method = (MethodDesc)_module.GetObject(handle);
+                    var method = (EcmaMethod)_module.GetObject(handle);
                     if (method.Signature.Length != 0)
                         continue;
 
@@ -435,7 +446,7 @@ namespace Internal.TypeSystem.Ecma
         {
             foreach (var handle in _typeDefinition.GetNestedTypes())
             {
-                yield return (MetadataType)_module.GetObject(handle);
+                yield return (EcmaType)_module.GetObject(handle);
             }
         }
 
@@ -460,7 +471,7 @@ namespace Internal.TypeSystem.Ecma
                 }
 
                 if (nameMatched)
-                    return (MetadataType)_module.GetObject(handle);
+                    return (EcmaType)_module.GetObject(handle);
             }
 
             return null;
@@ -527,7 +538,7 @@ namespace Internal.TypeSystem.Ecma
                     // Note: GetOffset() returns -1 when offset was not set in the metadata
                     int specifiedOffset = fieldDefinition.GetOffset();
                     result.Offsets[index] =
-                        new FieldAndOffset((FieldDesc)_module.GetObject(handle), specifiedOffset == -1 ? FieldAndOffset.InvalidOffset : new LayoutInt(specifiedOffset));
+                        new FieldAndOffset((EcmaField)_module.GetObject(handle), specifiedOffset == -1 ? FieldAndOffset.InvalidOffset : new LayoutInt(specifiedOffset));
 
                     index++;
                 }

--- a/src/coreclr/tools/Common/TypeSystem/IL/TypeSystemContext.EnumMethods.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/TypeSystemContext.EnumMethods.cs
@@ -68,8 +68,15 @@ namespace Internal.TypeSystem
             return resolvedMethod;
         }
 
-        protected virtual IEnumerable<MethodDesc> GetAllMethodsForEnum(TypeDesc enumType)
+        protected virtual IEnumerable<MethodDesc> GetAllMethodsForEnum(TypeDesc enumType, bool virtualOnly)
         {
+            if (virtualOnly)
+            {
+                // We devirtualize these, but they're not actually virtual. We don't want standalone method bodies
+                // referenced from vtables. The base implementation on System.Enum is perflectly adequate.
+                yield break;
+            }
+
             if (_objectEqualsMethod == null)
                 _objectEqualsMethod = GetWellKnownType(WellKnownType.Object).GetMethod("Equals", null);
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/TypeSystemContext.ValueTypeMethods.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/TypeSystemContext.ValueTypeMethods.cs
@@ -28,7 +28,7 @@ namespace Internal.TypeSystem
 
         private ValueTypeMethodHashtable _valueTypeMethodHashtable = new ValueTypeMethodHashtable();
 
-        protected virtual IEnumerable<MethodDesc> GetAllMethodsForValueType(TypeDesc valueType)
+        protected virtual IEnumerable<MethodDesc> GetAllMethodsForValueType(TypeDesc valueType, bool virtualOnly)
         {
             TypeDesc valueTypeDefinition = valueType.GetTypeDefinition();
 
@@ -46,7 +46,8 @@ namespace Internal.TypeSystem
                 }
             }
 
-            foreach (MethodDesc method in valueType.GetMethods())
+            IEnumerable<MethodDesc> metadataMethods = virtualOnly ? valueType.GetVirtualMethods() : valueType.GetMethods();
+            foreach (MethodDesc method in metadataMethods)
                 yield return method;
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -114,6 +114,14 @@ namespace Internal.TypeSystem
             }
         }
 
+        public override IEnumerable<MethodDesc> GetVirtualMethods()
+        {
+            foreach (var method in _rawCanonType.GetVirtualMethods())
+            {
+                yield return Context.GetMethodForRuntimeDeterminedType(method.GetTypicalMethodDefinition(), this);
+            }
+        }
+
         public override MethodDesc GetMethod(string name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc method = _rawCanonType.GetMethod(name, signature, substitution);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -36,9 +36,11 @@ namespace ILCompiler.DependencyAnalysis
                     // First, check if this type has any GVM that overrides a GVM on a parent type. If that's the case, this makes
                     // the current type interesting for GVM analysis (i.e. instantiate its overriding GVMs for existing GVMDependenciesNodes
                     // of the instantiated GVM on the parent types).
-                    foreach (var method in _type.GetAllMethods())
+                    foreach (var method in _type.GetAllVirtualMethods())
                     {
-                        if (method.HasInstantiation && method.IsVirtual)
+                        Debug.Assert(method.IsVirtual);
+
+                        if (method.HasInstantiation)
                         {
                             MethodDesc slotDecl = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
                             if (slotDecl != method)
@@ -50,9 +52,11 @@ namespace ILCompiler.DependencyAnalysis
                     // make the current type interesting for dynamic dependency analysis to that we can instantiate its GVMs.
                     foreach (DefType interfaceImpl in _type.RuntimeInterfaces)
                     {
-                        foreach (var method in interfaceImpl.GetAllMethods())
+                        foreach (var method in interfaceImpl.GetAllVirtualMethods())
                         {
-                            if (method.HasInstantiation && method.IsVirtual)
+                            Debug.Assert(method.IsVirtual);
+
+                            if (method.HasInstantiation)
                             {
                                 // We found a GVM on one of the implemented interfaces. Find if the type implements this method. 
                                 // (Note, do this comparision against the generic definition of the method, not the specific method instantiation

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -201,12 +201,12 @@ namespace ILCompiler.DependencyAnalysis
                 {
                     if (currentType == _type || (currentType is MetadataType mdType && mdType.IsAbstract))
                     {
-                        foreach (var method in currentType.GetAllMethods())
+                        foreach (var method in currentType.GetAllVirtualMethods())
                         {
                             // Abstract methods don't have a body associated with it so there's no conditional
                             // dependency to add.
                             // Generic virtual methods are tracked by an orthogonal mechanism.
-                            if (method.IsVirtual && !method.IsAbstract && !method.HasInstantiation)
+                            if (!method.IsAbstract && !method.HasInstantiation)
                                 return true;
                         }
                     }
@@ -308,11 +308,8 @@ namespace ILCompiler.DependencyAnalysis
 
                     bool isVariantInterfaceImpl = VariantInterfaceMethodUseNode.IsVariantInterfaceImplementation(factory, _type, interfaceType);
 
-                    foreach (MethodDesc interfaceMethod in interfaceType.GetAllMethods())
+                    foreach (MethodDesc interfaceMethod in interfaceType.GetAllVirtualMethods())
                     {
-                        if (interfaceMethod.Signature.IsStatic || !interfaceMethod.IsVirtual)
-                            continue;
-
                         // Generic virtual methods are tracked by an orthogonal mechanism.
                         if (interfaceMethod.HasInstantiation)
                             continue;
@@ -1100,9 +1097,9 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (factory.TypeSystemContext.SupportsUniversalCanon)
             {
-                foreach (MethodDesc method in type.GetMethods())
+                foreach (MethodDesc method in type.GetVirtualMethods())
                 {
-                    if (!method.IsVirtual || !method.HasInstantiation)
+                    if (!method.HasInstantiation)
                         continue;
 
                     if (method.IsAbstract)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -97,14 +97,13 @@ namespace ILCompiler.DependencyAnalysis
                 if (vtableSlice.HasFixedSlots)
                     slots = vtableSlice.Slots;
                 else
-                    slots = interfaceType.GetAllMethods();
+                    slots = interfaceType.GetAllVirtualMethods();
 
                 foreach (MethodDesc slotMethod in slots)
                 {
                     MethodDesc declMethod = slotMethod;
 
-                    if (declMethod.Signature.IsStatic || !declMethod.IsVirtual)
-                        continue;
+                    Debug.Assert(!declMethod.Signature.IsStatic && declMethod.IsVirtual);
 
                     if (interfaceOnDefinitionType != null)
                         declMethod = factory.TypeSystemContext.GetMethodForInstantiatedType(declMethod.GetTypicalMethodDefinition(), interfaceOnDefinitionType);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
@@ -94,9 +94,11 @@ namespace ILCompiler.DependencyAnalysis
             //
             foreach (var iface in type.RuntimeInterfaces)
             {
-                foreach (var method in iface.GetMethods())
+                foreach (var method in iface.GetVirtualMethods())
                 {
-                    if (!method.HasInstantiation || method.Signature.IsStatic)
+                    Debug.Assert(!method.Signature.IsStatic);
+
+                    if (!method.HasInstantiation)
                         continue;
 
                     MethodDesc slotDecl = type.ResolveInterfaceMethodTarget(method);
@@ -127,9 +129,11 @@ namespace ILCompiler.DependencyAnalysis
         {
             foreach (var iface in _associatedType.RuntimeInterfaces)
             {
-                foreach (var method in iface.GetMethods())
+                foreach (var method in iface.GetVirtualMethods())
                 {
-                    if (!method.HasInstantiation || method.Signature.IsStatic)
+                    Debug.Assert(!method.Signature.IsStatic);
+
+                    if (!method.HasInstantiation)
                         continue;
 
                     MethodDesc slotDecl = _associatedType.ResolveInterfaceMethodTarget(method);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -59,15 +59,6 @@ namespace ILCompiler.DependencyAnalysis
         public override bool InterestingForDynamicDependencyAnalysis => false;
         public override bool HasDynamicDependencies => false;
         public override bool HasConditionalStaticDependencies => false;
-
-        protected static IEnumerable<MethodDesc> GetAllVirtualMethods(TypeDesc type)
-        {
-            foreach (MethodDesc method in type.GetAllMethods())
-            {
-                if (method.IsVirtual)
-                    yield return method;
-            }
-        }
     }
 
     /// <summary>
@@ -119,7 +110,7 @@ namespace ILCompiler.DependencyAnalysis
             DefType defType = type.GetClosestDefType();
 
             IEnumerable<MethodDesc> allSlots = type.IsInterface ?
-                GetAllVirtualMethods(type) : defType.EnumAllVirtualSlots();
+                type.GetAllVirtualMethods() : defType.EnumAllVirtualSlots();
 
             foreach (var method in allSlots)
             {
@@ -222,7 +213,7 @@ namespace ILCompiler.DependencyAnalysis
             DefType defType = _type.GetClosestDefType();
 
             IEnumerable<MethodDesc> allSlots = _type.IsInterface ?
-                GetAllVirtualMethods(_type) : defType.EnumAllVirtualSlots();
+                _type.GetAllVirtualMethods() : defType.EnumAllVirtualSlots();
 
             foreach (var method in allSlots)
             {


### PR DESCRIPTION
We were spending around 8% of time in GetMethods due to various virtual method resolution code. In .NET, not that many methods are virtual, so restricting the iteration to virtual methods can save significant amount of time. The type system didn't have a facility to do this, so I'm adding one.

I'm seeing 2980 ms -> 2740 ms wallclock time improvement when compiling a Hello World with this.