### PR TITLE
Fix ordering of variant and default interface method resolution

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/EEType.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/EEType.cs
@@ -70,27 +70,34 @@ namespace Internal.Runtime
             internal ushort _usImplMethodSlot;
         }
 
-        private uint _entryCount;
+        private ushort _standardEntryCount; // Implementations on the class
+        private ushort _defaultEntryCount; // Default implementations
         private DispatchMapEntry _dispatchMap; // at least one entry if any interfaces defined
 
-        public bool IsEmpty
+        public uint NumStandardEntries
         {
             get
             {
-                return _entryCount == 0;
-            }
-        }
-
-        public uint NumEntries
-        {
-            get
-            {
-                return _entryCount;
+                return _standardEntryCount;
             }
 #if TYPE_LOADER_IMPLEMENTATION
             set
             {
-                _entryCount = value;
+                _standardEntryCount = checked((ushort)value);
+            }
+#endif
+        }
+
+        public uint NumDefaultEntries
+        {
+            get
+            {
+                return _defaultEntryCount;
+            }
+#if TYPE_LOADER_IMPLEMENTATION
+            set
+            {
+                _defaultEntryCount = checked((ushort)value);
             }
 #endif
         }
@@ -99,7 +106,7 @@ namespace Internal.Runtime
         {
             get
             {
-                return sizeof(uint) + sizeof(DispatchMapEntry) * (int)_entryCount;
+                return sizeof(ushort) + sizeof(ushort) + sizeof(DispatchMapEntry) * ((int)_standardEntryCount + (int)_defaultEntryCount);
             }
         }
 
@@ -107,8 +114,7 @@ namespace Internal.Runtime
         {
             get
             {
-                fixed (DispatchMap* pThis = &this)
-                    return (DispatchMapEntry*)((byte*)pThis + sizeof(uint) + (sizeof(DispatchMapEntry) * index));
+                return (DispatchMapEntry*)Unsafe.AsPointer(ref Unsafe.Add(ref _dispatchMap, index));
             }
         }
     }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -583,9 +583,10 @@ namespace Internal.Runtime.TypeLoader
                     *((IntPtr*)((byte*)pEEType + cbDynamicDispatchMapOffset)) = dynamicDispatchMapPtr;
 
                     DispatchMap* pDynamicDispatchMap = (DispatchMap*)dynamicDispatchMapPtr;
-                    pDynamicDispatchMap->NumEntries = pTemplateDispatchMap->NumEntries;
+                    pDynamicDispatchMap->NumStandardEntries = pTemplateDispatchMap->NumStandardEntries;
+                    pDynamicDispatchMap->NumDefaultEntries = pTemplateDispatchMap->NumDefaultEntries;
 
-                    for (int i = 0; i < pTemplateDispatchMap->NumEntries; i++)
+                    for (int i = 0; i < pTemplateDispatchMap->NumStandardEntries + pTemplateDispatchMap->NumDefaultEntries; i++)
                     {
                         DispatchMap.DispatchMapEntry* pTemplateEntry = (*pTemplateDispatchMap)[i];
                         DispatchMap.DispatchMapEntry* pDynamicEntry = (*pDynamicDispatchMap)[i];

--- a/src/tests/nativeaot/SmokeTests/Interfaces/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/Interfaces/Interfaces.cs
@@ -35,6 +35,7 @@ public class BringUpTest
             return Fail;
 
         TestDefaultInterfaceMethods.Run();
+        TestDefaultInterfaceVariance.Run();
         TestVariantInterfaceOptimizations.Run();
         TestSharedIntefaceMethods.Run();
         TestCovariantReturns.Run();
@@ -507,6 +508,31 @@ public class BringUpTest
                 throw new Exception();
 
             if (((IFoo<int>)new Foo<int>()).GetInterfaceType() != typeof(IFoo<int>))
+                throw new Exception();
+        }
+    }
+
+    class TestDefaultInterfaceVariance
+    {
+        class Foo : IVariant<string>, IVariant<object>
+        {
+            string IVariant<object>.Frob() => "Hello class";
+        }
+
+        interface IVariant<in T>
+        {
+            string Frob() => "Hello default";
+        }
+
+        public static void Run()
+        {
+            Console.WriteLine("Testing default interface variant ordering...");
+
+            if (((IVariant<object>)new Foo()).Frob() != "Hello class")
+                throw new Exception();
+            if (((IVariant<string>)new Foo()).Frob() != "Hello class")
+                throw new Exception();
+            if (((IVariant<ValueType>)new Foo()).Frob() != "Hello class")
                 throw new Exception();
         }
     }


### PR DESCRIPTION
Default interface methods need to be looked at only if the "old rules" didn't come up with an answer. We need to split default implementations in the dispatch map so that they can be looked at separately. This is to prevent an exact default implementation match from preempting a variant "old rule" match.