### PR TITLE
Improved Win Statics debugging

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/CoreRTNatVis.natvis
+++ b/src/coreclr/nativeaot/BuildIntegration/CoreRTNatVis.natvis
@@ -60,4 +60,21 @@
             </ArrayItems>
         </Expand>
     </Type>
+    <Type Name="__ThreadStaticHelper&lt;*&gt;">
+        <Intrinsic Name="HasModuleStorage" Expression="TypeManagerSlot-&gt;ModuleIndex &lt; tls_CurrentThread.m_numThreadLocalModuleStatics"/>
+        <Intrinsic Name="GetStorage" Expression="*(__Array&lt;Object&gt;**)tls_CurrentThread.m_pThreadLocalModuleStatics[TypeManagerSlot-&gt;ModuleIndex]"/>
+        <Intrinsic Name="Get" Expression="*($T1**)(&amp;(*GetStorage()).values)[ClassIndex]"/>
+        <Intrinsic Name="IsInit" Expression="HasModuleStorage() &amp;&amp; GetStorage() != nullptr &amp;&amp; ClassIndex &lt; GetStorage()-&gt;count &amp;&amp; Get() != nullptr"/>
+
+        <DisplayString  Condition="!IsInit()">Null</DisplayString>
+        <DisplayString  Condition="IsInit()">{*Get()}</DisplayString>
+        <Expand>
+            <ExpandedItem Condition="IsInit()">Get()</ExpandedItem>
+        </Expand>
+    </Type>
+    <Type Name="Object" Inheritable="false">
+        <Expand>
+            <!--Empty to hide Object fields outside of raw view-->
+        </Expand>
+    </Type>
 </AutoVisualizer>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -659,7 +659,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                return ExternSymbol("__TypeThreadStaticIndex_" + NameMangler.GetMangledTypeName(type));
+                return ExternSymbol(NameMangler.NodeMangler.ThreadStaticsIndex(type));
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeThreadStaticIndexNode.cs
@@ -20,8 +20,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append("__TypeThreadStaticIndex_")
-              .Append(nameMangler.GetMangledTypeName(_type));
+            sb.Append(nameMangler.NodeMangler.ThreadStaticsIndex(_type));
         }
         public int Offset => 0;
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/NodeMangler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/NodeMangler.cs
@@ -24,6 +24,7 @@ namespace ILCompiler
         public abstract string GCStatics(TypeDesc type);
         public abstract string NonGCStatics(TypeDesc type);
         public abstract string ThreadStatics(TypeDesc type);
+        public abstract string ThreadStaticsIndex(TypeDesc type);
         public abstract string TypeGenericDictionary(TypeDesc type);
         public abstract string MethodGenericDictionary(MethodDesc method);
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnixNodeMangler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnixNodeMangler.cs
@@ -44,6 +44,11 @@ namespace ILCompiler
             return NameMangler.CompilationUnitPrefix + "__THREADSTATICS" + NameMangler.GetMangledTypeName(type);
         }
 
+        public sealed override string ThreadStaticsIndex(TypeDesc type)
+        {
+            return "__TypeThreadStaticIndex" + NameMangler.GetMangledTypeName(type);
+        }
+
         public sealed override string TypeGenericDictionary(TypeDesc type)
         {
             return GenericDictionaryNamePrefix + NameMangler.GetMangledTypeName(type);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -789,7 +789,6 @@ namespace ILCompiler
                         }
                     };
 
