### PR TITLE
Use WindowsBase from Desktop SDK if present

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -107,6 +107,9 @@ The .NET Foundation licenses this file to you under the MIT license.
     <!-- Exclude System.IO.Compression.Native.dll -->
     <FrameworkAssemblies Include="$(IlcPath)\framework\*.dll" Exclude="$(IlcPath)\framework\*.Native.dll" />
 
+    <!-- Exclude simplified WindowsBase.dll when building WPF applications -->
+    <FrameworkAssemblies Remove="$(IlcPath)\framework\WindowsBase.dll" Condition="'$(UseWPF)' == 'true'" />
+
     <MibcFile Include="$(IlcPath)\mibc\*.mibc" Condition="'$(IlcPgoOptimize)' == 'true'" />
 
     <DefaultFrameworkAssemblies Include="@(FrameworkAssemblies)" />
@@ -140,6 +143,9 @@ The .NET Foundation licenses this file to you under the MIT license.
 
       <!-- Exclude System.IO.Compression.Native.dll -->
       <FrameworkAssemblies Include="$(IlcPath)\framework\*.dll" Exclude="$(IlcPath)\framework\*.Native.dll" />
+
+      <!-- Exclude simplified WindowsBase.dll when building WPF applications -->
+      <FrameworkAssemblies Remove="$(IlcPath)\framework\WindowsBase.dll" Condition="'$(UseWPF)' == 'true'" />
 
       <MibcFile Include="$(IlcPath)\mibc\*.mibc" Condition="'$(IlcPgoOptimize)' == 'true'" />
 
@@ -343,7 +349,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_IgnoreLinkerWarnings>false</_IgnoreLinkerWarnings>
       <_IgnoreLinkerWarnings Condition="'$(TargetOS)' == 'OSX'">true</_IgnoreLinkerWarnings>
     </PropertyGroup>
-    
+
     <Exec Command="$(CppLinker) @(CustomLinkerArg, ' ')" Condition="'$(TargetOS)' != 'windows' and '$(NativeLib)' != 'Static'" IgnoreStandardErrorWarningFormat="$(_IgnoreLinkerWarnings)" />
     <Exec Command="$(CppLibCreator) @(CustomLibArg, ' ')" Condition="'$(TargetOS)' != 'windows' and '$(NativeLib)' == 'Static'" />
 


### PR DESCRIPTION
Suppress usage of minimal WindowsBase.dll which comes with NativeAOT
Superseeds #1211

Closes #1106