### PR TITLE
Resolve SizeParamIndex to a TypePositionInfo during MarshallingInfo parsing

### DIFF
--- a/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CodeSnippets.cs
@@ -1331,6 +1331,17 @@ partial class Test
     );
 }
 ";
+        public static string MutuallyRecursiveSizeParamIndexOnParameter => @"
+using System.Runtime.InteropServices;
+partial class Test
+{
+    [GeneratedDllImport(""DoesNotExist"")]
+    public static partial void Method(
+        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=1)] ref int[] arr,
+        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex=0)] ref int[] arr2
+    );
+}
+";
 
         public static string CollectionsOfCollectionsStress => @"
 using System.Runtime.InteropServices;

--- a/DllImportGenerator/DllImportGenerator.UnitTests/CompileFails.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/CompileFails.cs
@@ -121,6 +121,7 @@ namespace DllImportGenerator.UnitTests
             yield return new object[] { CodeSnippets.RecursiveCountElementNameOnReturnValue, 2, 0 };
             yield return new object[] { CodeSnippets.RecursiveCountElementNameOnParameter, 2, 0 };
             yield return new object[] { CodeSnippets.MutuallyRecursiveCountElementNameOnParameter, 4, 0 };
+            yield return new object[] { CodeSnippets.MutuallyRecursiveSizeParamIndexOnParameter, 4, 0 };
         }
 
         [Theory]

--- a/DllImportGenerator/DllImportGenerator/ContiguousCollectionElementMarshallingCodeContext.cs
+++ b/DllImportGenerator/DllImportGenerator/ContiguousCollectionElementMarshallingCodeContext.cs
@@ -57,12 +57,6 @@ namespace Microsoft.Interop
             return $"{nativeSpanIdentifier}__{IndexerIdentifier}__{name}";
         }
 
-        public override TypePositionInfo? GetTypePositionInfoForManagedIndex(int index)
-        {
-            // We don't have parameters to look at when we're in the middle of marshalling an array.
-            return null;
-        }
-
         private static string CalculateIndexerIdentifierBasedOnParentContext(StubCodeContext? parentContext)
         {
             int i = 0;

--- a/DllImportGenerator/DllImportGenerator/Marshalling/Forwarder.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/Forwarder.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Interop
                                     Literal(countInfo.ConstSize)))
                         );
                     }
-                    if (countInfo.ParamIndex != SizeAndParamIndexInfo.UnspecifiedData)
+                    if (countInfo.ParamAtIndex is { ManagedIndex: int paramIndex })
                     {
                         marshalAsArguments.Add(
                             AttributeArgument(NameEquals("SizeParamIndex"), null,
                                 LiteralExpression(SyntaxKind.NumericLiteralExpression,
-                                    Literal(countInfo.ParamIndex)))
+                                    Literal(paramIndex)))
                         );
                     }
                 }

