### PR TITLE
NativeAOT-LLVM remove restriction of 0 params for compiling with clrjit

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -109,7 +109,7 @@ namespace Internal.IL
         private ExceptionRegion[] _exceptionRegions;
         public ILImporter(LLVMCodegenCompilation compilation, MethodDesc method, MethodIL methodIL, string mangledName, bool isUnboxingThunk)
         {
-            Module = compilation.Module;
+            Module = LLVMCodegenCompilation.Module;
             _compilation = compilation;
             _method = method;
             _isUnboxingThunk = isUnboxingThunk;
@@ -222,17 +222,7 @@ namespace Internal.IL
             finally
             {
                 // Generate thunk for runtime exports
-                if ((_method.IsRuntimeExport || _method.IsUnmanagedCallersOnly) && _method is EcmaMethod)  // TODO: Reverse delegate invokes probably need something here, but what would be the export name?
-                {
-                    EcmaMethod ecmaMethod = ((EcmaMethod)_method);
-                    string exportName = ecmaMethod.IsRuntimeExport ? ecmaMethod.GetRuntimeExportName() : ecmaMethod.GetUnmanagedCallersOnlyExportName();
-                    if (exportName == null)
-                    {
-                        exportName = ecmaMethod.Name;
-                    }
-
-                    EmitNativeToManagedThunk(_compilation, _method, exportName, _llvmFunction);
-                }
+                GenerateRuntimeExportThunk(_compilation, _method, _llvmFunction);
             }
         }
 
@@ -447,13 +437,7 @@ namespace Internal.IL
 
         private LLVMValueRef GetOrCreateLLVMFunction(string mangledName, LLVMTypeRef functionType)
         {
-            LLVMValueRef llvmFunction = Module.GetNamedFunction(mangledName);
-
-            if (llvmFunction.Handle == IntPtr.Zero)
-            {
-                return Module.AddFunction(mangledName, functionType);
-            }
-            return llvmFunction;
+            return GetOrCreateLLVMFunction(Module, mangledName, functionType);
         }
 
         /// <summary>
@@ -482,19 +466,6 @@ namespace Internal.IL
             }
 
             return funclet;
-        }
-
-        private void ImportCallMemset(LLVMValueRef targetPointer, byte value, int length, LLVMBuilderRef builder)
-        {
-            LLVMValueRef objectSizeValue = BuildConstInt32(length);
-            ImportCallMemset(targetPointer, value, objectSizeValue, builder);
-        }
-
-        private void ImportCallMemset(LLVMValueRef targetPointer, byte value, LLVMValueRef length, LLVMBuilderRef builder = default(LLVMBuilderRef))
-        {
-            if (builder.Handle == IntPtr.Zero) builder = _builder;
-            var memsetSignature = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), LLVMTypeRef.Int8, LLVMTypeRef.Int32, LLVMTypeRef.Int1 }, false);
-            builder.BuildCall(GetOrCreateLLVMFunction("llvm.memset.p0i8.i32", memsetSignature), new LLVMValueRef[] { targetPointer, BuildConstInt8(value), length, BuildConstInt1(0) }, String.Empty);
         }
 
         private void PushLoadExpression(StackValueKind kind, string name, LLVMValueRef rawLLVMValue, TypeDesc type)
@@ -1716,20 +1687,6 @@ namespace Internal.IL
             }
             offset = PadOffset(spill.Type, offset);
             return offset;
-        }
-
-        public int PadNextOffset(TypeDesc type, int atOffset)
-        {
-            var size = type is DefType && type.IsValueType ? ((DefType)type).InstanceFieldSize : type.Context.Target.LayoutPointerSize;
-            return PadOffset(type, atOffset) + size.AsInt;
-        }
-
-        public int PadOffset(TypeDesc type, int atOffset)
-        {
-            var fieldAlignment = type is DefType && type.IsValueType ? ((DefType)type).InstanceFieldAlignment : type.Context.Target.LayoutPointerSize;
-            var alignment = LayoutInt.Min(fieldAlignment, new LayoutInt(ComputePackingSize(type))).AsInt;
-            var padding = (atOffset + (alignment - 1)) & ~(alignment - 1);
-            return padding;
         }
 
         private static int ComputePackingSize(TypeDesc type)
