### PR TITLE
Optimize out full EEType in the scanner if they're used for comparison

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Augments/ReflectionAugments.cs
@@ -91,7 +91,7 @@ namespace Internal.Reflection.Augments
             if (type == typeof(decimal))
                 return TypeCode.Decimal;
 
-            if (eeType == DBNull.Value.EETypePtr)
+            if (type == typeof(DBNull))
                 return TypeCode.DBNull;
 
             return TypeCode.Object;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
@@ -28,15 +28,12 @@ namespace ILCompiler
         private readonly Dictionary<FieldDesc, MetadataCategory> _reflectableFields = new Dictionary<FieldDesc, MetadataCategory>();
         private readonly HashSet<ReflectableCustomAttribute> _reflectableAttributes = new HashSet<ReflectableCustomAttribute>();
 
-        private readonly HashSet<TypeDesc> _ldtokenReferenceableTypes;
-
         public AnalysisBasedMetadataManager(CompilerTypeSystemContext typeSystemContext)
             : this(typeSystemContext, new FullyBlockedMetadataBlockingPolicy(),
                 new FullyBlockedManifestResourceBlockingPolicy(), null, new NoStackTraceEmissionPolicy(),
                 new NoDynamicInvokeThunkGenerationPolicy(), Array.Empty<ModuleDesc>(),
                 Array.Empty<ReflectableEntity<TypeDesc>>(), Array.Empty<ReflectableEntity<MethodDesc>>(),
-                Array.Empty<ReflectableEntity<FieldDesc>>(), Array.Empty<ReflectableCustomAttribute>(),
-                Array.Empty<TypeDesc>())
+                Array.Empty<ReflectableEntity<FieldDesc>>(), Array.Empty<ReflectableCustomAttribute>())
         {
         }
 
@@ -51,8 +48,7 @@ namespace ILCompiler
             IEnumerable<ReflectableEntity<TypeDesc>> reflectableTypes,
             IEnumerable<ReflectableEntity<MethodDesc>> reflectableMethods,
             IEnumerable<ReflectableEntity<FieldDesc>> reflectableFields,
-            IEnumerable<ReflectableCustomAttribute> reflectableAttributes,
-            IEnumerable<TypeDesc> ldtokenReferenceableTypes)
+            IEnumerable<ReflectableCustomAttribute> reflectableAttributes)
             : base(typeSystemContext, blockingPolicy, resourceBlockingPolicy, logFile, stackTracePolicy, invokeThunkGenerationPolicy)
         {
             _modulesWithMetadata = new List<ModuleDesc>(modulesWithMetadata);
@@ -88,8 +84,6 @@ namespace ILCompiler
             {
                 _reflectableAttributes.Add(refAttribute);
             }
-
-            _ldtokenReferenceableTypes = new HashSet<TypeDesc>(ldtokenReferenceableTypes);
 
 #if DEBUG
             HashSet<ModuleDesc> moduleHash = new HashSet<ModuleDesc>(_modulesWithMetadata);
@@ -127,11 +121,6 @@ namespace ILCompiler
         public override IEnumerable<ModuleDesc> GetCompilationModulesWithMetadata()
         {
             return _modulesWithMetadata;
-        }
-
-        public override bool ShouldConsiderLdTokenReferenceAConstruction(TypeDesc type)
-        {
-            return _ldtokenReferenceableTypes.Contains(type);
         }
 
         protected override void ComputeMetadata(NodeFactory factory,

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -245,7 +245,8 @@ namespace ILCompiler
 
         public ReadyToRunHelperId GetLdTokenHelperForType(TypeDesc type)
         {
-            return _nodeFactory.MetadataManager.ShouldConsiderLdTokenReferenceAConstruction(type)
+            bool canConstructPerWholeProgramAnalysis = _devirtualizationManager == null ? true : _devirtualizationManager.CanConstructType(type);
+            return canConstructPerWholeProgramAnalysis & DependencyAnalysis.ConstructedEETypeNode.CreationAllowed(type)
                 ? ReadyToRunHelperId.TypeHandle
                 : ReadyToRunHelperId.NecessaryTypeHandle;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -538,8 +538,6 @@ namespace ILCompiler
             ComputeMetadata(factory, out _metadataBlob, out _typeMappings, out _methodMappings, out _fieldMappings, out _stackTraceMappings);
         }
 
-        public abstract bool ShouldConsiderLdTokenReferenceAConstruction(TypeDesc type);
-
         void ICompilationRootProvider.AddCompilationRoots(IRootingServiceProvider rootProvider)
         {
             // MetadataManagers can override this to provide metadata compilation roots that need to be added to the graph ahead of time.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -387,24 +387,6 @@ namespace ILCompiler
             dependencies.Add(factory.ReflectableMethod(method), "LDTOKEN method");
         }
 
-        public override bool ShouldConsiderLdTokenReferenceAConstruction(TypeDesc type)
-        {
-            // TODO: this can be further optimized
-            //
-            // Codegen will consult metadata manager on this whenever it sees LDTOKEN of some type.
-            // We could report false here if we had guarantees some other code (e.g. GetDependenciesDueToMethodCodePresenceInternal)
-            // is going to look at this again and create a constructed type dependendency if it's what's necessary
-            // (don't forget that "necessary" and "constructed" EETypes get coalesced into a single constructed EEType
-            // if there's at least one constructed EEType for this type in the graph, so telling codegen to just grab
-            // a necessary EEType doesn't hurt anything.
-            //
-            // The advantage of reporting false and trying to narrow this down is in being able to eliminate
-            // constructed EETypes for patterns like "if (typeof(T) == typeof(Foo))". The typecheck
-            // doesn't need a constructed EEType with a full vtable - we can get away with a stripped down
-            // EEType that has a lot less dependencies (the virtual methods are not generated).
-            return ConstructedEETypeNode.CreationAllowed(type);
-        }
-
         protected override void GetDependenciesDueToMethodCodePresenceInternal(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)
         {
             bool scanReflection = (_generationOptions & UsageBasedMetadataGenerationOptions.ReflectionILScanning) != 0;
@@ -748,7 +730,7 @@ namespace ILCompiler
             return new AnalysisBasedMetadataManager(
                 _typeSystemContext, _blockingPolicy, _resourceBlockingPolicy, _metadataLogFile, _stackTraceEmissionPolicy, _dynamicInvokeThunkGenerationPolicy,
                 _modulesWithMetadata, reflectableTypes.ToEnumerable(), reflectableMethods.ToEnumerable(),
-                reflectableFields.ToEnumerable(), _customAttributesWithMetadata, GetTypesWithConstructedEETypes());
+                reflectableFields.ToEnumerable(), _customAttributesWithMetadata);
         }
 
         private struct ReflectableEntityBuilder<T>


### PR DESCRIPTION
* If a result of a typeof is fed to Type::Equals, ask for a "necessary" EEType as opposed to a "constructed" EEType in the scanner. Necessary EEType doesn't have a vtable and if nothing else asks for a full EEType, we just saved some space.
* Give answers based on whole program view to RyuJIT during compilation phase.