### PR TITLE
Implement marshallers for Span and ReadOnlySpan

### DIFF
--- a/DllImportGenerator/Ancillary.Interop/SpanMarshallers.cs
+++ b/DllImportGenerator/Ancillary.Interop/SpanMarshallers.cs
@@ -7,44 +7,44 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
     [GenericContiguousCollectionMarshaller]
     public unsafe ref struct ReadOnlySpanMarshaller<T>
     {
-        private ReadOnlySpan<T> managedSpan;
-        private readonly int sizeOfNativeElement;
-        private IntPtr allocatedMemory;
+        private ReadOnlySpan<T> _managedSpan;
+        private readonly int _sizeOfNativeElement;
+        private IntPtr _allocatedMemory;
 
         public ReadOnlySpanMarshaller(int sizeOfNativeElement)
             : this()
         {
-            this.sizeOfNativeElement = sizeOfNativeElement;
+            _sizeOfNativeElement = sizeOfNativeElement;
         }
 
         public ReadOnlySpanMarshaller(ReadOnlySpan<T> managed, int sizeOfNativeElement)
         {
-            allocatedMemory = default;
-            this.sizeOfNativeElement = sizeOfNativeElement;
+            _allocatedMemory = default;
+            _sizeOfNativeElement = sizeOfNativeElement;
             if (managed.Length == 0)
             {
-                managedSpan = default;
+                _managedSpan = default;
                 NativeValueStorage = default;
                 return;
             }
-            managedSpan = managed;
-            this.sizeOfNativeElement = sizeOfNativeElement;
+            _managedSpan = managed;
+            _sizeOfNativeElement = sizeOfNativeElement;
             int spaceToAllocate = managed.Length * sizeOfNativeElement;
-            allocatedMemory = Marshal.AllocCoTaskMem(managed.Length);
-            NativeValueStorage = new Span<byte>((void*)allocatedMemory, spaceToAllocate);
+            _allocatedMemory = Marshal.AllocCoTaskMem(managed.Length);
+            NativeValueStorage = new Span<byte>((void*)_allocatedMemory, spaceToAllocate);
         }
 
         public ReadOnlySpanMarshaller(ReadOnlySpan<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
         {
-            allocatedMemory = default;
-            this.sizeOfNativeElement = sizeOfNativeElement;
+            _allocatedMemory = default;
+            _sizeOfNativeElement = sizeOfNativeElement;
             if (managed.Length == 0)
             {
-                managedSpan = default;
+                _managedSpan = default;
                 NativeValueStorage = default;
                 return;
             }
-            managedSpan = managed;
+            _managedSpan = managed;
             int spaceToAllocate = managed.Length * sizeOfNativeElement;
             if (spaceToAllocate <= stackSpace.Length)
             {
@@ -52,8 +52,8 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
             }
             else
             {
-                allocatedMemory = Marshal.AllocCoTaskMem(spaceToAllocate);
-                NativeValueStorage = new Span<byte>((void*)allocatedMemory, spaceToAllocate);
+                _allocatedMemory = Marshal.AllocCoTaskMem(spaceToAllocate);
+                NativeValueStorage = new Span<byte>((void*)_allocatedMemory, spaceToAllocate);
             }
         }
 
@@ -64,7 +64,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// </summary>
         public const int StackBufferSize = 0x200;
 
-        public Span<T> ManagedValues => MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(managedSpan), managedSpan.Length);
+        public Span<T> ManagedValues => MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(_managedSpan), _managedSpan.Length);
 
         public Span<byte> NativeValueStorage { get; private set; }
 
@@ -72,58 +72,58 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
 
         public void SetUnmarshalledCollectionLength(int length)
         {
-            managedSpan = new T[length];
+            _managedSpan = new T[length];
         }
 
         public byte* Value
         {
             get
             {
-                Debug.Assert(managedSpan.IsEmpty || allocatedMemory != IntPtr.Zero);
-                return (byte*)allocatedMemory;
+                Debug.Assert(_managedSpan.IsEmpty || _allocatedMemory != IntPtr.Zero);
+                return (byte*)_allocatedMemory;
             }
             set
             {
                 if (value == null)
                 {
-                    managedSpan = null;
+                    _managedSpan = null;
                     NativeValueStorage = default;
                 }
                 else
                 {
-                    allocatedMemory = (IntPtr)value;
-                    NativeValueStorage = new Span<byte>(value, managedSpan.Length * sizeOfNativeElement);
+                    _allocatedMemory = (IntPtr)value;
+                    NativeValueStorage = new Span<byte>(value, _managedSpan.Length * _sizeOfNativeElement);
                 }
             }
         }
 
