### PR TITLE
Forward special P/Invoke attributes to the target DllImport method

### DIFF
--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/CallingConventionTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/CallingConventionTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace DllImportGenerator.IntegrationTests
 {
@@ -23,5 +24,22 @@ namespace DllImportGenerator.IntegrationTests
 
     public class CallingConventionTests
     {
+        [Fact]
+        public void UnmanagedCallConvPropagated()
+        {
+            Random rng = new Random(1234);
+            long i = rng.Next();
+            long j = rng.Next();
+            long k = rng.Next();
+            long l = rng.Next();
+            long m = rng.Next();
+            long n = rng.Next();
+            long o = rng.Next();
+            long p = rng.Next();
+            long q = rng.Next();
+            long expected = i + j + k + l + m + n + o + p + q;
+            Assert.Equal(expected, NativeExportsNE.CallingConventions.AddLongsCdecl(i, j, k, l, m, n, o, p, q));
+            Assert.Equal(expected, NativeExportsNE.CallingConventions.AddLongsStdcall(i, j, k, l, m, n, o, p, q));
+        }
     }
 }

--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/CallingConventionTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/CallingConventionTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DllImportGenerator.IntegrationTests
+{
+    internal partial class NativeExportsNE
+    {
+        internal partial class CallingConventions
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary)]
+            [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
+            public static partial long AddLongsCdecl(long i, long j, long k, long l, long m, long n, long o, long p, long q);
+            [GeneratedDllImport(NativeExportsNE_Binary)]
+            [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvStdcall) })]
+            public static partial long AddLongsStdcall(long i, long j, long k, long l, long m, long n, long o, long p, long q);
+        }
+    }
+
+    public class CallingConventionTests
+    {
+    }
+}

--- a/DllImportGenerator/DllImportGenerator.IntegrationTests/CallingConventionTests.cs
+++ b/DllImportGenerator/DllImportGenerator.IntegrationTests/CallingConventionTests.cs
@@ -13,10 +13,10 @@ namespace DllImportGenerator.IntegrationTests
     {
         internal partial class CallingConventions
         {
-            [GeneratedDllImport(NativeExportsNE_Binary)]
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "add_integers_cdecl")]
             [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvCdecl) })]
             public static partial long AddLongsCdecl(long i, long j, long k, long l, long m, long n, long o, long p, long q);
-            [GeneratedDllImport(NativeExportsNE_Binary)]
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "add_integers_stdcall")]
             [UnmanagedCallConv(CallConvs = new[] { typeof(CallConvStdcall) })]
             public static partial long AddLongsStdcall(long i, long j, long k, long l, long m, long n, long o, long p, long q);
         }