--- a/DllImportGenerator/DllImportGenerator/Marshalling/Forwarder.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/Forwarder.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Interop
 
                 if (collectionMarshalling.ElementCountInfo is SizeAndParamIndexInfo countInfo)
                 {
-                    if (countInfo.ConstSize != SizeAndParamIndexInfo.UnspecifiedData)
+                    if (countInfo.ConstSize != SizeAndParamIndexInfo.UnspecifiedConstSize)
                     {
                         marshalAsArguments.Add(
                             AttributeArgument(NameEquals("SizeConst"), null,

--- a/DllImportGenerator/DllImportGenerator/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/ICustomNativeTypeMarshallingStrategy.cs
@@ -137,11 +137,6 @@ namespace Microsoft.Interop
 
         public override bool AdditionalTemporaryStateLivesAcrossStages => ParentContext!.AdditionalTemporaryStateLivesAcrossStages;
 
-        public override TypePositionInfo? GetTypePositionInfoForManagedIndex(int index)
-        {
-            return ParentContext!.GetTypePositionInfoForManagedIndex(index);
-        }
-
         public override (string managed, string native) GetIdentifiers(TypePositionInfo info)
         {
             return (ParentContext!.GetIdentifiers(info).managed, MarshallerHelpers.GetMarshallerIdentifier(info, ParentContext));

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -376,13 +376,13 @@ namespace Microsoft.Interop
             throw new MarshallingNotSupportedException(info, context);
         }
         
-        private static ExpressionSyntax GetNumElementsExpressionFromMarshallingInfo(TypePositionInfo info, CountInfo count, StubCodeContext context, AnalyzerConfigOptions options)
+        private static ExpressionSyntax GetNumElementsExpressionFromMarshallingInfo(TypePositionInfo info, CountInfo count, StubCodeContext context)
         {
             return count switch
             {
-                SizeAndParamIndexInfo(int size, null) => GetConstSizeExpression(size),
+                SizeAndParamIndexInfo(int size, SizeAndParamIndexInfo.UnspecifiedParam) => GetConstSizeExpression(size),
                 ConstSizeCountInfo(int size) => GetConstSizeExpression(size),
-                SizeAndParamIndexInfo(SizeAndParamIndexInfo.UnspecifiedData, TypePositionInfo param) => CheckedExpression(SyntaxKind.CheckedExpression, GetExpressionForParam(param)),
+                SizeAndParamIndexInfo(SizeAndParamIndexInfo.UnspecifiedConstSize, TypePositionInfo param) => CheckedExpression(SyntaxKind.CheckedExpression, GetExpressionForParam(param)),
                 SizeAndParamIndexInfo(int size, TypePositionInfo param) => CheckedExpression(SyntaxKind.CheckedExpression, BinaryExpression(SyntaxKind.AddExpression, GetConstSizeExpression(size), GetExpressionForParam(param))),
                 CountElementCountInfo(TypePositionInfo elementInfo) => CheckedExpression(SyntaxKind.CheckedExpression, GetExpressionForParam(elementInfo)),
                 _ => throw new MarshallingNotSupportedException(info, context)
@@ -396,53 +396,43 @@ namespace Microsoft.Interop
                 return LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(size));
             }
 
-            ExpressionSyntax GetExpressionForParam(TypePositionInfo? paramInfo)
+            ExpressionSyntax GetExpressionForParam(TypePositionInfo paramInfo)
             {
-                if (paramInfo is null)
-                {
-                    throw new MarshallingNotSupportedException(info, context)
-                    {
-                        NotSupportedDetails = Resources.ArraySizeParamIndexOutOfRange
-                    };
-                }
-                else
-                {
-                    ExpressionSyntax numElementsExpression = GetIndexedNumElementsExpression(
-                        context,
-                        paramInfo,
-                        out int numIndirectionLevels);
+                ExpressionSyntax numElementsExpression = GetIndexedNumElementsExpression(
+                           context,
+                           paramInfo,
+                           out int numIndirectionLevels);
 
-                    ITypeSymbol type = paramInfo.ManagedType;
-                    MarshallingInfo marshallingInfo = paramInfo.MarshallingAttributeInfo;
+                ITypeSymbol type = paramInfo.ManagedType;
+                MarshallingInfo marshallingInfo = paramInfo.MarshallingAttributeInfo;
 
-                    for (int i = 0; i < numIndirectionLevels; i++)
+                for (int i = 0; i < numIndirectionLevels; i++)
+                {
+                    if (marshallingInfo is NativeContiguousCollectionMarshallingInfo collectionInfo)
                     {
-                        if (marshallingInfo is NativeContiguousCollectionMarshallingInfo collectionInfo)
-                        {
-                            type = collectionInfo.ElementType;
-                            marshallingInfo = collectionInfo.ElementMarshallingInfo;
-                        }
-                        else
-                        {
-                            throw new MarshallingNotSupportedException(info, context)
-                            {
-                                NotSupportedDetails = Resources.CollectionSizeParamTypeMustBeIntegral
-                            };
-                        }
+                        type = collectionInfo.ElementType;
+                        marshallingInfo = collectionInfo.ElementMarshallingInfo;
                     }
-
-                    if (!type.IsIntegralType())
+                    else
                     {
                         throw new MarshallingNotSupportedException(info, context)
                         {
                             NotSupportedDetails = Resources.CollectionSizeParamTypeMustBeIntegral
                         };
                     }
-
-                    return CastExpression(
-                            PredefinedType(Token(SyntaxKind.IntKeyword)),
-                            ParenthesizedExpression(numElementsExpression));
                 }
+
+                if (!type.IsIntegralType())
+                {
+                    throw new MarshallingNotSupportedException(info, context)
+                    {
+                        NotSupportedDetails = Resources.CollectionSizeParamTypeMustBeIntegral
+                    };
+                }
+
+                return CastExpression(
+                        PredefinedType(Token(SyntaxKind.IntKeyword)),
+                        ParenthesizedExpression(numElementsExpression));
             }
 
             static ExpressionSyntax GetIndexedNumElementsExpression(StubCodeContext context, TypePositionInfo numElementsInfo, out int numIndirectionLevels)
@@ -607,7 +597,7 @@ namespace Microsoft.Interop
             if (info.IsManagedReturnPosition || (info.IsByRef && info.RefKind != RefKind.In))
             {
                 // In this case, we need a numElementsExpression supplied from metadata, so we'll calculate it here.
-                numElementsExpression = GetNumElementsExpressionFromMarshallingInfo(info, collectionInfo.ElementCountInfo, context, options);
+                numElementsExpression = GetNumElementsExpressionFromMarshallingInfo(info, collectionInfo.ElementCountInfo, context);
             }
 
             marshallingStrategy = new NumElementsExpressionMarshalling(

--- a/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/Marshalling/MarshallingGenerator.cs
@@ -380,10 +380,10 @@ namespace Microsoft.Interop
         {
             return count switch
             {
-                SizeAndParamIndexInfo(int size, SizeAndParamIndexInfo.UnspecifiedData) => GetConstSizeExpression(size),
+                SizeAndParamIndexInfo(int size, null) => GetConstSizeExpression(size),
                 ConstSizeCountInfo(int size) => GetConstSizeExpression(size),
-                SizeAndParamIndexInfo(SizeAndParamIndexInfo.UnspecifiedData, int paramIndex) => CheckedExpression(SyntaxKind.CheckedExpression, GetExpressionForParam(context.GetTypePositionInfoForManagedIndex(paramIndex))),
-                SizeAndParamIndexInfo(int size, int paramIndex) => CheckedExpression(SyntaxKind.CheckedExpression, BinaryExpression(SyntaxKind.AddExpression, GetConstSizeExpression(size), GetExpressionForParam(context.GetTypePositionInfoForManagedIndex(paramIndex)))),
+                SizeAndParamIndexInfo(SizeAndParamIndexInfo.UnspecifiedData, TypePositionInfo param) => CheckedExpression(SyntaxKind.CheckedExpression, GetExpressionForParam(param)),
+                SizeAndParamIndexInfo(int size, TypePositionInfo param) => CheckedExpression(SyntaxKind.CheckedExpression, BinaryExpression(SyntaxKind.AddExpression, GetConstSizeExpression(size), GetExpressionForParam(param))),
                 CountElementCountInfo(TypePositionInfo elementInfo) => CheckedExpression(SyntaxKind.CheckedExpression, GetExpressionForParam(elementInfo)),
                 _ => throw new MarshallingNotSupportedException(info, context)
                 {

--- a/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
+++ b/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
@@ -375,6 +375,12 @@ namespace Microsoft.Interop
                 return null;
             }
             IParameterSymbol param = method.Parameters[paramIndex];
+
+            if (inspectedElements.Contains(param.Name))
+            {
+                throw new CyclicalCountElementInfoException(inspectedElements, param.Name);
+            }
+
             try
             {
                 return TypePositionInfo.CreateForParameter(

--- a/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
+++ b/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
@@ -145,12 +145,12 @@ namespace Microsoft.Interop
 
     internal class MarshallingAttributeInfoParser
     {
-        private readonly Compilation compilation;
-        private readonly GeneratorDiagnostics diagnostics;
-        private readonly DefaultMarshallingInfo defaultInfo;
-        private readonly ISymbol contextSymbol;
-        private readonly ITypeSymbol marshalAsAttribute;
-        private readonly ITypeSymbol marshalUsingAttribute;
+        private readonly Compilation _compilation;
+        private readonly GeneratorDiagnostics _diagnostics;
+        private readonly DefaultMarshallingInfo _defaultInfo;
+        private readonly ISymbol _contextSymbol;
+        private readonly ITypeSymbol _marshalAsAttribute;
+        private readonly ITypeSymbol _marshalUsingAttribute;
 
         public MarshallingAttributeInfoParser(
             Compilation compilation,
@@ -158,12 +158,12 @@ namespace Microsoft.Interop
             DefaultMarshallingInfo defaultInfo,
             ISymbol contextSymbol)
         {
-            this.compilation = compilation;
-            this.diagnostics = diagnostics;
-            this.defaultInfo = defaultInfo;
-            this.contextSymbol = contextSymbol;
-            marshalAsAttribute = compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute)!;
-            marshalUsingAttribute = compilation.GetTypeByMetadataName(TypeNames.MarshalUsingAttribute)!;
+            _compilation = compilation;
+            _diagnostics = diagnostics;
+            _defaultInfo = defaultInfo;
+            _contextSymbol = contextSymbol;
+            _marshalAsAttribute = compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute)!;
+            _marshalUsingAttribute = compilation.GetTypeByMetadataName(TypeNames.MarshalUsingAttribute)!;
         }
 
         public MarshallingInfo ParseMarshallingInfo(
@@ -186,7 +186,7 @@ namespace Microsoft.Interop
                 {
                     if (marshallingAttributesByIndirectionLevel.ContainsKey(indirectionLevel))
                     {
-                        diagnostics.ReportConfigurationNotSupported(attribute, "Marshalling Data for Indirection Level", indirectionLevel.ToString());
+                        _diagnostics.ReportConfigurationNotSupported(attribute, "Marshalling Data for Indirection Level", indirectionLevel.ToString());
                         return NoMarshallingInfo.Instance;
                     }
                     marshallingAttributesByIndirectionLevel.Add(indirectionLevel, attribute);
@@ -203,7 +203,7 @@ namespace Microsoft.Interop
                 ref maxIndirectionLevelUsed);
             if (maxIndirectionLevelUsed < maxIndirectionLevelDataProvided)
             {
-                diagnostics.ReportConfigurationNotSupported(marshallingAttributesByIndirectionLevel[maxIndirectionLevelDataProvided], ManualTypeMarshallingHelper.MarshalUsingProperties.ElementIndirectionLevel, maxIndirectionLevelDataProvided.ToString());
+                _diagnostics.ReportConfigurationNotSupported(marshallingAttributesByIndirectionLevel[maxIndirectionLevelDataProvided], ManualTypeMarshallingHelper.MarshalUsingProperties.ElementIndirectionLevel, maxIndirectionLevelDataProvided.ToString());
             }
             return info;
         }
@@ -223,16 +223,16 @@ namespace Microsoft.Interop
                 INamedTypeSymbol attributeClass = useSiteAttribute.AttributeClass!;
 
                 if (indirectionLevel == 0
-                    && SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute), attributeClass))
+                    && SymbolEqualityComparer.Default.Equals(_compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_MarshalAsAttribute), attributeClass))
                 {
                     // https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshalasattribute
                     return CreateInfoFromMarshalAs(type, useSiteAttribute, inspectedElements, ref maxIndirectionLevelUsed);
                 }
-                else if (SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(TypeNames.MarshalUsingAttribute), attributeClass))
+                else if (SymbolEqualityComparer.Default.Equals(_compilation.GetTypeByMetadataName(TypeNames.MarshalUsingAttribute), attributeClass))
                 {
                     if (parsedCountInfo != NoCountInfo.Instance)
                     {
-                        diagnostics.ReportConfigurationNotSupported(useSiteAttribute, "Duplicate Count Info");
+                        _diagnostics.ReportConfigurationNotSupported(useSiteAttribute, "Duplicate Count Info");
                         return NoMarshallingInfo.Instance;
                     }
                     parsedCountInfo = CreateCountInfo(useSiteAttribute, inspectedElements);
@@ -257,7 +257,7 @@ namespace Microsoft.Interop
             {
                 INamedTypeSymbol attributeClass = typeAttribute.AttributeClass!;
 
-                if (SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(TypeNames.BlittableTypeAttribute), attributeClass))
+                if (SymbolEqualityComparer.Default.Equals(_compilation.GetTypeByMetadataName(TypeNames.BlittableTypeAttribute), attributeClass))
                 {
                     // If type is generic, then we need to re-evaluate that it is blittable at usage time.
                     if (type is INamedTypeSymbol { IsGenericType: false } || type.HasOnlyBlittableFields())
@@ -266,7 +266,7 @@ namespace Microsoft.Interop
                     }
                     break;
                 }
-                else if (SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(TypeNames.NativeMarshallingAttribute), attributeClass))
+                else if (SymbolEqualityComparer.Default.Equals(_compilation.GetTypeByMetadataName(TypeNames.NativeMarshallingAttribute), attributeClass))
                 {
                     return CreateNativeMarshallingInfo(
                         type,
@@ -278,7 +278,7 @@ namespace Microsoft.Interop
                         inspectedElements,
                         ref maxIndirectionLevelUsed);
                 }
-                else if (SymbolEqualityComparer.Default.Equals(compilation.GetTypeByMetadataName(TypeNames.GeneratedMarshallingAttribute), attributeClass))
+                else if (SymbolEqualityComparer.Default.Equals(_compilation.GetTypeByMetadataName(TypeNames.GeneratedMarshallingAttribute), attributeClass))
                 {
                     return type.IsConsideredBlittable() ? new BlittableTypeAttributeInfo() : new GeneratedNativeMarshallingAttributeInfo(null! /* TODO: determine naming convention */);
                 }
@@ -300,11 +300,11 @@ namespace Microsoft.Interop
 
             // No marshalling info was computed, but a character encoding was provided.
             // If the type is a character or string then pass on these details.
-            if (defaultInfo.CharEncoding != CharEncoding.Undefined
+            if (_defaultInfo.CharEncoding != CharEncoding.Undefined
                 && (type.SpecialType == SpecialType.System_Char
                     || type.SpecialType == SpecialType.System_String))
             {
-                return new MarshallingInfoStringSupport(defaultInfo.CharEncoding);
+                return new MarshallingInfoStringSupport(_defaultInfo.CharEncoding);
             }
 
             return NoMarshallingInfo.Instance;
@@ -324,7 +324,7 @@ namespace Microsoft.Interop
                 {
                     if (arg.Value.Value is null)
                     {
-                        diagnostics.ReportConfigurationNotSupported(marshalUsingData, ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName, "null");
+                        _diagnostics.ReportConfigurationNotSupported(marshalUsingData, ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName, "null");
                         return NoCountInfo.Instance;
                     }
                     elementName = (string)arg.Value.Value!;
@@ -333,7 +333,7 @@ namespace Microsoft.Interop
 
             if (constSize is not null && elementName is not null)
             {
-                diagnostics.ReportConfigurationNotSupported(marshalUsingData, $"{ManualTypeMarshallingHelper.MarshalUsingProperties.ConstantElementCount} and {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName} combined");
+                _diagnostics.ReportConfigurationNotSupported(marshalUsingData, $"{ManualTypeMarshallingHelper.MarshalUsingProperties.ConstantElementCount} and {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName} combined");
             }
             else if (constSize is not null)
             {
@@ -351,7 +351,7 @@ namespace Microsoft.Interop
                     TypePositionInfo? elementInfo = CreateForElementName(elementName, inspectedElements.Add(elementName));
                     if (elementInfo is null)
                     {
-                        diagnostics.ReportConfigurationNotSupported(marshalUsingData, ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName, elementName);
+                        _diagnostics.ReportConfigurationNotSupported(marshalUsingData, ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName, elementName);
                         return NoCountInfo.Instance;
                     }
                     return new CountElementCountInfo(elementInfo);
@@ -360,7 +360,7 @@ namespace Microsoft.Interop
                 // This ensures that we've unwound the whole cycle so when we return NoCountInfo.Instance, there will be no cycles in the count info.
                 catch (CyclicalCountElementInfoException ex) when (ex.StartOfCycle == elementName)
                 {
-                    diagnostics.ReportConfigurationNotSupported(marshalUsingData, $"Cyclical {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName}");
+                    _diagnostics.ReportConfigurationNotSupported(marshalUsingData, $"Cyclical {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName}");
                     return NoCountInfo.Instance;
                 }
             }
@@ -370,7 +370,7 @@ namespace Microsoft.Interop
 
         private TypePositionInfo? CreateForParamIndex(AttributeData attrData, int paramIndex, ImmutableHashSet<string> inspectedElements)
         {
-            if (!(contextSymbol is IMethodSymbol method && 0 <= paramIndex && paramIndex < method.Parameters.Length))
+            if (!(_contextSymbol is IMethodSymbol method && 0 <= paramIndex && paramIndex < method.Parameters.Length))
             {
                 return null;
             }
@@ -379,21 +379,21 @@ namespace Microsoft.Interop
             {
                 return TypePositionInfo.CreateForParameter(
                     param,
-                    ParseMarshallingInfo(param.Type, param.GetAttributes(), inspectedElements.Add(param.Name)), compilation) with
+                    ParseMarshallingInfo(param.Type, param.GetAttributes(), inspectedElements.Add(param.Name)), _compilation) with
                 { ManagedIndex = paramIndex };
             }
             // Specifically catch the exception when we're trying to inspect the element that started the cycle.
             // This ensures that we've unwound the whole cycle so when we return, there will be no cycles in the count info.
             catch (CyclicalCountElementInfoException ex) when (ex.StartOfCycle == param.Name)
             {
-                diagnostics.ReportConfigurationNotSupported(attrData, $"Cyclical {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName}");
+                _diagnostics.ReportConfigurationNotSupported(attrData, $"Cyclical {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName}");
                 return SizeAndParamIndexInfo.UnspecifiedParam;
             }
         }
 
         private TypePositionInfo? CreateForElementName(string elementName, ImmutableHashSet<string> inspectedElements)
         {
-            if (contextSymbol is IMethodSymbol method)
+            if (_contextSymbol is IMethodSymbol method)
             {
                 if (elementName == CountElementCountInfo.ReturnValueElementName)
                 {
@@ -410,11 +410,11 @@ namespace Microsoft.Interop
                     IParameterSymbol param = method.Parameters[i];
                     if (param.Name == elementName)
                     {
-                        return TypePositionInfo.CreateForParameter(param, ParseMarshallingInfo(param.Type, param.GetAttributes(), inspectedElements), compilation) with { ManagedIndex = i };
+                        return TypePositionInfo.CreateForParameter(param, ParseMarshallingInfo(param.Type, param.GetAttributes(), inspectedElements), _compilation) with { ManagedIndex = i };
                     }
                 }
             }
-            else if (contextSymbol is INamedTypeSymbol _)
+            else if (_contextSymbol is INamedTypeSymbol _)
             {
                 // TODO: Handle when we create a struct marshalling generator
                 // Do we want to support CountElementName pointing to only fields, or properties as well?
@@ -438,7 +438,7 @@ namespace Microsoft.Interop
                 || unmanagedType == UnmanagedType.CustomMarshaler
                 || unmanagedType == UnmanagedType.SafeArray)
             {
-                diagnostics.ReportConfigurationNotSupported(attrData, nameof(UnmanagedType), unmanagedType.ToString());
+                _diagnostics.ReportConfigurationNotSupported(attrData, nameof(UnmanagedType), unmanagedType.ToString());
             }
             bool isArrayType = unmanagedType == UnmanagedType.LPArray || unmanagedType == UnmanagedType.ByValArray;
             UnmanagedType elementUnmanagedType = (UnmanagedType)SizeAndParamIndexInfo.UnspecifiedConstSize;
@@ -458,32 +458,32 @@ namespace Microsoft.Interop
                     case nameof(MarshalAsAttribute.MarshalTypeRef):
                     case nameof(MarshalAsAttribute.MarshalType):
                     case nameof(MarshalAsAttribute.MarshalCookie):
-                        diagnostics.ReportConfigurationNotSupported(attrData, $"{attrData.AttributeClass!.Name}{Type.Delimiter}{namedArg.Key}");
+                        _diagnostics.ReportConfigurationNotSupported(attrData, $"{attrData.AttributeClass!.Name}{Type.Delimiter}{namedArg.Key}");
                         break;
                     case nameof(MarshalAsAttribute.ArraySubType):
                         if (!isArrayType)
                         {
-                            diagnostics.ReportConfigurationNotSupported(attrData, $"{attrData.AttributeClass!.Name}{Type.Delimiter}{namedArg.Key}");
+                            _diagnostics.ReportConfigurationNotSupported(attrData, $"{attrData.AttributeClass!.Name}{Type.Delimiter}{namedArg.Key}");
                         }
                         elementUnmanagedType = (UnmanagedType)namedArg.Value.Value!;
                         break;
                     case nameof(MarshalAsAttribute.SizeConst):
                         if (!isArrayType)
                         {
-                            diagnostics.ReportConfigurationNotSupported(attrData, $"{attrData.AttributeClass!.Name}{Type.Delimiter}{namedArg.Key}");
+                            _diagnostics.ReportConfigurationNotSupported(attrData, $"{attrData.AttributeClass!.Name}{Type.Delimiter}{namedArg.Key}");
                         }
                         arraySizeInfo = arraySizeInfo with { ConstSize = (int)namedArg.Value.Value! };
                         break;
                     case nameof(MarshalAsAttribute.SizeParamIndex):
                         if (!isArrayType)
                         {
-                            diagnostics.ReportConfigurationNotSupported(attrData, $"{attrData.AttributeClass!.Name}{Type.Delimiter}{namedArg.Key}");
+                            _diagnostics.ReportConfigurationNotSupported(attrData, $"{attrData.AttributeClass!.Name}{Type.Delimiter}{namedArg.Key}");
                         }
                         TypePositionInfo? paramIndexInfo = CreateForParamIndex(attrData, (short)namedArg.Value.Value!, inspectedElements);
 
                         if (paramIndexInfo is null)
                         {
-                            diagnostics.ReportConfigurationNotSupported(attrData, nameof(MarshalAsAttribute.SizeParamIndex), namedArg.Value.Value.ToString());
+                            _diagnostics.ReportConfigurationNotSupported(attrData, nameof(MarshalAsAttribute.SizeParamIndex), namedArg.Value.Value.ToString());
                         }
                         arraySizeInfo = arraySizeInfo with { ParamAtIndex = paramIndexInfo };
                         break;
@@ -492,19 +492,19 @@ namespace Microsoft.Interop
 
             if (!isArrayType)
             {
-                return new MarshalAsInfo(unmanagedType, defaultInfo.CharEncoding);
+                return new MarshalAsInfo(unmanagedType, _defaultInfo.CharEncoding);
             }
 
             if (type is not IArrayTypeSymbol { ElementType: ITypeSymbol elementType })
             {
-                diagnostics.ReportConfigurationNotSupported(attrData, nameof(UnmanagedType), unmanagedType.ToString());
+                _diagnostics.ReportConfigurationNotSupported(attrData, nameof(UnmanagedType), unmanagedType.ToString());
                 return NoMarshallingInfo.Instance;
             }
 
             MarshallingInfo elementMarshallingInfo = NoMarshallingInfo.Instance;
             if (elementUnmanagedType != (UnmanagedType)SizeAndParamIndexInfo.UnspecifiedConstSize)
             {
-                elementMarshallingInfo = new MarshalAsInfo(elementUnmanagedType, defaultInfo.CharEncoding);
+                elementMarshallingInfo = new MarshalAsInfo(elementUnmanagedType, _defaultInfo.CharEncoding);
             }
             else
             {
@@ -516,11 +516,11 @@ namespace Microsoft.Interop
 
             if (elementType is IPointerTypeSymbol { PointedAtType: ITypeSymbol pointedAt })
             {
-                arrayMarshaller = compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_GeneratedMarshalling_PtrArrayMarshaller_Metadata)?.Construct(pointedAt);
+                arrayMarshaller = _compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_GeneratedMarshalling_PtrArrayMarshaller_Metadata)?.Construct(pointedAt);
             }
             else
             {
-                arrayMarshaller = compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_GeneratedMarshalling_ArrayMarshaller_Metadata)?.Construct(elementType);
+                arrayMarshaller = _compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_GeneratedMarshalling_ArrayMarshaller_Metadata)?.Construct(elementType);
             }
 
             if (arrayMarshaller is null)
@@ -557,7 +557,7 @@ namespace Microsoft.Interop
                 methods |= SupportedMarshallingMethods.Pinning;
             }
 
-            ITypeSymbol spanOfByte = compilation.GetTypeByMetadataName(TypeNames.System_Span_Metadata)!.Construct(compilation.GetSpecialType(SpecialType.System_Byte));
+            ITypeSymbol spanOfByte = _compilation.GetTypeByMetadataName(TypeNames.System_Span_Metadata)!.Construct(_compilation.GetSpecialType(SpecialType.System_Byte));
 
             INamedTypeSymbol nativeType = (INamedTypeSymbol)attrData.ConstructorArguments[0].Value!;
 
@@ -565,14 +565,14 @@ namespace Microsoft.Interop
             {
                 if (isMarshalUsingAttribute)
                 {
-                    diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                    _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
                     return NoMarshallingInfo.Instance;
                 }
                 else if (type is INamedTypeSymbol namedType)
                 {
                     if (namedType.Arity != nativeType.Arity)
                     {
-                        diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                        _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
                         return NoMarshallingInfo.Instance;
                     }
                     else
@@ -582,12 +582,12 @@ namespace Microsoft.Interop
                 }
                 else
                 {
-                    diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                    _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
                     return NoMarshallingInfo.Instance;
                 }
             }
 
-            ITypeSymbol contiguousCollectionMarshalerAttribute = compilation.GetTypeByMetadataName(TypeNames.GenericContiguousCollectionMarshallerAttribute)!;
+            ITypeSymbol contiguousCollectionMarshalerAttribute = _compilation.GetTypeByMetadataName(TypeNames.GenericContiguousCollectionMarshallerAttribute)!;
 
             bool isContiguousCollectionMarshaller = nativeType.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, contiguousCollectionMarshalerAttribute));
             IPropertySymbol? valueProperty = ManualTypeMarshallingHelper.FindValueProperty(nativeType);
