### PR TITLE
Implement handling PreserveSig = false for interfaces

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/MetadataExtensions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/MetadataExtensions.cs
@@ -196,8 +196,8 @@ namespace Internal.TypeSystem.Ecma
 
         public static PInvokeFlags GetDelegatePInvokeFlags(this EcmaType type)
         {
-            PInvokeFlags flags = new PInvokeFlags();
-
+            PInvokeFlags flags = new PInvokeFlags(PInvokeAttributes.PreserveSig);
+            
             if (!type.IsDelegate)
             {
                 return flags;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -233,14 +233,6 @@ namespace Internal.IL.Stubs
 
         private void EmitPInvokeCall(PInvokeILCodeStreams ilCodeStreams)
         {
-            if (!_flags.PreserveSig)
-            {
-                TypeDesc managedReturnType = _targetMethod.Signature.ReturnType;
-                bool supportedType = managedReturnType.IsPrimitive || managedReturnType.IsInterface || managedReturnType.IsObject;
-                if (!supportedType)
-                    throw new NotSupportedException();
-            }
-
             ILEmitter emitter = ilCodeStreams.Emitter;
             ILCodeStream fnptrLoadStream = ilCodeStreams.FunctionPointerLoadStream;
             ILCodeStream callsiteSetupCodeStream = ilCodeStreams.CallsiteSetupCodeStream;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeILEmitter.cs
@@ -253,7 +253,7 @@ namespace Internal.IL.Stubs
             ILCodeStream callsiteSetupCodeStream = ilCodeStreams.CallsiteSetupCodeStream;
             TypeSystemContext context = _targetMethod.Context;
 
-            bool isHRSwappedRetVal = !_flags.PreserveSig && _targetMethod.Signature.ReturnType.IsVoid;
+            bool isHRSwappedRetVal = !_flags.PreserveSig && !_targetMethod.Signature.ReturnType.IsVoid;
             TypeDesc nativeReturnType = _flags.PreserveSig ? _marshallers[0].NativeParameterType : context.GetWellKnownType(WellKnownType.Int32);
             TypeDesc[] nativeParameterTypes = new TypeDesc[isHRSwappedRetVal ? _marshallers.Length : _marshallers.Length - 1];
 
@@ -377,7 +377,7 @@ namespace Internal.IL.Stubs
             cleanupCodestream.BeginHandler(tryFinally);
 
             // Marshal the arguments
-            bool isHRSwappedRetVal = !_flags.PreserveSig && _targetMethod.Signature.ReturnType.IsVoid;
+            bool isHRSwappedRetVal = !_flags.PreserveSig && !_targetMethod.Signature.ReturnType.IsVoid;
             for (int i = isHRSwappedRetVal ? 1 : 0; i < _marshallers.Length; i++)
             {
                 _marshallers[i].EmitMarshallingIL(pInvokeILCodeStreams);

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -512,7 +512,7 @@ namespace Internal.TypeSystem.Interop
 
         public virtual void LoadReturnValue(ILCodeStream codeStream)
         {
-            Debug.Assert(Index == 0);
+            Debug.Assert(Return || Index == 0);
 
             switch (MarshalDirection)
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -512,7 +512,7 @@ namespace Internal.TypeSystem.Interop
 
         public virtual void LoadReturnValue(ILCodeStream codeStream)
         {
-            Debug.Assert(Return);
+            Debug.Assert(Index == 0);
 
             switch (MarshalDirection)
             {
@@ -653,9 +653,18 @@ namespace Internal.TypeSystem.Interop
         /// </summary>
         protected void PropagateToByRefArg(ILCodeStream stream, Home home)
         {
-            stream.EmitLdArg(Index - 1);
-            home.LoadValue(stream);
-            stream.EmitStInd(ManagedType);
+            // If by-ref arg has index == 0 then that argument is used for HR swapping and we just return that value.
+            if (Index == 0)
+            {
+                // Returning result would be handled by LoadReturnValue
+                return;
+            }
+            else
+            {
+                stream.EmitLdArg(Index - 1);
+                home.LoadValue(stream);
+                stream.EmitStInd(ManagedType);
+            }
         }
 
         protected virtual void EmitMarshalArgumentManagedToNative()

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -912,7 +912,7 @@ namespace Internal.TypeSystem.Interop
     {
         protected override void EmitMarshalArgumentManagedToNative()
         {
-            if (IsNativeByRef && MarshalDirection == MarshalDirection.Forward)
+            if (IsNativeByRef && MarshalDirection == MarshalDirection.Forward && Index > 0)
             {
                 ILCodeStream marshallingCodeStream = _ilCodeStreams.MarshallingCodeStream;
                 ILEmitter emitter = _ilCodeStreams.Emitter;
@@ -926,9 +926,13 @@ namespace Internal.TypeSystem.Interop
                 marshallingCodeStream.EmitStLoc(native);
                 _ilCodeStreams.CallsiteSetupCodeStream.EmitLdLoc(native);
             }
-            else
+            else if (Index > 0)
             {
                 _ilCodeStreams.CallsiteSetupCodeStream.EmitLdArg(Index - 1);
+            }
+            else
+            {
+                base.EmitMarshalArgumentManagedToNative();
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -659,12 +659,10 @@ namespace Internal.TypeSystem.Interop
                 // Returning result would be handled by LoadReturnValue
                 return;
             }
-            else
-            {
-                stream.EmitLdArg(Index - 1);
-                home.LoadValue(stream);
-                stream.EmitStInd(ManagedType);
-            }
+
+            stream.EmitLdArg(Index - 1);
+            home.LoadValue(stream);
+            stream.EmitStInd(ManagedType);
         }
 
         protected virtual void EmitMarshalArgumentManagedToNative()

--- a/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.cs
+++ b/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.cs
@@ -64,6 +64,9 @@ namespace ComWrappersTests
         [DllImport("ComWrappersNative", CallingConvention = CallingConvention.StdCall)]
         static extern int BuildComPointer(out IComInterface foo);
 
+        [DllImport("ComWrappersNative", CallingConvention = CallingConvention.StdCall, PreserveSig = false, EntryPoint="BuildComPointer")]
+        static extern IComInterface BuildComPointerNoPreserveSig();
+
         public static void TestComInteropNullPointers()
         {
             Console.WriteLine("Testing Marshal APIs for COM interfaces");
@@ -160,6 +163,9 @@ namespace ComWrappersTests
             int result = BuildComPointer(out var comPointer);
             ThrowIfNotEquals(0, result, "Seems to be COM marshalling behave strange.");
             comPointer.DoWork(11);
+
+            comPointer = BuildComPointerNoPreserveSig();
+            comPointer.DoWork(22);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
@@ -275,8 +275,19 @@ namespace PInvokeTests
         [DllImport("PInvokeNative", CallingConvention = CallingConvention.StdCall, PreserveSig = false)]
         static extern void ValidateSuccessCall(int errorCode);
 
+        [DllImport("PInvokeNative", CallingConvention = CallingConvention.StdCall, PreserveSig = false)]
+        static extern int ValidateIntResult(int errorCode);
+
+        [DllImport("PInvokeNative", EntryPoint = "ValidateIntResult", CallingConvention = CallingConvention.StdCall, PreserveSig = false)]
+        static extern MagicEnum ValidateEnumResult(int errorCode);
+
         [DllImport("PInvokeNative", CallingConvention = CallingConvention.StdCall)]
         internal static extern decimal DecimalTest(decimal value);
+
+        internal enum MagicEnum
+        {
+            MagicResult = 42,
+        }
 
         public static int Main(string[] args)
         {
@@ -1035,6 +1046,22 @@ namespace PInvokeTests
             catch (NotImplementedException)
             {
             }
+
+            var intResult = ValidateIntResult(0);
+            ThrowIfNotEquals(intResult, 42, "Int32 marshalling failed.");
+
+            try
+            {
+                const int E_NOTIMPL = -2147467263;
+                intResult = ValidateIntResult(E_NOTIMPL);
+                throw new Exception("Exception should be thrown for E_NOTIMPL error code");
+            }
+            catch (NotImplementedException)
+            {
+            }
+
+            var enumResult = ValidateEnumResult(0);
+            ThrowIfNotEquals(enumResult, MagicEnum.MagicResult, "Enum marshalling failed.");
         }
 
         public static unsafe void TestForwardDelegateWithUnmanagedCallersOnly()

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
@@ -678,6 +678,12 @@ DLL_EXPORT int __stdcall ValidateSuccessCall(int errorCode)
     return errorCode;
 }
 
+DLL_EXPORT int __stdcall ValidateIntResult(int errorCode, int* result)
+{
+    *result = 42;
+    return errorCode;
+}
+
 #ifndef DECIMAL_NEG // defined in wtypes.h
 typedef struct tagDEC {
     uint16_t wReserved;


### PR DESCRIPTION
This was done by pretending return value is out argument passed as last value.
We still need to return that value, so this require change in the Marshaller.cs so it would not throw assertion, since previously only Return values can return value.
- For now only primitive types and Interface and Object are supported.
- I opt out of DelegateMarshallingMethodThunk because when these classes created with PreserveSig = false. I assume this is because of laziness during creation of this class because this flag was not used previously. I'm not sure should I optout of DelegateMarshallingMethodThunk or just set PreserveSig flag?
- I add special case for handling blittable types which are return type for PreserveSig=false methods. In this case I fallback to default marshalling implementation.

Closes #1183