### PR TITLE
disabled use of Boyer-Moore for prefix of length 1

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -378,7 +378,7 @@ namespace System.Text.RegularExpressions.SRM
 
         private void InitializePrefixBoyerMoore()
         {
-            if (this.A_prefix != string.Empty && this.A_prefix.Length <= RegexBoyerMoore.MaxLimit)
+            if (this.A_prefix != string.Empty && this.A_prefix.Length <= RegexBoyerMoore.MaxLimit && this.A_prefix.Length > 1)
             {
                 string prefix = this.A_prefix;
                 // RegexBoyerMoore expects the prefix to be lower case when case is ignored


### PR DESCRIPTION
Use of Boyer-Moore on prefix of length 1 blocked use of string.IndexOnAny -- the latter is much faster for a single character.