@@ -626,7 +626,7 @@ namespace Microsoft.Interop
 
             if (methods == SupportedMarshallingMethods.None)
             {
-                diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
                 return NoMarshallingInfo.Instance;
             }
 
@@ -634,13 +634,13 @@ namespace Microsoft.Interop
             {
                 if (!ManualTypeMarshallingHelper.HasNativeValueStorageProperty(nativeType, spanOfByte))
                 {
-                    diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                    _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
                     return NoMarshallingInfo.Instance;
                 }
 
                 if (!ManualTypeMarshallingHelper.TryGetElementTypeFromContiguousCollectionMarshaller(nativeType, out ITypeSymbol elementType))
                 {
-                    diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                    _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
                     return NoMarshallingInfo.Instance;
                 }
 
@@ -673,7 +673,7 @@ namespace Microsoft.Interop
             out MarshallingInfo marshallingInfo)
         {
             // Check for an implicit SafeHandle conversion.
-            var conversion = compilation.ClassifyCommonConversion(type, compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_SafeHandle)!);
+            var conversion = _compilation.ClassifyCommonConversion(type, _compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_SafeHandle)!);
             if (conversion.Exists
                 && conversion.IsImplicit
                 && (conversion.IsReference || conversion.IsIdentity))
@@ -685,7 +685,7 @@ namespace Microsoft.Interop
                     {
                         if (ctor.Parameters.Length == 0)
                         {
-                            hasAccessibleDefaultConstructor = compilation.IsSymbolAccessibleWithin(ctor, contextSymbol.ContainingType);
+                            hasAccessibleDefaultConstructor = _compilation.IsSymbolAccessibleWithin(ctor, _contextSymbol.ContainingType);
                             break;
                         }
                     }
