### PR TITLE
Use WindowsBase from Desktop SDK if present

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -124,7 +124,7 @@ namespace Build.Tasks
 
                 // Remove any assemblies whose implementation we want to come from CoreRT's package.
                 // Currently that's System.Private.* SDK assemblies and a bunch of framework assemblies.
-                var assemblyName = Path.GetFileName(itemSpec);
+                var assemblyFileName = Path.GetFileName(itemSpec);
                 if (coreRTFrameworkAssembliesToUse.Contains(assemblyName) && assemblyName != "WindowsBase.dll")
                 {
                     assembliesToSkipPublish.Add(taskItem);

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -122,24 +122,29 @@ namespace Build.Tasks
                     continue;
                 }
 
-                // Remove any assemblies whose implementation we want to come from CoreRT's package.
-                // Currently that's System.Private.* SDK assemblies and a bunch of framework assemblies.
                 var assemblyFileName = Path.GetFileName(itemSpec);
-                if (coreRTFrameworkAssembliesToUse.Contains(assemblyName) && assemblyName != "WindowsBase.dll")
+                if (assemblyFileName == "WindowsBase.dll")
                 {
-                    assembliesToSkipPublish.Add(taskItem);
-                    continue;
-                }
-
-                if (assemblyName == "WindowsBase.dll")
-                {
+                    // There two instances of WindowsBase.dll, one small one, in the NativeAOT framework
+                    // and real one in WindowsDesktop SDK. We want to make sure that if both are present,
+                    // we will use ne from WindowsDesktop SDK, and not from NativeAOT framework.
                     foreach (ITaskItem taskItemToSkip in FrameworkAssemblies)
                     {
                         if (Path.GetFileName(taskItemToSkip.ItemSpec) == assemblyFileName)
                         {
                             assembliesToSkipPublish.Add(taskItemToSkip);
-                            break;
+                            continue;
                         }
+                    }
+                }
+                else
+                {
+                    // Remove any assemblies whose implementation we want to come from CoreRT's package.
+                    // Currently that's System.Private.* SDK assemblies and a bunch of framework assemblies.
+                    if (coreRTFrameworkAssembliesToUse.Contains(assemblyFileName))
+                    {
+                        assembliesToSkipPublish.Add(taskItem);
+                        continue;
                     }
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -126,7 +126,7 @@ namespace Build.Tasks
 
                 if (assemblyFileName == "WindowsBase.dll")
                 {
-                    // There two instances of WindowsBase.dll, one small one, in the NativeAOT framework
+                    // There are two instances of WindowsBase.dll, one small one, in the NativeAOT framework
                     // and real one in WindowsDesktop SDK. We want to make sure that if both are present,
                     // we will use the one from WindowsDesktop SDK, and not from NativeAOT framework.
                     foreach (ITaskItem taskItemToSkip in FrameworkAssemblies)

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -44,7 +44,7 @@ namespace Build.Tasks
         }
 
         /// <summary>
-        /// The native apphost (whose name ends up colliding with the CoreRT output binary) 
+        /// The native apphost (whose name ends up colliding with the CoreRT output binary)
         /// </summary>
         [Required]
         public string DotNetAppHostExecutableName
@@ -133,9 +133,11 @@ namespace Build.Tasks
                         if (Path.GetFileName(taskItemToSkip.ItemSpec) == assemblyFileName)
                         {
                             assembliesToSkipPublish.Add(taskItemToSkip);
-                            continue;
+                            break;
                         }
                     }
+
+                    continue;
                 }
                 else
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -124,10 +124,23 @@ namespace Build.Tasks
 
                 // Remove any assemblies whose implementation we want to come from CoreRT's package.
                 // Currently that's System.Private.* SDK assemblies and a bunch of framework assemblies.
-                if (coreRTFrameworkAssembliesToUse.Contains(Path.GetFileName(itemSpec)))
+                var assemblyName = Path.GetFileName(itemSpec);
+                if (coreRTFrameworkAssembliesToUse.Contains(assemblyName) && assemblyName != "WindowsBase.dll")
                 {
                     assembliesToSkipPublish.Add(taskItem);
                     continue;
+                }
+
+                if (assemblyName == "WindowsBase.dll")
+                {
+                    foreach (ITaskItem taskItemToSkip in FrameworkAssemblies)
+                    {
+                        if (Path.GetFileName(taskItemToSkip.ItemSpec) == "WindowsBase.dll")
+                        {
+                            assembliesToSkipPublish.Add(taskItemToSkip);
+                            break;
+                        }
+                    }
                 }
 
                 try

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -123,11 +123,12 @@ namespace Build.Tasks
                 }
 
                 var assemblyFileName = Path.GetFileName(itemSpec);
+
                 if (assemblyFileName == "WindowsBase.dll")
                 {
                     // There two instances of WindowsBase.dll, one small one, in the NativeAOT framework
                     // and real one in WindowsDesktop SDK. We want to make sure that if both are present,
-                    // we will use ne from WindowsDesktop SDK, and not from NativeAOT framework.
+                    // we will use the one from WindowsDesktop SDK, and not from NativeAOT framework.
                     foreach (ITaskItem taskItemToSkip in FrameworkAssemblies)
                     {
                         if (Path.GetFileName(taskItemToSkip.ItemSpec) == assemblyFileName)
@@ -139,15 +140,13 @@ namespace Build.Tasks
 
                     continue;
                 }
-                else
+
+                // Remove any assemblies whose implementation we want to come from CoreRT's package.
+                // Currently that's System.Private.* SDK assemblies and a bunch of framework assemblies.
+                if (coreRTFrameworkAssembliesToUse.Contains(assemblyFileName))
                 {
-                    // Remove any assemblies whose implementation we want to come from CoreRT's package.
-                    // Currently that's System.Private.* SDK assemblies and a bunch of framework assemblies.
-                    if (coreRTFrameworkAssembliesToUse.Contains(assemblyFileName))
-                    {
-                        assembliesToSkipPublish.Add(taskItem);
-                        continue;
-                    }
+                    assembliesToSkipPublish.Add(taskItem);
+                    continue;
                 }
 
                 try

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -135,7 +135,7 @@ namespace Build.Tasks
                 {
                     foreach (ITaskItem taskItemToSkip in FrameworkAssemblies)
                     {
-                        if (Path.GetFileName(taskItemToSkip.ItemSpec) == "WindowsBase.dll")
+                        if (Path.GetFileName(taskItemToSkip.ItemSpec) == assemblyFileName)
                         {
                             assembliesToSkipPublish.Add(taskItemToSkip);
                             break;


### PR DESCRIPTION
Suppress usage of minimal WindowsBase.dll which comes with NativeAOT

Closes #1106