@@ -3204,134 +3161,6 @@ namespace Internal.IL
             return nativeFunc;
         }
 
-        static LLVMValueRef s_shadowStackTop = default(LLVMValueRef);
-
-        LLVMValueRef ShadowStackTop
-        {
-            get
-            {
-                if (s_shadowStackTop.Handle.Equals(IntPtr.Zero))
-                {
-                    s_shadowStackTop = Module.AddGlobal(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "t_pShadowStackTop");
-                    s_shadowStackTop.Linkage = LLVMLinkage.LLVMExternalLinkage;
-                    s_shadowStackTop.Initializer = LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
-                    s_shadowStackTop.ThreadLocalMode = LLVMThreadLocalMode.LLVMLocalDynamicTLSModel;
-                }
-                return s_shadowStackTop;
-            }
-        }
-
-        private void EmitNativeToManagedThunk(LLVMCodegenCompilation compilation, MethodDesc method, string nativeName, LLVMValueRef managedFunction)
-        {
-            if (_pinvokeMap.TryGetValue(nativeName, out MethodDesc existing))
-            {
-                if (existing != method)
-                    throw new InvalidProgramException("export and import function were mismatched");
-            }
-            else
-            {
-                _pinvokeMap.Add(nativeName, method);
-            }
-
-            LLVMTypeRef[] llvmParams = new LLVMTypeRef[method.Signature.Length];
-            for (int i = 0; i < llvmParams.Length; i++)
-            {
-                llvmParams[i] = GetLLVMTypeForTypeDesc(method.Signature[i]);
-            }
-
-            LLVMTypeRef thunkSig = LLVMTypeRef.CreateFunction(GetLLVMTypeForTypeDesc(method.Signature.ReturnType), llvmParams, false);
-            LLVMValueRef thunkFunc = GetOrCreateLLVMFunction(nativeName, thunkSig);
-
-            LLVMBasicBlockRef shadowStackSetupBlock = thunkFunc.AppendBasicBlock("ShadowStackSetupBlock");
-            LLVMBasicBlockRef allocateShadowStackBlock = thunkFunc.AppendBasicBlock("allocateShadowStackBlock");
-            LLVMBasicBlockRef managedCallBlock = thunkFunc.AppendBasicBlock("ManagedCallBlock");
-
-            LLVMBuilderRef builder = Context.CreateBuilder();
-            builder.PositionAtEnd(shadowStackSetupBlock);
-
-            // Allocate shadow stack if it's null
-            LLVMValueRef shadowStackPtr = builder.BuildAlloca(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "ShadowStackPtr");
-            LLVMValueRef savedShadowStack = builder.BuildLoad(ShadowStackTop, "SavedShadowStack");
-            builder.BuildStore(savedShadowStack, shadowStackPtr);
-            LLVMValueRef shadowStackNull = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, savedShadowStack, LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)), "ShadowStackNull");
-            builder.BuildCondBr(shadowStackNull, allocateShadowStackBlock, managedCallBlock);
-
-            builder.PositionAtEnd(allocateShadowStackBlock);
-
-            LLVMValueRef newShadowStack = builder.BuildArrayMalloc(LLVMTypeRef.Int8, BuildConstInt32(1000000), "NewShadowStack");
-            builder.BuildStore(newShadowStack, shadowStackPtr);
-            builder.BuildBr(managedCallBlock);
-
-            builder.PositionAtEnd(managedCallBlock);
-            LLVMTypeRef reversePInvokeFrameType = LLVMTypeRef.CreateStruct(new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) }, false);
-            LLVMValueRef reversePInvokeFrame = default(LLVMValueRef);
-            LLVMTypeRef reversePInvokeFunctionType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(reversePInvokeFrameType, 0) }, false);
-            if (method.IsUnmanagedCallersOnly)
-            {
-                reversePInvokeFrame = builder.BuildAlloca(reversePInvokeFrameType, "ReversePInvokeFrame");
-                LLVMValueRef RhpReversePInvoke2 = GetOrCreateLLVMFunction("RhpReversePInvoke2", reversePInvokeFunctionType);
-                builder.BuildCall(RhpReversePInvoke2, new LLVMValueRef[] { reversePInvokeFrame }, "");
-            }
-
-            LLVMValueRef shadowStack = builder.BuildLoad(shadowStackPtr, "ShadowStack");
-            int curOffset = 0;
-            curOffset = PadNextOffset(method.Signature.ReturnType, curOffset);
-            ImportCallMemset(shadowStack, 0, curOffset, builder); // clear any uncovered object references for GC.Collect
-            LLVMValueRef calleeFrame = builder.BuildGEP(shadowStack, new LLVMValueRef[] { BuildConstInt32(curOffset) }, "calleeFrame");
-
-            List<LLVMValueRef> llvmArgs = new List<LLVMValueRef>();
-            llvmArgs.Add(calleeFrame);
-
-            bool needsReturnSlot = LLVMCodegenCompilation.NeedsReturnStackSlot(method.Signature);
-
-            if (needsReturnSlot)
-            {
-                // Slot for return value if necessary
-                llvmArgs.Add(shadowStack);
-            }
-
-            for (int i = 0; i < llvmParams.Length; i++)
-            {
-                LLVMValueRef argValue = thunkFunc.GetParam((uint)i);
-
-                if (CanStoreTypeOnStack(method.Signature[i]))
-                {
-                    llvmArgs.Add(argValue);
-                }
-                else
-                {
-                    curOffset = PadOffset(method.Signature[i], curOffset);
-                    LLVMValueRef argAddr = builder.BuildGEP(shadowStack, new LLVMValueRef[] { LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, (ulong)curOffset, false) }, "arg" + i);
-                    builder.BuildStore(argValue, CastIfNecessary(builder, argAddr, LLVMTypeRef.CreatePointer(llvmParams[i], 0), $"parameter{i}_"));
-                    curOffset = PadNextOffset(method.Signature[i], curOffset);
-                }
-            }
-
-            LLVMValueRef llvmReturnValue = builder.BuildCall(managedFunction, llvmArgs.ToArray(), "");
-
-            if (method.IsUnmanagedCallersOnly)
-            {
-                LLVMValueRef RhpReversePInvokeReturn2 = GetOrCreateLLVMFunction("RhpReversePInvokeReturn2", reversePInvokeFunctionType);
-                builder.BuildCall(RhpReversePInvokeReturn2, new LLVMValueRef[] { reversePInvokeFrame }, "");
-            }
-
-            if (!method.Signature.ReturnType.IsVoid)
-            {
-                if (needsReturnSlot)
-                {
-                    builder.BuildRet(builder.BuildLoad(CastIfNecessary(builder, shadowStack, LLVMTypeRef.CreatePointer(GetLLVMTypeForTypeDesc(method.Signature.ReturnType), 0)), "returnValue"));
-                }
-                else
-                {
-                    builder.BuildRet(llvmReturnValue);
-                }
-            }
-            else
-            {
-                builder.BuildRetVoid();
-            }
-        }
-
         private void ImportCalli(int token)
         {
             MethodSignature methodSignature = (MethodSignature)_canonMethodIL.GetObject(token);
@@ -4429,7 +4258,7 @@ namespace Internal.IL
             allocatedMemory.Alignment = (uint)_pointerSize;
             if (_methodIL.IsInitLocals)
             {
-                ImportCallMemset(allocatedMemory, 0, allocSize);
+                ImportCallMemset(allocatedMemory, 0, allocSize, _builder);
             }
 
             PushExpression(StackValueKind.NativeInt, "localloc" + _currentOffset, allocatedMemory, _compilation.TypeSystemContext.GetPointerType(GetWellKnownType(WellKnownType.Void)));

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter_Statics.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter_Statics.cs
@@ -218,5 +218,185 @@ namespace Internal.IL
             }
             return llvmFunction;
         }
