### PR TITLE
Enable marshalling collections of types with marshallers that have a Value property

### DIFF
--- a/DllImportGenerator/DllImportGenerator.UnitTests/CompileFails.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CompileFails.cs
@@ -94,9 +94,6 @@ namespace DllImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.CustomStructMarshallingNativeToManagedOnlyInParameter, 1, 0 };
             yield return new object[] { CodeSnippets.CustomStructMarshallingStackallocOnlyRefParameter, 1, 0 };
 
-            // Custom type marshalling in arrays (complex case with Value property)
-            yield return new object[] { CodeSnippets.ArrayMarshallingWithCustomStructElementWithValueProperty, 5, 0 };
-
             // Abstract SafeHandle type by reference
             yield return new object[] { CodeSnippets.BasicParameterWithByRefModifier("ref", "System.Runtime.InteropServices.SafeHandle"), 1, 0 };
 

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -178,6 +178,7 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CustomStructMarshallingNativeTypePinnable };
             yield return new[] { CodeSnippets.CustomStructMarshallingMarshalUsingParametersAndModifiers };
             yield return new[] { CodeSnippets.ArrayMarshallingWithCustomStructElement };
+            yield return new[] { CodeSnippets.ArrayMarshallingWithCustomStructElementWithValueProperty };
 
             // Escaped C# keyword identifiers
             yield return new[] { CodeSnippets.ByValueParameterWithName("Method", "@event") };

--- a/DllImportGenerator/DllImportGenerator/ContiguousCollectionElementMarshallingCodeContext.cs
+++ b/DllImportGenerator/DllImportGenerator/ContiguousCollectionElementMarshallingCodeContext.cs
@@ -16,20 +16,9 @@ namespace Microsoft.Interop
         private readonly string nativeSpanIdentifier;
         private readonly StubCodeContext parentContext;
 
-        public override bool PinningSupported => false;
+        public override bool SingleFrameSpansNativeContext => false;
 
-        public override bool StackSpaceUsable => false;
-
-        /// <summary>
-        /// Additional variables other than the {managedIdentifier} and {nativeIdentifier} variables
-        /// can be added to the stub to track additional state for the marshaller in the stub.
-        /// </summary>
-        /// <remarks>
-        /// Currently, collection scenarios do not support declaring additional temporary variables to support
-        /// marshalling. This can be accomplished in the future with some additional infrastructure to support
-        /// declaring additional arrays in the stub to support the temporary state.
-        /// </remarks>
-        public override bool CanUseAdditionalTemporaryState => false;
+        public override bool AdditionalTemporaryStateLivesAcrossStages => false;
 
         /// <summary>
         /// Create a <see cref="StubCodeContext"/> for marshalling elements of an collection.
@@ -62,6 +51,11 @@ namespace Microsoft.Interop
                 $"{native}.ManagedValues[{indexerIdentifier}]",
                 $"{nativeSpanIdentifier}[{indexerIdentifier}]"
             );
+        }
+
+        public override string GetAdditionalIdentifier(TypePositionInfo info, string name)
+        {
+            return $"{nativeSpanIdentifier}__{indexerIdentifier}__{name}";
         }
 
         public override TypePositionInfo? GetTypePositionInfoForManagedIndex(int index)

