### PR TITLE
Use NetCoreAppToolCurrent for ilc

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,7 +90,7 @@
     <SystemMemoryVersion>4.5.4</SystemMemoryVersion>
     <SystemNetPrimitivesVersion>4.3.1</SystemNetPrimitivesVersion>
     <SystemNumericsVectorsVersion>4.5.0</SystemNumericsVectorsVersion>
-    <SystemReflectionMetadataVersion>6.0.0-preview.4.21174.13</SystemReflectionMetadataVersion>
+    <SystemReflectionMetadataVersion>5.0.0</SystemReflectionMetadataVersion>
     <SystemReflectionEmitVersion>4.7.0</SystemReflectionEmitVersion>
     <SystemReflectionEmitILGenerationVersion>4.7.0</SystemReflectionEmitILGenerationVersion>
     <SystemReflectionEmitLightweightVersion>4.7.0</SystemReflectionEmitLightweightVersion>

--- a/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
@@ -245,20 +245,14 @@ namespace Internal.TypeSystem
             if (sentinel == null)
                 return null;
 
-            TValue value = Volatile.Read(ref hashtable[tableIndex]);
+            var sw = new SpinWait();
             while (true)
             {
-                for (int i = 0; (i < 10000) && value == sentinel; i++)
-                {
-                    value = Volatile.Read(ref hashtable[tableIndex]);
-                }
+                TValue value = Volatile.Read(ref hashtable[tableIndex]);
                 if (value != sentinel)
-                    break;
-
-                Task.Delay(1).Wait();
+                    return value;
+                sw.SpinOnce();
             }
-
-            return value;
         }
 
         /// <summary>

--- a/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtableOfPointers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtableOfPointers.cs
@@ -213,20 +213,14 @@ namespace Internal.TypeSystem
         /// <returns>The value that replaced the sentinel, or null</returns>
         IntPtr WaitForSentinelInHashtableToDisappear(IntPtr[] hashtable, int tableIndex)
         {
-            IntPtr value = Volatile.Read(ref hashtable[tableIndex]);
+            var sw = new SpinWait();
             while (true)
             {
-                for (int i = 0; (i < 10000) && value == new IntPtr(1); i++)
-                {
-                    value = Volatile.Read(ref hashtable[tableIndex]);
-                }
+                IntPtr value = Volatile.Read(ref hashtable[tableIndex]);
                 if (value != new IntPtr(1))
-                    break;
-
-                Task.Delay(1).Wait();
+                    return value;
+                sw.SpinOnce();
             }
-
-            return value;
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>ilc</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <NoWarn>8002,NU1701</NoWarn>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
- Allows us to dogfood .NET 6, crossgen2 is on the same plan
- Undo custom System.Reflection.Metadata version that is no longer needed