### PR TITLE
Update analyzer to correctly handle collection marshallers

### DIFF
--- a/DllImportGenerator/DllImportGenerator/Analyzers/AnalyzerDiagnostics.cs
+++ b/DllImportGenerator/DllImportGenerator/Analyzers/AnalyzerDiagnostics.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Interop.Analyzers
             public const string StackallocMarshallingShouldSupportAllocatingMarshallingFallback = Prefix + "011";
             public const string StackallocConstructorMustHaveStackBufferSizeConstant = Prefix + "012";
             public const string RefValuePropertyUnsupported = Prefix + "014";
-            public const string NativeGenericTypeMustBeClosed = Prefix + "016";
+            public const string NativeGenericTypeMustBeClosedOrMatchArity = Prefix + "016";
 
             // GeneratedDllImport
             public const string GeneratedDllImportMissingRequiredModifiers = Prefix + "013";

--- a/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
+++ b/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
@@ -115,6 +115,24 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A native type with the &apos;GenericContiguousCollectionMarshallerAttribute&apos; must have at least one of the two marshalling methods as well as a &apos;ManagedValues&apos; property of type &apos;Span&lt;T&gt;&apos; for some &apos;T&apos; and a &apos;NativeValueStorage&apos; property of type &apos;Span&lt;byte&gt;&apos; to enable marshalling the managed type..
+        /// </summary>
+        internal static string CollectionNativeTypeMustHaveRequiredShapeDescription {
+            get {
+                return ResourceManager.GetString("CollectionNativeTypeMustHaveRequiredShapeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The native type &apos;{0}&apos; must be a value type and have a constructor that takes two parameters, one of type &apos;{1}&apos; and an &apos;int&apos;, or have a parameterless instance method named &apos;ToManaged&apos; that returns &apos;{1}&apos; as well as a &apos;ManagedValues&apos; property of type &apos;Span&lt;T&gt;&apos; for some &apos;T&apos; and a &apos;NativeValueStorage&apos; property of type &apos;Span&lt;byte&gt;&apos;.
+        /// </summary>
+        internal static string CollectionNativeTypeMustHaveRequiredShapeMessage {
+            get {
+                return ResourceManager.GetString("CollectionNativeTypeMustHaveRequiredShapeMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified collection size parameter for an collection must be an integer type. If the size information is applied to a nested collection, the size parameter must be a collection of one less level of nesting with an integral element..
         /// </summary>
         internal static string CollectionSizeParamTypeMustBeIntegral {

--- a/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
+++ b/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
@@ -394,20 +394,20 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The native type &apos;{0}&apos; must be a closed generic so the emitted code can use a specific instantiation..
+        ///   Looks up a localized string similar to The native type &apos;{0}&apos; must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation..
         /// </summary>
-        internal static string NativeGenericTypeMustBeClosedDescription {
+        internal static string NativeGenericTypeMustBeClosedOrMatchArityDescription {
             get {
-                return ResourceManager.GetString("NativeGenericTypeMustBeClosedDescription", resourceCulture);
+                return ResourceManager.GetString("NativeGenericTypeMustBeClosedOrMatchArityDescription", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The native type &apos;{0}&apos; for managed type &apos;{1}&apos; must be a closed generic type..
+        ///   Looks up a localized string similar to The native type &apos;{0}&apos; for managed type &apos;{1}&apos; must be a closed generic type or have the same arity as the managed type..
         /// </summary>
-        internal static string NativeGenericTypeMustBeClosedMessage {
+        internal static string NativeGenericTypeMustBeClosedOrMatchArityMessage {
             get {
-                return ResourceManager.GetString("NativeGenericTypeMustBeClosedMessage", resourceCulture);
+                return ResourceManager.GetString("NativeGenericTypeMustBeClosedOrMatchArityMessage", resourceCulture);
             }
         }
         

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -229,11 +229,11 @@
   <data name="MarshallingStringOrCharAsUndefinedNotSupported" xml:space="preserve">
     <value>Marshalling string or char without explicit marshalling information is not supported. Specify either 'GeneratedDllImportAttribute.CharSet' or 'MarshalAsAttribute'.</value>
   </data>
-  <data name="NativeGenericTypeMustBeClosedDescription" xml:space="preserve">
-    <value>The native type '{0}' must be a closed generic so the emitted code can use a specific instantiation.</value>
+  <data name="NativeGenericTypeMustBeClosedOrMatchArityDescription" xml:space="preserve">
+    <value>The native type '{0}' must be a closed generic or have the same number of generic parameters as the managed type so the emitted code can use a specific instantiation.</value>
   </data>
-  <data name="NativeGenericTypeMustBeClosedMessage" xml:space="preserve">
-    <value>The native type '{0}' for managed type '{1}' must be a closed generic type.</value>
+  <data name="NativeGenericTypeMustBeClosedOrMatchArityMessage" xml:space="preserve">
+    <value>The native type '{0}' for managed type '{1}' must be a closed generic type or have the same arity as the managed type.</value>
   </data>
   <data name="NativeTypeMustBeBlittableDescription" xml:space="preserve">
     <value>A native type for a given type must be blittable.</value>

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -259,6 +259,12 @@
   <data name="NativeTypeMustHaveRequiredShapeMessage" xml:space="preserve">
     <value>The native type '{0}' must be a value type and have a constructor that takes one parameter of type '{1}' or a parameterless instance method named 'ToManaged' that returns '{1}'</value>
   </data>
+  <data name="CollectionNativeTypeMustHaveRequiredShapeDescription" xml:space="preserve">
+    <value>A native type with the 'GenericContiguousCollectionMarshallerAttribute' must have at least one of the two marshalling methods as well as a 'ManagedValues' property of type 'Span&lt;T&gt;' for some 'T' and a 'NativeValueStorage' property of type 'Span&lt;byte&gt;' to enable marshalling the managed type.</value>
+  </data>
+  <data name="CollectionNativeTypeMustHaveRequiredShapeMessage" xml:space="preserve">
+    <value>The native type '{0}' must be a value type and have a constructor that takes two parameters, one of type '{1}' and an 'int', or have a parameterless instance method named 'ToManaged' that returns '{1}' as well as a 'ManagedValues' property of type 'Span&lt;T&gt;' for some 'T' and a 'NativeValueStorage' property of type 'Span&lt;byte&gt;'</value>
+  </data>
   <data name="OutByValueNotSupportedDescription" xml:space="preserve">
     <value>The '[Out]' attribute is only supported on array parameters.</value>
   </data>

--- a/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
+++ b/DllImportGenerator/DllImportGenerator/TypeSymbolExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Interop
                 return true;
             }
 
-            if (!type.IsValueType || type.IsReferenceType)
+            if (type.IsReferenceType)
             {
                 return false;
             }


### PR DESCRIPTION
Collection marshallers have a different shape, so we need to update the analyzer to detect them and correctly validate them.