### PR TITLE
Fix SafeHandle benchmarks and add string benchmarks

### DIFF
--- a/DllImportGenerator/Benchmarks/Strings.cs
+++ b/DllImportGenerator/Benchmarks/Strings.cs
@@ -1,0 +1,419 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Benchmarks
+{
+    partial class NativeExportsNE
+    {
+        private class EntryPoints
+        {
+            private const string ReturnLength = "return_length";
+            private const string ReverseReturn = "reverse_return";
+            private const string ReverseOut = "reverse_out";
+            private const string ReverseInplace = "reverse_inplace_ref";
+            private const string ReverseReplace = "reverse_replace_ref";
+
+            private const string UShortSuffix = "_ushort";
+            private const string ByteSuffix = "_byte";
+
+            public class Byte
+            {
+                public const string ReturnLength = EntryPoints.ReturnLength + ByteSuffix;
+                public const string ReverseReturn = EntryPoints.ReverseReturn + ByteSuffix;
+                public const string ReverseOut = EntryPoints.ReverseOut + ByteSuffix;
+                public const string ReverseInplace = EntryPoints.ReverseInplace + ByteSuffix;
+                public const string ReverseReplace = EntryPoints.ReverseReplace + ByteSuffix;
+            }
+
+            public class UShort
+            {
+                public const string ReturnLength = EntryPoints.ReturnLength + UShortSuffix;
+                public const string ReverseReturn = EntryPoints.ReverseReturn + UShortSuffix;
+                public const string ReverseOut = EntryPoints.ReverseOut + UShortSuffix;
+                public const string ReverseInplace = EntryPoints.ReverseInplace + UShortSuffix;
+                public const string ReverseReplace = EntryPoints.ReverseReplace + UShortSuffix;
+            }
+        }
+
+        public partial class Unicode
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength, CharSet = CharSet.Unicode)]
+            public static partial int ReturnLength(string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReturn, CharSet = CharSet.Unicode)]
+            public static partial string Reverse_Return(string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseOut, CharSet = CharSet.Unicode)]
+            public static partial void Reverse_Out(string s, out string ret);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Unicode)]
+            public static partial void Reverse_Ref(ref string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Unicode)]
+            public static partial void Reverse_In(in string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReplace, CharSet = CharSet.Unicode)]
+            public static partial void Reverse_Replace_Ref(ref string s);
+        }
+
+        public partial class LPTStr
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength)]
+            public static partial int ReturnLength([MarshalAs(UnmanagedType.LPTStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength, CharSet = CharSet.None)]
+            public static partial int ReturnLength_IgnoreCharSet([MarshalAs(UnmanagedType.LPTStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReturn)]
+            [return: MarshalAs(UnmanagedType.LPTStr)]
+            public static partial string Reverse_Return([MarshalAs(UnmanagedType.LPTStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseOut)]
+            public static partial void Reverse_Out([MarshalAs(UnmanagedType.LPTStr)] string s, [MarshalAs(UnmanagedType.LPTStr)] out string ret);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
+            public static partial void Reverse_Ref([MarshalAs(UnmanagedType.LPTStr)] ref string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
+            public static partial void Reverse_In([MarshalAs(UnmanagedType.LPTStr)] in string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
+            public static partial void Reverse_Replace_Ref([MarshalAs(UnmanagedType.LPTStr)] ref string s);
+        }
+
+        public partial class LPWStr
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength)]
+            public static partial int ReturnLength([MarshalAs(UnmanagedType.LPWStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength, CharSet = CharSet.None)]
+            public static partial int ReturnLength_IgnoreCharSet([MarshalAs(UnmanagedType.LPWStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReturn)]
+            [return: MarshalAs(UnmanagedType.LPWStr)]
+            public static partial string Reverse_Return([MarshalAs(UnmanagedType.LPWStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseOut)]
+            public static partial void Reverse_Out([MarshalAs(UnmanagedType.LPWStr)] string s, [MarshalAs(UnmanagedType.LPWStr)] out string ret);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
+            public static partial void Reverse_Ref([MarshalAs(UnmanagedType.LPWStr)] ref string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
+            public static partial void Reverse_In([MarshalAs(UnmanagedType.LPWStr)] in string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
+            public static partial void Reverse_Replace_Ref([MarshalAs(UnmanagedType.LPWStr)] ref string s);
+        }
+
+        public partial class LPUTF8Str
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength)]
+            public static partial int ReturnLength([MarshalAs(UnmanagedType.LPUTF8Str)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength, CharSet = CharSet.None)]
+            public static partial int ReturnLength_IgnoreCharSet([MarshalAs(UnmanagedType.LPUTF8Str)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReturn)]
+            [return: MarshalAs(UnmanagedType.LPUTF8Str)]
+            public static partial string Reverse_Return([MarshalAs(UnmanagedType.LPUTF8Str)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseOut)]
+            public static partial void Reverse_Out([MarshalAs(UnmanagedType.LPUTF8Str)] string s, [MarshalAs(UnmanagedType.LPUTF8Str)] out string ret);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
+            public static partial void Reverse_In([MarshalAs(UnmanagedType.LPUTF8Str)] in string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
+            public static partial void Reverse_Ref([MarshalAs(UnmanagedType.LPUTF8Str)] ref string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
+            public static partial void Reverse_Replace_Ref([MarshalAs(UnmanagedType.LPUTF8Str)] ref string s);
+        }
+
+        public partial class Ansi
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength, CharSet = CharSet.Ansi)]
+            public static partial int ReturnLength(string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReturn, CharSet = CharSet.Ansi)]
+            public static partial string Reverse_Return(string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseOut, CharSet = CharSet.Ansi)]
+            public static partial void Reverse_Out(string s, out string ret);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Ansi)]
+            public static partial void Reverse_Ref(ref string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Ansi)]
+            public static partial void Reverse_In(in string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Ansi)]
+            public static partial void Reverse_Replace_Ref(ref string s);
+        }
+
+        public partial class LPStr
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength)]
+            public static partial int ReturnLength([MarshalAs(UnmanagedType.LPStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength, CharSet = CharSet.None)]
+            public static partial int ReturnLength_IgnoreCharSet([MarshalAs(UnmanagedType.LPStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReturn)]
+            [return: MarshalAs(UnmanagedType.LPStr)]
+            public static partial string Reverse_Return([MarshalAs(UnmanagedType.LPStr)] string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseOut)]
+            public static partial void Reverse_Out([MarshalAs(UnmanagedType.LPStr)] string s, [MarshalAs(UnmanagedType.LPStr)] out string ret);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
+            public static partial void Reverse_Ref([MarshalAs(UnmanagedType.LPStr)] ref string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
+            public static partial void Reverse_In([MarshalAs(UnmanagedType.LPStr)] in string s);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
+            public static partial void Reverse_Replace_Ref([MarshalAs(UnmanagedType.LPStr)] ref string s);
+        }
+
+        public partial class Auto
+        {
+            public partial class Unix
+            {
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength, CharSet = CharSet.Auto)]
+                public static partial int ReturnLength(string s);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReturn, CharSet = CharSet.Auto)]
+                public static partial string Reverse_Return(string s);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseOut, CharSet = CharSet.Auto)]
+                public static partial void Reverse_Out(string s, out string ret);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Auto)]
+                public static partial void Reverse_Ref(ref string s);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Auto)]
+                public static partial void Reverse_In(in string s);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Auto)]
+                public static partial void Reverse_Replace_Ref(ref string s);
+            }
+
+            public partial class Windows
+            {
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength, CharSet = CharSet.Auto)]
+                public static partial int ReturnLength(string s);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReturn, CharSet = CharSet.Auto)]
+                public static partial string Reverse_Return(string s);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseOut, CharSet = CharSet.Auto)]
+                public static partial void Reverse_Out(string s, out string ret);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Auto)]
+                public static partial void Reverse_Ref(ref string s);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Auto)]
+                public static partial void Reverse_In(in string s);
+
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Auto)]
+                public static partial void Reverse_Replace_Ref(ref string s);
+            }
+        }
+    }
+
+    public class Strings
+    {
+        public static IEnumerable<object> UnicodeStrings{ get; } = new []
+        {
+            "ABCdef 123$%^",
+            "🍜 !! 🍜 !!",
+            "🌲 木 🔥 火 🌾 土 🛡 金 🌊 水",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae posuere mauris, sed ultrices leo. Suspendisse potenti. Mauris enim enim, blandit tincidunt consequat in, varius sit amet neque. Morbi eget porttitor ex. Duis mattis aliquet ante quis imperdiet. Duis sit.",
+            string.Empty,
+            null,
+        };
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public int StringByValue_CharSetUnicode(string str)
+        {
+            return NativeExportsNE.Unicode.ReturnLength(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public int StringByValue_LPWStr(string str)
+        {
+            return NativeExportsNE.LPWStr.ReturnLength(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public int StringByValue_LPTStr(string str)
+        {
+            return NativeExportsNE.LPTStr.ReturnLength(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public int StringByValue_LPUTF8Str(string str)
+        {
+            return NativeExportsNE.LPUTF8Str.ReturnLength(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public int StringByValue_LPStr(string str)
+        {
+            return NativeExportsNE.LPStr.ReturnLength(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public int StringByValue_CharSetAnsi(string str)
+        {
+            return NativeExportsNE.Ansi.ReturnLength(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public int StringByValue_Auto(string str)
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return NativeExportsNE.Auto.Windows.ReturnLength(str);
+            }
+            else
+            {
+                return NativeExportsNE.Auto.Unix.ReturnLength(str);
+            }
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringReturn_CharSetUnicode(string str)
+        {
+            return NativeExportsNE.Unicode.Reverse_Return(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringReturn_LPWStr(string str)
+        {
+            return NativeExportsNE.LPWStr.Reverse_Return(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringReturn_LPTStr(string str)
+        {
+            return NativeExportsNE.LPTStr.Reverse_Return(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringReturn_LPUTF8Str(string str)
+        {
+            return NativeExportsNE.LPUTF8Str.Reverse_Return(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringReturn_LPStr(string str)
+        {
+            return NativeExportsNE.LPStr.Reverse_Return(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringReturn_CharSetAnsi(string str)
+        {
+            return NativeExportsNE.Ansi.Reverse_Return(str);
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringReturn_Auto(string str)
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return NativeExportsNE.Auto.Windows.Reverse_Return(str);
+            }
+            else
+            {
+                return NativeExportsNE.Auto.Unix.Reverse_Return(str);
+            }
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringByRef_CharSetUnicode(string str)
+        {
+            NativeExportsNE.Unicode.Reverse_Replace_Ref(ref str);
+            return str;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringByRef_LPWStr(string str)
+        {
+            NativeExportsNE.LPWStr.Reverse_Replace_Ref(ref str);
+            return str;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringByRef_LPTStr(string str)
+        {
+            NativeExportsNE.LPTStr.Reverse_Replace_Ref(ref str);
+            return str;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringByRef_LPUTF8Str(string str)
+        {
+            NativeExportsNE.LPUTF8Str.Reverse_Replace_Ref(ref str);
+            return str;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringByRef_LPStr(string str)
+        {
+            NativeExportsNE.LPStr.Reverse_Replace_Ref(ref str);
+            return str;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringByRef_CharSetAnsi(string str)
+        {
+            NativeExportsNE.Ansi.Reverse_Replace_Ref(ref str);
+            return str;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(UnicodeStrings))]
+        public string StringByRef_Auto(string str)
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                NativeExportsNE.Auto.Windows.Reverse_Replace_Ref(ref str);
+            }
+            else
+            {
+                NativeExportsNE.Auto.Windows.Reverse_Replace_Ref(ref str);
+            }
+            return str;
+        }
+    }
+}

--- a/DllImportGenerator/Benchmarks/Strings.cs
+++ b/DllImportGenerator/Benchmarks/Strings.cs
@@ -49,15 +49,6 @@ namespace Benchmarks
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReturn, CharSet = CharSet.Unicode)]
             public static partial string Reverse_Return(string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseOut, CharSet = CharSet.Unicode)]
-            public static partial void Reverse_Out(string s, out string ret);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Unicode)]
-            public static partial void Reverse_Ref(ref string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Unicode)]
-            public static partial void Reverse_In(in string s);
-
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReplace, CharSet = CharSet.Unicode)]
             public static partial void Reverse_Replace_Ref(ref string s);
         }
@@ -67,23 +58,11 @@ namespace Benchmarks
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength)]
             public static partial int ReturnLength([MarshalAs(UnmanagedType.LPTStr)] string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength, CharSet = CharSet.None)]
-            public static partial int ReturnLength_IgnoreCharSet([MarshalAs(UnmanagedType.LPTStr)] string s);
-
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReturn)]
             [return: MarshalAs(UnmanagedType.LPTStr)]
             public static partial string Reverse_Return([MarshalAs(UnmanagedType.LPTStr)] string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseOut)]
-            public static partial void Reverse_Out([MarshalAs(UnmanagedType.LPTStr)] string s, [MarshalAs(UnmanagedType.LPTStr)] out string ret);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
-            public static partial void Reverse_Ref([MarshalAs(UnmanagedType.LPTStr)] ref string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
-            public static partial void Reverse_In([MarshalAs(UnmanagedType.LPTStr)] in string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReplace)]
             public static partial void Reverse_Replace_Ref([MarshalAs(UnmanagedType.LPTStr)] ref string s);
         }
 
@@ -92,23 +71,11 @@ namespace Benchmarks
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength)]
             public static partial int ReturnLength([MarshalAs(UnmanagedType.LPWStr)] string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReturnLength, CharSet = CharSet.None)]
-            public static partial int ReturnLength_IgnoreCharSet([MarshalAs(UnmanagedType.LPWStr)] string s);
-
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReturn)]
             [return: MarshalAs(UnmanagedType.LPWStr)]
             public static partial string Reverse_Return([MarshalAs(UnmanagedType.LPWStr)] string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseOut)]
