### PR TITLE
Implement support for collections of collections marshalling

### DIFF
--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/ArrayTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/ArrayTests.cs
@@ -62,6 +62,11 @@ namespace DllImportGenerator.IntegrationTests
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "and_all_members")]
             [return:MarshalAs(UnmanagedType.U1)]
             public static partial bool AndAllMembers(BoolStruct[] pArray, int length);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "transpose_matrix")]
+            [return: MarshalUsing(CountElementName = "numColumns")]
+            [return: MarshalUsing(CountElementName = "numRows", ElementIndirectionLevel = 1)]
+            public static partial int[][] TransposeMatrix(int[][] matrix, int[] numRows, int numColumns);
         }
     }
 
@@ -271,6 +276,35 @@ namespace DllImportGenerator.IntegrationTests
             };
 
             Assert.Equal(result, NativeExportsNE.Arrays.AndAllMembers(boolValues, boolValues.Length));
+        }
+
+        [Fact]
+        public void ArraysOfArrays()
+        {
+            var random = new Random(42);
+            int numRows = random.Next(1, 5);
+            int numColumns = random.Next(1, 5);
+            int[][] matrix = new int[numRows][];
+            int[] numRowsArray = new int[numColumns];
+            for (int i = 0; i < numRows; i++)
+            {
+                matrix[i] = new int[numColumns];
+                for (int j = 0; j < numColumns; j++)
+                {
+                    matrix[i][j] = random.Next();
+                    numRowsArray[j] = numRows;
+                }
+            }
+
+            int[][] transposed = NativeExportsNE.Arrays.TransposeMatrix(matrix, numRowsArray, numColumns);
+            
+            for (int i = 0; i < numRows; i++)
+            {
+                for (int j = 0; j < numColumns; j++)
+                {
+                    Assert.Equal(matrix[i][j], transposed[j][i]);
+                }
+            }
         }
 
         private static string ReverseChars(string value)

--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/ArrayTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/ArrayTests.cs
@@ -285,16 +285,17 @@ namespace DllImportGenerator.IntegrationTests
             int numRows = random.Next(1, 5);
             int numColumns = random.Next(1, 5);
             int[][] matrix = new int[numRows][];
-            int[] numRowsArray = new int[numColumns];
             for (int i = 0; i < numRows; i++)
             {
                 matrix[i] = new int[numColumns];
                 for (int j = 0; j < numColumns; j++)
                 {
                     matrix[i][j] = random.Next();
-                    numRowsArray[j] = numRows;
                 }
             }
+
+            int[] numRowsArray = new int[numColumns];
+            numRowsArray.AsSpan().Fill(numRows);
 
             int[][] transposed = NativeExportsNE.Arrays.TransposeMatrix(matrix, numRowsArray, numColumns);
             

--- a/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -1331,5 +1331,82 @@ partial class Test
     );
 }
 ";
