### PR TITLE
fixed conjunction over counting in srm

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -29,6 +29,30 @@ namespace System.Text.RegularExpressions.Tests
         private const char Turkish_i_withoutDot = '\u0131';
         private const char Kelvin_sign = '\u212A';
 
+        [Theory]
+        [InlineData("[abc]{0,10}", "a[abc]{0,3}", "xxxabbbbbbbyyy", true, "abbb")]
+        [InlineData("[abc]{0,10}?", "a[abc]{0,3}?", "xxxabbbbbbbyyy", true, "a")]
+        public void TestConjunctionOverCounting(string conjunct1, string conjunct2, string input, bool success, string match)
+        {
+            string pattern = And(conjunct1, conjunct2);
+            Regex re = new Regex(pattern, DFA);
+            Match m = re.Match(input);
+            Assert.Equal(success, m.Success);
+            Assert.Equal(match, m.Value);
+        }
+
+        [Theory]
+        [InlineData("a[abc]{0,10}", "a[abc]{0,3}", "xxxabbbbbbbyyy", true, "abbbbbbb")]
+        [InlineData("a[abc]{0,10}?", "a[abc]{0,3}?", "xxxabbbbbbbyyy", true, "a")]
+        public void TestDisjunctionOverCounting(string disjunct1, string disjunct2, string input, bool success, string match)
+        {
+            string pattern = disjunct1 + "|" + disjunct2;
+            Regex re = new Regex(pattern, DFA);
+            Match m = re.Match(input);
+            Assert.Equal(success, m.Success);
+            Assert.Equal(match, m.Value);
+        }
+
 
         [Theory]
         [InlineData("(?i:[a-dÕ]+k*)", "xyxaBõc\u212AKAyy", true, "aBõc\u212AK")]


### PR DESCRIPTION
Fixed two things:
1) Updated support of subsumption simplification of conjunction over counting the same way this is done for disjunction. It was not handled efficiently before.
2) Fixed the issue that lazy loop information was forgotten in subsumption optimization:
e.g. R{0,10}?S|R{0,7}?S is internally represented by (R,S):max(7,10) but at that point the info that this was a lazy loop was lost, when 
it is later converted back to R{0,10}?S
(similarly for conjunction but with min(7,10))