### PR TITLE
NativeAOT-LLVM: For GT_IND, cast the address, not the result of the load.

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -447,7 +447,7 @@ Value* buildCnsInt(llvm::IRBuilder<>& builder, GenTree* node)
 
 Value* buildInd(llvm::IRBuilder<>& builder, GenTree* node, Value* ptr)
 {
-    return mapTreeIdValue(node->gtTreeID, castIfNecessary(builder, builder.CreateLoad(ptr), getLLVMTypeForVarType(node->TypeGet())));
+    return mapTreeIdValue(node->gtTreeID, builder.CreateLoad(castIfNecessary(builder, ptr, getLLVMTypeForVarType(node->TypeGet())->getPointerTo())));
 }
 
 Value* buildNe(llvm::IRBuilder<>& builder, GenTree* node, Value* op1, Value* op2)


### PR DESCRIPTION
This PR fixes an issue with GT_IND where the resulting type was incorrect due to misplacement of the bitcast.  Pointers were getting loaded into i8 instead of i8*.