### PR TITLE
NativeAOT-LLVM: sort call operands by argNum

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -555,8 +555,8 @@ llvm::Value* buildUserFuncCall(GenTreeCall* call, llvm::IRBuilder<>& builder)
 
     unsigned int shadowStackUseOffest = 0;
     int          argIx                = 0;
+    GenTree*     thisArg              = nullptr;
     std::vector<struct OperandArgNum> sortedOperands;
-    GenTree*                          thisArg = nullptr;
 
     // "this" goes first
     if (call->gtCallThisArg != nullptr)
@@ -577,10 +577,9 @@ llvm::Value* buildUserFuncCall(GenTreeCall* call, llvm::IRBuilder<>& builder)
             continue;
         }
         fgArgTabEntry* curArgTabEntry = _compiler->gtArgEntryByNode(call, operand);
-        //unsigned int   lateArgIndex   = curArgTabEntry->GetLateArgInx();
-        //fgArgTabEntry* curArgTabEntry = _compiler->gtArgEntryByLateArgIndex(call, lateArgIndex);
         unsigned int   argNum         = curArgTabEntry->argNum;
         unsigned int   i              = 0;
+
         while (i < sortedOperands.size() && argNum > sortedOperands[i].argNum)
         {
             i++;


### PR DESCRIPTION
This PR sorts the operands by argNum to ensure the call order matches the signature.  This addresses the issue with the current code mentioned https://github.com/dotnet/runtimelab/issues/1266 

I've closed that issue as some actual code to look at is often better.  Apart from the general issue of whether there is a better way to access the operands sorted by arg number, I've used a `std::vector` and `emplace` to perform an insert sort.   This is not the best, but the number of args is typically small, and I don't know if any other strategy would be better.  That's mute of course if there is a way to access them by argNum.  I could `reserve` on the vector a small number, e.g. 5, which may improve the `emplace` performance, but I left that out as sometimes there are no args, and the internal algorithm in `emplace` for creating more capacity may be better anyway.