### PR TITLE
Add configuration option for Unsafe type name.

### DIFF
--- a/DllImportGenerator/DllImportGenerator/Marshalling/ArrayMarshaller.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/ArrayMarshaller.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Interop
@@ -10,12 +11,14 @@ namespace Microsoft.Interop
         private readonly IMarshallingGenerator manualMarshallingGenerator;
         private readonly TypeSyntax elementType;
         private readonly bool enablePinning;
+        private readonly AnalyzerConfigOptions options;
 
-        public ArrayMarshaller(IMarshallingGenerator manualMarshallingGenerator, TypeSyntax elementType, bool enablePinning)
+        public ArrayMarshaller(IMarshallingGenerator manualMarshallingGenerator, TypeSyntax elementType, bool enablePinning, AnalyzerConfigOptions options)
         {
             this.manualMarshallingGenerator = manualMarshallingGenerator;
             this.elementType = elementType;
             this.enablePinning = enablePinning;
+            this.options = options;
         }
 
         public ArgumentSyntax AsArgument(TypePositionInfo info, StubCodeContext context)
@@ -127,7 +130,7 @@ namespace Microsoft.Interop
                                 PrefixUnaryExpression(SyntaxKind.AddressOfExpression,
                                 InvocationExpression(
                                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                        ParseTypeName(TypeNames.System_Runtime_CompilerServices_Unsafe),
+                                        ParseTypeName(TypeNames.Unsafe(options)),
                                         GenericName("As").AddTypeArgumentListArguments(
                                             arrayElementType,
                                             PredefinedType(Token(SyntaxKind.ByteKeyword)))))

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -566,7 +566,8 @@ namespace Microsoft.Interop
                 return new ArrayMarshaller(
                     new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: true),
                     elementType,
-                    isBlittable);
+                    isBlittable,
+                    options);
             }
 
             IMarshallingGenerator marshallingGenerator = new CustomNativeTypeMarshallingGenerator(marshallingStrategy, enableByValueContentsMarshalling: false);

--- a/DllImportGenerator/DllImportGenerator/Microsoft.Interop.DllImportGenerator.props
+++ b/DllImportGenerator/DllImportGenerator/Microsoft.Interop.DllImportGenerator.props
@@ -15,6 +15,11 @@
         of generating a stub that handles all of the marshalling.
       -->
       <CompilerVisibleProperty Include="DllImportGenerator_GenerateForwarders" />
+      <!--
+        Use the Internal.Runtime.ComplierServices.Unsafe type instead of
+        the System.Runtime.CompilerServices.Unsafe type when emitting code.
+      -->
+    <CompilerVisibleProperty Include="DllImportGenerator_UseInternalUnsafeType" />
   </ItemGroup>
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);DLLIMPORTGENERATOR_ENABLED</DefineConstants>

--- a/DllImportGenerator/DllImportGenerator/OptionsHelper.cs
+++ b/DllImportGenerator/DllImportGenerator/OptionsHelper.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Interop
     {
         public const string UseMarshalTypeOption = "build_property.DllImportGenerator_UseMarshalType";
         public const string GenerateForwardersOption = "build_property.DllImportGenerator_GenerateForwarders";
+        public const string UseInternalUnsafeTypeOption = "build_property.DllImportGenerator_UseInternalUnsafeType";
 
         private static bool GetBoolOption(this AnalyzerConfigOptions options, string key)
         {
@@ -22,5 +23,7 @@ namespace Microsoft.Interop
         internal static bool UseMarshalType(this AnalyzerConfigOptions options) => options.GetBoolOption(UseMarshalTypeOption);
 
         internal static bool GenerateForwarders(this AnalyzerConfigOptions options) => options.GetBoolOption(GenerateForwardersOption);
+
+        internal static bool UseInternalUnsafeType(this AnalyzerConfigOptions options) => options.GetBoolOption(UseInternalUnsafeTypeOption);
     }
 }

--- a/DllImportGenerator/DllImportGenerator/TypeNames.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeNames.cs
@@ -53,8 +53,13 @@ namespace Microsoft.Interop
 
         public const string System_Runtime_CompilerServices_SkipLocalsInitAttribute = "System.Runtime.CompilerServices.SkipLocalsInitAttribute";
 
-        // TODO: Add configuration for using Internal.Runtime.CompilerServices.Unsafe to support
-        // running against System.Private.CoreLib
-        public const string System_Runtime_CompilerServices_Unsafe = "System.Runtime.CompilerServices.Unsafe";
+        private const string System_Runtime_CompilerServices_Unsafe = "System.Runtime.CompilerServices.Unsafe";
+
+        private const string Internal_Runtime_CompilerServices_Unsafe = "Internal.Runtime.CompilerServices.Unsafe";
+
+        public static string Unsafe(AnalyzerConfigOptions options)
+        {
+            return options.UseInternalUnsafeType() ? Internal_Runtime_CompilerServices_Unsafe : System_Runtime_CompilerServices_Unsafe;
+        }
     }
 }


### PR DESCRIPTION
In System.Private.CoreLib, the Unsafe type is internal, in a different namespace, and it is implemented in C# + Intrinsics instead of IL. Use a config option to enable switching the API name the generated code uses so the generator can be used with System.Private.CoreLib.