### PR TITLE
Fix stresslog deadlock

### DIFF
--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -639,7 +639,7 @@ bool Thread::Hijack()
     Thread* pCurrentThread = ThreadStore::GetCurrentThread();
     pCurrentThread->EnterCantAllocRegion();
     uint32_t result = PalHijack(m_hPalThread, HijackCallback, this);
-    pCurrentThread->LeaveCanntAllocRegion();
+    pCurrentThread->LeaveCantAllocRegion();
     return result == 0;
 
 }

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -87,6 +87,7 @@ struct ThreadBuffer
     uint64_t                  m_uPalThreadIdForLogging;               // @TODO: likely debug-only
     EEThreadId              m_threadId;
     PTR_VOID                m_pThreadStressLog;                     // pointer to head of thread's StressLogChunks
+    uint32_t                m_canntAlloc;
 #ifdef FEATURE_GC_STRESS
     uint32_t                  m_uRand;                                // current per-thread random number
 #endif // FEATURE_GC_STRESS
@@ -191,10 +192,9 @@ public:
     void                GetStackBounds(PTR_VOID * ppStackLow, PTR_VOID * ppStackHigh);
 
     PTR_UInt8           AllocateThreadLocalStorageForDynamicType(uint32_t uTlsTypeOffset, uint32_t tlsStorageSize, uint32_t numTlsCells);
-    // mrt100 Debugger (dac) has dependencies on the GetThreadLocalStorageForDynamicType method.
+
     PTR_UInt8           GetThreadLocalStorageForDynamicType(uint32_t uTlsTypeOffset);
     PTR_UInt8           GetThreadLocalStorage(uint32_t uTlsIndex, uint32_t uTlsStartOffset);
-    PTR_UInt8           GetTEB();
 
     void                PushExInfo(ExInfo * pExInfo);
     void                ValidateExInfoPop(ExInfo * pExInfo, void * limitSP);
@@ -210,6 +210,9 @@ public:
 #ifndef DACCESS_COMPILE
     void                SetThreadStressLog(void * ptsl);
 #endif // DACCESS_COMPILE
+    void                EnterCantAllocRegion();
+    void                LeaveCanntAllocRegion();
+    bool                IsInCantAllocStressLogRegion();
 #ifdef FEATURE_GC_STRESS
     void                SetRandomSeed(uint32_t seed);
     uint32_t              NextRand();

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -87,7 +87,7 @@ struct ThreadBuffer
     uint64_t                  m_uPalThreadIdForLogging;               // @TODO: likely debug-only
     EEThreadId              m_threadId;
     PTR_VOID                m_pThreadStressLog;                     // pointer to head of thread's StressLogChunks
-    uint32_t                m_canntAlloc;
+    uint32_t                m_cantAlloc;
 #ifdef FEATURE_GC_STRESS
     uint32_t                  m_uRand;                                // current per-thread random number
 #endif // FEATURE_GC_STRESS
@@ -211,7 +211,7 @@ public:
     void                SetThreadStressLog(void * ptsl);
 #endif // DACCESS_COMPILE
     void                EnterCantAllocRegion();
-    void                LeaveCanntAllocRegion();
+    void                LeaveCantAllocRegion();
     bool                IsInCantAllocStressLogRegion();
 #ifdef FEATURE_GC_STRESS
     void                SetRandomSeed(uint32_t seed);

--- a/src/coreclr/nativeaot/Runtime/thread.inl
+++ b/src/coreclr/nativeaot/Runtime/thread.inl
@@ -44,15 +44,15 @@ inline PTR_VOID Thread::GetThreadStressLog() const
 
 inline void Thread::EnterCantAllocRegion()
 {
-    m_canntAlloc++;
+    m_cantAlloc++;
 }
 
-inline void Thread::LeaveCanntAllocRegion()
+inline void Thread::LeaveCantAllocRegion()
 {
-    m_canntAlloc--;
+    m_cantAlloc--;
 }
 
 inline bool Thread::IsInCantAllocStressLogRegion()
 {
-    return m_canntAlloc != 0;
+    return m_cantAlloc != 0;
 }

--- a/src/coreclr/nativeaot/Runtime/thread.inl
+++ b/src/coreclr/nativeaot/Runtime/thread.inl
@@ -29,3 +29,30 @@ inline void Thread::GetStackBounds(PTR_VOID * ppStackLow, PTR_VOID * ppStackHigh
     *ppStackLow = m_pStackLow;
     *ppStackHigh = m_pStackHigh;
 }
+
+#ifndef DACCESS_COMPILE
+inline void Thread::SetThreadStressLog(void* ptsl)
+{
+    m_pThreadStressLog = ptsl;
+}
+#endif // DACCESS_COMPILE
+
+inline PTR_VOID Thread::GetThreadStressLog() const
+{
+    return m_pThreadStressLog;
+}
+
+inline void Thread::EnterCantAllocRegion()
+{
+    m_canntAlloc++;
+}
+
+inline void Thread::LeaveCanntAllocRegion()
+{
+    m_canntAlloc--;
+}
+
+inline bool Thread::IsInCantAllocStressLogRegion()
+{
+    return m_canntAlloc != 0;
+}


### PR DESCRIPTION
Stress log cannot allocate new memory blocks when the current thread has other threads suspended. Other thread may get suspended with lock taken inside memory allocator and thus attempt to allocate a new memory block on current thread may lead to deadlock.