-            public static partial void Reverse_Out([MarshalAs(UnmanagedType.LPWStr)] string s, [MarshalAs(UnmanagedType.LPWStr)] out string ret);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
-            public static partial void Reverse_Ref([MarshalAs(UnmanagedType.LPWStr)] ref string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
-            public static partial void Reverse_In([MarshalAs(UnmanagedType.LPWStr)] in string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace)]
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReplace)]
             public static partial void Reverse_Replace_Ref([MarshalAs(UnmanagedType.LPWStr)] ref string s);
         }
 
@@ -117,23 +84,11 @@ namespace Benchmarks
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength)]
             public static partial int ReturnLength([MarshalAs(UnmanagedType.LPUTF8Str)] string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength, CharSet = CharSet.None)]
-            public static partial int ReturnLength_IgnoreCharSet([MarshalAs(UnmanagedType.LPUTF8Str)] string s);
-
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReturn)]
             [return: MarshalAs(UnmanagedType.LPUTF8Str)]
             public static partial string Reverse_Return([MarshalAs(UnmanagedType.LPUTF8Str)] string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseOut)]
-            public static partial void Reverse_Out([MarshalAs(UnmanagedType.LPUTF8Str)] string s, [MarshalAs(UnmanagedType.LPUTF8Str)] out string ret);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
-            public static partial void Reverse_In([MarshalAs(UnmanagedType.LPUTF8Str)] in string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
-            public static partial void Reverse_Ref([MarshalAs(UnmanagedType.LPUTF8Str)] ref string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReplace)]
             public static partial void Reverse_Replace_Ref([MarshalAs(UnmanagedType.LPUTF8Str)] ref string s);
         }
 
@@ -145,16 +100,7 @@ namespace Benchmarks
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReturn, CharSet = CharSet.Ansi)]
             public static partial string Reverse_Return(string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseOut, CharSet = CharSet.Ansi)]
-            public static partial void Reverse_Out(string s, out string ret);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Ansi)]
-            public static partial void Reverse_Ref(ref string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Ansi)]
-            public static partial void Reverse_In(in string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Ansi)]
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReplace, CharSet = CharSet.Ansi)]
             public static partial void Reverse_Replace_Ref(ref string s);
         }
 
@@ -163,23 +109,11 @@ namespace Benchmarks
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength)]
             public static partial int ReturnLength([MarshalAs(UnmanagedType.LPStr)] string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReturnLength, CharSet = CharSet.None)]
-            public static partial int ReturnLength_IgnoreCharSet([MarshalAs(UnmanagedType.LPStr)] string s);
-
             [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReturn)]
             [return: MarshalAs(UnmanagedType.LPStr)]
             public static partial string Reverse_Return([MarshalAs(UnmanagedType.LPStr)] string s);
 
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseOut)]
-            public static partial void Reverse_Out([MarshalAs(UnmanagedType.LPStr)] string s, [MarshalAs(UnmanagedType.LPStr)] out string ret);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
-            public static partial void Reverse_Ref([MarshalAs(UnmanagedType.LPStr)] ref string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
-            public static partial void Reverse_In([MarshalAs(UnmanagedType.LPStr)] in string s);
-
-            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace)]
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReplace)]
             public static partial void Reverse_Replace_Ref([MarshalAs(UnmanagedType.LPStr)] ref string s);
         }
 
@@ -193,16 +127,7 @@ namespace Benchmarks
                 [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReturn, CharSet = CharSet.Auto)]
                 public static partial string Reverse_Return(string s);
 
-                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseOut, CharSet = CharSet.Auto)]
-                public static partial void Reverse_Out(string s, out string ret);
-
-                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Auto)]
-                public static partial void Reverse_Ref(ref string s);
-
-                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Auto)]
-                public static partial void Reverse_In(in string s);
-
-                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseInplace, CharSet = CharSet.Auto)]
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.Byte.ReverseReplace, CharSet = CharSet.Auto)]
                 public static partial void Reverse_Replace_Ref(ref string s);
             }
 
