### PR TITLE
Analyze GVM dependencies from native layout

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -235,6 +235,28 @@ namespace ILCompiler.DependencyAnalysis
         {
         }
 
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context)
+        {
+            if (_method.IsVirtual && _method.HasInstantiation)
+            {
+                return GetGenericVirtualMethodDependencies(context);
+            }
+            else
+            {
+                return base.GetStaticDependencies(context);
+            }
+        }
+
+        private IEnumerable<DependencyListEntry> GetGenericVirtualMethodDependencies(NodeFactory factory)
+        {
+            foreach (var dep in base.GetStaticDependencies(factory))
+            {
+                yield return dep;
+            }
+
+            yield return new DependencyListEntry(factory.GVMDependencies(_method.GetCanonMethodTarget(CanonicalFormKind.Specific)), "Potential generic virtual method call");
+        }
+
         public override Vertex WriteVertex(NodeFactory factory)
         {
             Debug.Assert(Marked, "WriteVertex should only happen for marked vertices");

--- a/src/tests/nativeaot/SmokeTests/Generics/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/Generics/Generics.cs
@@ -2602,9 +2602,7 @@ class Program
         {
             // Regression test for https://github.com/dotnet/runtimelab/issues/537
             IFoo f = new Bar();
-            Console.WriteLine(f.FrobToo<object>());
-
-            if (f.FrobToo<object>() != "")
+            if (f.FrobToo<object>() != "Bar.Frob<System.Object>()")
                 throw new Exception();
         }
     }

--- a/src/tests/nativeaot/SmokeTests/Generics/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/Generics/Generics.cs
@@ -34,7 +34,8 @@ class Program
         TestDevirtualization.Run();
         TestGenericInlining.Run();
         TestGenericInliningDoesntHappen.Run();
-#if !CODEGEN_CPP 
+        TestGvmDependenciesFromLazy.Run();
+#if !CODEGEN_CPP
         TestNullableCasting.Run();
         TestVariantCasting.Run();
         TestMDArrayAddressMethod.Run();
@@ -2576,6 +2577,35 @@ class Program
         {
             // Regression test for https://github.com/dotnet/runtimelab/issues/485
             GenericType<object>.GenericMethod<int>();
+        }
+    }
+
+    class TestGvmDependenciesFromLazy
+    {
+        interface IFoo
+        {
+            string FrobToo<T>();
+        }
+
+        class Foo : IFoo
+        {
+            public virtual string Frob<T>() => $"Foo.Frob<{typeof(T)}>()";
+            public virtual string FrobToo<T>() => Frob<T>();
+        }
+
+        class Bar : Foo
+        {
+            public override string Frob<T>() => $"Bar.Frob<{typeof(T)}>()";
+        }
+
+        public static void Run()
+        {
+            // Regression test for https://github.com/dotnet/runtimelab/issues/537
+            IFoo f = new Bar();
+            Console.WriteLine(f.FrobToo<object>());
+
+            if (f.FrobToo<object>() != "")
+                throw new Exception();
         }
     }
 }


### PR DESCRIPTION
If we're generating native layout for a potential† GVM callsite, we should ensure the GVM analysis is aware of the callsite and generates necessary templates in template constructable types implementing the GVM.

Contributes to #537 (Avalonia now works with fully dynamic GVM resolution).

†We can't tell between LDTOKEN of a GVM and a GVM call right now and it's probably fine.