@@ -700,11 +700,11 @@ namespace Microsoft.Interop
 
                 if (elementType is IPointerTypeSymbol { PointedAtType: ITypeSymbol pointedAt })
                 {
-                    arrayMarshaller = compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_GeneratedMarshalling_PtrArrayMarshaller_Metadata)?.Construct(pointedAt);
+                    arrayMarshaller = _compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_GeneratedMarshalling_PtrArrayMarshaller_Metadata)?.Construct(pointedAt);
                 }
                 else
                 {
-                    arrayMarshaller = compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_GeneratedMarshalling_ArrayMarshaller_Metadata)?.Construct(elementType);
+                    arrayMarshaller = _compilation.GetTypeByMetadataName(TypeNames.System_Runtime_InteropServices_GeneratedMarshalling_ArrayMarshaller_Metadata)?.Construct(elementType);
                 }
 
                 if (arrayMarshaller is null)
@@ -741,13 +741,13 @@ namespace Microsoft.Interop
 
         private bool TryGetAttributeIndirectionLevel(AttributeData attrData, out int indirectionLevel)
         {
-            if (SymbolEqualityComparer.Default.Equals(attrData.AttributeClass, marshalAsAttribute))
+            if (SymbolEqualityComparer.Default.Equals(attrData.AttributeClass, _marshalAsAttribute))
             {
                 indirectionLevel = 0;
                 return true;
             }
 
-            if (!SymbolEqualityComparer.Default.Equals(attrData.AttributeClass, marshalUsingAttribute))
+            if (!SymbolEqualityComparer.Default.Equals(attrData.AttributeClass, _marshalUsingAttribute))
             {
                 indirectionLevel = 0;
                 return false;

--- a/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
+++ b/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
@@ -70,15 +70,6 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The &apos;SizeParamIndex&apos; value in the &apos;MarshalAsAttribute&apos; is out of range..
-        /// </summary>
-        internal static string ArraySizeParamIndexOutOfRange {
-            get {
-                return ResourceManager.GetString("ArraySizeParamIndexOutOfRange", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A type marked with &apos;BlittableTypeAttribute&apos; must be blittable..
         /// </summary>
         internal static string BlittableTypeMustBeBlittableDescription {

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -120,9 +120,6 @@
   <data name="ArraySizeMustBeSpecified" xml:space="preserve">
     <value>Marshalling an array from unmanaged to managed requires either the 'SizeParamIndex' or 'SizeConst' fields to be set on a 'MarshalAsAttribute' or the 'ConstantElementCount' or 'CountElementName' properties to be set on a 'MarshalUsingAttribute'.</value>
   </data>
-  <data name="ArraySizeParamIndexOutOfRange" xml:space="preserve">
-    <value>The 'SizeParamIndex' value in the 'MarshalAsAttribute' is out of range.</value>
-  </data>
   <data name="BlittableTypeMustBeBlittableDescription" xml:space="preserve">
     <value>A type marked with 'BlittableTypeAttribute' must be blittable.</value>
   </data>

--- a/DllImportGenerator/DllImportGenerator/StubCodeContext.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeContext.cs
@@ -104,7 +104,5 @@ namespace Microsoft.Interop
         {
             return $"{GetIdentifiers(info).native}__{name}";
         }
-
-        public abstract TypePositionInfo? GetTypePositionInfoForManagedIndex(int index);
     }
 }

--- a/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
+++ b/DllImportGenerator/DllImportGenerator/StubCodeGenerator.cs
@@ -465,18 +465,6 @@ namespace Microsoft.Interop
             }
         }
 
-        public override TypePositionInfo? GetTypePositionInfoForManagedIndex(int index)
-        {
-            foreach (var info in paramsTypeInfo)
-            {
-                if (info.ManagedIndex == index)
-                {
-                    return info;
-                }
-            }
-            return null;
-        }
-
         private void AppendVariableDeclations(List<StatementSyntax> statementsToUpdate, TypePositionInfo info, IMarshallingGenerator generator)
         {
             var (managed, native) = GetIdentifiers(info);


### PR DESCRIPTION
Move the resolution/validation of SizeParamIndex up to MarshallingAttributeInfo.

Enables us to remove the concept of mapping an "index" -> element name/TypePositionInfo from the context and make it only part of the attribute parser. Since this mapping only makes sense in certain scenarios, this allows custom contexts to not have to provide overrides of the `GetTypePositionInfoForManagedIndex` method that either always return `null` or delegate to a parent context.