### PR TITLE
Add array benchmarks.

### DIFF
--- a/DllImportGenerator/Benchmarks/Arrays.cs
+++ b/DllImportGenerator/Benchmarks/Arrays.cs
@@ -1,0 +1,117 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Benchmarks
+{
+    partial class NativeExportsNE
+    {
+        public partial class Arrays
+        {
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array")]
+            public static partial int Sum(int[] values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_int_array_ref")]
+            public static partial int SumInArray(in int[] values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "duplicate_int_array")]
+            public static partial void Duplicate([MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] ref int[] values, int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "create_range_array")]
+            [return:MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+            public static partial int[] CreateRange(int start, int end, out int numValues);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "create_range_array_out")]
+            public static partial void CreateRange_Out(int start, int end, out int numValues, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] out int[] res);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "sum_string_lengths")]
+            public static partial int SumStringLengths([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] strArray);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "reverse_strings_replace")]
+            public static partial void ReverseStrings_Ref([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] ref string[] strArray, out int numElements);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "reverse_strings_return")]
+            [return: MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)]
+            public static partial string[] ReverseStrings_Return([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] strArray, out int numElements);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "reverse_strings_out")]
+            public static partial void ReverseStrings_Out([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr)] string[] strArray, out int numElements, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] out string[] res);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "get_long_bytes")]
+            [return:MarshalAs(UnmanagedType.LPArray, SizeConst = sizeof(long))]
+            public static partial byte[] GetLongBytes(long l);
+
+            [GeneratedDllImport(NativeExportsNE_Binary, EntryPoint = "append_int_to_array")]
+            public static partial void Append([MarshalAs(UnmanagedType.LPArray, SizeConst = 1, SizeParamIndex = 1)] ref int[] values, int numOriginalValues, int newValue);
+        }
+    }
+
+    public class Arrays
+    {
+        public int[] IntArray => new[] { 1, 2, 3, 6, 243, 42 };
+
+        public string[] StringArray => new[]
+        {
+            "ABCdef 123$%^",
+            "🍜 !! 🍜 !!",
+            "🌲 木 🔥 火 🌾 土 🛡 金 🌊 水",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae posuere mauris, sed ultrices leo. Suspendisse potenti. Mauris enim enim, blandit tincidunt consequat in, varius sit amet neque. Morbi eget porttitor ex. Duis mattis aliquet ante quis imperdiet. Duis sit.",
+            string.Empty,
+            null,
+        };
+
+        [Benchmark]
+        public int BlittableArrayByValue()
+        {
+            int[] local = IntArray;
+            return NativeExportsNE.Arrays.Sum(local, local.Length);
+        }
+
+        [Benchmark]
+        public int NullArrayByValue()
+        {
+            return NativeExportsNE.Arrays.Sum(null, 0);
+        }
+
+        [Benchmark]
+        public int ZeroLengthArrayByValue()
+        {
+            return NativeExportsNE.Arrays.Sum(Array.Empty<int>(), 0);
+        }
+
+        [Benchmark]
+        public int[] BlittableArrayByRef()
+        {
+            int[] local = IntArray;
+            NativeExportsNE.Arrays.Duplicate(ref local, local.Length);
+            return local;
+        }
+
+        [Benchmark]
+        public int[] BlittableArrayByRef_SizeParamIndex_SizeConst()
+        {
+            int[] local = IntArray;
+            NativeExportsNE.Arrays.Append(ref local, local.Length, 17);
+            return local;
+        }
+
+        [Benchmark]
+        public int NonBlittableArrayByValue()
+        {
+            return NativeExportsNE.Arrays.SumStringLengths(StringArray);
+        }
+
+        [Benchmark]
+        public string[] NonBlittableArrayByRef()
+        {
+            string[] local = StringArray;
+            NativeExportsNE.Arrays.ReverseStrings_Ref(ref local, out _);
+            return local;
+        }
+    }
+}


### PR DESCRIPTION
Add array benchmarks for blittable and non-blittable arrays.

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1052 (21H1/May2021Update)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100-preview.6.21316.11
  [Host]    : .NET 6.0.0 (6.0.21.31704), X64 RyuJIT
  Built-in  : .NET 6.0.0 (6.0.21.31704), X64 RyuJIT
  Generated : .NET 6.0.0 (6.0.21.31704), X64 RyuJIT


