### PR TITLE
Report diagnostics for bad opt-in marshallers at MarshalUsing use-site if the marshaler is in a different compilation than the current compilation.

### DIFF
--- a/DllImportGenerator/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
+++ b/DllImportGenerator/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
@@ -334,7 +334,7 @@ namespace Microsoft.Interop.Analyzers
                 if (!nativeType.IsValueType)
                 {
                     context.ReportDiagnostic(
-                        nativeType.CreateDiagnostic(
+                        GetDiagnosticLocations(context, nativeType, nativeMarshalerAttributeData).CreateDiagnostic(
                             NativeTypeMustHaveRequiredShapeRule,
                             nativeType.ToDisplayString(),
                             type.ToDisplayString()));
@@ -379,7 +379,7 @@ namespace Microsoft.Interop.Analyzers
                         if (stackAllocSizeField is null or { DeclaredAccessibility: not Accessibility.Public } or { IsConst: false } or { Type: not { SpecialType: SpecialType.System_Int32 } })
                         {
                             context.ReportDiagnostic(
-                                ctor.CreateDiagnostic(
+                                GetDiagnosticLocations(context, ctor, nativeMarshalerAttributeData).CreateDiagnostic(
                                     StackallocConstructorMustHaveStackBufferSizeConstantRule,
                                     nativeType.ToDisplayString()));
                         }
@@ -392,7 +392,7 @@ namespace Microsoft.Interop.Analyzers
                 if (!hasConstructor && !hasStackallocConstructor && !hasToManaged)
                 {
                     context.ReportDiagnostic(
-                        marshalerType.CreateDiagnostic(
+                        GetDiagnosticLocations(context, marshalerType, nativeMarshalerAttributeData).CreateDiagnostic(
                             NativeTypeMustHaveRequiredShapeRule,
                             marshalerType.ToDisplayString(),
                             type.ToDisplayString()));
@@ -402,7 +402,7 @@ namespace Microsoft.Interop.Analyzers
                 if (validateAllScenarioSupport && hasStackallocConstructor && !hasConstructor)
                 {
                     context.ReportDiagnostic(
-                        marshalerType.CreateDiagnostic(
+                        GetDiagnosticLocations(context, marshalerType, nativeMarshalerAttributeData).CreateDiagnostic(
                             StackallocMarshallingShouldSupportAllocatingMarshallingFallbackRule,
                             marshalerType.ToDisplayString()));
                 }
@@ -415,7 +415,7 @@ namespace Microsoft.Interop.Analyzers
                     if (valuePropertyIsRefReturn)
                     {
                         context.ReportDiagnostic(
-                            valueProperty.CreateDiagnostic(
+                            GetDiagnosticLocations(context, valueProperty, nativeMarshalerAttributeData).CreateDiagnostic(
                                 RefValuePropertyUnsupportedRule,
                                 marshalerType.ToDisplayString()));
                     }
@@ -430,14 +430,14 @@ namespace Microsoft.Interop.Analyzers
                     if ((hasConstructor || hasStackallocConstructor) && valueProperty.GetMethod is null)
                     {
                         context.ReportDiagnostic(
-                            valueProperty.CreateDiagnostic(
+                            GetDiagnosticLocations(context, valueProperty, nativeMarshalerAttributeData).CreateDiagnostic(
                                 ValuePropertyMustHaveGetterRule,
                                 marshalerType.ToDisplayString()));
                     }
                     if (hasToManaged && valueProperty.SetMethod is null)
                     {
                         context.ReportDiagnostic(
-                            valueProperty.CreateDiagnostic(
+                            GetDiagnosticLocations(context, valueProperty, nativeMarshalerAttributeData).CreateDiagnostic(
                                 ValuePropertyMustHaveSetterRule,
                                 marshalerType.ToDisplayString()));
                     }
@@ -446,7 +446,7 @@ namespace Microsoft.Interop.Analyzers
                 if (!nativeType.IsConsideredBlittable())
                 {
                     context.ReportDiagnostic(
-                        nativeTypeDiagnosticsTargetSymbol.CreateDiagnostic(
+                        GetDiagnosticLocations(context, nativeTypeDiagnosticsTargetSymbol, nativeMarshalerAttributeData).CreateDiagnostic(
                             NativeTypeMustBeBlittableRule,
                             nativeType.ToDisplayString(),
                             type.ToDisplayString()));
@@ -486,11 +486,22 @@ namespace Microsoft.Interop.Analyzers
                     IMethodSymbol getPinnableReferenceMethodToMention = getPinnableReferenceMethods.Managed ?? getPinnableReferenceMethods.Marshaler!;
 
                     context.ReportDiagnostic(
-                        nativeTypeDiagnosticsTargetSymbol.CreateDiagnostic(
+                        GetDiagnosticLocations(context, nativeTypeDiagnosticsTargetSymbol, nativeMarshalerAttributeData).CreateDiagnostic(
                             NativeTypeMustBePointerSizedRule,
                             nativeType.ToDisplayString(),
                             getPinnableReferenceMethodToMention.ContainingType.ToDisplayString()));
                 }
+            }
+
+            private ImmutableArray<Location> GetDiagnosticLocations(SymbolAnalysisContext context, ISymbol targetSymbol, AttributeData marshallingAttribute)
+            {
+                // If we're using a compilation that references another compilation, the symbol locations can be in source in the wrong compilation,
+                // which can cause exceptions when reporting diagnostics. Make sure the symbol is defined in the current Compilation's source module before using its locations.
+                if (SymbolEqualityComparer.Default.Equals(context.Compilation.SourceModule, targetSymbol.ContainingModule))
+                {
+                    return targetSymbol.Locations;
+                }
+                return ImmutableArray.Create(marshallingAttribute.ApplicationSyntaxReference?.GetSyntax().GetLocation() ?? Location.None);
             }
         }
     }

--- a/DllImportGenerator/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
+++ b/DllImportGenerator/DllImportGenerator/Analyzers/ManualTypeMarshallingAnalyzer.cs
@@ -497,6 +497,7 @@ namespace Microsoft.Interop.Analyzers
             {
                 // If we're using a compilation that references another compilation, the symbol locations can be in source in the wrong compilation,
                 // which can cause exceptions when reporting diagnostics. Make sure the symbol is defined in the current Compilation's source module before using its locations.
+                // If the symbol is not defined in the current Compilation's source module, report the diagnostic at the marshalling attribute's location.
                 if (SymbolEqualityComparer.Default.Equals(context.Compilation.SourceModule, targetSymbol.ContainingModule))
                 {
                     return targetSymbol.Locations;

--- a/DllImportGenerator/DllImportGenerator/GeneratorDiagnostics.cs
+++ b/DllImportGenerator/DllImportGenerator/GeneratorDiagnostics.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 
@@ -15,6 +16,22 @@ namespace Microsoft.Interop
             params object[] args)
         {
             IEnumerable<Location> locationsInSource = symbol.Locations.Where(l => l.IsInSource);
+            if (!locationsInSource.Any())
+                return Diagnostic.Create(descriptor, Location.None, args);
+
+            return Diagnostic.Create(
+                descriptor,
+                location: locationsInSource.First(),
+                additionalLocations: locationsInSource.Skip(1),
+                messageArgs: args);
+        }
+
+        public static Diagnostic CreateDiagnostic(
+            this ImmutableArray<Location> locations,
+            DiagnosticDescriptor descriptor,
+            params object[] args)
+        {
+            IEnumerable<Location> locationsInSource = locations.Where(l => l.IsInSource);
             if (!locationsInSource.Any())
                 return Diagnostic.Create(descriptor, Location.None, args);
 


### PR DESCRIPTION
Ensures that we still provide diagnostics for custom native type marshallers even if the marshaller lives in a different assembly.