+
+        internal static void GenerateRuntimeExportThunk(LLVMCodegenCompilation compilation, MethodDesc compiledMethod, LLVMValueRef llvmFunction)
+        {
+            if ((compiledMethod.IsRuntimeExport || compiledMethod.IsUnmanagedCallersOnly) && compiledMethod is EcmaMethod)  // TODO: Reverse delegate invokes probably need something here, but what would be the export name?
+            {
+                EcmaMethod ecmaMethod = ((EcmaMethod)compiledMethod);
+                string exportName = ecmaMethod.IsRuntimeExport ? ecmaMethod.GetRuntimeExportName() : ecmaMethod.GetUnmanagedCallersOnlyExportName();
+                if (exportName == null)
+                {
+                    exportName = ecmaMethod.Name;
+                }
+
+                EmitNativeToManagedThunk(compilation, compiledMethod, exportName, llvmFunction);
+            }
+        }
+
+        internal static void EmitNativeToManagedThunk(LLVMCodegenCompilation compilation, MethodDesc method, string nativeName, LLVMValueRef managedFunction)
+        {
+            if (_pinvokeMap.TryGetValue(nativeName, out MethodDesc existing))
+            {
+                if (existing != method)
+                    throw new InvalidProgramException("export and import function were mismatched");
+            }
+            else
+            {
+                _pinvokeMap.Add(nativeName, method);
+            }
+
+            LLVMTypeRef[] llvmParams = new LLVMTypeRef[method.Signature.Length];
+            for (int i = 0; i < llvmParams.Length; i++)
+            {
+                llvmParams[i] = GetLLVMTypeForTypeDesc(method.Signature[i]);
+            }
+
+            LLVMTypeRef thunkSig = LLVMTypeRef.CreateFunction(GetLLVMTypeForTypeDesc(method.Signature.ReturnType), llvmParams, false);
+            LLVMValueRef thunkFunc = GetOrCreateLLVMFunction(LLVMCodegenCompilation.Module, nativeName, thunkSig);
+
+            LLVMBasicBlockRef shadowStackSetupBlock = thunkFunc.AppendBasicBlock("ShadowStackSetupBlock");
+            LLVMBasicBlockRef allocateShadowStackBlock = thunkFunc.AppendBasicBlock("allocateShadowStackBlock");
+            LLVMBasicBlockRef managedCallBlock = thunkFunc.AppendBasicBlock("ManagedCallBlock");
+
+            LLVMBuilderRef builder = Context.CreateBuilder();
+            builder.PositionAtEnd(shadowStackSetupBlock);
+
+            // Allocate shadow stack if it's null
+            LLVMValueRef shadowStackPtr = builder.BuildAlloca(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "ShadowStackPtr");
+            LLVMValueRef savedShadowStack = builder.BuildLoad(ShadowStackTop, "SavedShadowStack");
+            builder.BuildStore(savedShadowStack, shadowStackPtr);
+            LLVMValueRef shadowStackNull = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, savedShadowStack, LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)), "ShadowStackNull");
+            builder.BuildCondBr(shadowStackNull, allocateShadowStackBlock, managedCallBlock);
+
+            builder.PositionAtEnd(allocateShadowStackBlock);
+
+            LLVMValueRef newShadowStack = builder.BuildArrayMalloc(LLVMTypeRef.Int8, BuildConstInt32(1000000), "NewShadowStack");
+            builder.BuildStore(newShadowStack, shadowStackPtr);
+            builder.BuildBr(managedCallBlock);
+
+            builder.PositionAtEnd(managedCallBlock);
+            LLVMTypeRef reversePInvokeFrameType = LLVMTypeRef.CreateStruct(new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) }, false);
+            LLVMValueRef reversePInvokeFrame = default(LLVMValueRef);
+            LLVMTypeRef reversePInvokeFunctionType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(reversePInvokeFrameType, 0) }, false);
+            if (method.IsUnmanagedCallersOnly)
+            {
+                reversePInvokeFrame = builder.BuildAlloca(reversePInvokeFrameType, "ReversePInvokeFrame");
+                LLVMValueRef RhpReversePInvoke2 = GetOrCreateLLVMFunction(LLVMCodegenCompilation.Module, "RhpReversePInvoke2", reversePInvokeFunctionType);
+                builder.BuildCall(RhpReversePInvoke2, new LLVMValueRef[] { reversePInvokeFrame }, "");
+            }
+
+            LLVMValueRef shadowStack = builder.BuildLoad(shadowStackPtr, "ShadowStack");
+            int curOffset = 0;
+            curOffset = PadNextOffset(method.Signature.ReturnType, curOffset);
+            ImportCallMemset(shadowStack, 0, curOffset, builder); // clear any uncovered object references for GC.Collect
+            LLVMValueRef calleeFrame = builder.BuildGEP(shadowStack, new LLVMValueRef[] { BuildConstInt32(curOffset) }, "calleeFrame");
+
+            List<LLVMValueRef> llvmArgs = new List<LLVMValueRef>();
+            llvmArgs.Add(calleeFrame);
+
+            bool needsReturnSlot = LLVMCodegenCompilation.NeedsReturnStackSlot(method.Signature);
+
+            if (needsReturnSlot)
+            {
+                // Slot for return value if necessary
+                llvmArgs.Add(shadowStack);
+            }
+
+            for (int i = 0; i < llvmParams.Length; i++)
+            {
+                LLVMValueRef argValue = thunkFunc.GetParam((uint)i);
+
+                if (CanStoreTypeOnStack(method.Signature[i]))
+                {
+                    llvmArgs.Add(argValue);
+                }
+                else
+                {
+                    curOffset = PadOffset(method.Signature[i], curOffset);
+                    LLVMValueRef argAddr = builder.BuildGEP(shadowStack, new LLVMValueRef[] { LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, (ulong)curOffset, false) }, "arg" + i);
+                    builder.BuildStore(argValue, CastIfNecessary(builder, argAddr, LLVMTypeRef.CreatePointer(llvmParams[i], 0), $"parameter{i}_"));
+                    curOffset = PadNextOffset(method.Signature[i], curOffset);
+                }
+            }
+
+            LLVMValueRef llvmReturnValue = builder.BuildCall(managedFunction, llvmArgs.ToArray(), "");
+
+            if (method.IsUnmanagedCallersOnly)
+            {
+                LLVMValueRef RhpReversePInvokeReturn2 = GetOrCreateLLVMFunction(LLVMCodegenCompilation.Module, "RhpReversePInvokeReturn2", reversePInvokeFunctionType);
+                builder.BuildCall(RhpReversePInvokeReturn2, new LLVMValueRef[] { reversePInvokeFrame }, "");
+            }
+
+            if (!method.Signature.ReturnType.IsVoid)
+            {
+                if (needsReturnSlot)
+                {
+                    builder.BuildRet(builder.BuildLoad(CastIfNecessary(builder, shadowStack, LLVMTypeRef.CreatePointer(GetLLVMTypeForTypeDesc(method.Signature.ReturnType), 0)), "returnValue"));
+                }
+                else
+                {
+                    builder.BuildRet(llvmReturnValue);
+                }
+            }
+            else
+            {
+                builder.BuildRetVoid();
+            }
+        }
+
+        internal static LLVMValueRef GetOrCreateLLVMFunction(LLVMModuleRef module, string mangledName, LLVMTypeRef functionType)
+        {
+            LLVMValueRef llvmFunction = module.GetNamedFunction(mangledName);
+
+            if (llvmFunction.Handle == IntPtr.Zero)
+            {
+                return module.AddFunction(mangledName, functionType);
+            }
+            return llvmFunction;
+        }
+
+        private static void ImportCallMemset(LLVMValueRef targetPointer, byte value, int length, LLVMBuilderRef builder)
+        {
+            LLVMValueRef objectSizeValue = BuildConstInt32(length);
+            ImportCallMemset(targetPointer, value, objectSizeValue, builder);
+        }
+
+        private static void ImportCallMemset(LLVMValueRef targetPointer, byte value, LLVMValueRef length, LLVMBuilderRef builder)
+        {
+            var memsetSignature = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), LLVMTypeRef.Int8, LLVMTypeRef.Int32, LLVMTypeRef.Int1 }, false);
+            builder.BuildCall(GetOrCreateLLVMFunction(LLVMCodegenCompilation.Module, "llvm.memset.p0i8.i32", memsetSignature), new LLVMValueRef[] { targetPointer, BuildConstInt8(value), length, BuildConstInt1(0) }, String.Empty);
+        }
+
+        public static int PadNextOffset(TypeDesc type, int atOffset)
+        {
+            var size = type is DefType && type.IsValueType ? ((DefType)type).InstanceFieldSize : type.Context.Target.LayoutPointerSize;
+            return PadOffset(type, atOffset) + size.AsInt;
+        }
+
+        public static int PadOffset(TypeDesc type, int atOffset)
+        {
+            var fieldAlignment = type is DefType && type.IsValueType ? ((DefType)type).InstanceFieldAlignment : type.Context.Target.LayoutPointerSize;
+            var alignment = LayoutInt.Min(fieldAlignment, new LayoutInt(ComputePackingSize(type))).AsInt;
+            var padding = (atOffset + (alignment - 1)) & ~(alignment - 1);
+            return padding;
+        }
+
+        static LLVMValueRef s_shadowStackTop = default(LLVMValueRef);
+
+        static LLVMValueRef ShadowStackTop
+        {
+            get
+            {
+                if (s_shadowStackTop.Handle.Equals(IntPtr.Zero))
+                {
+                    s_shadowStackTop = LLVMCodegenCompilation.Module.AddGlobal(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "t_pShadowStackTop");
+                    s_shadowStackTop.Linkage = LLVMLinkage.LLVMExternalLinkage;
+                    s_shadowStackTop.Initializer = LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
+                    s_shadowStackTop.ThreadLocalMode = LLVMThreadLocalMode.LLVMLocalDynamicTLSModel;
+                }
+                return s_shadowStackTop;
+            }
+        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -636,7 +636,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             _nodeFactory = factory;
             _objectFilePath = objectFilePath;
-            Module = compilation.Module;
+            Module = LLVMCodegenCompilation.Module;
             DIBuilder = compilation.DIBuilder;
         }
 
