### PR TITLE
fixed prefix computation bug in srm that caused perf regression

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
@@ -34,6 +34,11 @@ namespace System.Text.RegularExpressions.SRM
 
         private Unicode.IgnoreCaseTransformer _IgnoreCase;
 
+        public BDD ApplyIgnoreCase(BDD set, string culture = null)
+        {
+            return _IgnoreCase.Apply(set, culture);
+        }
+
         /// <summary>
         /// Make a character predicate for the given character c.
         /// </summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -364,8 +364,8 @@ namespace System.Text.RegularExpressions.SRM
             else
                 this.A_startset_array = Array.Empty<char>();
 
-            this.A_prefix = A.GetFixedPrefix(css, out this.A_fixedPrefix_ignoreCase);
-            this.Ar_prefix = Ar.GetFixedPrefix(css, out _);
+            this.A_prefix = A.GetFixedPrefix(css, culture.Name, out this.A_fixedPrefix_ignoreCase);
+            this.Ar_prefix = Ar.GetFixedPrefix(css, culture.Name, out _);
 
             InitializePrefixBoyerMoore();
 

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -189,7 +189,7 @@ namespace System.Text.RegularExpressions.Tests
         {
             Regex reC = new Regex(rawregex, RegexOptions.Compiled, new TimeSpan(0, 0, 10));
             Regex reN = new Regex(rawregex, RegexOptions.None, new TimeSpan(0, 0, 10));
-            Regex reD = new Regex(rawregex, DFA, new TimeSpan(0, 0, 10));
+            Regex reD = new Regex(rawregex, DFA);
             Match mC;
             Match mN;
             Match mD;


### PR DESCRIPTION
This bug caused performance regression in cases when the regex has a fixed prefix. The prefix was in most cases not computed fully and resulted in the boyer-moore algo not being utilized.