### PR TITLE
Improve diagnostics messages for invalid custom native type marshalling and cyclical element info.

### DIFF
--- a/DllImportGenerator/DllImportGenerator/GeneratorDiagnostics.cs
+++ b/DllImportGenerator/DllImportGenerator/GeneratorDiagnostics.cs
@@ -154,6 +154,16 @@ namespace Microsoft.Interop
                 isEnabledByDefault: true,
                 description: GetResourceString(nameof(Resources.ConfigurationNotSupportedDescription)));
 
+        public readonly static DiagnosticDescriptor MarshallingAttributeConfigurationNotSupported =
+            new DiagnosticDescriptor(
+                Ids.ConfigurationNotSupported,
+                GetResourceString(nameof(Resources.ConfigurationNotSupportedTitle)),
+                GetResourceString(nameof(Resources.ConfigurationNotSupportedMessageMarshallingInfo)),
+                Category,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                description: GetResourceString(nameof(Resources.ConfigurationNotSupportedDescription)));
+
         public readonly static DiagnosticDescriptor TargetFrameworkNotSupported =
             new DiagnosticDescriptor(
                 Ids.TargetFrameworkNotSupported,
@@ -278,6 +288,17 @@ namespace Microsoft.Interop
                             paramSymbol.Name));
                 }
             }
+        }
+
+        internal void ReportInvalidMarshallingAttributeInfo(
+            AttributeData attributeData,
+            string reasonResourceName,
+            params string[] reasonArgs)
+        {
+            this.context.ReportDiagnostic(
+                attributeData.CreateDiagnostic(
+                    GeneratorDiagnostics.MarshallingAttributeConfigurationNotSupported,
+                    new LocalizableResourceString(reasonResourceName, Resources.ResourceManager, typeof(Resources), reasonArgs)));
         }
 
         /// <summary>

--- a/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
+++ b/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Interop
                 {
                     if (marshallingAttributesByIndirectionLevel.ContainsKey(indirectionLevel))
                     {
-                        _diagnostics.ReportConfigurationNotSupported(attribute, "Marshalling Data for Indirection Level", indirectionLevel.ToString());
+                        _diagnostics.ReportInvalidMarshallingAttributeInfo(attribute, nameof(Resources.DuplicateMarshallingInfo), indirectionLevel.ToString());
                         return NoMarshallingInfo.Instance;
                     }
                     marshallingAttributesByIndirectionLevel.Add(indirectionLevel, attribute);
@@ -203,7 +203,11 @@ namespace Microsoft.Interop
                 ref maxIndirectionLevelUsed);
             if (maxIndirectionLevelUsed < maxIndirectionLevelDataProvided)
             {
-                _diagnostics.ReportConfigurationNotSupported(marshallingAttributesByIndirectionLevel[maxIndirectionLevelDataProvided], ManualTypeMarshallingHelper.MarshalUsingProperties.ElementIndirectionLevel, maxIndirectionLevelDataProvided.ToString());
+                _diagnostics.ReportInvalidMarshallingAttributeInfo(
+                    marshallingAttributesByIndirectionLevel[maxIndirectionLevelDataProvided],
+                    nameof(Resources.ExtraneousMarshallingInfo),
+                    maxIndirectionLevelDataProvided.ToString(),
+                    maxIndirectionLevelUsed.ToString());
             }
             return info;
         }