+
+        public static string CollectionsOfCollectionsStress => @"
+using System.Runtime.InteropServices;
+partial class Test
+{
+    [GeneratedDllImport(""DoesNotExist"")]
+    public static partial void Method(
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]
+        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionLevel = 3)]
+        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionLevel = 4)]
+        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionLevel = 5)]
+        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionLevel = 6)]
+        [MarshalUsing(CountElementName=""arr7"", ElementIndirectionLevel = 7)]
+        [MarshalUsing(CountElementName=""arr8"", ElementIndirectionLevel = 8)]
+        [MarshalUsing(CountElementName=""arr9"", ElementIndirectionLevel = 9)]
+        [MarshalUsing(CountElementName=""arr10"", ElementIndirectionLevel = 10)] ref int[][][][][][][][][][][] arr11,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]
+        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionLevel = 3)]
+        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionLevel = 4)]
+        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionLevel = 5)]
+        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionLevel = 6)]
+        [MarshalUsing(CountElementName=""arr7"", ElementIndirectionLevel = 7)]
+        [MarshalUsing(CountElementName=""arr8"", ElementIndirectionLevel = 8)]
+        [MarshalUsing(CountElementName=""arr9"", ElementIndirectionLevel = 9)]ref int[][][][][][][][][][] arr10,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]
+        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionLevel = 3)]
+        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionLevel = 4)]
+        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionLevel = 5)]
+        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionLevel = 6)]
+        [MarshalUsing(CountElementName=""arr7"", ElementIndirectionLevel = 7)]
+        [MarshalUsing(CountElementName=""arr8"", ElementIndirectionLevel = 8)]ref int[][][][][][][][][] arr9,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]
+        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionLevel = 3)]
+        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionLevel = 4)]
+        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionLevel = 5)]
+        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionLevel = 6)]
+        [MarshalUsing(CountElementName=""arr7"", ElementIndirectionLevel = 7)]ref int[][][][][][][][][] arr8,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]
+        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionLevel = 3)]
+        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionLevel = 4)]
+        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionLevel = 5)]
+        [MarshalUsing(CountElementName=""arr6"", ElementIndirectionLevel = 6)]ref int[][][][][][][] arr7,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]
+        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionLevel = 3)]
+        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionLevel = 4)]
+        [MarshalUsing(CountElementName=""arr5"", ElementIndirectionLevel = 5)]ref int[][][][][][] arr6,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]
+        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionLevel = 3)]
+        [MarshalUsing(CountElementName=""arr4"", ElementIndirectionLevel = 4)]ref int[][][][][] arr5,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]
+        [MarshalUsing(CountElementName=""arr3"", ElementIndirectionLevel = 3)]ref int[][][][] arr4,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]
+        [MarshalUsing(CountElementName=""arr2"", ElementIndirectionLevel = 2)]ref int[][][] arr3,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]
+        [MarshalUsing(CountElementName=""arr1"", ElementIndirectionLevel = 1)]ref int[][] arr2,
+        [MarshalUsing(CountElementName=""arr0"", ElementIndirectionLevel = 0)]ref int[] arr1,
+        ref int arr0
+    );
+}
+";
     }
 }

--- a/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/Compiles.cs
@@ -260,6 +260,7 @@ namespace DllImportGenerator.UnitTests
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerParametersAndModifiers<UIntPtr>() };
             yield return new[] { CodeSnippets.CustomCollectionCustomMarshallerReturnValueLength<int>() };
             yield return new[] { CodeSnippets.GenericCollectionWithCustomElementMarshalling };
+            yield return new[] { CodeSnippets.CollectionsOfCollectionsStress };
         }
 
         [Theory]