--- a/DllImportGenerator/DllImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/AttributeForwarding.cs
@@ -77,7 +77,6 @@ partial class C
         public async Task UnmanagedCallConvAttribute_SingleCallConvType()
         {
             string source = @"
-using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 partial class C
@@ -114,7 +113,6 @@ partial class C
         public async Task UnmanagedCallConvAttribute_MultipleCallConvTypes()
         {
             string source = @"
-using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 partial class C

--- a/DllImportGenerator/DllImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/AttributeForwarding.cs
@@ -1,0 +1,194 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DllImportGenerator.UnitTests
+{
+    public class AttributeForwarding
+    {
+        [Theory]
+        [InlineData("SuppressGCTransition", "System.Runtime.InteropServices.SuppressGCTransitionAttribute")]
+        [InlineData("UnmanagedCallConv", "System.Runtime.InteropServices.UnmanagedCallConvAttribute")]
+        public async Task KnownParameterlessAttribute(string attributeSourceName, string attributeMetadataName)
+        {
+            string source = @$"
+using System.Runtime.InteropServices;
+partial class C
+{{
+    [{attributeSourceName}]
+    [GeneratedDllImportAttribute(""DoesNotExist"")]
+    public static partial void Method1();
+}}
+";
+            Compilation origComp = await TestUtils.CreateCompilation(source);
+            Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+
+            ITypeSymbol attributeType = newComp.GetTypeByMetadataName(attributeMetadataName)!;
+
+            Assert.NotNull(attributeType);
+
+            // The last syntax tree is the generated code
+            IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
+
+            Assert.Contains(
+                targetMethod.GetAttributes(),
+                attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType));
+        }
+
+        [Fact]
+        public async Task UnmanagedCallConvAttribute_EmptyCallConvArray()
+        {
+            string source = @"
+using System;
+using System.Runtime.InteropServices;
+partial class C
+{
+    [UnmanagedCallConv(CallConvs = new Type[0])]
+    [GeneratedDllImportAttribute(""DoesNotExist"")]
+    public static partial void Method1();
+}
+";
+            Compilation origComp = await TestUtils.CreateCompilation(source);
+            Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+
+            ITypeSymbol attributeType = newComp.GetTypeByMetadataName("System.Runtime.InteropServices.UnmanagedCallConvAttribute")!;
+
+            Assert.NotNull(attributeType);
+
+            // The last syntax tree is the generated code
+            IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
+
+            Assert.Contains(
+                targetMethod.GetAttributes(),
+                attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType)
+                    && attr.NamedArguments.Length == 1
+                    && attr.NamedArguments[0].Key == "CallConvs"
+                    && attr.NamedArguments[0].Value.Values.Length == 0);
+        }
+
+        [Fact]
+        public async Task UnmanagedCallConvAttribute_SingleCallConvType()
+        {
+            string source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+partial class C
+{
+    [UnmanagedCallConv(CallConvs = new[]{typeof(CallConvStdcall)})]
+    [GeneratedDllImportAttribute(""DoesNotExist"")]
+    public static partial void Method1();
+}
+";
+            Compilation origComp = await TestUtils.CreateCompilation(source);
+            Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+
+            ITypeSymbol attributeType = newComp.GetTypeByMetadataName("System.Runtime.InteropServices.UnmanagedCallConvAttribute")!;
+            ITypeSymbol callConvType = newComp.GetTypeByMetadataName("System.Runtime.CompilerServices.CallConvStdcall")!;
+
+            Assert.NotNull(attributeType);
+
+            // The last syntax tree is the generated code
+            IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
+
+            Assert.Contains(
+                targetMethod.GetAttributes(),
+                attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType)
+                    && attr.NamedArguments.Length == 1
+                    && attr.NamedArguments[0].Key == "CallConvs"
+                    && attr.NamedArguments[0].Value.Values.Length == 1
+                    && SymbolEqualityComparer.Default.Equals(
+                        (INamedTypeSymbol?)attr.NamedArguments[0].Value.Values[0].Value!,
+                        callConvType));
+        }
+
+        [Fact]
+        public async Task UnmanagedCallConvAttribute_MultipleCallConvTypes()
+        {
+            string source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+partial class C
+{
+    [UnmanagedCallConv(CallConvs = new[]{typeof(CallConvStdcall), typeof(CallConvSuppressGCTransition)})]
+    [GeneratedDllImportAttribute(""DoesNotExist"")]
+    public static partial void Method1();
+}
+";
+            Compilation origComp = await TestUtils.CreateCompilation(source);
+            Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+
+            ITypeSymbol attributeType = newComp.GetTypeByMetadataName("System.Runtime.InteropServices.UnmanagedCallConvAttribute")!;
+            ITypeSymbol callConvType = newComp.GetTypeByMetadataName("System.Runtime.CompilerServices.CallConvStdcall")!;
+            ITypeSymbol callConvType2 = newComp.GetTypeByMetadataName("System.Runtime.CompilerServices.CallConvSuppressGCTransition")!;
+
+            Assert.NotNull(attributeType);
+
+            // The last syntax tree is the generated code
+            IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
+
+            Assert.Contains(
+                targetMethod.GetAttributes(),
+                attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType)
+                    && attr.NamedArguments.Length == 1
+                    && attr.NamedArguments[0].Key == "CallConvs"
+                    && attr.NamedArguments[0].Value.Values.Length == 2
+                    && SymbolEqualityComparer.Default.Equals(
+                        (INamedTypeSymbol?)attr.NamedArguments[0].Value.Values[0].Value!,
+                        callConvType)
+                    && SymbolEqualityComparer.Default.Equals(
+                        (INamedTypeSymbol?)attr.NamedArguments[0].Value.Values[1].Value!,
+                        callConvType2));
+        }
+
+        [Fact]
+        public async Task OtherAttributeType()
+        {
+            string source = @"
+using System;
+using System.Runtime.InteropServices;
+
+class OtherAttribute : Attribute {}
+
+partial class C
+{
+    [Other]
+    [GeneratedDllImportAttribute(""DoesNotExist"")]
+    public static partial void Method1();
+}
+";
+            Compilation origComp = await TestUtils.CreateCompilation(source);
+            Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+
+            ITypeSymbol attributeType = newComp.GetTypeByMetadataName("OtherAttribute")!;
+
+            Assert.NotNull(attributeType);
+
+            // The last syntax tree is the generated code
+            IMethodSymbol targetMethod = GetGeneratedPInvokeTargetFromCompilation(newComp);
+
+            Assert.DoesNotContain(
+                targetMethod.GetAttributes(),
+                attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType));
+        }
+
+        private static IMethodSymbol GetGeneratedPInvokeTargetFromCompilation(Compilation newComp)
+        {
+            SyntaxTree generatedCode = newComp.SyntaxTrees.Last();
+            SemanticModel model = newComp.GetSemanticModel(generatedCode);
+
+            var localFunctions = generatedCode.GetRoot()
+                .DescendantNodes().OfType<LocalFunctionStatementSyntax>()
+                .ToList();
+            Assert.Single(localFunctions);
+            IMethodSymbol targetMethod = (IMethodSymbol)model.GetDeclaredSymbol(localFunctions[0])!;
+            return targetMethod;
+        }
+    }
+}

