### PR TITLE
Don't place unconstructed EETypes in the types hashtable

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -232,6 +232,8 @@ namespace ILCompiler.DependencyAnalysis
             if (maximallyConstructableType != this)
             {
                 // EEType upgrading from necessary to constructed if some template instantation exists that matches up
+                // This ensures we don't end up having two EETypes in the system (one is this necessary type, and another one
+                // that was dynamically created at runtime).
                 if (CanonFormTypeMayExist)
                 {
                     result.Add(new CombinedDependencyListEntry(maximallyConstructableType, factory.MaximallyConstructableType(_type.ConvertToCanonForm(CanonicalFormKind.Specific)), "Trigger full type generation if canonical form exists"));


### PR DESCRIPTION
We shouldn't need to see the unconstructed types at runtime for anything.

Fixes #1262.