### PR TITLE
RuntimeType devirtualization when using different reflection stack

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -102,7 +102,8 @@ The .NET Foundation licenses this file to you under the MIT license.
   </ItemGroup>
 
   <ItemGroup>
-    <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" />
+    <_ExcludedPrivateSdkAssemblies Include="$(IlcPath)\sdk\System.Private.Reflection.Core.dll" Condition="$(IlcDisableReflection) == 'true'" />
+    <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" Exclude="@(_ExcludedPrivateSdkAssemblies)"/>
 
     <!-- Exclude System.IO.Compression.Native.dll -->
     <FrameworkAssemblies Include="$(IlcPath)\framework\*.dll" Exclude="$(IlcPath)\framework\*.Native.dll" />
@@ -136,7 +137,8 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <!-- If running from a package these values need to be set again with the resolved IlcPath -->
     <ItemGroup>
-      <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" />
+      <_ExcludedPrivateSdkAssemblies Include="$(IlcPath)\sdk\System.Private.Reflection.Core.dll" Condition="$(IlcDisableReflection) == 'true'" />
+      <PrivateSdkAssemblies Include="$(IlcPath)\sdk\*.dll" Exclude="@(_ExcludedPrivateSdkAssemblies)"/>
 
       <!-- Exclude System.IO.Compression.Native.dll -->
       <FrameworkAssemblies Include="$(IlcPath)\framework\*.dll" Exclude="$(IlcPath)\framework\*.Native.dll" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -406,7 +406,7 @@ namespace ILCompiler
                 return reflectionCoreModule.GetKnownType("System.Reflection.Runtime.TypeInfos", "RuntimeTypeInfo");
             }
 
-            return null;
+            return TypeSystemContext.SystemModule.GetKnownType("System", "Type");
         }
 
         public bool IsFatPointerCandidate(MethodDesc containingMethod, MethodSignature signature)


### PR DESCRIPTION
* Don't pass reference to System.Private.Reflectin.Core when reflection is disabled
* Give System.Type to RyuJIT (RyuJIT asserts if we give back null). This should be fine since RyuJIT has to assume inexact type.