--- a/DllImportGenerator/DllImportGenerator.UnitTests/AttributeForwarding.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/AttributeForwarding.cs
@@ -27,6 +27,7 @@ partial class C
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+            Assert.Empty(newComp.GetDiagnostics());
 
             ITypeSymbol attributeType = newComp.GetTypeByMetadataName(attributeMetadataName)!;
 
@@ -55,6 +56,7 @@ partial class C
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+            Assert.Empty(newComp.GetDiagnostics());
 
             ITypeSymbol attributeType = newComp.GetTypeByMetadataName("System.Runtime.InteropServices.UnmanagedCallConvAttribute")!;
 
@@ -87,6 +89,7 @@ partial class C
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+            Assert.Empty(newComp.GetDiagnostics());
 
             ITypeSymbol attributeType = newComp.GetTypeByMetadataName("System.Runtime.InteropServices.UnmanagedCallConvAttribute")!;
             ITypeSymbol callConvType = newComp.GetTypeByMetadataName("System.Runtime.CompilerServices.CallConvStdcall")!;
@@ -123,6 +126,7 @@ partial class C
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+            Assert.Empty(newComp.GetDiagnostics());
 
             ITypeSymbol attributeType = newComp.GetTypeByMetadataName("System.Runtime.InteropServices.UnmanagedCallConvAttribute")!;
             ITypeSymbol callConvType = newComp.GetTypeByMetadataName("System.Runtime.CompilerServices.CallConvStdcall")!;
@@ -165,6 +169,8 @@ partial class C
 ";
             Compilation origComp = await TestUtils.CreateCompilation(source);
             Compilation newComp = TestUtils.RunGenerators(origComp, out _, new Microsoft.Interop.DllImportGenerator());
+
+            Assert.Empty(newComp.GetDiagnostics());
 
             ITypeSymbol attributeType = newComp.GetTypeByMetadataName("OtherAttribute")!;
 

--- a/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
@@ -95,7 +95,7 @@ namespace DllImportGenerator.UnitTests
                     "net6.0",
                     new PackageIdentity(
                         "Microsoft.NETCore.App.Ref",
-                        "6.0.0-preview.5.21226.5"),
+                        "6.0.0-preview.6.21317.4"),
                     Path.Combine("ref", "net6.0"));
 
             // Include the assembly containing the new attribute and all of its references.

