### PR TITLE
NativeAOT-LLVM: add null terminator to name strings for c++

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -75,9 +75,9 @@ namespace Internal.JitInterface
             node.AppendMangledName(_this._compilation.NameMangler, sb);
             if (node is FrozenStringNode)
             {
-                sb.Append("___SYMBOL");
+                sb.Append("___SYMBOL\0");
             }
-            return (byte*)_this.GetPin(AppendNullByte(sb.UnderlyingArray));
+            return (byte*)_this.GetPin(sb.UnderlyingArray);
         }
 
         [UnmanagedCallersOnly]

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -46,6 +46,15 @@ namespace Internal.JitInterface
             }
         }
 
+        // so the char* in cpp is terminated
+        private static byte[] AppendNullByte(byte[] inputArray)
+        {
+            byte[] nullTerminated = new byte[inputArray.Length + 1];
+            inputArray.CopyTo(nullTerminated, 0);
+            nullTerminated[inputArray.Length] = 0;
+            return nullTerminated;
+        }
+
         [UnmanagedCallersOnly]
         public static byte* getMangledMethodName(IntPtr thisHandle, CORINFO_METHOD_STRUCT_* ftn)
         {
@@ -53,7 +62,7 @@ namespace Internal.JitInterface
 
             MethodDesc method = _this.HandleToObject(ftn);
 
-            return (byte*)_this.GetPin(_this._compilation.NameMangler.GetMangledMethodName(method).UnderlyingArray);
+            return (byte*)_this.GetPin(AppendNullByte(_this._compilation.NameMangler.GetMangledMethodName(method).UnderlyingArray));
         }
 
         [UnmanagedCallersOnly]
@@ -68,7 +77,7 @@ namespace Internal.JitInterface
             {
                 sb.Append("___SYMBOL");
             }
-            return (byte*)_this.GetPin(sb.UnderlyingArray);
+            return (byte*)_this.GetPin(AppendNullByte(sb.UnderlyingArray));
         }
 
         [UnmanagedCallersOnly]

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -75,8 +75,10 @@ namespace Internal.JitInterface
             node.AppendMangledName(_this._compilation.NameMangler, sb);
             if (node is FrozenStringNode)
             {
-                sb.Append("___SYMBOL\0");
+                sb.Append("___SYMBOL");
             }
+            
+            sb.Append("\0");
             return (byte*)_this.GetPin(sb.UnderlyingArray);
         }
 


### PR DESCRIPTION
This PR fixes an issue passing byte arrays from managed to c++ where the array is interpreted as a string and was not previously null terminated.