### PR TITLE
Add WindowsBase.dll to list of managed assemblies

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -138,6 +138,7 @@ namespace Build.Tasks
                         }
                     }
 
+                    list.Add(taskItem);
                     continue;
                 }
 


### PR DESCRIPTION
I miss that after adding `continue`