--- a/DllImportGenerator/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
+++ b/DllImportGenerator/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
@@ -313,6 +313,12 @@ namespace Microsoft.Interop.Analyzers
 
             private void AnalyzeNativeMarshalerType(SymbolAnalysisContext context, ITypeSymbol type, AttributeData nativeMarshalerAttributeData, bool validateManagedGetPinnableReference, bool validateAllScenarioSupport)
             {
+                if (nativeMarshalerAttributeData.ConstructorArguments.Length == 0)
+                {
+                    // This is a MarshalUsing with just count information.
+                    return;
+                }
+
                 if (nativeMarshalerAttributeData.ConstructorArguments[0].IsNull)
                 {
                     context.ReportDiagnostic(

--- a/DllImportGenerator/DllImportGenerator/ContiguousCollectionElementMarshallingCodeContext.cs
+++ b/DllImportGenerator/DllImportGenerator/ContiguousCollectionElementMarshallingCodeContext.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -12,13 +12,14 @@ namespace Microsoft.Interop
 {
     internal sealed class ContiguousCollectionElementMarshallingCodeContext : StubCodeContext
     {
-        private readonly string indexerIdentifier;
         private readonly string nativeSpanIdentifier;
         private readonly StubCodeContext parentContext;
 
         public override bool SingleFrameSpansNativeContext => false;
 
         public override bool AdditionalTemporaryStateLivesAcrossStages => false;
+
+        public string IndexerIdentifier { get; }
 
         /// <summary>
         /// Create a <see cref="StubCodeContext"/> for marshalling elements of an collection.
@@ -29,12 +30,11 @@ namespace Microsoft.Interop
         /// <param name="parentContext">The parent context.</param>
         public ContiguousCollectionElementMarshallingCodeContext(
             Stage currentStage,
-            string indexerIdentifier,
             string nativeSpanIdentifier,
             StubCodeContext parentContext)
         {
             CurrentStage = currentStage;
-            this.indexerIdentifier = indexerIdentifier;
+            IndexerIdentifier = CalculateIndexerIdentifierBasedOnParentContext(parentContext);
             this.nativeSpanIdentifier = nativeSpanIdentifier;
             this.parentContext = parentContext;
         }
@@ -48,20 +48,36 @@ namespace Microsoft.Interop
         {
             var (_, native) = parentContext.GetIdentifiers(info);
             return (
-                $"{native}.ManagedValues[{indexerIdentifier}]",
-                $"{nativeSpanIdentifier}[{indexerIdentifier}]"
+                $"{native}.ManagedValues[{IndexerIdentifier}]",
+                $"{nativeSpanIdentifier}[{IndexerIdentifier}]"
             );
         }
 
         public override string GetAdditionalIdentifier(TypePositionInfo info, string name)
         {
-            return $"{nativeSpanIdentifier}__{indexerIdentifier}__{name}";
+            return $"{nativeSpanIdentifier}__{IndexerIdentifier}__{name}";
         }
 
         public override TypePositionInfo? GetTypePositionInfoForManagedIndex(int index)
         {
             // We don't have parameters to look at when we're in the middle of marshalling an array.
             return null;
+        }
+
+        private static string CalculateIndexerIdentifierBasedOnParentContext(StubCodeContext parentContext)
+        {
+            int i = 0;
+            while (parentContext is ContiguousCollectionElementMarshallingCodeContext collectionContext)
+            {
+                i++;
+                parentContext = collectionContext.parentContext;
+            }
+
+            // Follow a progression of indexers of the following form:
+            // __i, __j, __k, __ii, __jj, __kk, etc.
+            StringBuilder indexerIdentifier = new StringBuilder("__");
+            indexerIdentifier.Append((char)('i' + (i % 3)), 1 + (i / 3));
+            return indexerIdentifier.ToString();
         }
     }
 }

--- a/DllImportGenerator/DllImportGenerator/ContiguousCollectionElementMarshallingCodeContext.cs
+++ b/DllImportGenerator/DllImportGenerator/ContiguousCollectionElementMarshallingCodeContext.cs
@@ -76,10 +76,8 @@ namespace Microsoft.Interop
             }
 
             // Follow a progression of indexers of the following form:
-            // __i, __j, __k, __ii, __jj, __kk, etc.
-            StringBuilder indexerIdentifier = new StringBuilder("__");
-            indexerIdentifier.Append((char)('i' + (i % 3)), 1 + (i / 3));
-            return indexerIdentifier.ToString();
+            // __i0, __i1, __i2, __i3, etc/
+            return $"__i{i}";
         }
     }
 }

--- a/DllImportGenerator/DllImportGenerator/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -859,8 +859,6 @@ namespace Microsoft.Interop
     /// </summary>
     internal sealed class ContiguousNonBlittableElementCollectionMarshalling : ICustomNativeTypeMarshallingStrategy
     {
-        private const string IndexerIdentifier = "__i";
-
         private readonly ICustomNativeTypeMarshallingStrategy innerMarshaller;
         private readonly IMarshallingGenerator elementMarshaller;
         private readonly TypePositionInfo elementInfo;
@@ -874,15 +872,10 @@ namespace Microsoft.Interop
             this.elementInfo = elementInfo;
         }
 
