### PR TITLE
Handle different dynamic member access for multiple branches

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/ReflectionMethodBodyScanner.cs
@@ -1771,15 +1771,17 @@ namespace Mono.Linker.Dataflow
 			}
 
 			// Validate that the return value has the correct annotations as per the method return value annotations
-			if (returnValueDynamicallyAccessedMemberTypes != 0 && methodReturnValue != null) {
-				if (methodReturnValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberTypes) {
-					if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (returnValueDynamicallyAccessedMemberTypes))
+			if (returnValueDynamicallyAccessedMemberTypes != 0) {
+				foreach (var uniqueValue in methodReturnValue.UniqueValues ()) {
+					if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberTypes) {
+						if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (returnValueDynamicallyAccessedMemberTypes))
+							throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+					} else if (uniqueValue is SystemTypeValue) {
+						// SystemTypeValue can fullfill any requirement, so it's always valid
+						// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
+					} else {
 						throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
-				} else if (methodReturnValue is SystemTypeValue) {
-					// SystemTypeValue can fullfill any requirement, so it's always valid
-					// The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
-				} else {
-					throw new InvalidOperationException ($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+					}
 				}
 			}
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -2222,21 +2222,24 @@ namespace ILCompiler.Dataflow
             }
 
             // Validate that the return value has the correct annotations as per the method return value annotations
-            if (returnValueDynamicallyAccessedMemberTypes != 0 && methodReturnValue != null)
+            if (returnValueDynamicallyAccessedMemberTypes != 0)
             {
-                if (methodReturnValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberTypes)
+                foreach (var uniqueValue in methodReturnValue.UniqueValues())
                 {
-                    if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag(returnValueDynamicallyAccessedMemberTypes))
+                    if (uniqueValue is LeafValueWithDynamicallyAccessedMemberNode methodReturnValueWithMemberTypes)
+                    {
+                        if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag(returnValueDynamicallyAccessedMemberTypes))
+                            throw new InvalidOperationException($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName()} to {calledMethod.GetDisplayName()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+                    }
+                    else if (uniqueValue is SystemTypeValue)
+                    {
+                        // SystemTypeValue can fullfill any requirement, so it's always valid
+                        // The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
+                    }
+                    else
+                    {
                         throw new InvalidOperationException($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName()} to {calledMethod.GetDisplayName()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
-                }
-                else if (methodReturnValue is SystemTypeValue)
-                {
-                    // SystemTypeValue can fullfill any requirement, so it's always valid
-                    // The requirements will be applied at the point where it's consumed (passed as a method parameter, set as field value, returned from the method)
-                }
-                else
-                {
-                    throw new InvalidOperationException($"Internal linker error: processing of call from {callingMethodDefinition.GetDisplayName()} to {calledMethod.GetDisplayName()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
+                    }
                 }
             }
 


### PR DESCRIPTION
This case assume that all code branches should have same minimal dynamic access pattern
Issue happens when 2 code blocks has diferent requirements for dynamic code access, and this produce MergePoint. This case was not handled.
Port of https://github.com/mono/linker/commit/f39ba1a20374ac6af0f2a866a7381192d28b8c37
Closes #1187