--- a/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Interop
                     generatorDiagnostics.ReportConfigurationNotSupported(lcidConversionAttr, nameof(TypeNames.LCIDConversionAttribute));
                 }
 
+                // TODO: These need to be propagaged to the P/Invoke target, which is this does not do correctly.
                 List<AttributeSyntax> additionalAttributes = GenerateSyntaxForForwardedAttributes(suppressGCTransitionAttribute, unmanagedCallConvAttribute);
 
                 // Create the stub.

--- a/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
@@ -32,6 +32,10 @@ namespace Microsoft.Interop
 
             INamedTypeSymbol? lcidConversionAttrType = context.Compilation.GetTypeByMetadataName(TypeNames.LCIDConversionAttribute);
 
+            INamedTypeSymbol? suppressGCTransitionAttrType = context.Compilation.GetTypeByMetadataName(TypeNames.SuppressGCTransitionAttribute);
+
+            INamedTypeSymbol? unmanagedCallConvAttrType = context.Compilation.GetTypeByMetadataName(TypeNames.UnmanagedCallConvAttribute);
+
             // Fire the start/stop pair for source generation
             using var _ = Diagnostics.Events.SourceGenerationStartStop(synRec.Methods.Count);
 
@@ -76,16 +80,30 @@ namespace Microsoft.Interop
                 // Get any attributes of interest on the method
                 AttributeData? generatedDllImportAttr = null;
                 AttributeData? lcidConversionAttr = null;
+                AttributeData? suppressGCTransitionAttribute = null;
+                AttributeData? unmanagedCallConvAttribute = null;
+
                 foreach (var attr in methodSymbolInfo.GetAttributes())
                 {
-                    if (attr.AttributeClass is not null
-                        && attr.AttributeClass.ToDisplayString() == TypeNames.GeneratedDllImportAttribute)
+                    if (attr.AttributeClass is null)
+                    {
+                        continue;
+                    }
+                    else if (attr.AttributeClass.ToDisplayString() == TypeNames.GeneratedDllImportAttribute)
                     {
                         generatedDllImportAttr = attr;
                     }
-                    else if (lcidConversionAttrType != null && SymbolEqualityComparer.Default.Equals(attr.AttributeClass, lcidConversionAttrType))
+                    else if (lcidConversionAttrType is not null && SymbolEqualityComparer.Default.Equals(attr.AttributeClass, lcidConversionAttrType))
                     {
                         lcidConversionAttr = attr;
+                    }
+                    else if (suppressGCTransitionAttrType is not null && SymbolEqualityComparer.Default.Equals(attr.AttributeClass, suppressGCTransitionAttrType))
+                    {
+                        suppressGCTransitionAttribute = attr;
+                    }
+                    else if (unmanagedCallConvAttrType is not null && SymbolEqualityComparer.Default.Equals(attr.AttributeClass, unmanagedCallConvAttrType))
+                    {
+                        unmanagedCallConvAttribute = attr;
                     }
                 }
 
@@ -112,8 +130,10 @@ namespace Microsoft.Interop
                     generatorDiagnostics.ReportConfigurationNotSupported(lcidConversionAttr, nameof(TypeNames.LCIDConversionAttribute));
                 }
 
+                List<AttributeSyntax> additionalAttributes = GenerateSyntaxForForwardedAttributes(suppressGCTransitionAttribute, unmanagedCallConvAttribute);
+
                 // Create the stub.
-                var dllImportStub = DllImportStub.Create(methodSymbolInfo, stubDllImportData!, env, generatorDiagnostics, context.CancellationToken);
+                var dllImportStub = DllImportStub.Create(methodSymbolInfo, stubDllImportData!, env, generatorDiagnostics, additionalAttributes, context.CancellationToken);
 
                 PrintGeneratedSource(generatedDllImports, methodSyntax, dllImportStub);
             }
