### PR TITLE
Correct the name of C++/CLI in documentation

### DIFF
--- a/docs/using-nativeaot/limitations.md
+++ b/docs/using-nativeaot/limitations.md
@@ -8,5 +8,5 @@ The key limitations include:
 
 - No dynamic loading (e.g. `Assembly.LoadFile`)
 - No runtime code generation (e.g. `System.Reflection.Emit`)
-- No managed C++, no built-in COM and WinRT interop support
+- No C++/CLI, no built-in COM and WinRT interop support
 - No [unconstrained reflection](reflection-in-aot-mode.md)


### PR DESCRIPTION
It's better that we use the latest official name - C++/CLI, instead of the former one - managed C++.