@@ -214,16 +139,7 @@ namespace Benchmarks
                 [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReturn, CharSet = CharSet.Auto)]
                 public static partial string Reverse_Return(string s);
 
-                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseOut, CharSet = CharSet.Auto)]
-                public static partial void Reverse_Out(string s, out string ret);
-
-                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Auto)]
-                public static partial void Reverse_Ref(ref string s);
-
-                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Auto)]
-                public static partial void Reverse_In(in string s);
-
-                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseInplace, CharSet = CharSet.Auto)]
+                [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = EntryPoints.UShort.ReverseReplace, CharSet = CharSet.Auto)]
                 public static partial void Reverse_Replace_Ref(ref string s);
             }
         }
@@ -411,7 +327,7 @@ namespace Benchmarks
             }
             else
             {
-                NativeExportsNE.Auto.Windows.Reverse_Replace_Ref(ref str);
+                NativeExportsNE.Auto.Unix.Reverse_Replace_Ref(ref str);
             }
             return str;
         }

--- a/DllImportGenerator/DllImportGenerator/Marshalling/Forwarder.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/Forwarder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Interop
             // If the parameter has [MarshalAs] marshalling, we resurface that
             // in the forwarding target since the built-in system understands it.
             // ICustomMarshaller marshalling requires additional information that we throw away earlier since it's unsupported,
-            // so explicitly do not resurface a [MarshalAs(UnmanagdType.CustomMarshaller)] attribute.
+            // so explicitly do not resurface a [MarshalAs(UnmanagdType.CustomMarshaler)] attribute.
             if (info.MarshallingAttributeInfo is MarshalAsInfo { UnmanagedType: not UnmanagedType.CustomMarshaler } marshalAs)
             {
                 marshalAsAttribute = Attribute(ParseName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute))
@@ -89,10 +89,6 @@ namespace Microsoft.Interop
                 .WithModifiers(TokenList(Token(info.RefKindSyntax)))
                 .WithType(info.ManagedType.AsTypeSyntax());
 
-            // If the parameter has [MarshalAs] marshalling, we resurface that
-            // in the forwarding target since the built-in system understands it.
-            // ICustomMarshaller marshalling requires additional information that we throw away earlier since it's unsupported,
-            // so explicitly do not resurface a [MarshalAs(UnmanagdType.CustomMarshaller)] attribute.
             if (TryRehydrateMarshalAsAttribute(info, out AttributeSyntax marshalAsAttribute))
             {
                 param = param.AddAttributeLists(AttributeList(SingletonSeparatedList(marshalAsAttribute)));

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -73,6 +73,19 @@ namespace Microsoft.Interop
     }
 
     /// <summary>
+    /// Interface for generating attributes for native return types.
+    /// </summary>
+    internal interface IAttributedReturnTypeMarshallingGenerator : IMarshallingGenerator
+    {
+        /// <summary>
+        /// Gets any attributes that should be applied to the return type for this <paramref name="info"/>.
+        /// </summary>
+        /// <param name="info">Object to marshal</param>
+        /// <returns>Attributes for the return type for this <paramref name="info"/>, or <c>null</c> if no attributes should be added.</returns>
+        AttributeListSyntax? GenerateAttributesForReturnType(TypePositionInfo info);
+    }
+
+    /// <summary>
     /// Exception used to indicate marshalling isn't supported.
     /// </summary>
     internal class MarshallingNotSupportedException : Exception

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -354,6 +354,16 @@ namespace Microsoft.Interop
                 .WithAttributeLists(
                     SingletonList(AttributeList(
                         SingletonSeparatedList(CreateDllImportAttributeForTarget(GetTargetDllImportDataFromStubData())))));
