### PR TITLE
Assert argument to LDARG is non-negative

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ILEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ILEmitter.cs
@@ -102,6 +102,7 @@ namespace Internal.IL.Stubs
 
         public void EmitLdArg(int index)
         {
+            Debug.Assert(index >= 0);
             if (index < 4)
             {
                 Emit((ILOpcode)(ILOpcode.ldarg_0 + index));
@@ -115,6 +116,7 @@ namespace Internal.IL.Stubs
 
         public void EmitLdArga(int index)
         {
+            Debug.Assert(index >= 0);
             if (index < 0x100)
             {
                 Emit(ILOpcode.ldarga_s);


### PR DESCRIPTION
Negative argument has a funny failure mode.