### PR TITLE
Another round of changes required to compile on ARM

### DIFF
--- a/src/coreclr/nativeaot/libunwind/src/libunwind.cpp
+++ b/src/coreclr/nativeaot/libunwind/src/libunwind.cpp
@@ -93,7 +93,7 @@ _LIBUNWIND_HIDDEN int __unw_set_reg(unw_cursor_t *cursor, unw_regnum_t regNum,
                                     unw_word_t value, unw_word_t *pos) {
   _LIBUNWIND_TRACE_API("__unw_set_reg(cursor=%p, regNum=%d, value=0x%" PRIxPTR
                        ")",
-                       static_cast<void *>(cursor), regNum, (unsigned long)value);
+                       static_cast<void *>(cursor), regNum, value);
   typedef LocalAddressSpace::pint_t pint_t;
   AbstractUnwindCursor *co = (AbstractUnwindCursor *)cursor;
   if (co->validReg(regNum)) {
@@ -155,7 +155,7 @@ _LIBUNWIND_HIDDEN int __unw_set_fpreg(unw_cursor_t *cursor, unw_regnum_t regNum,
 _LIBUNWIND_WEAK_ALIAS(__unw_set_fpreg, unw_set_fpreg)
 
 /// Get location of specified register at cursor position in stack frame.
-_LIBUNWIND_HIDDEN int __unw_get_save_loc(unw_cursor_t *cursor, int regNum, 
+_LIBUNWIND_HIDDEN int __unw_get_save_loc(unw_cursor_t *cursor, int regNum,
                                        unw_save_loc_t* location)
 {
   AbstractUnwindCursor *co = (AbstractUnwindCursor *)cursor;

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -1486,23 +1486,23 @@ OBJECTREF* GcInfoDecoder::GetRegisterSlot(
     _ASSERTE(regNum >= 0 && regNum <= 14);
     _ASSERTE(regNum != 13);  // sp
 
-    DWORD **ppReg;
+    uint32_t **ppReg;
 
     if(regNum <= 3)
     {
-        ppReg = &pRD->volatileCurrContextPointers.R0;
+        ppReg = &pRD->pR0;
         return (OBJECTREF*)*(ppReg + regNum);
     }
     else if(regNum == 12)
     {
-        return (OBJECTREF*) pRD->volatileCurrContextPointers.R12;
+        return (OBJECTREF*) pRD->pR12;
     }
     else if(regNum == 14)
     {
-        return (OBJECTREF*) pRD->pCurrentContextPointers->Lr;
+        return (OBJECTREF*) pRD->pLr;
     }
 
-    ppReg = &pRD->pCurrentContextPointers->R4;
+    ppReg = &pRD->pR4;
 
     return (OBJECTREF*)*(ppReg + regNum-4);
 

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -1486,26 +1486,31 @@ OBJECTREF* GcInfoDecoder::GetRegisterSlot(
     _ASSERTE(regNum >= 0 && regNum <= 14);
     _ASSERTE(regNum != 13);  // sp
 
-    uint32_t **ppReg;
+#ifdef FEATURE_REDHAWK
+    PTR_UIntNative* ppReg = &pRD->pR0;
+
+    return (OBJECTREF*)*(ppReg + regNum);
+#else
+    DWORD **ppReg;
 
     if(regNum <= 3)
     {
-        ppReg = &pRD->pR0;
+        ppReg = &pRD->volatileCurrContextPointers.R0;
         return (OBJECTREF*)*(ppReg + regNum);
     }
     else if(regNum == 12)
     {
-        return (OBJECTREF*) pRD->pR12;
+        return (OBJECTREF*) pRD->volatileCurrContextPointers.R12;
     }
     else if(regNum == 14)
     {
-        return (OBJECTREF*) pRD->pLr;
+        return (OBJECTREF*) pRD->pCurrentContextPointers->Lr;
     }
 
-    ppReg = &pRD->pR4;
+    ppReg = &pRD->pCurrentContextPointers->R4;
 
     return (OBJECTREF*)*(ppReg + regNum-4);
-
+#endif
 }
 
 #if defined(TARGET_UNIX) && !defined(FEATURE_REDHAWK)

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -1487,9 +1487,15 @@ OBJECTREF* GcInfoDecoder::GetRegisterSlot(
     _ASSERTE(regNum != 13);  // sp
 
 #ifdef FEATURE_REDHAWK
-    PTR_UIntNative* ppReg = &pRD->pR0;
-
-    return (OBJECTREF*)*(ppReg + regNum);
+    if(regNum < 14)
+    {
+        PTR_UIntNative* ppReg = &pRD->pR0;
+        return (OBJECTREF*)*(ppReg + regNum);
+    }
+    else
+    {
+        return (OBJECTREF*) pRD->pLR;
+    }
 #else
     DWORD **ppReg;
 


### PR DESCRIPTION
- libunwind change is fix compilation type mismatch.  Present in upstream https://github.com/llvm/llvm-project/blob/d480f968ad8b56d3ee4a6b6df5532d485b0ad01e/libunwind/src/libunwind.cpp#L102
- gcinfodecoder.cpp This one looks like leftover from other times? Would like to be educated. This location assumes that `src\coreclr\inc\regdisp.h` included, but `src\coreclr\nativeaot\Runtime\regdisplay.h` included. I again do not understand how this happens and why this is working for other targets.

I try search in runtime repo, https://github.com/dotnet/runtime/search?q=volatileCurrContextPointers but results very limited and looks like this variables not used a lot, so this again adds to the puzzle.