-                    _objectWriter.GetClassTypeIndex(classTypeDescriptor);
                     staticFieldRegionTypeIndex = _objectWriter.GetCompleteClassTypeIndex(helperClassTypeDescriptor, helperFieldsDescriptor, helperFields, null);
                     staticFieldRegionSymbolTypeIndex = staticFieldRegionTypeIndex;
                     staticFieldForm = WindowsNodeMangler.ThreadStaticIndexName;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -684,9 +684,9 @@ namespace ILCompiler
 
             if (NodeFactory.Target.OperatingSystem == TargetOS.Windows)
             {
-                InsertStaticFieldRegionMember(fieldsDescs, defType, nonGcStaticFields, WindowsNodeMangler.NonGCStaticMemberName, "__type_" + WindowsNodeMangler.NonGCStaticMemberName, false);
-                InsertStaticFieldRegionMember(fieldsDescs, defType, gcStaticFields, WindowsNodeMangler.GCStaticMemberName, "__type_" + WindowsNodeMangler.GCStaticMemberName, IsCoreRTAbi);
-                InsertStaticFieldRegionMember(fieldsDescs, defType, threadStaticFields, WindowsNodeMangler.ThreadStaticMemberName, "__type_" + WindowsNodeMangler.ThreadStaticMemberName, IsCoreRTAbi);
+                InsertStaticFieldRegionMember(fieldsDescs, defType, nonGcStaticFields, WindowsNodeMangler.NonGCStaticMemberName, false, false);
+                InsertStaticFieldRegionMember(fieldsDescs, defType, gcStaticFields, WindowsNodeMangler.GCStaticMemberName, IsCoreRTAbi, false);
+                InsertStaticFieldRegionMember(fieldsDescs, defType, threadStaticFields, WindowsNodeMangler.ThreadStaticMemberName, IsCoreRTAbi, true);
             }
             else
             {
@@ -724,7 +724,8 @@ namespace ILCompiler
                 return typeIndex;
         }
 