```
|                                       Method |       Job | BuildConfiguration |        Mean |     Error |    StdDev |      Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------------- |---------- |------------------- |------------:|----------:|----------:|------------:|------:|--------:|-------:|------:|------:|----------:|
|                        BlittableArrayByValue |  Built-in | Release_Forwarders |    18.67 ns |  0.286 ns |  0.253 ns |    18.64 ns |  1.00 |    0.00 | 0.0115 |     - |     - |      48 B |
|                        BlittableArrayByValue | Generated |            Default |    18.51 ns |  0.383 ns |  0.359 ns |    18.51 ns |  0.99 |    0.02 | 0.0115 |     - |     - |      48 B |
|                                              |           |                    |             |           |           |             |       |         |        |       |       |           |
|                   LargeBlittableArrayByValue |  Built-in | Release_Forwarders |    83.47 ns |  0.977 ns |  0.914 ns |    83.55 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|                   LargeBlittableArrayByValue | Generated |            Default |    82.26 ns |  1.363 ns |  1.064 ns |    82.42 ns |  0.99 |    0.02 |      - |     - |     - |         - |
|                                              |           |                    |             |           |           |             |       |         |        |       |       |           |
|                             NullArrayByValue |  Built-in | Release_Forwarders |    11.52 ns |  0.179 ns |  0.167 ns |    11.55 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|                             NullArrayByValue | Generated |            Default |    11.61 ns |  0.253 ns |  0.577 ns |    11.41 ns |  1.02 |    0.08 |      - |     - |     - |         - |
|                                              |           |                    |             |           |           |             |       |         |        |       |       |           |
|                       ZeroLengthArrayByValue |  Built-in | Release_Forwarders |    11.97 ns |  0.191 ns |  0.159 ns |    12.06 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|                       ZeroLengthArrayByValue | Generated |            Default |    12.10 ns |  0.221 ns |  0.196 ns |    12.06 ns |  1.01 |    0.03 |      - |     - |     - |         - |
|                                              |           |                    |             |           |           |             |       |         |        |       |       |           |
|                          BlittableArrayByRef |  Built-in | Release_Forwarders |   280.99 ns |  4.490 ns |  3.980 ns |   281.63 ns |  1.00 |    0.00 | 0.0229 |     - |     - |      96 B |
|                          BlittableArrayByRef | Generated |            Default |   167.80 ns |  3.128 ns |  2.773 ns |   167.61 ns |  0.60 |    0.01 | 0.0229 |     - |     - |      96 B |
|                                              |           |                    |             |           |           |             |       |         |        |       |       |           |
| BlittableArrayByRef_SizeParamIndex_SizeConst |  Built-in | Release_Forwarders |   283.79 ns |  5.716 ns |  6.582 ns |   281.51 ns |  1.00 |    0.00 | 0.0248 |     - |     - |     104 B |
| BlittableArrayByRef_SizeParamIndex_SizeConst | Generated |            Default |   167.59 ns |  3.022 ns |  2.359 ns |   166.95 ns |  0.59 |    0.01 | 0.0248 |     - |     - |     104 B |
|                                              |           |                    |             |           |           |             |       |         |        |       |       |           |
|                     NonBlittableArrayByValue |  Built-in | Release_Forwarders |   525.40 ns |  4.742 ns |  3.702 ns |   526.83 ns |  1.00 |    0.00 | 0.1926 |     - |     - |     808 B |
|                     NonBlittableArrayByValue | Generated |            Default |   528.26 ns |  9.554 ns | 14.874 ns |   523.03 ns |  1.01 |    0.04 | 0.1926 |     - |     - |     808 B |
|                                              |           |                    |             |           |           |             |       |         |        |       |       |           |
|                       NonBlittableArrayByRef |  Built-in | Release_Forwarders | 1,620.51 ns | 27.436 ns | 25.664 ns | 1,606.78 ns |  1.00 |    0.00 | 0.2518 |     - |     - |   1,056 B |
|                       NonBlittableArrayByRef | Generated |            Default | 1,504.82 ns | 22.601 ns | 18.873 ns | 1,495.20 ns |  0.93 |    0.02 | 0.2518 |     - |     - |   1,056 B |


The byref improvements for blittable are due to the fact that we do a vectorized block copy of the elements with the generated stubs that the built-in system doesn't do.