+
+            if (retMarshaller.Generator is IAttributedReturnTypeMarshallingGenerator retGenerator)
+            {
+                AttributeListSyntax? returnAttribute = retGenerator.GenerateAttributesForReturnType(retMarshaller.TypeInfo);
+                if (returnAttribute is not null)
+                {
+                    dllImport = dllImport.AddAttributeLists(returnAttribute.WithTarget(AttributeTargetSpecifier(Identifier("return"))));
+                }
+            }
+
             foreach (var marshaller in paramMarshallers)
             {
                 ParameterSyntax paramSyntax = marshaller.Generator.AsParameter(marshaller.TypeInfo);

--- a/DllImportGenerator/DllImportGenerator/TypeNames.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeNames.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Interop
 
         public const string System_Runtime_InteropServices_MarshalAsAttribute = "System.Runtime.InteropServices.MarshalAsAttribute";
 
+        public const string System_Runtime_InteropServices_UnmanagedType = "System.Runtime.InteropServices.UnmanagedType";
+
         public const string System_Runtime_InteropServices_Marshal = "System.Runtime.InteropServices.Marshal";
 
         private const string System_Runtime_InteropServices_MarshalEx = "System.Runtime.InteropServices.MarshalEx";

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,7 @@
     <!-- Package dependencies -->
     <SystemCommandLineVersion>2.0.0-beta1.21118.1</SystemCommandLineVersion>
     <IcedVersion>1.8.0</IcedVersion>
-    <BenchmarkDotNetVersion>0.12.1.1528</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <CoverletVersion>1.3.0</CoverletVersion>
     <DNNEVersion>1.0.16</DNNEVersion>
     <!-- Set the custom NETCoreApp version based on the VS redist package version -->


### PR DESCRIPTION
Fix native side of SafeHandle benchmarks to handle asynchronous release (finalization).

Add benchmarks for all of our string marshalling.

~~Add support in the Forwarder marshaller to reconstitute the original MarshalAs attributes for a given parameter. This still doesn't handle the return value case, so some of the string return benchmarks are inaccurate in the Built-In jobs (StringReturn_LPUTF8Str in particular).~~ This PR also adds a specialized API to enable emitting the required attributes to get good benchmarking of this scenario.

The only regression that isn't due to the above issue with return values and Forwarders is with ANSI marshalling. The source generated stubs do not support the stackalloc optimization for ANSI string marshalling since there is no public API that enables it. As a result, by-value scenarios (so the by-value and return benchmarks) will show some regressions for the `_LPStr` benchmarks.

Other than that regression, we see a pretty nice improvement in throughput for string marshalling of a few percent in most every case, with many cases having a 10% improvement or more (likely due to better inlining and more JIT optimizations being possible).

<summary>Benchmark Run Results</summary>
<details>

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1052 (21H1/May2021Update)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100-preview.3.21202.5
  [Host]    : .NET 6.0.0 (6.0.21.22605), X64 RyuJIT
  Built-in  : .NET 6.0.0 (6.0.21.22605), X64 RyuJIT
  Generated : .NET 6.0.0 (6.0.21.22605), X64 RyuJIT


```
|                       Method |       Job | BuildConfiguration |                  str |        Mean |     Error |    StdDev |      Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |---------- |------------------- |--------------------- |------------:|----------:|----------:|------------:|------:|--------:|-------:|------:|------:|----------:|
| **StringByValue_CharSetUnicode** |  **Built-in** | **Release_Forwarders** |                    **?** |    **12.11 ns** |  **0.117 ns** |  **0.091 ns** |    **12.08 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringByValue_CharSetUnicode | Generated |            Default |                    ? |    10.92 ns |  0.029 ns |  0.022 ns |    10.92 ns |  0.90 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPWStr |  Built-in | Release_Forwarders |                    ? |    12.18 ns |  0.053 ns |  0.047 ns |    12.16 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPWStr | Generated |            Default |                    ? |    11.12 ns |  0.145 ns |  0.135 ns |    11.07 ns |  0.91 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPTStr |  Built-in | Release_Forwarders |                    ? |    12.24 ns |  0.062 ns |  0.048 ns |    12.24 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPTStr | Generated |            Default |                    ? |    11.01 ns |  0.074 ns |  0.066 ns |    10.98 ns |  0.90 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByValue_LPUTF8Str |  Built-in | Release_Forwarders |                    ? |    16.39 ns |  0.069 ns |  0.057 ns |    16.37 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|      StringByValue_LPUTF8Str | Generated |            Default |                    ? |    14.07 ns |  0.074 ns |  0.066 ns |    14.06 ns |  0.86 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringByValue_LPStr |  Built-in | Release_Forwarders |                    ? |    16.16 ns |  0.035 ns |  0.029 ns |    16.17 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringByValue_LPStr | Generated |            Default |                    ? |    15.84 ns |  0.234 ns |  0.219 ns |    15.73 ns |  0.98 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|    StringByValue_CharSetAnsi |  Built-in | Release_Forwarders |                    ? |    16.24 ns |  0.085 ns |  0.071 ns |    16.24 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|    StringByValue_CharSetAnsi | Generated |            Default |                    ? |    15.62 ns |  0.019 ns |  0.018 ns |    15.62 ns |  0.96 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByValue_Auto |  Built-in | Release_Forwarders |                    ? |    12.19 ns |  0.065 ns |  0.058 ns |    12.16 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByValue_Auto | Generated |            Default |                    ? |    12.69 ns |  0.040 ns |  0.033 ns |    12.70 ns |  1.04 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|  StringReturn_CharSetUnicode |  Built-in | Release_Forwarders |                    ? |    15.80 ns |  0.085 ns |  0.067 ns |    15.77 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|  StringReturn_CharSetUnicode | Generated |            Default |                    ? |    14.70 ns |  0.270 ns |  0.252 ns |    14.68 ns |  0.93 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPWStr |  Built-in | Release_Forwarders |                    ? |    16.33 ns |  0.199 ns |  0.176 ns |    16.27 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringReturn_LPWStr | Generated |            Default |                    ? |    14.58 ns |  0.126 ns |  0.105 ns |    14.57 ns |  0.89 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPTStr |  Built-in | Release_Forwarders |                    ? |    16.64 ns |  0.260 ns |  0.217 ns |    16.61 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringReturn_LPTStr | Generated |            Default |                    ? |    14.44 ns |  0.068 ns |  0.056 ns |    14.44 ns |  0.87 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|       StringReturn_LPUTF8Str |  Built-in | Release_Forwarders |                    ? |    20.70 ns |  0.088 ns |  0.073 ns |    20.69 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|       StringReturn_LPUTF8Str | Generated |            Default |                    ? |    17.28 ns |  0.151 ns |  0.133 ns |    17.24 ns |  0.84 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringReturn_LPStr |  Built-in | Release_Forwarders |                    ? |    21.34 ns |  0.257 ns |  0.393 ns |    21.21 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringReturn_LPStr | Generated |            Default |                    ? |    17.47 ns |  0.069 ns |  0.061 ns |    17.49 ns |  0.82 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|     StringReturn_CharSetAnsi |  Built-in | Release_Forwarders |                    ? |    22.53 ns |  0.334 ns |  0.296 ns |    22.40 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|     StringReturn_CharSetAnsi | Generated |            Default |                    ? |    17.54 ns |  0.057 ns |  0.044 ns |    17.54 ns |  0.78 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringReturn_Auto |  Built-in | Release_Forwarders |                    ? |    15.99 ns |  0.048 ns |  0.037 ns |    15.99 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|            StringReturn_Auto | Generated |            Default |                    ? |    15.27 ns |  0.302 ns |  0.282 ns |    15.31 ns |  0.95 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|   StringByRef_CharSetUnicode |  Built-in | Release_Forwarders |                    ? |    14.20 ns |  0.209 ns |  0.195 ns |    14.11 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|   StringByRef_CharSetUnicode | Generated |            Default |                    ? |    15.45 ns |  0.081 ns |  0.072 ns |    15.44 ns |  1.09 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPWStr |  Built-in | Release_Forwarders |                    ? |    14.51 ns |  0.069 ns |  0.058 ns |    14.50 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByRef_LPWStr | Generated |            Default |                    ? |    14.89 ns |  0.077 ns |  0.060 ns |    14.89 ns |  1.03 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPTStr |  Built-in | Release_Forwarders |                    ? |    14.58 ns |  0.076 ns |  0.063 ns |    14.58 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByRef_LPTStr | Generated |            Default |                    ? |    14.57 ns |  0.103 ns |  0.081 ns |    14.58 ns |  1.00 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|        StringByRef_LPUTF8Str |  Built-in | Release_Forwarders |                    ? |    24.04 ns |  0.284 ns |  0.266 ns |    23.94 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|        StringByRef_LPUTF8Str | Generated |            Default |                    ? |    18.12 ns |  0.099 ns |  0.092 ns |    18.08 ns |  0.75 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringByRef_LPStr |  Built-in | Release_Forwarders |                    ? |    24.24 ns |  0.468 ns |  0.438 ns |    24.14 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|            StringByRef_LPStr | Generated |            Default |                    ? |    16.92 ns |  0.093 ns |  0.072 ns |    16.90 ns |  0.70 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByRef_CharSetAnsi |  Built-in | Release_Forwarders |                    ? |    23.68 ns |  0.142 ns |  0.126 ns |    23.64 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|      StringByRef_CharSetAnsi | Generated |            Default |                    ? |    18.19 ns |  0.409 ns |  0.471 ns |    18.03 ns |  0.77 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|             StringByRef_Auto |  Built-in | Release_Forwarders |                    ? |    14.02 ns |  0.148 ns |  0.123 ns |    13.99 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|             StringByRef_Auto | Generated |            Default |                    ? |    14.62 ns |  0.356 ns |  0.410 ns |    14.45 ns |  1.05 |    0.03 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
| **StringByValue_CharSetUnicode** |  **Built-in** | **Release_Forwarders** |                     **** |    **15.54 ns** |  **0.053 ns** |  **0.050 ns** |    **15.53 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringByValue_CharSetUnicode | Generated |            Default |                      |    12.38 ns |  0.031 ns |  0.026 ns |    12.37 ns |  0.80 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPWStr |  Built-in | Release_Forwarders |                      |    15.83 ns |  0.211 ns |  0.187 ns |    15.79 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPWStr | Generated |            Default |                      |    12.44 ns |  0.096 ns |  0.080 ns |    12.39 ns |  0.79 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPTStr |  Built-in | Release_Forwarders |                      |    15.65 ns |  0.066 ns |  0.055 ns |    15.65 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPTStr | Generated |            Default |                      |    12.39 ns |  0.054 ns |  0.045 ns |    12.38 ns |  0.79 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByValue_LPUTF8Str |  Built-in | Release_Forwarders |                      |    27.43 ns |  0.090 ns |  0.075 ns |    27.44 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|      StringByValue_LPUTF8Str | Generated |            Default |                      |    24.65 ns |  0.261 ns |  0.244 ns |    24.52 ns |  0.90 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringByValue_LPStr |  Built-in | Release_Forwarders |                      |    34.87 ns |  0.168 ns |  0.149 ns |    34.82 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringByValue_LPStr | Generated |            Default |                      |    92.23 ns |  1.821 ns |  2.168 ns |    91.95 ns |  2.67 |    0.06 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|    StringByValue_CharSetAnsi |  Built-in | Release_Forwarders |                      |    32.69 ns |  0.189 ns |  0.177 ns |    32.70 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|    StringByValue_CharSetAnsi | Generated |            Default |                      |    89.37 ns |  1.566 ns |  1.388 ns |    89.37 ns |  2.73 |    0.05 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByValue_Auto |  Built-in | Release_Forwarders |                      |    15.64 ns |  0.178 ns |  0.149 ns |    15.59 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByValue_Auto | Generated |            Default |                      |    14.24 ns |  0.219 ns |  0.194 ns |    14.13 ns |  0.91 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|  StringReturn_CharSetUnicode |  Built-in | Release_Forwarders |                      |   109.73 ns |  0.717 ns |  0.635 ns |   109.57 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|  StringReturn_CharSetUnicode | Generated |            Default |                      |    89.30 ns |  1.141 ns |  1.012 ns |    89.20 ns |  0.81 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPWStr |  Built-in | Release_Forwarders |                      |   106.74 ns |  1.478 ns |  1.382 ns |   107.20 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringReturn_LPWStr | Generated |            Default |                      |    89.46 ns |  1.181 ns |  1.105 ns |    89.67 ns |  0.84 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPTStr |  Built-in | Release_Forwarders |                      |   108.21 ns |  1.942 ns |  1.817 ns |   107.71 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringReturn_LPTStr | Generated |            Default |                      |    88.76 ns |  1.115 ns |  0.988 ns |    88.66 ns |  0.82 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|       StringReturn_LPUTF8Str |  Built-in | Release_Forwarders |                      |   125.27 ns |  2.142 ns |  2.003 ns |   125.16 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|       StringReturn_LPUTF8Str | Generated |            Default |                      |   113.35 ns |  1.505 ns |  1.175 ns |   113.18 ns |  0.91 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringReturn_LPStr |  Built-in | Release_Forwarders |                      |   128.89 ns |  1.835 ns |  1.532 ns |   128.92 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringReturn_LPStr | Generated |            Default |                      |   173.02 ns |  3.198 ns |  5.602 ns |   171.58 ns |  1.38 |    0.05 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|     StringReturn_CharSetAnsi |  Built-in | Release_Forwarders |                      |   130.93 ns |  2.325 ns |  2.061 ns |   131.34 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|     StringReturn_CharSetAnsi | Generated |            Default |                      |   171.55 ns |  3.411 ns |  4.189 ns |   169.78 ns |  1.32 |    0.04 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringReturn_Auto |  Built-in | Release_Forwarders |                      |   108.45 ns |  1.820 ns |  1.702 ns |   108.69 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|            StringReturn_Auto | Generated |            Default |                      |    91.29 ns |  1.629 ns |  1.524 ns |    91.17 ns |  0.84 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|   StringByRef_CharSetUnicode |  Built-in | Release_Forwarders |                      |   177.71 ns |  3.614 ns |  4.947 ns |   176.02 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|   StringByRef_CharSetUnicode | Generated |            Default |                      |   147.62 ns |  1.421 ns |  1.329 ns |   148.06 ns |  0.82 |    0.03 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPWStr |  Built-in | Release_Forwarders |                      |   104.45 ns |  1.009 ns |  0.895 ns |   104.69 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByRef_LPWStr | Generated |            Default |                      |    89.27 ns |  0.860 ns |  0.804 ns |    89.62 ns |  0.85 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPTStr |  Built-in | Release_Forwarders |                      |    99.36 ns |  1.139 ns |  1.010 ns |    99.25 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByRef_LPTStr | Generated |            Default |                      |    90.67 ns |  0.798 ns |  0.708 ns |    90.51 ns |  0.91 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|        StringByRef_LPUTF8Str |  Built-in | Release_Forwarders |                      |   119.13 ns |  2.442 ns |  2.508 ns |   118.32 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|        StringByRef_LPUTF8Str | Generated |            Default |                      |   108.73 ns |  0.969 ns |  0.859 ns |   108.75 ns |  0.91 |    0.03 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringByRef_LPStr |  Built-in | Release_Forwarders |                      |   112.96 ns |  1.250 ns |  1.170 ns |   113.09 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|            StringByRef_LPStr | Generated |            Default |                      |   107.03 ns |  1.859 ns |  1.648 ns |   106.90 ns |  0.95 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByRef_CharSetAnsi |  Built-in | Release_Forwarders |                      |   116.60 ns |  1.302 ns |  1.016 ns |   116.83 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|      StringByRef_CharSetAnsi | Generated |            Default |                      |   105.28 ns |  2.070 ns |  1.936 ns |   104.40 ns |  0.91 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|             StringByRef_Auto |  Built-in | Release_Forwarders |                      |   100.40 ns |  0.829 ns |  0.735 ns |   100.69 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|             StringByRef_Auto | Generated |            Default |                      |    90.05 ns |  1.166 ns |  1.091 ns |    89.81 ns |  0.90 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
| **StringByValue_CharSetUnicode** |  **Built-in** | **Release_Forwarders** |        **ABCdef 123$%^** |    **32.72 ns** |  **0.088 ns** |  **0.078 ns** |    **32.73 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringByValue_CharSetUnicode | Generated |            Default |        ABCdef 123$%^ |    15.73 ns |  0.336 ns |  0.425 ns |    15.50 ns |  0.48 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPWStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |    32.77 ns |  0.137 ns |  0.122 ns |    32.71 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPWStr | Generated |            Default |        ABCdef 123$%^ |    15.50 ns |  0.110 ns |  0.092 ns |    15.46 ns |  0.47 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPTStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |    33.27 ns |  0.694 ns |  0.615 ns |    33.06 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPTStr | Generated |            Default |        ABCdef 123$%^ |    15.53 ns |  0.178 ns |  0.148 ns |    15.46 ns |  0.47 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByValue_LPUTF8Str |  Built-in | Release_Forwarders |        ABCdef 123$%^ |    47.66 ns |  0.333 ns |  0.295 ns |    47.54 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|      StringByValue_LPUTF8Str | Generated |            Default |        ABCdef 123$%^ |    28.85 ns |  0.180 ns |  0.160 ns |    28.83 ns |  0.61 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringByValue_LPStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |    58.61 ns |  0.458 ns |  0.406 ns |    58.43 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringByValue_LPStr | Generated |            Default |        ABCdef 123$%^ |   109.32 ns |  1.965 ns |  1.838 ns |   109.41 ns |  1.87 |    0.04 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|    StringByValue_CharSetAnsi |  Built-in | Release_Forwarders |        ABCdef 123$%^ |    58.93 ns |  0.729 ns |  0.682 ns |    58.69 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|    StringByValue_CharSetAnsi | Generated |            Default |        ABCdef 123$%^ |   108.68 ns |  1.961 ns |  1.835 ns |   108.19 ns |  1.84 |    0.04 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByValue_Auto |  Built-in | Release_Forwarders |        ABCdef 123$%^ |    32.54 ns |  0.136 ns |  0.114 ns |    32.52 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByValue_Auto | Generated |            Default |        ABCdef 123$%^ |    17.30 ns |  0.223 ns |  0.209 ns |    17.24 ns |  0.53 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|  StringReturn_CharSetUnicode |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   140.68 ns |  1.376 ns |  1.219 ns |   140.61 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|  StringReturn_CharSetUnicode | Generated |            Default |        ABCdef 123$%^ |   102.20 ns |  1.321 ns |  1.171 ns |   102.02 ns |  0.73 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPWStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   155.63 ns |  1.485 ns |  1.317 ns |   155.78 ns |  1.00 |    0.00 | 0.0057 |     - |     - |      24 B |
|          StringReturn_LPWStr | Generated |            Default |        ABCdef 123$%^ |   103.57 ns |  2.139 ns |  2.781 ns |   103.46 ns |  0.67 |    0.02 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPTStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   153.83 ns |  0.832 ns |  0.779 ns |   153.94 ns |  1.00 |    0.00 | 0.0057 |     - |     - |      24 B |
|          StringReturn_LPTStr | Generated |            Default |        ABCdef 123$%^ |   103.86 ns |  0.946 ns |  0.790 ns |   103.68 ns |  0.68 |    0.00 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|       StringReturn_LPUTF8Str |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   176.71 ns |  1.933 ns |  1.614 ns |   176.37 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|       StringReturn_LPUTF8Str | Generated |            Default |        ABCdef 123$%^ |   134.40 ns |  0.846 ns |  0.706 ns |   134.51 ns |  0.76 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringReturn_LPStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   207.06 ns |  1.318 ns |  1.100 ns |   206.74 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|           StringReturn_LPStr | Generated |            Default |        ABCdef 123$%^ |   218.54 ns |  1.041 ns |  0.923 ns |   218.73 ns |  1.06 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|     StringReturn_CharSetAnsi |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   205.69 ns |  1.451 ns |  1.286 ns |   205.34 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|     StringReturn_CharSetAnsi | Generated |            Default |        ABCdef 123$%^ |   217.20 ns |  1.131 ns |  0.883 ns |   217.01 ns |  1.06 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringReturn_Auto |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   144.43 ns |  2.160 ns |  1.803 ns |   144.03 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|            StringReturn_Auto | Generated |            Default |        ABCdef 123$%^ |   102.13 ns |  1.026 ns |  0.801 ns |   102.05 ns |  0.71 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|   StringByRef_CharSetUnicode |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   201.24 ns |  1.774 ns |  1.572 ns |   200.76 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|   StringByRef_CharSetUnicode | Generated |            Default |        ABCdef 123$%^ |   162.40 ns |  1.128 ns |  0.942 ns |   162.01 ns |  0.81 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPWStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   125.28 ns |  0.653 ns |  0.510 ns |   125.21 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|           StringByRef_LPWStr | Generated |            Default |        ABCdef 123$%^ |   101.39 ns |  0.530 ns |  0.470 ns |   101.41 ns |  0.81 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPTStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   128.56 ns |  2.581 ns |  2.535 ns |   128.19 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|           StringByRef_LPTStr | Generated |            Default |        ABCdef 123$%^ |   102.02 ns |  1.141 ns |  1.012 ns |   101.90 ns |  0.79 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|        StringByRef_LPUTF8Str |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   161.30 ns |  1.331 ns |  1.245 ns |   161.21 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|        StringByRef_LPUTF8Str | Generated |            Default |        ABCdef 123$%^ |   134.46 ns |  0.913 ns |  0.810 ns |   134.46 ns |  0.83 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringByRef_LPStr |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   177.61 ns |  1.609 ns |  1.343 ns |   177.64 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|            StringByRef_LPStr | Generated |            Default |        ABCdef 123$%^ |   158.95 ns |  3.148 ns |  2.791 ns |   158.11 ns |  0.89 |    0.02 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByRef_CharSetAnsi |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   177.63 ns |  1.771 ns |  1.656 ns |   177.42 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|      StringByRef_CharSetAnsi | Generated |            Default |        ABCdef 123$%^ |   159.95 ns |  3.196 ns |  4.584 ns |   158.65 ns |  0.92 |    0.02 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|             StringByRef_Auto |  Built-in | Release_Forwarders |        ABCdef 123$%^ |   132.56 ns |  1.360 ns |  1.206 ns |   133.00 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|             StringByRef_Auto | Generated |            Default |        ABCdef 123$%^ |   102.56 ns |  1.109 ns |  0.866 ns |   102.67 ns |  0.77 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
| **StringByValue_CharSetUnicode** |  **Built-in** | **Release_Forwarders** |  **Lore(...)sit. [270]** |   **426.25 ns** |  **1.790 ns** |  **1.587 ns** |   **425.77 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringByValue_CharSetUnicode | Generated |            Default |  Lore(...)sit. [270] |   109.52 ns |  1.193 ns |  1.057 ns |   109.02 ns |  0.26 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPWStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   428.41 ns |  3.050 ns |  2.853 ns |   426.84 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPWStr | Generated |            Default |  Lore(...)sit. [270] |   109.94 ns |  2.192 ns |  1.943 ns |   108.99 ns |  0.26 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPTStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   429.35 ns |  3.792 ns |  3.547 ns |   428.88 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPTStr | Generated |            Default |  Lore(...)sit. [270] |   109.33 ns |  0.475 ns |  0.421 ns |   109.13 ns |  0.25 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByValue_LPUTF8Str |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   539.24 ns |  1.361 ns |  1.206 ns |   539.61 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|      StringByValue_LPUTF8Str | Generated |            Default |  Lore(...)sit. [270] |   205.61 ns |  1.164 ns |  1.032 ns |   205.48 ns |  0.38 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringByValue_LPStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   651.11 ns |  3.514 ns |  2.934 ns |   650.98 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringByValue_LPStr | Generated |            Default |  Lore(...)sit. [270] |   395.90 ns |  2.131 ns |  1.779 ns |   396.02 ns |  0.61 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|    StringByValue_CharSetAnsi |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   648.69 ns |  3.323 ns |  2.775 ns |   648.31 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|    StringByValue_CharSetAnsi | Generated |            Default |  Lore(...)sit. [270] |   400.45 ns |  3.480 ns |  3.085 ns |   399.94 ns |  0.62 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByValue_Auto |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   425.66 ns |  0.868 ns |  0.769 ns |   425.51 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByValue_Auto | Generated |            Default |  Lore(...)sit. [270] |   110.77 ns |  0.375 ns |  0.313 ns |   110.68 ns |  0.26 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|  StringReturn_CharSetUnicode |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   681.77 ns |  5.444 ns |  4.546 ns |   680.32 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|  StringReturn_CharSetUnicode | Generated |            Default |  Lore(...)sit. [270] |   313.22 ns |  1.398 ns |  1.239 ns |   312.91 ns |  0.46 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPWStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   650.63 ns |  2.592 ns |  2.023 ns |   651.05 ns |  1.00 |    0.00 | 0.0057 |     - |     - |      24 B |
|          StringReturn_LPWStr | Generated |            Default |  Lore(...)sit. [270] |   314.55 ns |  2.475 ns |  2.315 ns |   313.49 ns |  0.48 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPTStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   652.99 ns |  5.003 ns |  4.679 ns |   653.24 ns |  1.00 |    0.00 | 0.0048 |     - |     - |      24 B |
|          StringReturn_LPTStr | Generated |            Default |  Lore(...)sit. [270] |   318.59 ns |  5.668 ns |  5.301 ns |   317.33 ns |  0.49 |    0.01 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|       StringReturn_LPUTF8Str |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   905.12 ns |  7.382 ns |  6.544 ns |   903.34 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|       StringReturn_LPUTF8Str | Generated |            Default |  Lore(...)sit. [270] |   441.40 ns |  7.832 ns | 10.721 ns |   436.36 ns |  0.49 |    0.01 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringReturn_LPStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] | 1,043.80 ns | 20.019 ns | 23.832 ns | 1,032.69 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|           StringReturn_LPStr | Generated |            Default |  Lore(...)sit. [270] |   738.37 ns |  5.500 ns |  4.876 ns |   736.60 ns |  0.71 |    0.01 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|     StringReturn_CharSetAnsi |  Built-in | Release_Forwarders |  Lore(...)sit. [270] | 1,013.95 ns |  4.847 ns |  3.784 ns | 1,013.48 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|     StringReturn_CharSetAnsi | Generated |            Default |  Lore(...)sit. [270] |   739.02 ns |  3.023 ns |  2.524 ns |   738.24 ns |  0.73 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringReturn_Auto |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   667.07 ns |  2.760 ns |  2.305 ns |   666.93 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|            StringReturn_Auto | Generated |            Default |  Lore(...)sit. [270] |   320.15 ns |  2.281 ns |  2.022 ns |   319.68 ns |  0.48 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|   StringByRef_CharSetUnicode |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   738.77 ns |  3.964 ns |  3.095 ns |   737.56 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|   StringByRef_CharSetUnicode | Generated |            Default |  Lore(...)sit. [270] |   381.62 ns |  1.398 ns |  1.091 ns |   381.59 ns |  0.52 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPWStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   655.47 ns |  3.580 ns |  3.174 ns |   654.37 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|           StringByRef_LPWStr | Generated |            Default |  Lore(...)sit. [270] |   316.13 ns |  4.355 ns |  5.508 ns |   314.11 ns |  0.48 |    0.01 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPTStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   657.17 ns |  4.737 ns |  3.955 ns |   656.46 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|           StringByRef_LPTStr | Generated |            Default |  Lore(...)sit. [270] |   311.24 ns |  1.485 ns |  1.316 ns |   310.87 ns |  0.47 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|        StringByRef_LPUTF8Str |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   710.90 ns |  3.752 ns |  3.326 ns |   709.47 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|        StringByRef_LPUTF8Str | Generated |            Default |  Lore(...)sit. [270] |   361.64 ns |  2.604 ns |  2.436 ns |   361.16 ns |  0.51 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringByRef_LPStr |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   938.55 ns |  7.842 ns |  6.549 ns |   935.21 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|            StringByRef_LPStr | Generated |            Default |  Lore(...)sit. [270] |   672.85 ns |  4.569 ns |  3.815 ns |   672.03 ns |  0.72 |    0.01 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByRef_CharSetAnsi |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   938.87 ns |  1.516 ns |  1.184 ns |   938.86 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|      StringByRef_CharSetAnsi | Generated |            Default |  Lore(...)sit. [270] |   673.94 ns |  5.316 ns |  4.439 ns |   673.71 ns |  0.72 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|             StringByRef_Auto |  Built-in | Release_Forwarders |  Lore(...)sit. [270] |   657.09 ns |  2.980 ns |  2.642 ns |   656.62 ns |  1.00 |    0.00 | 0.1354 |     - |     - |     568 B |
|             StringByRef_Auto | Generated |            Default |  Lore(...)sit. [270] |   312.37 ns |  1.197 ns |  0.934 ns |   312.50 ns |  0.48 |    0.00 | 0.1354 |     - |     - |     568 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
| **StringByValue_CharSetUnicode** |  **Built-in** | **Release_Forwarders** | **🌲 木 (...) 🌊 水 [24]** |    **51.31 ns** |  **0.137 ns** |  **0.107 ns** |    **51.30 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringByValue_CharSetUnicode | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |    18.29 ns |  0.120 ns |  0.100 ns |    18.28 ns |  0.36 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPWStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |    49.95 ns |  0.224 ns |  0.210 ns |    49.88 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPWStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |    18.20 ns |  0.138 ns |  0.108 ns |    18.21 ns |  0.36 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPTStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |    49.27 ns |  0.410 ns |  0.364 ns |    49.25 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPTStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |    18.18 ns |  0.043 ns |  0.038 ns |    18.19 ns |  0.37 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByValue_LPUTF8Str |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   117.32 ns |  2.131 ns |  1.889 ns |   116.38 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|      StringByValue_LPUTF8Str | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |    61.03 ns |  1.220 ns |  1.198 ns |    60.57 ns |  0.52 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringByValue_LPStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |    80.57 ns |  1.570 ns |  1.468 ns |    79.88 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringByValue_LPStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   132.71 ns |  1.472 ns |  1.377 ns |   132.56 ns |  1.65 |    0.03 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|    StringByValue_CharSetAnsi |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |    79.93 ns |  0.484 ns |  0.453 ns |    79.84 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|    StringByValue_CharSetAnsi | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   128.29 ns |  1.809 ns |  1.412 ns |   128.40 ns |  1.60 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByValue_Auto |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |    49.63 ns |  0.164 ns |  0.128 ns |    49.60 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByValue_Auto | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |    20.21 ns |  0.293 ns |  0.498 ns |    20.02 ns |  0.42 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|  StringReturn_CharSetUnicode |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   156.55 ns |  1.250 ns |  1.108 ns |   156.44 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|  StringReturn_CharSetUnicode | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   105.89 ns |  1.119 ns |  0.935 ns |   105.52 ns |  0.68 |    0.01 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPWStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   174.34 ns |  1.287 ns |  1.204 ns |   174.10 ns |  1.00 |    0.00 | 0.0076 |     - |     - |      32 B |
|          StringReturn_LPWStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   105.46 ns |  0.584 ns |  0.456 ns |   105.55 ns |  0.60 |    0.01 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPTStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   173.49 ns |  1.377 ns |  1.220 ns |   173.94 ns |  1.00 |    0.00 | 0.0076 |     - |     - |      32 B |
|          StringReturn_LPTStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   106.17 ns |  0.553 ns |  0.517 ns |   106.21 ns |  0.61 |    0.00 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|       StringReturn_LPUTF8Str |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   283.46 ns |  2.853 ns |  2.529 ns |   282.64 ns |  1.00 |    0.00 | 0.0267 |     - |     - |     112 B |
|       StringReturn_LPUTF8Str | Generated |            Default | 🌲 木 (...) 🌊 水 [24] | 1,842.95 ns |  4.589 ns |  3.832 ns | 1,842.81 ns |  6.50 |    0.06 | 0.3109 |     - |     - |   1,304 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringReturn_LPStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   224.13 ns |  2.049 ns |  1.816 ns |   223.56 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|           StringReturn_LPStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   255.37 ns |  1.528 ns |  1.276 ns |   255.24 ns |  1.14 |    0.01 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|     StringReturn_CharSetAnsi |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   226.14 ns |  4.574 ns |  4.697 ns |   224.79 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|     StringReturn_CharSetAnsi | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   252.63 ns |  1.304 ns |  1.089 ns |   252.48 ns |  1.12 |    0.02 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringReturn_Auto |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   157.23 ns |  0.632 ns |  0.494 ns |   157.33 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|            StringReturn_Auto | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   108.37 ns |  0.825 ns |  0.689 ns |   108.16 ns |  0.69 |    0.01 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|   StringByRef_CharSetUnicode |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   222.93 ns |  1.102 ns |  1.031 ns |   222.97 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|   StringByRef_CharSetUnicode | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   169.26 ns |  1.072 ns |  0.950 ns |   169.43 ns |  0.76 |    0.00 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPWStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   156.21 ns |  1.230 ns |  1.027 ns |   155.96 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|           StringByRef_LPWStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   105.06 ns |  0.752 ns |  0.667 ns |   105.03 ns |  0.67 |    0.01 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPTStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   157.59 ns |  1.004 ns |  0.838 ns |   157.39 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|           StringByRef_LPTStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   108.12 ns |  0.429 ns |  0.358 ns |   108.19 ns |  0.69 |    0.00 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|        StringByRef_LPUTF8Str |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] | 2,047.47 ns | 39.653 ns | 54.278 ns | 2,058.68 ns |  1.00 |    0.00 | 0.3090 |     - |     - |   1,304 B |
|        StringByRef_LPUTF8Str | Generated |            Default | 🌲 木 (...) 🌊 水 [24] | 1,826.56 ns |  7.819 ns |  6.530 ns | 1,826.76 ns |  0.90 |    0.03 | 0.3109 |     - |     - |   1,304 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringByRef_LPStr |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   224.92 ns |  4.556 ns |  9.511 ns |   219.94 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|            StringByRef_LPStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   190.44 ns |  2.550 ns |  2.260 ns |   189.63 ns |  0.82 |    0.04 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByRef_CharSetAnsi |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   220.12 ns |  1.422 ns |  1.110 ns |   220.11 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|      StringByRef_CharSetAnsi | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   188.71 ns |  1.710 ns |  1.516 ns |   187.98 ns |  0.86 |    0.01 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|             StringByRef_Auto |  Built-in | Release_Forwarders | 🌲 木 (...) 🌊 水 [24] |   154.31 ns |  1.324 ns |  1.173 ns |   154.35 ns |  1.00 |    0.00 | 0.0172 |     - |     - |      72 B |
|             StringByRef_Auto | Generated |            Default | 🌲 木 (...) 🌊 水 [24] |   106.62 ns |  0.794 ns |  0.704 ns |   106.46 ns |  0.69 |    0.01 | 0.0172 |     - |     - |      72 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
| **StringByValue_CharSetUnicode** |  **Built-in** | **Release_Forwarders** |          **🍜 !! 🍜 !!** |    **29.86 ns** |  **0.301 ns** |  **0.267 ns** |    **29.75 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringByValue_CharSetUnicode | Generated |            Default |          🍜 !! 🍜 !! |    15.45 ns |  0.336 ns |  0.314 ns |    15.37 ns |  0.52 |    0.01 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPWStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |    29.80 ns |  0.195 ns |  0.163 ns |    29.73 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPWStr | Generated |            Default |          🍜 !! 🍜 !! |    14.91 ns |  0.085 ns |  0.075 ns |    14.90 ns |  0.50 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|         StringByValue_LPTStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |    29.88 ns |  0.162 ns |  0.151 ns |    29.82 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|         StringByValue_LPTStr | Generated |            Default |          🍜 !! 🍜 !! |    14.88 ns |  0.060 ns |  0.050 ns |    14.86 ns |  0.50 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByValue_LPUTF8Str |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |    58.94 ns |  0.239 ns |  0.199 ns |    58.97 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|      StringByValue_LPUTF8Str | Generated |            Default |          🍜 !! 🍜 !! |    40.11 ns |  0.210 ns |  0.186 ns |    40.13 ns |  0.68 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringByValue_LPStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |    55.80 ns |  0.837 ns |  0.783 ns |    55.52 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|          StringByValue_LPStr | Generated |            Default |          🍜 !! 🍜 !! |   112.16 ns |  1.512 ns |  1.340 ns |   112.06 ns |  2.01 |    0.03 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|    StringByValue_CharSetAnsi |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |    55.37 ns |  0.339 ns |  0.301 ns |    55.29 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|    StringByValue_CharSetAnsi | Generated |            Default |          🍜 !! 🍜 !! |   107.98 ns |  1.326 ns |  1.107 ns |   107.80 ns |  1.95 |    0.02 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByValue_Auto |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |    29.55 ns |  0.068 ns |  0.060 ns |    29.53 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|           StringByValue_Auto | Generated |            Default |          🍜 !! 🍜 !! |    16.64 ns |  0.057 ns |  0.044 ns |    16.64 ns |  0.56 |    0.00 |      - |     - |     - |         - |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|  StringReturn_CharSetUnicode |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   131.34 ns |  2.038 ns |  1.907 ns |   130.72 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|  StringReturn_CharSetUnicode | Generated |            Default |          🍜 !! 🍜 !! |    99.38 ns |  0.950 ns |  0.842 ns |    99.36 ns |  0.76 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPWStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   151.52 ns |  1.476 ns |  1.380 ns |   151.93 ns |  1.00 |    0.00 | 0.0055 |     - |     - |      24 B |
|          StringReturn_LPWStr | Generated |            Default |          🍜 !! 🍜 !! |    98.38 ns |  0.832 ns |  0.650 ns |    98.57 ns |  0.65 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|          StringReturn_LPTStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   148.77 ns |  0.814 ns |  0.680 ns |   148.80 ns |  1.00 |    0.00 | 0.0057 |     - |     - |      24 B |
|          StringReturn_LPTStr | Generated |            Default |          🍜 !! 🍜 !! |    98.45 ns |  0.652 ns |  0.509 ns |    98.56 ns |  0.66 |    0.00 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|       StringReturn_LPUTF8Str |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   197.71 ns |  1.322 ns |  1.172 ns |   198.02 ns |  1.00 |    0.00 | 0.0134 |     - |     - |      56 B |
|       StringReturn_LPUTF8Str | Generated |            Default |          🍜 !! 🍜 !! |   559.12 ns |  9.999 ns |  8.864 ns |   556.00 ns |  2.83 |    0.05 | 0.0916 |     - |     - |     384 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringReturn_LPStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   201.58 ns |  2.042 ns |  1.705 ns |   201.28 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|           StringReturn_LPStr | Generated |            Default |          🍜 !! 🍜 !! |   218.95 ns |  1.141 ns |  0.953 ns |   219.06 ns |  1.09 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|     StringReturn_CharSetAnsi |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   188.75 ns |  3.586 ns |  6.735 ns |   185.43 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|     StringReturn_CharSetAnsi | Generated |            Default |          🍜 !! 🍜 !! |   218.12 ns |  0.837 ns |  0.653 ns |   218.21 ns |  1.13 |    0.04 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringReturn_Auto |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   128.42 ns |  1.028 ns |  0.962 ns |   128.45 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|            StringReturn_Auto | Generated |            Default |          🍜 !! 🍜 !! |   101.89 ns |  1.840 ns |  1.721 ns |   101.68 ns |  0.79 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|   StringByRef_CharSetUnicode |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   199.06 ns |  0.912 ns |  0.712 ns |   199.18 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|   StringByRef_CharSetUnicode | Generated |            Default |          🍜 !! 🍜 !! |   160.83 ns |  1.266 ns |  1.184 ns |   160.62 ns |  0.81 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPWStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   123.85 ns |  2.350 ns |  2.198 ns |   123.20 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|           StringByRef_LPWStr | Generated |            Default |          🍜 !! 🍜 !! |   100.19 ns |  0.947 ns |  0.840 ns |   100.12 ns |  0.81 |    0.02 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|           StringByRef_LPTStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   122.33 ns |  1.099 ns |  0.974 ns |   122.33 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|           StringByRef_LPTStr | Generated |            Default |          🍜 !! 🍜 !! |    97.96 ns |  0.714 ns |  0.596 ns |    97.89 ns |  0.80 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|        StringByRef_LPUTF8Str |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   586.18 ns |  2.386 ns |  1.992 ns |   585.15 ns |  1.00 |    0.00 | 0.0916 |     - |     - |     384 B |
|        StringByRef_LPUTF8Str | Generated |            Default |          🍜 !! 🍜 !! |   557.66 ns |  8.529 ns |  7.561 ns |   554.38 ns |  0.95 |    0.01 | 0.0916 |     - |     - |     384 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|            StringByRef_LPStr |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   174.35 ns |  1.549 ns |  1.374 ns |   174.31 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|            StringByRef_LPStr | Generated |            Default |          🍜 !! 🍜 !! |   155.24 ns |  1.651 ns |  1.544 ns |   154.79 ns |  0.89 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|      StringByRef_CharSetAnsi |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   171.07 ns |  1.764 ns |  1.563 ns |   170.68 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|      StringByRef_CharSetAnsi | Generated |            Default |          🍜 !! 🍜 !! |   155.31 ns |  1.358 ns |  1.204 ns |   155.31 ns |  0.91 |    0.01 | 0.0114 |     - |     - |      48 B |
|                              |           |                    |                      |             |           |           |             |       |         |        |       |       |           |
|             StringByRef_Auto |  Built-in | Release_Forwarders |          🍜 !! 🍜 !! |   124.60 ns |  0.629 ns |  0.558 ns |   124.37 ns |  1.00 |    0.00 | 0.0114 |     - |     - |      48 B |
|             StringByRef_Auto | Generated |            Default |          🍜 !! 🍜 !! |    99.26 ns |  0.794 ns |  0.663 ns |    99.20 ns |  0.80 |    0.01 | 0.0114 |     - |     - |      48 B |

</details>

<summary>Updated Benchmark Runs after enabling return-type attributes (subset because a full run of this suite takes 1:30hr on my machine)</summary>
<details>

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1052 (21H1/May2021Update)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100-preview.3.21202.5
  [Host]    : .NET 6.0.0 (6.0.21.22605), X64 RyuJIT
  Built-in  : .NET 6.0.0 (6.0.21.22605), X64 RyuJIT
  Generated : .NET 6.0.0 (6.0.21.22605), X64 RyuJIT


```
|             Method |       Job | BuildConfiguration |                  str |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------- |------------------- |--------------------- |----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| **StringReturn_LPStr** |  **Built-in** | **Release_Forwarders** |                    **?** |  **17.99 ns** | **0.251 ns** | **0.210 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringReturn_LPStr | Generated |            Default |                    ? |  17.86 ns | 0.213 ns | 0.189 ns |  0.99 |    0.02 |      - |     - |     - |         - |
|                    |           |                    |                      |           |          |          |       |         |        |       |       |           |
| **StringReturn_LPStr** |  **Built-in** | **Release_Forwarders** |                     **** | **114.18 ns** | **2.257 ns** | **2.415 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringReturn_LPStr | Generated |            Default |                      | 168.66 ns | 0.729 ns | 0.646 ns |  1.48 |    0.03 |      - |     - |     - |         - |
|                    |           |                    |                      |           |          |          |       |         |        |       |       |           |
| **StringReturn_LPStr** |  **Built-in** | **Release_Forwarders** |        **ABCdef 123$%^** | **162.35 ns** | **1.483 ns** | **1.387 ns** |  **1.00** |    **0.00** | **0.0114** |     **-** |     **-** |      **48 B** |
| StringReturn_LPStr | Generated |            Default |        ABCdef 123$%^ | 229.04 ns | 2.135 ns | 1.892 ns |  1.41 |    0.02 | 0.0114 |     - |     - |      48 B |
|                    |           |                    |                      |           |          |          |       |         |        |       |       |           |
| **StringReturn_LPStr** |  **Built-in** | **Release_Forwarders** |  **Lore(...)sit. [270]** | **701.69 ns** | **9.696 ns** | **8.097 ns** |  **1.00** |    **0.00** | **0.1354** |     **-** |     **-** |     **568 B** |
| StringReturn_LPStr | Generated |            Default |  Lore(...)sit. [270] | 762.96 ns | 4.916 ns | 4.105 ns |  1.09 |    0.01 | 0.1354 |     - |     - |     568 B |
|                    |           |                    |                      |           |          |          |       |         |        |       |       |           |
| **StringReturn_LPStr** |  **Built-in** | **Release_Forwarders** | **🌲 木 (...) 🌊 水 [24]** | **184.08 ns** | **1.512 ns** | **1.340 ns** |  **1.00** |    **0.00** | **0.0172** |     **-** |     **-** |      **72 B** |
| StringReturn_LPStr | Generated |            Default | 🌲 木 (...) 🌊 水 [24] | 264.70 ns | 2.260 ns | 2.114 ns |  1.44 |    0.02 | 0.0172 |     - |     - |      72 B |
|                    |           |                    |                      |           |          |          |       |         |        |       |       |           |
| **StringReturn_LPStr** |  **Built-in** | **Release_Forwarders** |          **🍜 !! 🍜 !!** | **160.69 ns** | **1.583 ns** | **1.480 ns** |  **1.00** |    **0.00** | **0.0114** |     **-** |     **-** |      **48 B** |
| StringReturn_LPStr | Generated |            Default |          🍜 !! 🍜 !! | 228.92 ns | 2.381 ns | 1.988 ns |  1.42 |    0.02 | 0.0114 |     - |     - |      48 B |
| **StringReturn_LPUTF8Str** |  **Built-in** | **Release_Forwarders** |                    **?** |    **18.71 ns** |  **0.446 ns** |  **0.438 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringReturn_LPUTF8Str | Generated |            Default |                    ? |    17.87 ns |  0.221 ns |  0.207 ns |  0.96 |    0.02 |      - |     - |     - |         - |
|                        |           |                    |                      |             |           |           |       |         |        |       |       |           |
| **StringReturn_LPUTF8Str** |  **Built-in** | **Release_Forwarders** |                     **** |   **112.32 ns** |  **2.220 ns** |  **2.726 ns** |  **1.00** |    **0.00** |      **-** |     **-** |     **-** |         **-** |
| StringReturn_LPUTF8Str | Generated |            Default |                      |   114.44 ns |  2.180 ns |  3.330 ns |  1.02 |    0.04 |      - |     - |     - |         - |
|                        |           |                    |                      |             |           |           |       |         |        |       |       |           |
| **StringReturn_LPUTF8Str** |  **Built-in** | **Release_Forwarders** |        **ABCdef 123$%^** |   **143.06 ns** |  **2.809 ns** |  **6.676 ns** |  **1.00** |    **0.00** | **0.0114** |     **-** |     **-** |      **48 B** |
| StringReturn_LPUTF8Str | Generated |            Default |        ABCdef 123$%^ |   144.05 ns |  2.911 ns |  5.098 ns |  0.99 |    0.07 | 0.0114 |     - |     - |      48 B |
|                        |           |                    |                      |             |           |           |       |         |        |       |       |           |
| **StringReturn_LPUTF8Str** |  **Built-in** | **Release_Forwarders** |  **Lore(...)sit. [270]** |   **485.83 ns** |  **9.594 ns** | **11.782 ns** |  **1.00** |    **0.00** | **0.1354** |     **-** |     **-** |     **568 B** |
| StringReturn_LPUTF8Str | Generated |            Default |  Lore(...)sit. [270] |   456.03 ns |  8.464 ns | 15.477 ns |  0.95 |    0.05 | 0.1354 |     - |     - |     568 B |
|                        |           |                    |                      |             |           |           |       |         |        |       |       |           |
| **StringReturn_LPUTF8Str** |  **Built-in** | **Release_Forwarders** | **🌲 木 (...) 🌊 水 [24]** | **1,880.79 ns** | **32.725 ns** | **30.611 ns** |  **1.00** |    **0.00** | **0.3109** |     **-** |     **-** |   **1,304 B** |
| StringReturn_LPUTF8Str | Generated |            Default | 🌲 木 (...) 🌊 水 [24] | 1,898.60 ns | 26.531 ns | 23.519 ns |  1.01 |    0.02 | 0.3109 |     - |     - |   1,304 B |
|                        |           |                    |                      |             |           |           |       |         |        |       |       |           |
| **StringReturn_LPUTF8Str** |  **Built-in** | **Release_Forwarders** |          **🍜 !! 🍜 !!** |   **554.92 ns** |  **8.543 ns** |  **7.991 ns** |  **1.00** |    **0.00** | **0.0916** |     **-** |     **-** |     **384 B** |
| StringReturn_LPUTF8Str | Generated |            Default |          🍜 !! 🍜 !! |   566.60 ns |  8.271 ns |  6.907 ns |  1.02 |    0.02 | 0.0916 |     - |     - |     384 B |

</details>