-        private void InsertStaticFieldRegionMember(List<DataFieldDescriptor> fieldDescs, DefType defType, List<DataFieldDescriptor> staticFields, string staticFieldForm, string staticFieldFormTypePrefix, bool staticDataInObject)
+        private void InsertStaticFieldRegionMember(List<DataFieldDescriptor> fieldDescs, DefType defType, List<DataFieldDescriptor> staticFields, string staticFieldForm,
+                                                   bool staticDataInObject, bool isThreadStatic)
         {
             if (staticFields != null && (staticFields.Count > 0))
             {
@@ -738,7 +739,7 @@ namespace ILCompiler
                 ClassTypeDescriptor classTypeDescriptor = new ClassTypeDescriptor
                 {
                     IsStruct = !staticDataInObject ? 1 : 0,
-                    Name = staticFieldFormTypePrefix + _objectWriter.GetMangledName(defType),
+                    Name = $"__type{staticFieldForm}{_objectWriter.GetMangledName(defType)}",
                     BaseClassId = 0
                 };
 
@@ -750,8 +751,50 @@ namespace ILCompiler
                 uint staticFieldRegionTypeIndex = _objectWriter.GetCompleteClassTypeIndex(classTypeDescriptor, fieldsDescriptor, staticFields.ToArray(), null);
                 uint staticFieldRegionSymbolTypeIndex = staticFieldRegionTypeIndex;
 
-                // This means that access to this static region is done via a double indirection
-                if (staticDataInObject)
+                if (isThreadStatic)
+                {
+                    // Generate helper struct used by natvis to get to the actual thread static data
+                    ClassFieldsTypeDescriptor helperFieldsDescriptor = new ClassFieldsTypeDescriptor
+                    {
+                        Size = (ulong)NodeFactory.Target.PointerSize * 2ul,
+                        FieldsCount = 2
+                    };
+
+                    ClassTypeDescriptor helperClassTypeDescriptor = new ClassTypeDescriptor
+                    {
+                        IsStruct = 1,
+                        Name = $"__ThreadStaticHelper<{classTypeDescriptor.Name}>",
+                        BaseClassId = 0
+                    };
+                    var pointerTypeDescriptor = new PointerTypeDescriptor
+                    {
+                        Is64Bit = Is64Bit ? 1 : 0,
+                        IsConst = 0,
+                        IsReference = 0,
+                        ElementType = GetTypeIndex(defType.Context.SystemModule.GetType("Internal.Runtime.CompilerHelpers", "TypeManagerSlot"), true)
+                    };
+
+                    var helperFields = new DataFieldDescriptor[] {
+                        new DataFieldDescriptor
+                        {
+                            FieldTypeIndex = _objectWriter.GetPointerTypeIndex(pointerTypeDescriptor),
+                            Offset = 0,
+                            Name = "TypeManagerSlot"
+                        },
+                        new DataFieldDescriptor
+                        {
+                            FieldTypeIndex = GetVariableTypeIndex(defType.Context.GetWellKnownType(Is64Bit? WellKnownType.Int64 : WellKnownType.Int32), true),
+                            Offset = (ulong)NodeFactory.Target.PointerSize,
+                            Name = "ClassIndex"
+                        }
+                    };
+
+                    _objectWriter.GetClassTypeIndex(classTypeDescriptor);
+                    staticFieldRegionTypeIndex = _objectWriter.GetCompleteClassTypeIndex(helperClassTypeDescriptor, helperFieldsDescriptor, helperFields, null);
+                    staticFieldRegionSymbolTypeIndex = staticFieldRegionTypeIndex;
+                    staticFieldForm = WindowsNodeMangler.ThreadStaticIndexName;
+                }
+                else if (staticDataInObject)// This means that access to this static region is done via indirection
                 {
                     PointerTypeDescriptor pointerTypeDescriptor = new PointerTypeDescriptor();
                     pointerTypeDescriptor.Is64Bit = Is64Bit ? 1 : 0;
@@ -759,8 +802,6 @@ namespace ILCompiler
                     pointerTypeDescriptor.IsReference = 0;
                     pointerTypeDescriptor.ElementType = staticFieldRegionTypeIndex;
 
-                    uint intermediatePointerDescriptor = _objectWriter.GetPointerTypeIndex(pointerTypeDescriptor);
-                    pointerTypeDescriptor.ElementType = intermediatePointerDescriptor;
                     staticFieldRegionSymbolTypeIndex = _objectWriter.GetPointerTypeIndex(pointerTypeDescriptor);
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/WindowsNodeMangler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/WindowsNodeMangler.cs
@@ -56,7 +56,7 @@ namespace ILCompiler
 
         public sealed override string ThreadStatics(TypeDesc type)
         {
-            return CreateStaticFieldName(type, ThreadStaticMemberName);
+            return CreateStaticFieldName(type, NameMangler.CompilationUnitPrefix + ThreadStaticMemberName);
         }
 
         public sealed override string ThreadStaticsIndex(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/WindowsNodeMangler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/WindowsNodeMangler.cs
@@ -15,6 +15,7 @@ namespace ILCompiler
         public const string NonGCStaticMemberName = "__NONGCSTATICS";
         public const string GCStaticMemberName = "__GCSTATICS";
         public const string ThreadStaticMemberName = "__THREADSTATICS";
+        public const string ThreadStaticIndexName = "__THREADSTATICINDEX";
 
         // Mangled name of boxed version of a type
         public sealed override string MangledBoxedTypeName(TypeDesc type)
@@ -38,19 +39,29 @@ namespace ILCompiler
             return "??_7" + mangledJustTypeName + "@@6B@";
         }
 
+        private string CreateStaticFieldName(TypeDesc type, string fieldName)
+        {
+            return @$"?{fieldName}@{NameMangler.GetMangledTypeName(type)}@@";
+        }
+
         public sealed override string GCStatics(TypeDesc type)
         {
-            return NameMangler.GetMangledTypeName(type) + "::" + GCStaticMemberName;
+            return CreateStaticFieldName(type, GCStaticMemberName);
         }
 
         public sealed override string NonGCStatics(TypeDesc type)
         {
-            return NameMangler.GetMangledTypeName(type) + "::" + NonGCStaticMemberName;
+            return CreateStaticFieldName(type, NonGCStaticMemberName);
         }
 
         public sealed override string ThreadStatics(TypeDesc type)
         {
-            return NameMangler.CompilationUnitPrefix + NameMangler.GetMangledTypeName(type) + "::" + ThreadStaticMemberName;
+            return CreateStaticFieldName(type, ThreadStaticMemberName);
+        }
+
+        public sealed override string ThreadStaticsIndex(TypeDesc type)
+        {
+            return CreateStaticFieldName(type, ThreadStaticIndexName);
         }
 
         public sealed override string TypeGenericDictionary(TypeDesc type)


### PR DESCRIPTION
- Fixed static name mangling to something debugger understands
- Fixed GCStatics incorrect double indirection
- Added helper struct and natvis for thread static data

fixes dotnet/corert#5575