--- a/DllImportGenerator/DllImportGenerator/Marshalling/ArrayMarshaller.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/ArrayMarshaller.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Interop
 
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context)
         {
-            if (context.PinningSupported && enablePinning)
+            if (context.SingleFrameSpansNativeContext && enablePinning)
             {
                 return false;
             }
@@ -67,7 +67,7 @@ namespace Microsoft.Interop
 
         private bool IsPinningPathSupported(TypePositionInfo info, StubCodeContext context)
         {
-            return context.PinningSupported && enablePinning && !info.IsByRef && !info.IsManagedReturnPosition;
+            return context.SingleFrameSpansNativeContext && enablePinning && !info.IsByRef && !info.IsManagedReturnPosition;
         }
 
         private IEnumerable<StatementSyntax> GeneratePinningPath(TypePositionInfo info, StubCodeContext context)

--- a/DllImportGenerator/DllImportGenerator/Marshalling/BlittableMarshaller.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/BlittableMarshaller.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Interop
             {
                 return Argument(IdentifierName(info.InstanceIdentifier));
             }
-            else if (context.PinningSupported && !info.IsManagedReturnPosition)
+            else if (context.SingleFrameSpansNativeContext && !info.IsManagedReturnPosition)
             {
                 return Argument(IdentifierName(context.GetIdentifiers(info).native));
                 
@@ -47,7 +47,7 @@ namespace Microsoft.Interop
 
             (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
 
-            if (context.PinningSupported)
+            if (context.SingleFrameSpansNativeContext)
             {
                 if (context.CurrentStage == StubCodeContext.Stage.Pin)
                 {
@@ -97,7 +97,7 @@ namespace Microsoft.Interop
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return info.IsByRef && !info.IsManagedReturnPosition && !context.PinningSupported;
+            return info.IsByRef && !info.IsManagedReturnPosition && !context.SingleFrameSpansNativeContext;
         }
         
         public bool SupportsByValueMarshalKind(ByValueContentsMarshalKind marshalKind, StubCodeContext context) => false;

--- a/DllImportGenerator/DllImportGenerator/Marshalling/DelegateMarshaller.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/DelegateMarshaller.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Interop
     {
         public TypeSyntax AsNativeType(TypePositionInfo info)
         {
-            return ParseTypeName("global::System.IntPtr");
+            return MarshallerHelpers.SystemIntPtrType;
         }
 
         public ParameterSyntax AsParameter(TypePositionInfo info)
@@ -60,7 +60,10 @@ namespace Microsoft.Interop
                                         LiteralExpression(SyntaxKind.NullLiteralExpression)
                                     ),
                                     InvocationExpression(
-                                        ParseName("global::System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate"),
+                                        MemberAccessExpression(
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            ParseName(TypeNames.System_Runtime_InteropServices_Marshal),
+                                            IdentifierName("GetFunctionPointerForDelegate")),
                                         ArgumentList(SingletonSeparatedList(Argument(IdentifierName(managedIdentifier))))),
                                     LiteralExpression(SyntaxKind.DefaultLiteralExpression))));
                     }
@@ -81,7 +84,7 @@ namespace Microsoft.Interop
                                     InvocationExpression(
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
-                                            ParseName("global::System.Runtime.InteropServices.Marshal"),
+                                            ParseName(TypeNames.System_Runtime_InteropServices_Marshal),
                                             GenericName(Identifier("GetDelegateForFunctionPointer"))
                                             .WithTypeArgumentList(
                                                 TypeArgumentList(

--- a/DllImportGenerator/DllImportGenerator/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -582,7 +582,8 @@ namespace Microsoft.Interop
 
         public IEnumerable<ArgumentSyntax> GetNativeTypeConstructorArguments(TypePositionInfo info, StubCodeContext context)
         {
-            return innerMarshaller.GetNativeTypeConstructorArguments(info, context);
+            var subContext = new CustomNativeTypeWithValuePropertyStubContext(context);
+            return innerMarshaller.GetNativeTypeConstructorArguments(info, subContext);
         }
 
         public bool UsesNativeIdentifier(TypePositionInfo info, StubCodeContext context)
@@ -631,7 +632,7 @@ namespace Microsoft.Interop
                 }
             }
 
-            foreach (var statement in innerMarshaller.GenerateUnmarshalStatements(info, context))
+            foreach (var statement in innerMarshaller.GenerateCleanupStatements(info, context))
             {
                 yield return statement;
             }

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
@@ -86,11 +86,10 @@ namespace Microsoft.Interop
             return spanElementTypeSyntax;
         }
 
-        private const string MarshalerLocalSuffix = "__marshaler";
+        private const string MarshalerLocalSuffix = "marshaler";
         public static string GetMarshallerIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            var (_, nativeIdentifier) = context.GetIdentifiers(info);
