### PR TITLE
Small fixes to sealed vtables

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -56,6 +56,12 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
+        public override bool ShouldSkipEmittingObjectNode(NodeFactory factory)
+        {
+            BuildSealedVTableSlots(factory, relocsOnly: false);
+            return NumSealedVTableEntries == 0;
+        }
+
         /// <summary>
         /// Returns the slot of a method in the sealed vtable, or -1 if not found. This API should only be called after 
         /// successfully building the sealed vtable slots.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VirtualMethodCallHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VirtualMethodCallHelper.cs
@@ -15,10 +15,12 @@ namespace ILCompiler
         {
             Debug.Assert(method.GetTypicalMethodDefinition().OwningType == interfaceOnDefinition.GetTypeDefinition());
 
-            // Ensure the sealed vtable is built before computing the slot
-            factory.SealedVTable(implType).BuildSealedVTableSlots(factory, relocsOnly: false /* GetVirtualMethodSlot is called in the final emission phase */);
+            SealedVTableNode sealedVTable = factory.SealedVTable(implType);
 
-            int sealedVTableSlot = factory.SealedVTable(implType).ComputeDefaultInterfaceMethodSlot(method, interfaceOnDefinition);
+            // Ensure the sealed vtable is built before computing the slot
+            sealedVTable.BuildSealedVTableSlots(factory, relocsOnly: false /* GetVirtualMethodSlot is called in the final emission phase */);
+
+            int sealedVTableSlot = sealedVTable.ComputeDefaultInterfaceMethodSlot(method, interfaceOnDefinition);
             if (sealedVTableSlot == -1)
                 return -1;
 
@@ -42,10 +44,12 @@ namespace ILCompiler
                 // does not get any sealed vtable entries
                 Debug.Assert(!implType.IsArrayTypeWithoutGenericInterfaces());
 
-                // Ensure the sealed vtable is built before computing the slot
-                factory.SealedVTable(implType).BuildSealedVTableSlots(factory, relocsOnly: false /* GetVirtualMethodSlot is called in the final emission phase */);
+                SealedVTableNode sealedVTable = factory.SealedVTable(implType);
 
-                int sealedVTableSlot = factory.SealedVTable(implType).ComputeSealedVTableSlot(method);
+                // Ensure the sealed vtable is built before computing the slot
+                sealedVTable.BuildSealedVTableSlots(factory, relocsOnly: false /* GetVirtualMethodSlot is called in the final emission phase */);
+
+                int sealedVTableSlot = sealedVTable.ComputeSealedVTableSlot(method);
                 if (sealedVTableSlot == -1)
                     return -1;
 


### PR DESCRIPTION
* Avoid double hashtable lookup
* Avoid generating empty sealed vtables (basically, emitting a bunch of unreferenced symbol definitions in the object file)