### PR TITLE
NativeAOT: Typo in var name for 32 bit code

### DIFF
--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -226,7 +226,7 @@ Object* GcAllocInternal(EEType *pEEType, uint32_t uFlags, uintptr_t numElements,
         if (numElements > 0x10000)
         {
             // Perform the size computation using 64-bit integeres to detect overflow
-            uint64_t size64 = (uint64_t)cbSize + ((uint64_t)numElements * (uint64_t)pArrayEEType->get_ComponentSize());
+            uint64_t size64 = (uint64_t)cbSize + ((uint64_t)numElements * (uint64_t)pEEType->get_ComponentSize());
             size64 = (size64 + (sizeof(uintptr_t) - 1)) & ~(sizeof(uintptr_t) - 1);
 
             cbSize = (size_t)size64;


### PR DESCRIPTION
This PR corrects a typo in the 32 bit version of the code.  I assume this is a ctrl c/v error that is not picked up as this is not yet merged into NativeAOT-LLVM.  I've not tested it as I'm still working on the merge, and I could put this change in that PR if you prefer.