-        public ReadOnlySpan<T> ToManaged() => managedSpan;
+        public ReadOnlySpan<T> ToManaged() => _managedSpan;
 
         public void FreeNative()
         {
-            Marshal.FreeCoTaskMem(allocatedMemory);
+            Marshal.FreeCoTaskMem(_allocatedMemory);
         }
     }
 
     [GenericContiguousCollectionMarshaller]
     public unsafe ref struct SpanMarshaller<T>
     {
-        private ReadOnlySpanMarshaller<T> inner;
+        private ReadOnlySpanMarshaller<T> _inner;
 
         public SpanMarshaller(int sizeOfNativeElement)
             : this()
         {
-            inner = new ReadOnlySpanMarshaller<T>(sizeOfNativeElement);
+            _inner = new ReadOnlySpanMarshaller<T>(sizeOfNativeElement);
         }
 
         public SpanMarshaller(Span<T> managed, int sizeOfNativeElement)
         {
-            inner = new ReadOnlySpanMarshaller<T>(managed, sizeOfNativeElement);
+            _inner = new ReadOnlySpanMarshaller<T>(managed, sizeOfNativeElement);
         }
 
         public SpanMarshaller(Span<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
         {
-            inner = new ReadOnlySpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
+            _inner = new ReadOnlySpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
         }
 
         /// <summary>
@@ -133,57 +133,57 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// </summary>
         public const int StackBufferSize = ReadOnlySpanMarshaller<T>.StackBufferSize;
 
-        public Span<T> ManagedValues => inner.ManagedValues;
+        public Span<T> ManagedValues => _inner.ManagedValues;
 
         public Span<byte> NativeValueStorage
         {
-            get => inner.NativeValueStorage;
+            get => _inner.NativeValueStorage;
         }
 
-        public ref byte GetPinnableReference() => ref inner.GetPinnableReference();
+        public ref byte GetPinnableReference() => ref _inner.GetPinnableReference();
 
         public void SetUnmarshalledCollectionLength(int length)
         {
-            inner.SetUnmarshalledCollectionLength(length);
+            _inner.SetUnmarshalledCollectionLength(length);
         }
 
         public byte* Value
         {
-            get => inner.Value;
-            set => inner.Value = value;
+            get => _inner.Value;
+            set => _inner.Value = value;
         }
 
         public Span<T> ToManaged()
         {
-            ReadOnlySpan<T> managedInner = inner.ToManaged();
+            ReadOnlySpan<T> managedInner = _inner.ToManaged();
             return MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(managedInner), managedInner.Length);
         }
 
         public void FreeNative()
         {
-            inner.FreeNative();
+            _inner.FreeNative();
         }
     }
 
     [GenericContiguousCollectionMarshaller]
     public unsafe ref struct NeverNullSpanMarshaller<T>
     {
-        private SpanMarshaller<T> inner;
+        private SpanMarshaller<T> _inner;
 
         public NeverNullSpanMarshaller(int sizeOfNativeElement)
             : this()
         {
-            inner = new SpanMarshaller<T>(sizeOfNativeElement);
+            _inner = new SpanMarshaller<T>(sizeOfNativeElement);
         }
 
         public NeverNullSpanMarshaller(Span<T> managed, int sizeOfNativeElement)
         {
-            inner = new SpanMarshaller<T>(managed, sizeOfNativeElement);
+            _inner = new SpanMarshaller<T>(managed, sizeOfNativeElement);
         }
 
         public NeverNullSpanMarshaller(Span<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
         {
-            inner = new SpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
+            _inner = new SpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
         }
 
         /// <summary>
@@ -193,68 +193,68 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// </summary>
         public const int StackBufferSize = SpanMarshaller<T>.StackBufferSize;
 
-        public Span<T> ManagedValues => inner.ManagedValues;
+        public Span<T> ManagedValues => _inner.ManagedValues;
 
         public Span<byte> NativeValueStorage
         {
-            get => inner.NativeValueStorage;
+            get => _inner.NativeValueStorage;
         }
 
         public ref byte GetPinnableReference()
         {
-            if (inner.ManagedValues.Length == 0)
+            if (_inner.ManagedValues.Length == 0)
             {
                 return ref *(byte*)0xa5a5a5a5;
             }
-            return ref inner.GetPinnableReference();
+            return ref _inner.GetPinnableReference();
         }
 
         public void SetUnmarshalledCollectionLength(int length)
         {
-            inner.SetUnmarshalledCollectionLength(length);
+            _inner.SetUnmarshalledCollectionLength(length);
         }
 
         public byte* Value
         {
             get
             {
-                if (inner.ManagedValues.Length == 0)
+                if (_inner.ManagedValues.Length == 0)
                 {
                     return (byte*)0x1;
                 }
-                return inner.Value;
+                return _inner.Value;
             }
 
-            set => inner.Value = value;
+            set => _inner.Value = value;
         }
 
-        public Span<T> ToManaged() => inner.ToManaged();
+        public Span<T> ToManaged() => _inner.ToManaged();
 
         public void FreeNative()
         {
-            inner.FreeNative();
+            _inner.FreeNative();
         }
     }
 
     [GenericContiguousCollectionMarshaller]
     public unsafe ref struct NeverNullReadOnlySpanMarshaller<T>
     {
-        private ReadOnlySpanMarshaller<T> inner;
+        private ReadOnlySpanMarshaller<T> _inner;
 
         public NeverNullReadOnlySpanMarshaller(int sizeOfNativeElement)
             : this()
         {
-            inner = new ReadOnlySpanMarshaller<T>(sizeOfNativeElement);
+            _inner = new ReadOnlySpanMarshaller<T>(sizeOfNativeElement);
         }
 
         public NeverNullReadOnlySpanMarshaller(ReadOnlySpan<T> managed, int sizeOfNativeElement)
         {
-            inner = new ReadOnlySpanMarshaller<T>(managed, sizeOfNativeElement);
+            _inner = new ReadOnlySpanMarshaller<T>(managed, sizeOfNativeElement);
         }
 
         public NeverNullReadOnlySpanMarshaller(ReadOnlySpan<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
         {
-            inner = new ReadOnlySpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
+            _inner = new ReadOnlySpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
         }
 
         /// <summary>
@@ -264,46 +264,46 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// </summary>
         public const int StackBufferSize = SpanMarshaller<T>.StackBufferSize;
 
-        public Span<T> ManagedValues => inner.ManagedValues;
+        public Span<T> ManagedValues => _inner.ManagedValues;
 
         public Span<byte> NativeValueStorage
         {
-            get => inner.NativeValueStorage;
+            get => _inner.NativeValueStorage;
         }
 
         public ref byte GetPinnableReference()
         {
-            if (inner.ManagedValues.Length == 0)
+            if (_inner.ManagedValues.Length == 0)
             {
                 return ref *(byte*)0xa5a5a5a5;
             }
-            return ref inner.GetPinnableReference();
+            return ref _inner.GetPinnableReference();
         }
 
         public void SetUnmarshalledCollectionLength(int length)
         {
-            inner.SetUnmarshalledCollectionLength(length);
+            _inner.SetUnmarshalledCollectionLength(length);
         }
 
         public byte* Value
         {
             get
             {
-                if (inner.ManagedValues.Length == 0)
+                if (_inner.ManagedValues.Length == 0)
                 {
                     return (byte*)0x1;
                 }
-                return inner.Value;
+                return _inner.Value;
             }
 
-            set => inner.Value = value;
+            set => _inner.Value = value;
         }
 
-        public ReadOnlySpan<T> ToManaged() => inner.ToManaged();
+        public ReadOnlySpan<T> ToManaged() => _inner.ToManaged();
 
         public void FreeNative()
         {
-            inner.FreeNative();
+            _inner.FreeNative();
         }
     }
 
@@ -311,9 +311,9 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
     public unsafe ref struct DirectSpanMarshaller<T>
         where T : unmanaged
     {
-        private int unmarshalledLength;
-        private T* allocatedMemory;
-        private Span<T> data;
+        private int _unmarshalledLength;
+        private T* _allocatedMemory;
+        private Span<T> _data;
 
         public DirectSpanMarshaller(int sizeOfNativeElement)
             :this()
@@ -334,15 +334,15 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
             }
 
             int spaceToAllocate = managed.Length * Unsafe.SizeOf<T>();
-            allocatedMemory = (T*)Marshal.AllocCoTaskMem(spaceToAllocate);
-            data = managed;
+            _allocatedMemory = (T*)Marshal.AllocCoTaskMem(spaceToAllocate);
+            _data = managed;
         }
 
         public DirectSpanMarshaller(Span<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
             :this(sizeOfNativeElement)
         {
             Debug.Assert(stackSpace.IsEmpty);
-            data = managed;
+            _data = managed;
         }
 
         /// <summary>
@@ -350,44 +350,44 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         /// </summary>
         public const int StackBufferSize = 0;
 
-        public Span<T> ManagedValues => data;
+        public Span<T> ManagedValues => _data;
 
-        public Span<byte> NativeValueStorage => allocatedMemory != null
-            ? new Span<byte>(allocatedMemory, data.Length * Unsafe.SizeOf<T>())
-            : MemoryMarshal.Cast<T, byte>(data);
+        public Span<byte> NativeValueStorage => _allocatedMemory != null
+            ? new Span<byte>(_allocatedMemory, _data.Length * Unsafe.SizeOf<T>())
+            : MemoryMarshal.Cast<T, byte>(_data);
 
-        public ref T GetPinnableReference() => ref data.GetPinnableReference();
+        public ref T GetPinnableReference() => ref _data.GetPinnableReference();
 
         public void SetUnmarshalledCollectionLength(int length)
         {
-            unmarshalledLength = length;
+            _unmarshalledLength = length;
         }
 
         public T* Value
         {
             get
             {
-                Debug.Assert(data.IsEmpty || allocatedMemory != null);
-                return allocatedMemory;
+                Debug.Assert(_data.IsEmpty || _allocatedMemory != null);
+                return _allocatedMemory;
             }
             set
             {
                 // We don't save the pointer assigned here to be freed
                 // since this marshaller passes back the actual memory span from native code
                 // back to managed code.
-                allocatedMemory = null;
-                data = new Span<T>(value, unmarshalledLength);
+                _allocatedMemory = null;
+                _data = new Span<T>(value, _unmarshalledLength);
             }
         }
 
         public Span<T> ToManaged()
         {
-            return data;
+            return _data;
         }
 
         public void FreeNative()
         {
-            Marshal.FreeCoTaskMem((IntPtr)allocatedMemory);
+            Marshal.FreeCoTaskMem((IntPtr)_allocatedMemory);
         }
     }
 }