@@ -125,6 +145,36 @@ namespace Microsoft.Interop
         public void Initialize(GeneratorInitializationContext context)
         {
             context.RegisterForSyntaxNotifications(() => new SyntaxContextReceiver());
+        }
+
+        private List<AttributeSyntax> GenerateSyntaxForForwardedAttributes(AttributeData? suppressGCTransitionAttribute, AttributeData? unmanagedCallConvAttribute)
+        {
+            // Manually rehydrate the forwarded attributes with fully qualified types so we don't have to worry about any using directives.
+            List<AttributeSyntax> attributes = new List<AttributeSyntax>();
+
+            if (suppressGCTransitionAttribute is not null)
+            {
+                attributes.Add(Attribute(ParseName(TypeNames.SuppressGCTransitionAttribute)));
+            }
+            if (unmanagedCallConvAttribute is not null)
+            {
+                AttributeSyntax unmanagedCallConvSyntax = Attribute(ParseName(TypeNames.UnmanagedCallConvAttribute));
+                foreach (var arg in unmanagedCallConvAttribute.NamedArguments)
+                {
+                    if (arg.Key == "CallConvs")
+                    {
+                        InitializerExpressionSyntax callConvs = InitializerExpression(SyntaxKind.ArrayInitializerExpression);
+                        foreach (var callConv in arg.Value.Values)
+                        {
+                            callConvs = callConvs.AddExpressions(
+                                TypeOfExpression(((ITypeSymbol)callConv.Value!).AsTypeSyntax()));
+                        }
+                        unmanagedCallConvSyntax = unmanagedCallConvSyntax.AddArgumentListArguments(AttributeArgument(ImplicitArrayCreationExpression(callConvs)).WithNameEquals(NameEquals(IdentifierName("CallConv"))));
+                    }
+                }
+                attributes.Add(unmanagedCallConvSyntax);
+            }
+            return attributes;
         }
 
         private SyntaxTokenList StripTriviaFromModifiers(SyntaxTokenList tokenList)

--- a/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportGenerator.cs
@@ -130,7 +130,6 @@ namespace Microsoft.Interop
                     generatorDiagnostics.ReportConfigurationNotSupported(lcidConversionAttr, nameof(TypeNames.LCIDConversionAttribute));
                 }
 
-                // TODO: These need to be propagaged to the P/Invoke target, which is this does not do correctly.
                 List<AttributeSyntax> additionalAttributes = GenerateSyntaxForForwardedAttributes(suppressGCTransitionAttribute, unmanagedCallConvAttribute);
 
                 // Create the stub.
@@ -152,7 +151,7 @@ namespace Microsoft.Interop
         {
             const string CallConvsField = "CallConvs";
             // Manually rehydrate the forwarded attributes with fully qualified types so we don't have to worry about any using directives.
-            List<AttributeSyntax> attributes = new List<AttributeSyntax>();
+            List<AttributeSyntax> attributes = new();
 
             if (suppressGCTransitionAttribute is not null)
             {

--- a/DllImportGenerator/DllImportGenerator/DllImportStub.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportStub.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Interop
             GeneratedDllImportData dllImportData,
             StubEnvironment env,
             GeneratorDiagnostics diagnostics,
+            List<AttributeSyntax> additionalAttributes,
             CancellationToken token = default)
         {
             // Cancel early if requested
@@ -213,7 +214,10 @@ namespace Microsoft.Interop
             var stubGenerator = new StubCodeGenerator(method, dllImportData, paramsTypeInfo, retTypeInfo, diagnostics, env.Options);
             var code = stubGenerator.GenerateSyntax();
 
-            var additionalAttrs = new List<AttributeListSyntax>();
+            var additionalAttrs = new List<AttributeListSyntax>
+            {
+                AttributeList(SeparatedList(additionalAttributes))
+            };
 
             // Define additional attributes for the stub definition.
             if (env.TargetFrameworkVersion >= new Version(5, 0))

--- a/DllImportGenerator/DllImportGenerator/DllImportStub.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportStub.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Interop
             GeneratedDllImportData dllImportData,
             StubEnvironment env,
             GeneratorDiagnostics diagnostics,
-            List<AttributeSyntax> additionalAttributes,
+            List<AttributeSyntax> forwardedAttributes,
             CancellationToken token = default)
         {
             // Cancel early if requested
@@ -212,12 +212,9 @@ namespace Microsoft.Interop
 
             // Generate stub code
             var stubGenerator = new StubCodeGenerator(method, dllImportData, paramsTypeInfo, retTypeInfo, diagnostics, env.Options);
-            var code = stubGenerator.GenerateSyntax();
+            var code = stubGenerator.GenerateSyntax(forwardedAttributes: AttributeList(SeparatedList(forwardedAttributes)));
 
-            var additionalAttrs = new List<AttributeListSyntax>
-            {
-                AttributeList(SeparatedList(additionalAttributes))
-            };
+            var additionalAttrs = new List<AttributeListSyntax>();
 
             // Define additional attributes for the stub definition.
             if (env.TargetFrameworkVersion >= new Version(5, 0))

--- a/DllImportGenerator/DllImportGenerator/DllImportStub.cs
+++ b/DllImportGenerator/DllImportGenerator/DllImportStub.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Interop
 
             // Generate stub code
             var stubGenerator = new StubCodeGenerator(method, dllImportData, paramsTypeInfo, retTypeInfo, diagnostics, env.Options);
-            var code = stubGenerator.GenerateSyntax(forwardedAttributes: AttributeList(SeparatedList(forwardedAttributes)));
+            var code = stubGenerator.GenerateSyntax(forwardedAttributes: forwardedAttributes.Count != 0 ? AttributeList(SeparatedList(forwardedAttributes)) : null);
 
             var additionalAttrs = new List<AttributeListSyntax>();
 

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Interop
             }
         }
 
