### PR TITLE
Fix memory leaks for return values and some out params.

### DIFF
--- a/DllImportGenerator/DllImportGenerator/DllImportGenerator.csproj
+++ b/DllImportGenerator/DllImportGenerator/DllImportGenerator.csproj
@@ -10,6 +10,7 @@
     <LangVersion>Preview</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>Microsoft.Interop</RootNamespace>
+    <IsRoslynComponent>true</IsRoslynComponent>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/DllImportGenerator/DllImportGenerator/Marshalling/CustomNativeTypeMarshaller.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/CustomNativeTypeMarshaller.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Interop
                     }
                     break;
                 case StubCodeContext.Stage.Cleanup:
-                    if (info.RefKind != RefKind.Out && _hasFreeNative)
+                    if (_hasFreeNative)
                     {
                         // <marshalerIdentifier>.FreeNative();
                         yield return ExpressionStatement(

--- a/DllImportGenerator/DllImportGenerator/Marshalling/SafeHandleMarshaller.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/SafeHandleMarshaller.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Interop
                     }
                     break;
                 case StubCodeContext.Stage.Cleanup:
-                    if (!info.IsByRef || info.RefKind == RefKind.In)
+                    if (!info.IsManagedReturnPosition && (!info.IsByRef || info.RefKind == RefKind.In))
                     {
                         yield return IfStatement(
                             IdentifierName(addRefdIdentifier),

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Interop
                 int initialCount = statements.Count;
                 this.CurrentStage = stage;
 
-                if (!invokeReturnsVoid && (stage == Stage.Setup || stage == Stage.Unmarshal || stage == Stage.GuaranteedUnmarshal))
+                if (!invokeReturnsVoid && (stage is Stage.Setup or Stage.Unmarshal or Stage.GuaranteedUnmarshal or Stage.Cleanup))
                 {
                     // Handle setup and unmarshalling for return
                     var retStatements = retMarshaller.Generator.Generate(retMarshaller.TypeInfo, this);


### PR DESCRIPTION
Fix some memory leaks we had where we didn't generate code to free native resources for out parameters that use custom native type marshalling or all return values.

Also set a flag in the csproj that enables a nice debugging innerloop option for roslyn components in the csproj settings (in our case running the generator on the integration tests)