### PR TITLE
some code cleanup related to prefix use and experiment code

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -1762,7 +1762,7 @@ namespace System.Text.RegularExpressions.SRM
             #endregion
         }
 
-        internal const int maxPrefixLength = 5;
+        internal const int maxPrefixLength = 20;
         internal S[] GetPrefix()
         {
             return GetPrefixSequence(ImmutableList<S>.Empty, maxPrefixLength).ToArray();
@@ -1808,67 +1808,6 @@ namespace System.Text.RegularExpressions.SRM
                             return pref;
                         }
                 }
-            }
-        }
-
-        ///// <summary>
-        ///// If this node starts with a loop other than star or plus then
-        ///// returns the nonnegative id of the associated counter else returns -1
-        ///// </summary>
-        //public int CounterId
-        //{
-        //    get
-        //    {
-        //        if (this.kind == SymbolicRegexKind.Loop && !this.IsStar && !this.IsPlus)
-        //            return this.builder.GetCounterId(this);
-        //        else if (this.kind == SymbolicRegexKind.Concat)
-        //            return left.CounterId;
-        //        else
-        //            return -1;
-        //    }
-        //}
-
-        //0 means value is not computed,
-        //-1 means this is not a sequence of singletons
-        //1 means it is a sequence of singletons
-        internal int sequenceOfSingletons_count;
-
-        internal bool IsSequenceOfSingletons
-        {
-            get
-            {
-                if (sequenceOfSingletons_count == 0)
-                {
-                    var node = this;
-                    int k = 1;
-                    while (node.kind == SymbolicRegexKind.Concat && node.left.kind == SymbolicRegexKind.Singleton)
-                    {
-                        node = node.right;
-                        k += 1;
-                    }
-                    if (node.kind == SymbolicRegexKind.Singleton)
-                    {
-                        node.sequenceOfSingletons_count = 1;
-                        node = this;
-                        while (node.kind == SymbolicRegexKind.Concat)
-                        {
-                            node.sequenceOfSingletons_count = k;
-                            node = node.right;
-                            k = k - 1;
-                        }
-                    }
-                    else
-                    {
-                        node.sequenceOfSingletons_count = -1;
-                        node = this;
-                        while (node.kind == SymbolicRegexKind.Concat && node.left.kind == SymbolicRegexKind.Singleton)
-                        {
-                            node.sequenceOfSingletons_count = -1;
-                            node = node.right;
-                        }
-                    }
-                }
-                return sequenceOfSingletons_count > 0;
             }
         }
 
@@ -1967,38 +1906,6 @@ namespace System.Text.RegularExpressions.SRM
             get
             {
                 return (this.kind == SymbolicRegexKind.Loop && this.upper < int.MaxValue);
-            }
-        }
-
-        /// <summary>
-        /// Returns true if the match-end of this regex can be determined with a
-        /// single pass from the start.
-        /// </summary>
-        public bool IsSinglePass
-        {
-            get
-            {
-                if (this.IsSequenceOfSingletons)
-                    return true;
-                else
-                {
-                    switch (kind)
-                    {
-                        case SymbolicRegexKind.Or:
-                            {
-                                foreach (var member in alts)
-                                    if (!member.IsSinglePass)
-                                        return false;
-                                return true;
-                            }
-                        case SymbolicRegexKind.Concat:
-                            {
-                                return left.IsSinglePass && right.IsSinglePass;
-                            }
-                        default:
-                            return false;
-                    }
-                }
             }
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -605,8 +605,6 @@ namespace System.Text.RegularExpressions.SRM
             //initial start position in the input is i = 0
             int i = startat;
 
-            bool AisSingleSeq = A.IsSequenceOfSingletons;
-
             int i_q0_A1;
             int watchdog;
             i = FindFinalStatePosition(input, k, i, out i_q0_A1, out watchdog);
@@ -631,26 +629,8 @@ namespace System.Text.RegularExpressions.SRM
                 }
                 else
                 {
-                    ////If A is lazy then there is no need to maximize length of end-position
-                    //if (AisLazy)
-                    //{
-                    //    if (AisSingleSeq)
-                    //        i_start = i - A.sequenceOfSingletons_count + 1;
-                    //    else
-                    //        i_start = FindStartPosition(input, i, i_q0_A1);
-                    //    i_end = i;
-                    //}
-                    if (AisSingleSeq)
-                    {
-                        // TBD: this case should be covered by watchdog
-                        i_start = i - A.sequenceOfSingletons_count + 1;
-                        i_end = i;
-                    }
-                    else
-                    {
-                        i_start = FindStartPosition(input, i, i_q0_A1);
-                        i_end = FindEndPosition(input, k, i_start);
-                    }
+                    i_start = FindStartPosition(input, i, i_q0_A1);
+                    i_end = FindEndPosition(input, k, i_start);
                 }
 
                 return new Match(i_start, i_end + 1 - i_start);


### PR DESCRIPTION
- Updated experiment code.
- Added unit tests related to timeout detection.
- Added a unit test TestSRMTermination that shows I believe quadratic behavior in nonDFA case. The regex is a variant of a regex from one of the MS experiments, thus realistic. Adding this unit test was on the todo-list in summary email from Dan.
- Eliminated some dead code related to detection/use of prefixes, in particular IsSinglePass was dead code.
- Increased maxallowed prefix length from 5 to 20. Otherwise in some cases a fixed prefix like "every week" was cut down to "every" (that was a common phrase in the input, while "every week" was very uncommon, causing perf penalty in search when it was being cut)
This length bound is a leftover from an old algorithm where it could have caused perf regression. I think we can now eliminate it completely after carefully revisiting the code computing a fixed prefix one more time.