-        public BlockSyntax GenerateSyntax(AttributeListSyntax forwardedAttributes)
+        public BlockSyntax GenerateSyntax(AttributeListSyntax? forwardedAttributes)
         {
             string dllImportName = stubMethod.Name + "__PInvoke__";
             var setupStatements = new List<StatementSyntax>();
@@ -352,14 +352,15 @@ namespace Microsoft.Interop
                     Token(SyntaxKind.UnsafeKeyword))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
                 .WithAttributeLists(
-                    List(
-                        new[]
-                        {
-                            AttributeList(
+                    SingletonList(AttributeList(
                                 SingletonSeparatedList(
-                                    CreateDllImportAttributeForTarget(GetTargetDllImportDataFromStubData()))),
-                            forwardedAttributes
-                        }));
+                                    CreateDllImportAttributeForTarget(GetTargetDllImportDataFromStubData())))));
+            
+            if (forwardedAttributes is not null)
+            {
+                dllImport = dllImport.AddAttributeLists(forwardedAttributes);
+            }
+
             foreach (var marshaller in paramMarshallers)
             {
                 ParameterSyntax paramSyntax = marshaller.Generator.AsParameter(marshaller.TypeInfo);

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Interop
             }
         }
 
-        public BlockSyntax GenerateSyntax()
+        public BlockSyntax GenerateSyntax(AttributeListSyntax forwardedAttributes)
         {
             string dllImportName = stubMethod.Name + "__PInvoke__";
             var setupStatements = new List<StatementSyntax>();
@@ -352,8 +352,14 @@ namespace Microsoft.Interop
                     Token(SyntaxKind.UnsafeKeyword))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
                 .WithAttributeLists(
-                    SingletonList(AttributeList(
-                        SingletonSeparatedList(CreateDllImportAttributeForTarget(GetTargetDllImportDataFromStubData())))));
+                    List(
+                        new[]
+                        {
+                            AttributeList(
+                                SingletonSeparatedList(
+                                    CreateDllImportAttributeForTarget(GetTargetDllImportDataFromStubData()))),
+                            forwardedAttributes
+                        }));
             foreach (var marshaller in paramMarshallers)
             {
                 ParameterSyntax paramSyntax = marshaller.Generator.AsParameter(marshaller.TypeInfo);

--- a/DllImportGenerator/DllImportGenerator/TypeNames.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeNames.cs
@@ -21,6 +21,10 @@ namespace Microsoft.Interop
 
         public const string LCIDConversionAttribute = "System.Runtime.InteropServices.LCIDConversionAttribute";
 
+        public const string SuppressGCTransitionAttribute = "System.Runtime.InteropServices.SuppressGCTransitionAttribute";
+
+        public const string UnmanagedCallConvAttribute = "System.Runtime.InteropServices.UnmanagedCallConvAttribute";
+
         public const string System_Span_Metadata = "System.Span`1";
         public const string System_Span = "System.Span";
 

--- a/DllImportGenerator/DllImportGenerator/TypeNames.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeNames.cs
@@ -65,5 +65,7 @@ namespace Microsoft.Interop
         {
             return options.UseInternalUnsafeType() ? Internal_Runtime_CompilerServices_Unsafe : System_Runtime_CompilerServices_Unsafe;
         }
+
+        public const string System_Type = "System.Type";
     }
 }