--- a/DllImportGenerator/Ancillary.Interop/SpanMarshallers.cs
+++ b/DllImportGenerator/Ancillary.Interop/SpanMarshallers.cs
@@ -30,7 +30,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
             _managedSpan = managed;
             _sizeOfNativeElement = sizeOfNativeElement;
             int spaceToAllocate = managed.Length * sizeOfNativeElement;
-            _allocatedMemory = Marshal.AllocCoTaskMem(managed.Length);
+            _allocatedMemory = Marshal.AllocCoTaskMem(spaceToAllocate);
             NativeValueStorage = new Span<byte>((void*)_allocatedMemory, spaceToAllocate);
         }
 

--- a/DllImportGenerator/Ancillary.Interop/SpanMarshallers.cs
+++ b/DllImportGenerator/Ancillary.Interop/SpanMarshallers.cs
@@ -46,7 +46,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
             }
             managedSpan = managed;
             int spaceToAllocate = managed.Length * sizeOfNativeElement;
-            if (spaceToAllocate < stackSpace.Length)
+            if (spaceToAllocate <= stackSpace.Length)
             {
                 NativeValueStorage = stackSpace[0..spaceToAllocate];
             }
@@ -101,10 +101,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
 
         public void FreeNative()
         {
-            if (allocatedMemory != IntPtr.Zero)
-            {
-                Marshal.FreeCoTaskMem(allocatedMemory);
-            }
+            Marshal.FreeCoTaskMem(allocatedMemory);
         }
     }
 
