### PR TITLE
Add basic support for compiling to ARM32

### DIFF
--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -30,6 +30,25 @@
 #define __PN__MACHINECALL_CDECL_OR_DEFAULT __cdecl
 #endif
 
+#ifndef _MSC_VER
+
+// Note:  Win32-hosted GCC predefines __stdcall and __cdecl, but Unix-
+// hosted GCC does not.
+
+#ifdef __i386__
+
+#if !defined(__cdecl)
+#define __cdecl        __attribute__((cdecl))
+#endif
+
+#else   // !defined(__i386__)
+
+#define __cdecl
+
+#endif  // !defined(__i386__)
+
+#endif // !_MSC_VER
+
 #ifndef _INC_WINDOWS
 //#ifndef DACCESS_COMPILE
 

--- a/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
+++ b/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
@@ -447,7 +447,7 @@ COOP_PINVOKE_HELPER(PTR_VOID, RhGetRuntimeHelperForType, (EEType * pEEType, int 
     {
     case RuntimeHelperKind::AllocateObject:
 #ifdef HOST_ARM
-        if ((pEEType->get_RareFlags() & EEType::RareFlags::RequiresAlign8Flag) == EEType::RareFlags::RequiresAlign8Flag)
+        if ((pEEType->RequiresAlign8())
         {
             if (pEEType->HasFinalizer())
                 return INDIRECTION(RhpNewFinalizableAlign8);

--- a/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>
+#include "AsmOffsets.inc"
+
+    .global RhpGcPoll2
+
+    LEAF_ENTRY RhpGcPoll
+        PREPARE_EXTERNAL_VAR_INDIRECT_W RhpTrapThreads, 0
+        cbnz    w0, RhpGcPollRare // TrapThreadsFlags_None = 0
+        ret
+    LEAF_END RhpGcPoll
+
+    NESTED_ENTRY RhpGcPollRare, _TEXT, NoHandler
+        PUSH_COOP_PINVOKE_FRAME x0
+        bl RhpGcPoll2
+        POP_COOP_PINVOKE_FRAME
+        ret
+    NESTED_END RhpGcPollRare

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilderState.cs
@@ -1071,7 +1071,7 @@ namespace Internal.Runtime.TypeLoader
 #if TARGET_ARM
                 if (TypeBeingBuilt is DefType)
                 {
-                    return ((DefType)TypeBeingBuilt).IsHfa;
+                    return ((DefType)TypeBeingBuilt).IsHomogeneousAggregate;
                 }
                 else
                 {


### PR DESCRIPTION
This is what I do to make it compile on Raspbian on my Raspberry Pi 3B+
- GcProbe.S is just copy from ARM64
- __cdecl is not defined on ARM, so I suppress that
- I resurrect RareFlags from CoreRT in hopes that this is make it works, but no luck
I try to resurrect https://github.com/dotnet/corert/commit/d9847aff807f50e3fbd9393742ee7f9a24a21ded in changes to regdisp.h but seems to be I do wrong thing here, and I should resurrect definitions from there.

I would like to understand is RareFlags are still valid way, and if not what's the proper way.

See #833