@@ -232,7 +236,7 @@ namespace Microsoft.Interop
                 {
                     if (parsedCountInfo != NoCountInfo.Instance)
                     {
-                        _diagnostics.ReportConfigurationNotSupported(useSiteAttribute, "Duplicate Count Info");
+                        _diagnostics.ReportInvalidMarshallingAttributeInfo(useSiteAttribute, nameof(Resources.DuplicateCountInfo));
                         return NoMarshallingInfo.Instance;
                     }
                     parsedCountInfo = CreateCountInfo(useSiteAttribute, inspectedElements);
@@ -333,7 +337,7 @@ namespace Microsoft.Interop
 
             if (constSize is not null && elementName is not null)
             {
-                _diagnostics.ReportConfigurationNotSupported(marshalUsingData, $"{ManualTypeMarshallingHelper.MarshalUsingProperties.ConstantElementCount} and {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName} combined");
+                _diagnostics.ReportInvalidMarshallingAttributeInfo(marshalUsingData, nameof(Resources.ConstantAndElementCountInfoDisallowed));
             }
             else if (constSize is not null)
             {
@@ -360,7 +364,7 @@ namespace Microsoft.Interop
                 // This ensures that we've unwound the whole cycle so when we return NoCountInfo.Instance, there will be no cycles in the count info.
                 catch (CyclicalCountElementInfoException ex) when (ex.StartOfCycle == elementName)
                 {
-                    _diagnostics.ReportConfigurationNotSupported(marshalUsingData, $"Cyclical {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName}");
+                    _diagnostics.ReportInvalidMarshallingAttributeInfo(marshalUsingData, nameof(Resources.CyclicalCountInfo), elementName);
                     return NoCountInfo.Instance;
                 }
             }
@@ -392,7 +396,7 @@ namespace Microsoft.Interop
             // This ensures that we've unwound the whole cycle so when we return, there will be no cycles in the count info.
             catch (CyclicalCountElementInfoException ex) when (ex.StartOfCycle == param.Name)
             {
-                _diagnostics.ReportConfigurationNotSupported(attrData, $"Cyclical {ManualTypeMarshallingHelper.MarshalUsingProperties.CountElementName}");
+                _diagnostics.ReportInvalidMarshallingAttributeInfo(attrData, nameof(Resources.CyclicalCountInfo), param.Name);
                 return SizeAndParamIndexInfo.UnspecifiedParam;
             }
         }

