### PR TITLE
NativeAOT-LLVM: cherry pick cmake fixes from commit hash 

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -339,6 +339,17 @@ function(install_symbols symbol_file destination_path)
   endif()
 endfunction()
 
+function(install_static_library targetName destination)
+  install (TARGETS ${targetName} DESTINATION ${destination})
+  if (WIN32)
+    set_target_properties(${targetName} PROPERTIES
+        COMPILE_PDB_NAME "${targetName}"
+        COMPILE_PDB_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
+    )
+    install (FILES "$<TARGET_FILE_DIR:${targetName}>/${targetName}.pdb" DESTINATION ${destination})
+  endif()
+endfunction()
+
 # install_clr(TARGETS TARGETS targetName [targetName2 ...] [ADDITIONAL_DESTINATIONS destination])
 function(install_clr)
   set(multiValueArgs TARGETS ADDITIONAL_DESTINATIONS)

--- a/src/coreclr/nativeaot/Bootstrap/base/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Bootstrap/base/CMakeLists.txt
@@ -6,8 +6,4 @@ set(SOURCES
 
 add_library(bootstrapper STATIC ${SOURCES})
 
-# Install the static bootstrapper library
-install (TARGETS bootstrapper DESTINATION aotsdk)
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/bootstrapper.dir/$<CONFIG>/bootstrapper.pdb DESTINATION aotsdk)
-endif()
+install_static_library(bootstrapper aotsdk)

--- a/src/coreclr/nativeaot/Bootstrap/dll/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Bootstrap/dll/CMakeLists.txt
@@ -8,8 +8,4 @@ set(SOURCES
 
 add_library(bootstrapperdll STATIC ${SOURCES})
 
-# Install the static bootstrapperdll library
-install (TARGETS bootstrapperdll DESTINATION aotsdk)
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/bootstrapperdll.dir/$<CONFIG>/bootstrapperdll.pdb DESTINATION aotsdk)
-endif()
+install_static_library(bootstrapperdll aotsdk)

--- a/src/coreclr/nativeaot/Directory.Build.props
+++ b/src/coreclr/nativeaot/Directory.Build.props
@@ -45,6 +45,9 @@
     <DisableImplicitConfigurationDefines>true</DisableImplicitConfigurationDefines>
 
     <DocumentationFile>$(OutputPath)$(MSBuildProjectName).xml</DocumentationFile>
+
+    <!-- Send .deps.json to intermediate directory to avoid polluting published package -->
+    <ProjectDepsFilePath>$(IntermediateOutputPath)$(MSBuildProjectName).deps.json</ProjectDepsFilePath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -87,9 +87,5 @@ foreach(CONFIG IN LISTS CMAKE_CONFIGURATION_TYPES)
     set_property(SOURCE ${RUNTIME_SOURCES_ARCH_ASM} PROPERTY COMPILE_DEFINITIONS_${CONFIG} ${ASM_DEFINITIONS_${CONFIG}})
 endforeach()
 
-# Install the static Runtime library
-install (TARGETS Runtime Runtime.ServerGC DESTINATION aotsdk)
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/Runtime.dir/$<CONFIG>/Runtime.pdb DESTINATION aotsdk)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/Runtime.ServerGC.dir/$<CONFIG>/Runtime.ServerGC.pdb DESTINATION aotsdk)
-endif()
+install_static_library(Runtime aotsdk)
+install_static_library(Runtime.ServerGC aotsdk)

--- a/src/coreclr/nativeaot/Runtime/Portable/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Portable/CMakeLists.txt
@@ -28,9 +28,4 @@ add_custom_command(
    DEPENDS "${RUNTIME_DIR}/AsmOffsets.cpp" "${RUNTIME_DIR}/AsmOffsets.h"
 )
 
-# Install the static Runtime library
-install (TARGETS PortableRuntime DESTINATION aotsdk)
-
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/PortableRuntime.dir/$<CONFIG>/PortableRuntime.pdb DESTINATION aotsdk)
-endif()
+install_static_library(PortableRuntime aotsdk)

--- a/src/libraries/Native/Windows/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/libraries/Native/Windows/System.IO.Compression.Native/CMakeLists.txt
@@ -1,5 +1,7 @@
 project(System.IO.Compression.Native)
 
+include(../../../../../eng/native/functions.cmake)
+
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
     message(FATAL_ERROR "Binary directory isn't being correctly set before calling Cmake. Tree must be built in separate directory from source.")
 endif()
@@ -122,7 +124,4 @@ if (GEN_SHARED_LIB)
     install (FILES $<TARGET_PDB_FILE:System.IO.Compression.Native> DESTINATION .)
 endif()
 
-install (TARGETS System.IO.Compression.Native-Static DESTINATION ${STATIC_LIB_DESTINATION})
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/System.IO.Compression.Native-Static.dir/$<CONFIG>/System.IO.Compression.Native-Static.pdb DESTINATION ${STATIC_LIB_DESTINATION})
-endif()
+install_static_library(System.IO.Compression.Native-Static ${STATIC_LIB_DESTINATION})


### PR DESCRIPTION
1e27105e5bd12fc8457962e497a31fcaddcd307d

This PR fixes the build under recent versions of Visual Studio 2019 by cherry picking the relevant commit from NativeAOT branch.

Merged in NativeAOT branch in https://github.com/dotnet/runtimelab/pull/873