@@ -719,7 +719,7 @@ namespace ILCompiler.DependencyAnalysis
 
             try
             {
-                objectWriter.EmitReadyToRunHeaderCallback(compilation.Module.Context);
+                objectWriter.EmitReadyToRunHeaderCallback(LLVMCodegenCompilation.Module.Context);
                 //ObjectNodeSection managedCodeSection = null;
 
                 var listOfOffsets = new List<int>();
@@ -910,7 +910,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private void GetCodeForReadyToRunGenericHelper(LLVMCodegenCompilation compilation, ReadyToRunGenericHelperNode node, NodeFactory factory)
         {
-            LLVMBuilderRef builder = compilation.Module.Context.CreateBuilder();
+            LLVMBuilderRef builder = LLVMCodegenCompilation.Module.Context.CreateBuilder();
             var args = new List<LLVMTypeRef>();
             MethodDesc delegateCtor = null;
             if (node.Id == ReadyToRunHelperId.DelegateCtor)
@@ -1047,7 +1047,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private void GetCodeForReadyToRunHelper(LLVMCodegenCompilation compilation, ReadyToRunHelperNode node, NodeFactory factory)
         {
-            LLVMBuilderRef builder = compilation.Module.Context.CreateBuilder();
+            LLVMBuilderRef builder = LLVMCodegenCompilation.Module.Context.CreateBuilder();
 
             LLVMValueRef helperFunc = Module.AddFunction(node.GetMangledName(factory.NameMangler), LLVMTypeRef.CreateFunction(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) /* shadow stack */}));
 
@@ -1129,7 +1129,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private void GetCodeForTentativeMethod(LLVMCodegenCompilation compilation, TentativeMethodNode node, NodeFactory factory)
         {
-            LLVMBuilderRef builder = compilation.Module.Context.CreateBuilder();
+            LLVMBuilderRef builder = LLVMCodegenCompilation.Module.Context.CreateBuilder();
             MethodDesc method = node.Method;
             string mangledName = node.GetMangledName(factory.NameMangler);
             LLVMValueRef tentativeStub = ILImporter.GetOrCreateLLVMFunction(Module, mangledName, method.Signature, method.RequiresInstArg());


### PR DESCRIPTION
This PR removes the restriction on attempting to compile with clrjit any method with > 0 parameters.  Adds the generation of the managed to native thunk for runtime export functions compiled with clrjit.