--- a/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
+++ b/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
@@ -638,8 +638,8 @@ namespace Microsoft.Interop
             {
                 _diagnostics.ReportInvalidMarshallingAttributeInfo(
                     attrData,
-                    isContiguousCollectionMarshaller ?
-                        nameof(Resources.CollectionNativeTypeMustHaveRequiredShapeMessage)
+                    isContiguousCollectionMarshaller
+                        ? nameof(Resources.CollectionNativeTypeMustHaveRequiredShapeMessage)
                         : nameof(Resources.NativeTypeMustHaveRequiredShapeMessage),
                     nativeType.ToDisplayString());
                 return NoMarshallingInfo.Instance;

--- a/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
+++ b/DllImportGenerator/DllImportGenerator/MarshallingAttributeInfo.cs
@@ -575,14 +575,14 @@ namespace Microsoft.Interop
             {
                 if (isMarshalUsingAttribute)
                 {
-                    _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                    _diagnostics.ReportInvalidMarshallingAttributeInfo(attrData, nameof(Resources.NativeGenericTypeMustBeClosedOrMatchArityMessage), nativeType.ToDisplayString());
                     return NoMarshallingInfo.Instance;
                 }
                 else if (type is INamedTypeSymbol namedType)
                 {
                     if (namedType.Arity != nativeType.Arity)
                     {
-                        _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                        _diagnostics.ReportInvalidMarshallingAttributeInfo(attrData, nameof(Resources.NativeGenericTypeMustBeClosedOrMatchArityMessage), nativeType.ToDisplayString());
                         return NoMarshallingInfo.Instance;
                     }
                     else
@@ -592,7 +592,7 @@ namespace Microsoft.Interop
                 }
                 else
                 {
-                    _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                    _diagnostics.ReportInvalidMarshallingAttributeInfo(attrData, nameof(Resources.NativeGenericTypeMustBeClosedOrMatchArityMessage), nativeType.ToDisplayString());
                     return NoMarshallingInfo.Instance;
                 }
             }
@@ -636,7 +636,12 @@ namespace Microsoft.Interop
 
             if (methods == SupportedMarshallingMethods.None)
             {
-                _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                _diagnostics.ReportInvalidMarshallingAttributeInfo(
+                    attrData,
+                    isContiguousCollectionMarshaller ?
+                        nameof(Resources.CollectionNativeTypeMustHaveRequiredShapeMessage)
+                        : nameof(Resources.NativeTypeMustHaveRequiredShapeMessage),
+                    nativeType.ToDisplayString());
                 return NoMarshallingInfo.Instance;
             }
 
@@ -644,13 +649,13 @@ namespace Microsoft.Interop
             {
                 if (!ManualTypeMarshallingHelper.HasNativeValueStorageProperty(nativeType, spanOfByte))
                 {
-                    _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                    _diagnostics.ReportInvalidMarshallingAttributeInfo(attrData, nameof(Resources.CollectionNativeTypeMustHaveRequiredShapeMessage), nativeType.ToDisplayString());
                     return NoMarshallingInfo.Instance;
                 }
 
                 if (!ManualTypeMarshallingHelper.TryGetElementTypeFromContiguousCollectionMarshaller(nativeType, out ITypeSymbol elementType))
                 {
-                    _diagnostics.ReportConfigurationNotSupported(attrData, "Native Type", nativeType.ToDisplayString());
+                    _diagnostics.ReportInvalidMarshallingAttributeInfo(attrData, nameof(Resources.CollectionNativeTypeMustHaveRequiredShapeMessage), nativeType.ToDisplayString());
                     return NoMarshallingInfo.Instance;
                 }
 

--- a/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
+++ b/DllImportGenerator/DllImportGenerator/Resources.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.Interop {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The specified marshalling configuration is not supported by source-generated P/Invokes. {0}.
+        /// </summary>
+        internal static string ConfigurationNotSupportedMessageMarshallingInfo {
+            get {
+                return ResourceManager.GetString("ConfigurationNotSupportedMessageMarshallingInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified &apos;{0}&apos; configuration for parameter &apos;{1}&apos; is not supported by source-generated P/Invokes. If the specified configuration is required, use a regular `DllImport` instead..
         /// </summary>
         internal static string ConfigurationNotSupportedMessageParameter {
@@ -165,6 +174,15 @@ namespace Microsoft.Interop {
         internal static string ConfigurationNotSupportedTitle {
             get {
                 return ResourceManager.GetString("ConfigurationNotSupportedTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only one of &apos;ConstantElementCount&apos; or &apos;ElementCountInfo&apos; may be used in a &apos;MarshalUsingAttribute&apos; for a given &apos;ElementIndirectionLevel&apos;.
+        /// </summary>
+        internal static string ConstantAndElementCountInfoDisallowed {
+            get {
+                return ResourceManager.GetString("ConstantAndElementCountInfoDisallowed", resourceCulture);
             }
         }
         
@@ -237,6 +255,42 @@ namespace Microsoft.Interop {
         internal static string CustomTypeMarshallingNativeToManagedUnsupported {
             get {
                 return ResourceManager.GetString("CustomTypeMarshallingNativeToManagedUnsupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This element cannot depend on &apos;{0}&apos; for collection size information without creating a dependency cycle.
+        /// </summary>
+        internal static string CyclicalCountInfo {
+            get {
+                return ResourceManager.GetString("CyclicalCountInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Count information for a given element at a given indirection level can only be specified once.
+        /// </summary>
+        internal static string DuplicateCountInfo {
+            get {
+                return ResourceManager.GetString("DuplicateCountInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Multiple marshalling attributes per element per indirection level is unsupported, but duplicate information was provided for indirection level {0}.
+        /// </summary>
+        internal static string DuplicateMarshallingInfo {
+            get {
+                return ResourceManager.GetString("DuplicateMarshallingInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Marshalling info was specified for &apos;ElementIndirectionLevel&apos; {0}, but marshalling info was only needed for {1} levels of indirection.
+        /// </summary>
+        internal static string ExtraneousMarshallingInfo {
+            get {
+                return ResourceManager.GetString("ExtraneousMarshallingInfo", resourceCulture);
             }
         }
         

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -142,7 +142,7 @@
     <value>The '{0}' configuration is not supported by source-generated P/Invokes. If the specified configuration is required, use a regular `DllImport` instead.</value>
   </data>
   <data name="ConfigurationNotSupportedMessageMarshallingInfo" xml:space="preserve">
-    <value>The specified marshalling configuration is not supported by source-generated P/Invokes. {0}</value>
+    <value>The specified marshalling configuration is not supported by source-generated P/Invokes. {0}.</value>
   </data>
   <data name="ConfigurationNotSupportedMessageParameter" xml:space="preserve">
     <value>The specified '{0}' configuration for parameter '{1}' is not supported by source-generated P/Invokes. If the specified configuration is required, use a regular `DllImport` instead.</value>
@@ -194,7 +194,7 @@
     <value>Multiple marshalling attributes per element per indirection level is unsupported, but duplicate information was provided for indirection level {0}</value>
   </data>
   <data name="ExtraneousMarshallingInfo" xml:space="preserve">
-    <value>Marshalling info was specified for 'ElementIndirectionLevel' {0}, but marshalling info was only needed for {1} levels of indirection</value>
+    <value>Marshalling info was specified for 'ElementIndirectionLevel' {0}, but marshalling info was only needed for {1} level(s) of indirection</value>
   </data>
   <data name="GeneratedDllImportContainingTypeMissingModifiersDescription" xml:space="preserve">
     <value>Types that contain methods marked with 'GeneratedDllImportAttribute' must be 'partial'. P/Invoke source generation will ignore methods contained within non-partial types.</value>

--- a/DllImportGenerator/DllImportGenerator/Resources.resx
+++ b/DllImportGenerator/DllImportGenerator/Resources.resx
@@ -141,6 +141,9 @@
   <data name="ConfigurationNotSupportedMessage" xml:space="preserve">
     <value>The '{0}' configuration is not supported by source-generated P/Invokes. If the specified configuration is required, use a regular `DllImport` instead.</value>
   </data>
+  <data name="ConfigurationNotSupportedMessageMarshallingInfo" xml:space="preserve">
+    <value>The specified marshalling configuration is not supported by source-generated P/Invokes. {0}</value>
+  </data>
   <data name="ConfigurationNotSupportedMessageParameter" xml:space="preserve">
     <value>The specified '{0}' configuration for parameter '{1}' is not supported by source-generated P/Invokes. If the specified configuration is required, use a regular `DllImport` instead.</value>
   </data>
@@ -152,6 +155,9 @@
   </data>
   <data name="ConfigurationNotSupportedTitle" xml:space="preserve">
     <value>Specified configuration is not supported by source-generated P/Invokes.</value>
+  </data>
+  <data name="ConstantAndElementCountInfoDisallowed" xml:space="preserve">
+    <value>Only one of 'ConstantElementCount' or 'ElementCountInfo' may be used in a 'MarshalUsingAttribute' for a given 'ElementIndirectionLevel'</value>
   </data>
   <data name="ConvertToGeneratedDllImportDescription" xml:space="preserve">
     <value>Use 'GeneratedDllImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time</value>
@@ -177,6 +183,18 @@
   </data>
   <data name="CustomTypeMarshallingNativeToManagedUnsupported" xml:space="preserve">
     <value>The specified parameter needs to be marshalled from native to managed, but the native type '{0}' does not support it.</value>
+  </data>
+  <data name="CyclicalCountInfo" xml:space="preserve">
+    <value>This element cannot depend on '{0}' for collection size information without creating a dependency cycle</value>
+  </data>
+  <data name="DuplicateCountInfo" xml:space="preserve">
+    <value>Count information for a given element at a given indirection level can only be specified once</value>
+  </data>
+  <data name="DuplicateMarshallingInfo" xml:space="preserve">
+    <value>Multiple marshalling attributes per element per indirection level is unsupported, but duplicate information was provided for indirection level {0}</value>
+  </data>
+  <data name="ExtraneousMarshallingInfo" xml:space="preserve">
+    <value>Marshalling info was specified for 'ElementIndirectionLevel' {0}, but marshalling info was only needed for {1} levels of indirection</value>
   </data>
   <data name="GeneratedDllImportContainingTypeMissingModifiersDescription" xml:space="preserve">
     <value>Types that contain methods marked with 'GeneratedDllImportAttribute' must be 'partial'. P/Invoke source generation will ignore methods contained within non-partial types.</value>


### PR DESCRIPTION
Use custom resource messages to make the diagnostics more localizable.

Further improvements can come once #1299 is in, since it includes more diagnostics validation for the remaining cases.