-            return nativeIdentifier + MarshalerLocalSuffix;
+            return context.GetAdditionalIdentifier(info, MarshalerLocalSuffix);
         }
 
         public static class StringMarshaller

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -449,14 +449,6 @@ namespace Microsoft.Interop
 
         private static void ValidateCustomNativeTypeMarshallingSupported(TypePositionInfo info, StubCodeContext context, NativeMarshallingAttributeInfo marshalInfo)
         {
-            if (marshalInfo.ValuePropertyType is not null && !context.AdditionalTemporaryStateLivesAcrossStages)
-            {
-                throw new MarshallingNotSupportedException(info, context)
-                {
-                    NotSupportedDetails = Resources.ValuePropertyMarshallingRequiresAdditionalState
-                };
-            }
-
             // The marshalling method for this type doesn't support marshalling from native to managed,
             // but our scenario requires marshalling from native to managed.
             if ((info.RefKind == RefKind.Ref || info.RefKind == RefKind.Out || info.IsManagedReturnPosition)

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Interop
                     return Delegate;
 
                 case { MarshallingAttributeInfo: SafeHandleMarshallingInfo }:
-                    if (!context.CanUseAdditionalTemporaryState)
+                    if (!context.AdditionalTemporaryStateLivesAcrossStages)
                     {
                         throw new MarshallingNotSupportedException(info, context);
                     }
@@ -449,7 +449,7 @@ namespace Microsoft.Interop
 
         private static void ValidateCustomNativeTypeMarshallingSupported(TypePositionInfo info, StubCodeContext context, NativeMarshallingAttributeInfo marshalInfo)
         {
-            if (marshalInfo.ValuePropertyType is not null && !context.CanUseAdditionalTemporaryState)
+            if (marshalInfo.ValuePropertyType is not null && !context.AdditionalTemporaryStateLivesAcrossStages)
             {
                 throw new MarshallingNotSupportedException(info, context)
                 {
@@ -469,13 +469,9 @@ namespace Microsoft.Interop
             }
             // The marshalling method for this type doesn't support marshalling from managed to native by value,
             // but our scenario requires marshalling from managed to native by value.
-            // Pinning is required for the stackalloc marshalling to enable users to safely pass the stackalloc Span's byref
-            // to native if we ever start using a conditional stackalloc method and cannot guarantee that the Span we provide
-            // the user with is backed by stack allocated memory.
-            else if (!info.IsByRef
-                && (marshalInfo.MarshallingMethods & SupportedMarshallingMethods.ManagedToNative) == 0
-                && !(context.PinningSupported && (marshalInfo.MarshallingMethods & SupportedMarshallingMethods.Pinning) == 0)
-                && !(context.StackSpaceUsable && context.PinningSupported && (marshalInfo.MarshallingMethods & SupportedMarshallingMethods.ManagedToNativeStackalloc) == 0))
+            else if (!info.IsByRef 
+                && (marshalInfo.MarshallingMethods & SupportedMarshallingMethods.ManagedToNative) == 0 
+                && (context.SingleFrameSpansNativeContext && (marshalInfo.MarshallingMethods & (SupportedMarshallingMethods.Pinning | SupportedMarshallingMethods.ManagedToNativeStackalloc)) == 0))
             {
                 throw new MarshallingNotSupportedException(info, context)
                 {
@@ -485,9 +481,9 @@ namespace Microsoft.Interop
             // The marshalling method for this type doesn't support marshalling from managed to native by reference,
             // but our scenario requires marshalling from managed to native by reference.
             // "in" byref supports stack marshalling.
-            else if (info.RefKind == RefKind.In
-                && (marshalInfo.MarshallingMethods & SupportedMarshallingMethods.ManagedToNative) == 0
-                && !(context.StackSpaceUsable && context.PinningSupported && (marshalInfo.MarshallingMethods & SupportedMarshallingMethods.ManagedToNativeStackalloc) != 0))
+            else if (info.RefKind == RefKind.In 
+                && (marshalInfo.MarshallingMethods & SupportedMarshallingMethods.ManagedToNative) == 0 
+                && !(context.SingleFrameSpansNativeContext && (marshalInfo.MarshallingMethods & SupportedMarshallingMethods.ManagedToNativeStackalloc) != 0))
             {
                 throw new MarshallingNotSupportedException(info, context)
                 {

--- a/DllImportGenerator/DllImportGenerator/Marshalling/PinnableManagedValueMarshaller.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/PinnableManagedValueMarshaller.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Interop
         }
         private static bool IsPinningPathSupported(TypePositionInfo info, StubCodeContext context)
         {
-            return context.PinningSupported && !info.IsByRef && !info.IsManagedReturnPosition;
+            return context.SingleFrameSpansNativeContext && !info.IsByRef && !info.IsManagedReturnPosition;
         }
 
         private IEnumerable<StatementSyntax> GeneratePinningPath(TypePositionInfo info, StubCodeContext context)

--- a/DllImportGenerator/DllImportGenerator/Marshalling/StringMarshaller.Ansi.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/StringMarshaller.Ansi.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Interop
                                 ExpressionStatement(
                                     AssignmentExpression(
                                         SyntaxKind.SimpleAssignmentExpression,
-                                        IdentifierName(GetAllocationMarkerIdentifier(managedIdentifier)),
+                                        IdentifierName(GetAllocationMarkerIdentifier(info, context)),
                                         LiteralExpression(SyntaxKind.TrueLiteralExpression))));
                         }
 

--- a/DllImportGenerator/DllImportGenerator/Marshalling/StringMarshaller.Utf16.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/StringMarshaller.Utf16.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Interop
                         SyntaxKind.AddressOfExpression,
                         IdentifierName(identifier)));
             }
-            else if (context.PinningSupported)
+            else if (context.SingleFrameSpansNativeContext)
             {
                 // (ushort*)<pinned>
                 return Argument(
@@ -64,7 +64,7 @@ namespace Microsoft.Interop
         public override IEnumerable<StatementSyntax> Generate(TypePositionInfo info, StubCodeContext context)
         {
             (string managedIdentifier, string nativeIdentifier) = context.GetIdentifiers(info);
-            if (context.PinningSupported && !info.IsByRef && !info.IsManagedReturnPosition)
+            if (context.SingleFrameSpansNativeContext && !info.IsByRef && !info.IsManagedReturnPosition)
             {
                 if (context.CurrentStage == StubCodeContext.Stage.Pin)
                 {

--- a/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
+++ b/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
@@ -637,15 +637,6 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Marshalling a value between managed and native with a native type with a &apos;Value&apos; property requires extra state, which is not supported in this context..
-        /// </summary>
-        internal static string ValuePropertyMarshallingRequiresAdditionalState {
-            get {
-                return ResourceManager.GetString("ValuePropertyMarshallingRequiresAdditionalState", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The native type&apos;s &apos;Value&apos; property must have a getter to support marshalling from managed to native..
         /// </summary>
         internal static string ValuePropertyMustHaveGetterDescription {

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -316,9 +316,6 @@
   <data name="TypeNotSupportedTitle" xml:space="preserve">
     <value>Specified type is not supported by source-generated P/Invokes</value>
   </data>
-  <data name="ValuePropertyMarshallingRequiresAdditionalState" xml:space="preserve">
-    <value>Marshalling a value between managed and native with a native type with a 'Value' property requires extra state, which is not supported in this context.</value>
-  </data>
   <data name="ValuePropertyMustHaveGetterDescription" xml:space="preserve">
     <value>The native type's 'Value' property must have a getter to support marshalling from managed to native.</value>
   </data>

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Interop
     {
         public override bool SingleFrameSpansNativeContext => true;
 
+        public override bool AdditionalTemporaryStateLivesAcrossStages => true;
+
         /// <summary>
         /// Identifier for managed return value
         /// </summary>

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -13,11 +13,7 @@ namespace Microsoft.Interop
 {
     internal sealed class StubCodeGenerator : StubCodeContext
     {
-        public override bool PinningSupported => true;
-
-        public override bool StackSpaceUsable => true;
-
-        public override bool CanUseAdditionalTemporaryState => true;
+        public override bool SingleFrameSpansNativeContext => true;
 
         /// <summary>
         /// Identifier for managed return value


### PR DESCRIPTION
Combine the concepts of pinning and stackalloc because we don't guarantee that the Span we provide for the stack-alloc optimization is actually stack allocated (so the only safe way to access is to pin).

Change the concept of "additional temporary state supported" to "additional temporary state lives across stages" and update generators to either handle the new concept or reject working in a scenario where it is unsupported.

This PR can enable us to move more of our built-in marshallers (like our string marshallers) to use the custom type marshalling pattern under the hood.