@@ -207,7 +204,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         {
             if (inner.ManagedValues.Length == 0)
             {
-                return ref *(byte*)0x1;
+                return ref *(byte*)0xa5a5a5a5;
             }
             return ref inner.GetPinnableReference();
         }
@@ -278,7 +275,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         {
             if (inner.ManagedValues.Length == 0)
             {
-                return ref *(byte*)0x1;
+                return ref *(byte*)0xa5a5a5a5;
             }
             return ref inner.GetPinnableReference();
         }
@@ -344,6 +341,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
         public DirectSpanMarshaller(Span<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
             :this(sizeOfNativeElement)
         {
+            Debug.Assert(stackSpace.IsEmpty);
             data = managed;
         }
 
@@ -389,10 +387,7 @@ namespace System.Runtime.InteropServices.GeneratedMarshalling
 
         public void FreeNative()
         {
-            if (allocatedMemory != null)
-            {
-                Marshal.FreeCoTaskMem((IntPtr)allocatedMemory);
-            }
+            Marshal.FreeCoTaskMem((IntPtr)allocatedMemory);
         }
     }
 }

--- a/DllImportGenerator/Ancillary.Interop/SpanMarshallers.cs
+++ b/DllImportGenerator/Ancillary.Interop/SpanMarshallers.cs
@@ -1,0 +1,390 @@
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.InteropServices.GeneratedMarshalling
+{
+    public unsafe ref struct ReadOnlySpanMarshaller<T>
+    {
+        private ReadOnlySpan<T> managedSpan;
+        private readonly int sizeOfNativeElement;
+        private IntPtr allocatedMemory;
+
+        public ReadOnlySpanMarshaller(int sizeOfNativeElement)
+            : this()
+        {
+            this.sizeOfNativeElement = sizeOfNativeElement;
+        }
+
+        public ReadOnlySpanMarshaller(ReadOnlySpan<T> managed, int sizeOfNativeElement)
+        {
+            allocatedMemory = default;
+            this.sizeOfNativeElement = sizeOfNativeElement;
+            if (managed.Length == 0)
+            {
+                managedSpan = default;
+                NativeValueStorage = default;
+                return;
+            }
+            managedSpan = managed;
+            this.sizeOfNativeElement = sizeOfNativeElement;
+            int spaceToAllocate = managed.Length * sizeOfNativeElement;
+            allocatedMemory = Marshal.AllocCoTaskMem(managed.Length);
+            NativeValueStorage = new Span<byte>((void*)allocatedMemory, spaceToAllocate);
+        }
+
+        public ReadOnlySpanMarshaller(ReadOnlySpan<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
+        {
+            allocatedMemory = default;
+            this.sizeOfNativeElement = sizeOfNativeElement;
+            if (managed.Length == 0)
+            {
+                managedSpan = default;
+                NativeValueStorage = default;
+                return;
+            }
+            managedSpan = managed;
+            int spaceToAllocate = managed.Length * sizeOfNativeElement;
+            if (spaceToAllocate < stackSpace.Length)
+            {
+                NativeValueStorage = stackSpace[0..spaceToAllocate];
+            }
+            else
+            {
+                allocatedMemory = Marshal.AllocCoTaskMem(spaceToAllocate);
+                NativeValueStorage = new Span<byte>((void*)allocatedMemory, spaceToAllocate);
+            }
+        }
+
+        /// <summary>
+        /// Stack-alloc threshold set to 256 bytes to enable small arrays to be passed on the stack.
+        /// Number kept small to ensure that P/Invokes with a lot of array parameters doesn't
+        /// blow the stack since this is a new optimization in the code-generated interop.
+        /// </summary>
+        public const int StackBufferSize = 0x200;
+
+        public Span<T> ManagedValues => MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(managedSpan), managedSpan.Length);
+
+        public Span<byte> NativeValueStorage { get; private set; }
+
+        public ref byte GetPinnableReference() => ref MemoryMarshal.GetReference(NativeValueStorage);
+
+        public void SetUnmarshalledCollectionLength(int length)
+        {
+            managedSpan = new T[length];
+        }
+
+        public byte* Value
+        {
+            get
+            {
+                Debug.Assert(managedSpan.IsEmpty || allocatedMemory != IntPtr.Zero);
+                return (byte*)allocatedMemory;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    managedSpan = null;
+                    NativeValueStorage = default;
+                }
+                else
+                {
+                    allocatedMemory = (IntPtr)value;
+                    NativeValueStorage = new Span<byte>(value, managedSpan.Length * sizeOfNativeElement);
+                }
+            }
+        }
+
+        public ReadOnlySpan<T> ToManaged() => managedSpan;
+
+        public void FreeNative()
+        {
+            if (allocatedMemory != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(allocatedMemory);
+            }
+        }
+    }
+
+    public unsafe ref struct SpanMarshaller<T>
+    {
+        private ReadOnlySpanMarshaller<T> inner;
+
+        public SpanMarshaller(int sizeOfNativeElement)
+            : this()
+        {
+            inner = new ReadOnlySpanMarshaller<T>(sizeOfNativeElement);
+        }
+
+        public SpanMarshaller(Span<T> managed, int sizeOfNativeElement)
+        {
+            inner = new ReadOnlySpanMarshaller<T>(managed, sizeOfNativeElement);
+        }
+
+        public SpanMarshaller(Span<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
+        {
+            inner = new ReadOnlySpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
+        }
+
+        /// <summary>
+        /// Stack-alloc threshold set to 256 bytes to enable small arrays to be passed on the stack.
+        /// Number kept small to ensure that P/Invokes with a lot of array parameters doesn't
+        /// blow the stack since this is a new optimization in the code-generated interop.
+        /// </summary>
+        public const int StackBufferSize = ReadOnlySpanMarshaller<T>.StackBufferSize;
+
+        public Span<T> ManagedValues => inner.ManagedValues;
+
+        public Span<byte> NativeValueStorage
+        {
+            get => inner.NativeValueStorage;
+        }
+
+        public ref byte GetPinnableReference() => ref inner.GetPinnableReference();
+
+        public void SetUnmarshalledCollectionLength(int length)
+        {
+            inner.SetUnmarshalledCollectionLength(length);
+        }
+
+        public byte* Value
+        {
+            get => inner.Value;
+            set => inner.Value = value;
+        }
+
+        public Span<T> ToManaged()
+        {
+            ReadOnlySpan<T> managedInner = inner.ToManaged();
+            return MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(managedInner), managedInner.Length);
+        }
+
+        public void FreeNative()
+        {
+            inner.FreeNative();
+        }
+    }
+
+    public unsafe ref struct NeverNullSpanMarshaller<T>
+    {
+        private SpanMarshaller<T> inner;
+
+        public NeverNullSpanMarshaller(int sizeOfNativeElement)
+            : this()
+        {
+            inner = new SpanMarshaller<T>(sizeOfNativeElement);
+        }
+
+        public NeverNullSpanMarshaller(Span<T> managed, int sizeOfNativeElement)
+        {
+            inner = new SpanMarshaller<T>(managed, sizeOfNativeElement);
+        }
+
+        public NeverNullSpanMarshaller(Span<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
+        {
+            inner = new SpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
+        }
+
+        /// <summary>
+        /// Stack-alloc threshold set to 256 bytes to enable small spans to be passed on the stack.
+        /// Number kept small to ensure that P/Invokes with a lot of span parameters doesn't
+        /// blow the stack.
+        /// </summary>
+        public const int StackBufferSize = SpanMarshaller<T>.StackBufferSize;
+
+        public Span<T> ManagedValues => inner.ManagedValues;
+
+        public Span<byte> NativeValueStorage
+        {
+            get => inner.NativeValueStorage;
+        }
+
+        public ref byte GetPinnableReference()
+        {
+            if (inner.ManagedValues.Length == 0)
+            {
+                return ref *(byte*)0x1;
+            }
+            return ref inner.GetPinnableReference();
+        }
+
+        public void SetUnmarshalledCollectionLength(int length)
+        {
+            inner.SetUnmarshalledCollectionLength(length);
+        }
+
+        public byte* Value
+        {
+            get
+            {
+                if (inner.ManagedValues.Length == 0)
+                {
+                    return (byte*)0x1;
+                }
+                return inner.Value;
+            }
+
+            set => inner.Value = value;
+        }
+
+        public Span<T> ToManaged() => inner.ToManaged();
+
+        public void FreeNative()
+        {
+            inner.FreeNative();
+        }
+    }
+
+    public unsafe ref struct NeverNullReadOnlySpanMarshaller<T>
+    {
+        private ReadOnlySpanMarshaller<T> inner;
+
+        public NeverNullReadOnlySpanMarshaller(int sizeOfNativeElement)
+            : this()
+        {
+            inner = new ReadOnlySpanMarshaller<T>(sizeOfNativeElement);
+        }
+
+        public NeverNullReadOnlySpanMarshaller(Span<T> managed, int sizeOfNativeElement)
+        {
+            inner = new ReadOnlySpanMarshaller<T>(managed, sizeOfNativeElement);
+        }
+
+        public NeverNullReadOnlySpanMarshaller(Span<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
+        {
+            inner = new ReadOnlySpanMarshaller<T>(managed, stackSpace, sizeOfNativeElement);
+        }
+
+        /// <summary>
+        /// Stack-alloc threshold set to 256 bytes to enable small spans to be passed on the stack.
+        /// Number kept small to ensure that P/Invokes with a lot of span parameters doesn't
+        /// blow the stack.
+        /// </summary>
+        public const int StackBufferSize = SpanMarshaller<T>.StackBufferSize;
+
+        public Span<T> ManagedValues => inner.ManagedValues;
+
+        public Span<byte> NativeValueStorage
+        {
+            get => inner.NativeValueStorage;
+        }
+
+        public ref byte GetPinnableReference()
+        {
+            if (inner.ManagedValues.Length == 0)
+            {
+                return ref *(byte*)0x1;
+            }
+            return ref inner.GetPinnableReference();
+        }
+
+        public void SetUnmarshalledCollectionLength(int length)
+        {
+            inner.SetUnmarshalledCollectionLength(length);
+        }
+
+        public byte* Value
+        {
+            get
+            {
+                if (inner.ManagedValues.Length == 0)
+                {
+                    return (byte*)0x1;
+                }
+                return inner.Value;
+            }
+
+            set => inner.Value = value;
+        }
+
+        public ReadOnlySpan<T> ToManaged() => inner.ToManaged();
+
+        public void FreeNative()
+        {
+            inner.FreeNative();
+        }
+    }
+
+    public unsafe ref struct DirectSpanMarshaller<T>
+        where T : unmanaged
+    {
+        private int unmarshalledLength;
+        private T* allocatedMemory;
+        private Span<T> data;
+
+        public DirectSpanMarshaller(int sizeOfNativeElement)
+            :this()
+        {
+            if (typeof(T) == typeof(bool) || typeof(T) == typeof(char) || Unsafe.SizeOf<T>() != sizeOfNativeElement)
+            {
+                throw new ArgumentException("This marshaller only supports blittable element types. The provided type parameter must be blittable", nameof(T));
+            }
+        }
+
+        public DirectSpanMarshaller(Span<T> managed, int sizeOfNativeElement)
+            :this(sizeOfNativeElement)
+        {
+            if (managed.Length == 0)
+            {
+                return;
+            }
+
+            int spaceToAllocate = managed.Length * sizeof(T);
+            allocatedMemory = (T*)Marshal.AllocCoTaskMem(managed.Length);
+            data = new Span<T>(allocatedMemory, spaceToAllocate);
+        }
+
+        public DirectSpanMarshaller(Span<T> managed, Span<byte> stackSpace, int sizeOfNativeElement)
+            :this(sizeOfNativeElement)
+        {
+            data = managed;
+        }
+
+        /// <summary>
+        /// Stack-alloc threshold set to 0 so that the generator can use the constructor that takes a stackSpace to let the marshaller know that the original data span can be used and safely pinned.
+        /// </summary>
+        public const int StackBufferSize = 0;
+
+        public Span<T> ManagedValues => data;
+
+        public Span<byte> NativeValueStorage => MemoryMarshal.Cast<T, byte>(data);
+
+        public ref T GetPinnableReference() => ref data.GetPinnableReference();
+
+        public void SetUnmarshalledCollectionLength(int length)
+        {
+            unmarshalledLength = length;
+        }
+
+        public T* Value
+        {
+            get
+            {
+                Debug.Assert(data.Length == 0 || allocatedMemory != null);
+                return allocatedMemory;
+            }
+            set
+            {
+                // We don't save the pointer assigned here to be freed
+                // since this marshaller passes back the actual memory span from native code
+                // back to managed code.
+                allocatedMemory = null;
+                data = new Span<T>(Value, unmarshalledLength);
+            }
+        }
+
+        public Span<T> ToManaged()
+        {
+            return data;
+        }
+
+        public void FreeNative()
+        {
+            if (allocatedMemory != null)
+            {
+                Marshal.FreeCoTaskMem((IntPtr)allocatedMemory);
+            }
+        }
+    }
+}

--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/SpanTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/SpanTests.cs
@@ -1,0 +1,170 @@
+﻿using SharedTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.GeneratedMarshalling;
+using System.Text;
+
+using Xunit;
+
+namespace DllImportGenerator.IntegrationTests
+{
+    partial class NativeExportsNE
+    {
+        public partial class Span
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array")]
+            public static partial int Sum([MarshalUsing(typeof(SpanMarshaller<int>))] Span<int> values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array")]
+            public static partial int SumNeverNull([MarshalUsing(typeof(NeverNullSpanMarshaller<int>))] Span<int> values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array")]
+            public static partial int SumNeverNull([MarshalUsing(typeof(NeverNullReadOnlySpanMarshaller<int>))] ReadOnlySpan<int> values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array_ref")]
+            public static partial int SumInArray([MarshalUsing(typeof(SpanMarshaller<int>))] in Span<int> values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "duplicate_int_array")]
+            public static partial void Duplicate([MarshalUsing(typeof(SpanMarshaller<int>), CountElementName = "numValues")] ref Span<int> values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "duplicate_int_array")]
+            public static partial void DuplicateRaw([MarshalUsing(typeof(DirectSpanMarshaller<int>), CountElementName = "numValues")] ref Span<int> values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "create_range_array")]
+            [return: MarshalUsing(typeof(SpanMarshaller<int>), CountElementName = "numValues")]
+            public static partial Span<int> CreateRange(int start, int end, out int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "create_range_array_out")]
+            public static partial void CreateRange_Out(int start, int end, out int numValues, [MarshalUsing(typeof(SpanMarshaller<int>), CountElementName = "numValues")] out Span<int> res);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "get_long_bytes")]
+            [return: MarshalUsing(typeof(SpanMarshaller<byte>), ConstantElementCount = sizeof(long))]
+            public static partial Span<byte> GetLongBytes(long l);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "and_all_members")]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool AndAllMembers([MarshalUsing(typeof(SpanMarshaller<BoolStruct>))] Span<BoolStruct> pArray, int length);
+        }
+    }
+
+    public class SpanTests
+    {
+        [Fact]
+        public void BlittableElementSpanMarshalledToNativeAsExpected()
+        {
+            var list = new int[] { 1, 5, 79, 165, 32, 3 };
+            Assert.Equal(list.Sum(), NativeExportsNE.Span.Sum(list, list.Length));
+        }
+
+        [Fact]
+        public void DefaultBlittableElementSpanMarshalledToNativeAsExpected()
+        {
+            Assert.Equal(-1, NativeExportsNE.Span.Sum(default, 0));
+        }
+
+        [Fact]
+        public void NeverNullSpanMarshallerMarshalsDefaultAsNonNull()
+        {
+            Assert.Equal(0, NativeExportsNE.Span.SumNeverNull(Span<int>.Empty, 0));
+        }
+
+        [Fact]
+        public void NeverNullReadOnlySpanMarshallerMarshalsDefaultAsNonNull()
+        {
+            Assert.Equal(0, NativeExportsNE.Span.SumNeverNull(ReadOnlySpan<int>.Empty, 0));
+        }
+
+        [Fact]
+        public void BlittableElementSpanInParameter()
+        {
+            var list = new int[] { 1, 5, 79, 165, 32, 3 };
+            Assert.Equal(list.Sum(), NativeExportsNE.Span.SumInArray(list, list.Length));
+        }
+
+        [Fact]
+        public void BlittableElementSpanRefParameter()
+        {
+            var list = new int[] { 1, 5, 79, 165, 32, 3 };
+            Span<int> newSpan = list;
+            NativeExportsNE.Span.Duplicate(ref newSpan, list.Length);
+            Assert.Equal((IEnumerable<int>)list, newSpan.ToArray());
+        }
+
+        [Fact]
+        public unsafe void DirectSpanMarshaller()
+        {
+            var list = new int[] { 1, 5, 79, 165, 32, 3 };
+            Span<int> newSpan = list;
+            NativeExportsNE.Span.DuplicateRaw(ref newSpan, list.Length);
+            Assert.Equal((IEnumerable<int>)list, newSpan.ToArray());
+            Marshal.FreeCoTaskMem((IntPtr)Unsafe.AsPointer(ref newSpan.GetPinnableReference()));
+        }
+
+        [Fact]
+        public void BlittableElementSpanReturnedFromNative()
+        {
+            int start = 5;
+            int end = 20;
+
+            IEnumerable<int> expected = Enumerable.Range(start, end - start);
+            Assert.Equal(expected, NativeExportsNE.Collections.CreateRange(start, end, out _));
+
+            Span<int> res;
+            NativeExportsNE.Span.CreateRange_Out(start, end, out _, out res);
+            Assert.Equal(expected, res.ToArray());
+        }
+
+        [Fact]
+        public void NullBlittableElementSpanReturnedFromNative()
+        {
+            Assert.Null(NativeExportsNE.Collections.CreateRange(1, 0, out _));
+
+            Span<int> res;
+            NativeExportsNE.Span.CreateRange_Out(1, 0, out _, out res);
+            Assert.True(res.IsEmpty);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SpanWithSimpleNonBlittableTypeMarshalling(bool result)
+        {
+            var boolValues = new BoolStruct[]
+            {
+                new BoolStruct
+                {
+                    b1 = true,
+                    b2 = true,
+                    b3 = true,
+                },
+                new BoolStruct
+                {
+                    b1 = true,
+                    b2 = true,
+                    b3 = true,
+                },
+                new BoolStruct
+                {
+                    b1 = true,
+                    b2 = true,
+                    b3 = result,
+                },
+            };
+
+            Assert.Equal(result, NativeExportsNE.Span.AndAllMembers(boolValues, boolValues.Length));
+        }
+
+        private static string ReverseChars(string value)
+        {
+            if (value == null)
+                return null;
+
+            var chars = value.ToCharArray();
+            Array.Reverse(chars);
+            return new string(chars);
+        }
+    }
+}

--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/SpanTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/SpanTests.cs
@@ -156,15 +156,5 @@ namespace DllImportGenerator.IntegrationTests
 
             Assert.Equal(result, NativeExportsNE.Span.AndAllMembers(boolValues, boolValues.Length));
         }
-
-        private static string ReverseChars(string value)
-        {
-            if (value == null)
-                return null;
-
-            var chars = value.ToCharArray();
-            Array.Reverse(chars);
-            return new string(chars);
-        }
     }
 }


### PR DESCRIPTION
Implement marshallers for Span and ReadOnlySpan to show the extensibility model for a new interop type.

When we move in-box, we can annotate `Span<T>` and `ReadOnlySpan<T>` with `[NativeMarshalling]` attributes pointing to their default marshallers and remove some of the `[MarshalUsing]` attributes.