-        private string GetNativeSpanIdentifier(TypePositionInfo info, StubCodeContext context)
-        {
-            return context.GetAdditionalIdentifier(info, "nativeSpan");
-        }
-
         private LocalDeclarationStatementSyntax GenerateNativeSpanDeclaration(TypePositionInfo info, StubCodeContext context)
         {
             string nativeIdentifier = context.GetIdentifiers(info).native;
-            string nativeSpanIdentifier = GetNativeSpanIdentifier(info, context);
+            string nativeSpanIdentifier = MarshallerHelpers.GetNativeSpanIdentifier(info, context);
             return LocalDeclarationStatement(VariableDeclaration(
                 GenericName(
                     Identifier(TypeNames.System_Span),
@@ -915,15 +908,13 @@ namespace Microsoft.Interop
         private StatementSyntax GenerateContentsMarshallingStatement(TypePositionInfo info, StubCodeContext context, bool useManagedSpanForLength)
         {
             string nativeIdentifier = context.GetIdentifiers(info).native;
-            string nativeSpanIdentifier = GetNativeSpanIdentifier(info, context);
+            string nativeSpanIdentifier = MarshallerHelpers.GetNativeSpanIdentifier(info, context);
             var elementSetupSubContext = new ContiguousCollectionElementMarshallingCodeContext(
                 StubCodeContext.Stage.Setup,
-                IndexerIdentifier,
                 nativeSpanIdentifier,
                 context);
             var elementSubContext = new ContiguousCollectionElementMarshallingCodeContext(
                 context.CurrentStage,
-                IndexerIdentifier,
                 nativeSpanIdentifier,
                 context);
 
@@ -956,7 +947,7 @@ namespace Microsoft.Interop
                 // Iterate through the elements of the native collection to unmarshal them
                 return Block(
                     GenerateNativeSpanDeclaration(info, context),
-                    MarshallerHelpers.GetForLoop(collectionIdentifierForLength, IndexerIdentifier)
+                    MarshallerHelpers.GetForLoop(collectionIdentifierForLength, elementSubContext.IndexerIdentifier)
                                     .WithStatement(marshallingStatement));
             }
             return EmptyStatement();

--- a/DllImportGenerator/DllImportGenerator/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -127,26 +127,24 @@ namespace Microsoft.Interop
     /// </summary>
     internal class CustomNativeTypeWithValuePropertyStubContext : StubCodeContext
     {
-        private readonly StubCodeContext parentContext;
-
         public CustomNativeTypeWithValuePropertyStubContext(StubCodeContext parentContext)
         {
-            this.parentContext = parentContext;
+            ParentContext = parentContext;
             CurrentStage = parentContext.CurrentStage;
         }
 
-        public override bool SingleFrameSpansNativeContext => parentContext.SingleFrameSpansNativeContext;
+        public override bool SingleFrameSpansNativeContext => ParentContext!.SingleFrameSpansNativeContext;
 
-        public override bool AdditionalTemporaryStateLivesAcrossStages => parentContext.AdditionalTemporaryStateLivesAcrossStages;
+        public override bool AdditionalTemporaryStateLivesAcrossStages => ParentContext!.AdditionalTemporaryStateLivesAcrossStages;
 
         public override TypePositionInfo? GetTypePositionInfoForManagedIndex(int index)
         {
-            return parentContext.GetTypePositionInfoForManagedIndex(index);
+            return ParentContext!.GetTypePositionInfoForManagedIndex(index);
         }
 
         public override (string managed, string native) GetIdentifiers(TypePositionInfo info)
         {
-            return (parentContext.GetIdentifiers(info).managed, MarshallerHelpers.GetMarshallerIdentifier(info, parentContext));
+            return (ParentContext!.GetIdentifiers(info).managed, MarshallerHelpers.GetMarshallerIdentifier(info, ParentContext));
         }
     }
 

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
@@ -86,10 +86,14 @@ namespace Microsoft.Interop
             return spanElementTypeSyntax;
         }
 
-        private const string MarshalerLocalSuffix = "marshaler";
         public static string GetMarshallerIdentifier(TypePositionInfo info, StubCodeContext context)
         {
-            return context.GetAdditionalIdentifier(info, MarshalerLocalSuffix);
+            return context.GetAdditionalIdentifier(info, "marshaler");
+        }
+
+        public static string GetNativeSpanIdentifier(TypePositionInfo info, StubCodeContext context)
+        {
+            return context.GetAdditionalIdentifier(info, "nativeSpan");
         }
 
         public static class StringMarshaller

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Interop
         {
             Dictionary<U, int> elementIndexToEdgeMapNodeId = new(elements.Count);
             List<T> nodeIdToElement = new(elements.Count);
-            EdgeMap edgeMap = new EdgeMap(elements.Count);
+            EdgeMap edgeMap = new(elements.Count);
 
             int nextEdgeMapIndex = 0;
             foreach (var element in elements)
@@ -139,9 +139,9 @@ namespace Microsoft.Interop
             // Algorithm adapted from A. B. Kahn. 1962. Topological sorting of large networks. Commun. ACM 5, 11 (Nov. 1962), 558–562. DOI:https://doi.org/10.1145/368996.369025
 
             // L is the sorted list
-            List<T> L = new List<T>(elements.Count);
+            List<T> L = new(elements.Count);
             // S is the set of elements with no incoming edges (no dependencies on it)
-            List<T> S = new List<T>(elements.Count);
+            List<T> S = new(elements.Count);
 
             // Initialize S
             for (int node = 0; node < nodeIdToElement.Count; node++)
@@ -180,7 +180,7 @@ namespace Microsoft.Interop
             // If we have edges left, then we have a cycle.
             if (edgeMap.AnyEdges)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(Resources.GraphHasCycles);
             }
 
             // If we make it here, we have a topologically sorted list.

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Interop
 
             // Now that we have initialized our map of edges and we have our list of nodes,
             // we'll use Khan's algorithm to calculate a topological sort of the elements.
+            // Algorithm adapted from A. B. Kahn. 1962. Topological sorting of large networks. Commun. ACM 5, 11 (Nov. 1962), 558–562. DOI:https://doi.org/10.1145/368996.369025
 
             // L is the sorted list
             List<T> L = new List<T>(elements.Count);

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Interop
                 foreach (var dependentElementIndex in getDependentIndicesFn(element))
                 {
                     // Add an edge from an element to one that depends on it.
-                    edgeMap[dependentElementIndex][elementIndex] = true;
+                    edgeMap[elementIndex][dependentElementIndex] = true;
                 }
             }
 
@@ -155,11 +155,7 @@ namespace Microsoft.Interop
                 {
                     continue;
                 }
-                bool anyIncomingEdges = false;
-                for (int j = 0; j < edgeMap.Length; j++)
-                {
-                    anyIncomingEdges |= edgeMap[j][elementIndex];
-                }
+                bool anyIncomingEdges = Array.IndexOf(edgeMap[elementIndex], true) != -1;
                 if (!anyIncomingEdges)
                 {
                     S.Add(elementByElementIndex[elementIndex]);
@@ -177,18 +173,14 @@ namespace Microsoft.Interop
                 for (int i = 0; i < edgeMap.Length; i++)
                 {
                     int elementIndex = indexFn(element);
-                    if (!edgeMap[elementIndex][i])
+                    if (!edgeMap[i][elementIndex])
                     {
                         continue;
                     }
                     // Remove the edge from element to m
-                    edgeMap[elementIndex][i] = false;
+                    edgeMap[i][elementIndex] = false;
                     // If m does not have any incoming edges, add to S
-                    bool anyIncomingEdges = false;
-                    for (int j = 0; j < edgeMap.Length; j++)
-                    {
-                        anyIncomingEdges |= edgeMap[j][i];
-                    }
+                    bool anyIncomingEdges = Array.IndexOf(edgeMap[i], true) != -1;
                     if (!anyIncomingEdges)
                     {
                         S.Add(elementByElementIndex[i]);

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
@@ -103,13 +103,14 @@ namespace Microsoft.Interop
         /// </summary>
         /// <typeparam name="T">The type of element.</typeparam>
         /// <param name="elements">The initial collection of elements.</param>
-        /// <param name="indexFn">A function to create an element index value. This value must be non-negative and the maximum value is recommended to be close to <c><paramref name="elements"/>.Length</c> for best performance.</param>
+        /// <param name="indexFn">A function to create an element index value. This value must be non-negative and the maximum value is recommended to be close to <c><paramref name="elements"/>.Count</c> for best performance.</param>
         /// <param name="getDependentIndicesFn">A function to resolve the dependencies of a given item in the <paramref name="elements"/> collection as index values that would be returned by <paramref name="indexFn"/>.</param>
         /// <returns>A topologically sorted collection of the elemens of the <paramref name="elements"/> collection.</returns>
         public static IEnumerable<T> GetTopologicallySortedElements<T>(
             ICollection<T> elements,
             Func<T, int> indexFn,
             Func<T, IEnumerable<int>> getDependentIndicesFn)
+            where T : IEquatable<T?>
         {
             int highestManagedIndex = -1;
             foreach (var element in elements)
@@ -150,7 +151,7 @@ namespace Microsoft.Interop
             // Initialize S
             for (int elementIndex = 0; elementIndex <= highestManagedIndex; elementIndex++)
             {
-                if (elementByElementIndex[elementIndex] is null)
+                if (elementByElementIndex[elementIndex].Equals(default))
                 {
                     continue;
                 }

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallerHelpers.cs
@@ -174,10 +174,10 @@ namespace Microsoft.Interop
                 S.RemoveAt(S.Count - 1);
                 // Add element to L
                 L.Add(element);
+                int elementIndex = indexFn(element);
                 // For each node m that element points to
                 for (int i = 0; i < edgeMap.Length; i++)
                 {
-                    int elementIndex = indexFn(element);
                     if (!edgeMap[i][elementIndex])
                     {
                         continue;

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -513,10 +513,10 @@ namespace Microsoft.Interop
             AnalyzerConfigOptions options,
             ICustomNativeTypeMarshallingStrategy marshallingStrategy)
         {
-            var elementInfo = TypePositionInfo.CreateForType(collectionInfo.ElementType, collectionInfo.ElementMarshallingInfo);
+            var elementInfo = TypePositionInfo.CreateForType(collectionInfo.ElementType, collectionInfo.ElementMarshallingInfo) with { ManagedIndex = info.ManagedIndex };
             var elementMarshaller = Create(
                 elementInfo,
-                new ContiguousCollectionElementMarshallingCodeContext(StubCodeContext.Stage.Setup, string.Empty, string.Empty, context),
+                new ContiguousCollectionElementMarshallingCodeContext(StubCodeContext.Stage.Setup, string.Empty, context),
                 options);
             var elementType = elementMarshaller.AsNativeType(elementInfo);
 

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -451,10 +451,12 @@ namespace Microsoft.Interop
 
                 numIndirectionLevels = indexerStack.Count;
 
-                ExpressionSyntax indexedNumElements = IdentifierName(lastContext!.GetIdentifiers(numElementsInfo).managed);
+                ExpressionSyntax indexedNumElements = IdentifierName(lastContext.GetIdentifiers(numElementsInfo).managed);
                 while (indexerStack.Count > 0)
                 {
-                    indexedNumElements = ElementAccessExpression(indexedNumElements).AddArgumentListArguments(Argument(IdentifierName(indexerStack.Pop())));
+                    NameSyntax indexer = IdentifierName(indexerStack.Pop());
+                    indexedNumElements = ElementAccessExpression(indexedNumElements)
+                        .AddArgumentListArguments(Argument(indexer));
                 }
 
                 return indexedNumElements;

--- a/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
+++ b/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
@@ -371,11 +371,12 @@ namespace Microsoft.Interop
                     };
                 }
 
-                foreach (var param in method.Parameters)
+                for (int i = 0; i < method.Parameters.Length; i++)
                 {
+                    IParameterSymbol param = method.Parameters[i];
                     if (param.Name == elementName)
                     {
-                        return TypePositionInfo.CreateForParameter(param, ParseMarshallingInfo(param.Type, param.GetAttributes(), inspectedElements), compilation);
+                        return TypePositionInfo.CreateForParameter(param, ParseMarshallingInfo(param.Type, param.GetAttributes(), inspectedElements), compilation) with { ManagedIndex = i };
                     }
                 }
             }

--- a/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
+++ b/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
@@ -79,15 +79,6 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified array size parameter for an array must be an integer type..
-        /// </summary>
-        internal static string ArraySizeParamTypeMustBeIntegral {
-            get {
-                return ResourceManager.GetString("ArraySizeParamTypeMustBeIntegral", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A type marked with &apos;BlittableTypeAttribute&apos; must be blittable..
         /// </summary>
         internal static string BlittableTypeMustBeBlittableDescription {
@@ -120,6 +111,15 @@ namespace Microsoft.Interop {
         internal static string CannotHaveMultipleMarshallingAttributesMessage {
             get {
                 return ResourceManager.GetString("CannotHaveMultipleMarshallingAttributesMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The specified collection size parameter for an collection must be an integer type. If the size information is applied to a nested collection, the size parameter must be a collection of one less level of nesting with an integral element..
+        /// </summary>
+        internal static string CollectionSizeParamTypeMustBeIntegral {
+            get {
+                return ResourceManager.GetString("CollectionSizeParamTypeMustBeIntegral", resourceCulture);
             }
         }
         

--- a/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
+++ b/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
@@ -340,6 +340,15 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The provided graph has cycles and cannot be topologically sorted..
+        /// </summary>
+        internal static string GraphHasCycles {
+            get {
+                return ResourceManager.GetString("GraphHasCycles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;[In]&apos; attribute is not supported unless the &apos;[Out]&apos; attribute is also used. The behavior of the &apos;[In]&apos; attribute without the &apos;[Out]&apos; attribute is the same as the default behavior..
         /// </summary>
         internal static string InAttributeNotSupportedWithoutOut {

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -211,6 +211,9 @@
   <data name="GetPinnableReferenceShouldSupportAllocatingMarshallingFallbackMessage" xml:space="preserve">
     <value>Type '{0}' has a 'GetPinnableReference' method but its native type does not support marshalling in scenarios where pinning is impossible</value>
   </data>
+  <data name="GraphHasCycles" xml:space="preserve">
+    <value>The provided graph has cycles and cannot be topologically sorted.</value>
+  </data>
   <data name="InAttributeNotSupportedWithoutOut" xml:space="preserve">
     <value>The '[In]' attribute is not supported unless the '[Out]' attribute is also used. The behavior of the '[In]' attribute without the '[Out]' attribute is the same as the default behavior.</value>
   </data>

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -123,9 +123,6 @@
   <data name="ArraySizeParamIndexOutOfRange" xml:space="preserve">
     <value>The 'SizeParamIndex' value in the 'MarshalAsAttribute' is out of range.</value>
   </data>
-  <data name="ArraySizeParamTypeMustBeIntegral" xml:space="preserve">
-    <value>The specified array size parameter for an array must be an integer type.</value>
-  </data>
   <data name="BlittableTypeMustBeBlittableDescription" xml:space="preserve">
     <value>A type marked with 'BlittableTypeAttribute' must be blittable.</value>
   </data>
@@ -137,6 +134,9 @@
   </data>
   <data name="CannotHaveMultipleMarshallingAttributesMessage" xml:space="preserve">
     <value>Type '{0}' is marked with 'BlittableTypeAttribute' and 'NativeMarshallingAttribute'. A type can only have one of these two attributes.</value>
+  </data>
+  <data name="CollectionSizeParamTypeMustBeIntegral" xml:space="preserve">
+    <value>The specified collection size parameter for an collection must be an integer type. If the size information is applied to a nested collection, the size parameter must be a collection of one less level of nesting with an integral element.</value>
   </data>
   <data name="ConfigurationNotSupportedDescription" xml:space="preserve">
     <value>Source-generated P/Invokes will ignore any configuration that is not supported.</value>

--- a/DllImportGenerator/DllImportGenerator/StubCodeContext.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Interop
 {
@@ -81,6 +82,11 @@ namespace Microsoft.Interop
         /// When this property is <c>false</c>, any additional variables can only be considered to have the state they had immediately after the Setup phase.
         /// </remarks>
         public abstract bool AdditionalTemporaryStateLivesAcrossStages { get; }
+
+        /// <summary>
+        /// If this context is a nested context, return the parent context. Otherwise, return <c>null</c>.
+        /// </summary>
+        public StubCodeContext? ParentContext { get; protected set; }
 
         protected const string GeneratedNativeIdentifierSuffix = "_gen_native";
 

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -77,11 +77,9 @@ namespace Microsoft.Interop
             // Get marshaller for return
             this.retMarshaller = CreateGenerator(retTypeInfo);
 
-            List<(TypePositionInfo TypeInfo, IMarshallingGenerator Generator)> allMarshallers = new(this.paramMarshallers.Where(m => m.TypeInfo.ManagedIndex != TypePositionInfo.UnsetIndex));
-            if (retMarshaller.TypeInfo.ManagedIndex != TypePositionInfo.UnsetIndex)
-            {
-                allMarshallers.Add(retMarshaller);
-            }
+
+            List<(TypePositionInfo TypeInfo, IMarshallingGenerator Generator)> allMarshallers = new(this.paramMarshallers);
+            allMarshallers.Add(retMarshaller);
 
             this.sortedMarshallers = MarshallerHelpers.GetTopologicallySortedElements(
                 allMarshallers,

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -77,8 +77,11 @@ namespace Microsoft.Interop
             // Get marshaller for return
             this.retMarshaller = CreateGenerator(retTypeInfo);
 
-            List<(TypePositionInfo TypeInfo, IMarshallingGenerator Generator)> allMarshallers = new(this.paramMarshallers);
-            allMarshallers.Add(retMarshaller);
+            List<(TypePositionInfo TypeInfo, IMarshallingGenerator Generator)> allMarshallers = new(this.paramMarshallers.Where(m => m.TypeInfo.ManagedIndex != TypePositionInfo.UnsetIndex));
+            if (retMarshaller.TypeInfo.ManagedIndex != TypePositionInfo.UnsetIndex)
+            {
+                allMarshallers.Add(retMarshaller);
+            }
 
             this.sortedMarshallers = MarshallerHelpers.GetTopologicallySortedElements(
                 allMarshallers,

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -113,7 +113,13 @@ namespace Microsoft.Interop
 
             static int GetInfoIndex(TypePositionInfo info)
             {
-                return info.IsManagedReturnPosition ? 0 : info.ManagedIndex + 1;
+                if (info.ManagedIndex == TypePositionInfo.UnsetIndex)
+                {
+                    // A TypePositionInfo needs to have either a managed or native index.
+                    // We use negative values of the native index to distinguish them from the managed index.
+                    return -info.NativeIndex;
+                }
+                return info.ManagedIndex;
             }
         }
 

--- a/DllImportGenerator/TestAssets/NativeExports/Arrays.cs
+++ b/DllImportGenerator/TestAssets/NativeExports/Arrays.cs
@@ -154,6 +154,22 @@ namespace NativeExports
             return (byte)(result ? 1 : 0);
         }
 
+        [UnmanagedCallersOnly(EntryPoint = "transpose_matrix")]
+        public static int** TransposeMatrix(int** matrix, int* numRows, int numColumns)
+        {
+            int** newRows = (int**)Marshal.AllocCoTaskMem(numColumns * sizeof(int*));
+            for (int i = 0; i < numColumns; i++)
+            {
+                newRows[i] = (int*)Marshal.AllocCoTaskMem(numRows[i] * sizeof(int));
+                for (int j = 0; j < numRows[i]; j++)
+                {
+                    newRows[i][j] = matrix[j][i];
+                }
+            }
+
+            return newRows;
+        }
+
         private static int* CreateRangeImpl(int start, int end, int* numValues)
         {
             if (start >= end)


### PR DESCRIPTION
The current code in the feature/DllImportGenerator branch almost supports passing collections of collections (like jagged arrays) by value or by-ref `in` (it only needs the first commit that handles nested for loops), but it does not correctly support passing collections of collections in a way that requires unmarshalling.

This PR adds the functionality required to enable marshalling collections of collections like jagged arrays from native code back to managed code.

This code is designed such that if n levels of indirection is supported, then n+1 levels is also supported. The `CollectionsOfCollectionsStress` code snippet test validates this by testing 0-11 dimensional jagged arrays.

To enable safely tracing dependencies of "CountElementName" metadata values, this PR enhances the cycle-breaking in the MarshallingAttributeInfoParser to correctly break cycles.

To identify dependencies between parameters/return values, this PR also introduces a topological sorting algorithm to order the parameter/return value unmarshalling in an order that ensures dependencies are marshalled before elements that depend on them.

This algorithm is specified generically so developers of interop source generators could use this mechanism to support their own scenarios. For example, WinRT's implicit array length parameters could have part of their implementation supported by the topological sort.