--- a/DllImportGenerator/TestAssets/NativeExports/CallingConventions.cs
+++ b/DllImportGenerator/TestAssets/NativeExports/CallingConventions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NativeExports
+{
+    class CallingConventions
+    {
+        // Use 9 long arguments to ensure we spill to the stack on all platforms.
+        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) }, EntryPoint = "add_integers_cdecl")]
+        public static long AddLongsCdecl(long i, long j, long k, long l, long m, long n, long o, long p, long q)
+        {
+            return i + j + k + l + m + n + o + p + q;
+        }
+
+        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) }, EntryPoint = "add_integers_stdcall")]
+        public static long AddLongsStdcall(long i, long j, long k, long l, long m, long n, long o, long p, long q)
+        {
+            return i + j + k + l + m + n + o + p + q;
+        }
+    }
+}

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -3,9 +3,9 @@
   <ProductDependencies>
     <!-- This VS redist package is used as a way to get a non-shipping version number
          when using a custom runtime version.  -->
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.5.21226.5">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-preview.6.21317.4">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>ac82799250fe42c8ba2941aef487aca94ecf04cc</Sha>
+      <Sha>01188c75f06412dc86508e7b653deaeace9623ba</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
     <IcedVersion>1.8.0</IcedVersion>
     <BenchmarkDotNetVersion>0.12.1.1528</BenchmarkDotNetVersion>
     <CoverletVersion>1.3.0</CoverletVersion>
-    <DNNEVersion>1.0.21</DNNEVersion>
+    <DNNEVersion>1.0.22</DNNEVersion>
     <!-- Set the custom NETCoreApp version based on the VS redist package version -->
     <MicrosoftNETCoreAppVersion>$(VSRedistCommonNetCoreSharedFrameworkx6460Version)</MicrosoftNETCoreAppVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
     <UsingToolXliff>false</UsingToolXliff>
     <!-- Libs -->
     <MicrosoftNETTestSdkVersion>16.7.1</MicrosoftNETTestSdkVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-preview.5.21226.5</VSRedistCommonNetCoreSharedFrameworkx6460Version>
+    <VSRedistCommonNetCoreSharedFrameworkx6460Version>6.0.0-preview.6.21317.4</VSRedistCommonNetCoreSharedFrameworkx6460Version>
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
     <!-- Roslyn dependencies -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,7 +27,7 @@
     <IcedVersion>1.8.0</IcedVersion>
     <BenchmarkDotNetVersion>0.12.1.1528</BenchmarkDotNetVersion>
     <CoverletVersion>1.3.0</CoverletVersion>
-    <DNNEVersion>1.0.16</DNNEVersion>
+    <DNNEVersion>1.0.21</DNNEVersion>
     <!-- Set the custom NETCoreApp version based on the VS redist package version -->
     <MicrosoftNETCoreAppVersion>$(VSRedistCommonNetCoreSharedFrameworkx6460Version)</MicrosoftNETCoreAppVersion>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "6.0.100-preview.3.21202.5",
+    "version": "6.0.100-preview.6.21316.11",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "6.0.100-preview.3.21202.5",
+    "dotnet": "6.0.100-preview.6.21316.11",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppVersion)"


### PR DESCRIPTION
If the GeneratedDllImport-attributed method has SuppressGCTransition or UnmanagedCallConv attributes, apply the attributes to the generated DllImport method.