### PR TITLE
added unit test for ignore case relation of DFA

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/IgnoreCaseRelationGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/IgnoreCaseRelationGenerator.cs
@@ -55,7 +55,7 @@ internal static class " + classname + @"
         private static void WriteIgnoreCaseBDD(StreamWriter sw)
         {
             sw.WriteLine("/// <summary>");
-            sw.WriteLine("/// Serialized BDDs for mapping characters to their case-ignoring equivalence classes.");
+            sw.WriteLine("/// Serialized BDD for mapping characters to their case-ignoring equivalence classes in the default (en-US) culture");
             sw.WriteLine("/// </summary>");
             CharSetSolver solver = new CharSetSolver();
 
@@ -68,38 +68,6 @@ internal static class " + classname + @"
                 ignorecase = solver.MkOr(ignorecase, solver.MkAnd(solver.ShiftLeft(a, 16), b));
             }
             var ignorecase_repr = ignorecase.SerializeToString();
-
-            Dictionary<char, BDD> ignoreCase_inv = ComputeIgnoreCaseDictionary(solver, CultureInfo.InvariantCulture);
-            BDD ignorecase_inv = solver.False;
-            foreach (var kv in ignoreCase_inv)
-            {
-                var a = solver.MkCharSetFromRange(kv.Key, kv.Key);
-                var b = kv.Value;
-                ignorecase_inv = solver.MkOr(ignorecase_inv, solver.MkAnd(solver.ShiftLeft(a, 16), b));
-            }
-            var ignorecase_inv_repr = ignorecase_inv.SerializeToString();
-
-            Dictionary<char, BDD> ignoreCase_tr = ComputeIgnoreCaseDictionary(solver, new CultureInfo("tr-TR"));
-            BDD ignorecase_tr = solver.False;
-            foreach (var kv in ignoreCase_tr)
-            {
-                var a = solver.MkCharSetFromRange(kv.Key, kv.Key);
-                var b = kv.Value;
-                ignorecase_tr = solver.MkOr(ignorecase_tr, solver.MkAnd(solver.ShiftLeft(a, 16), b));
-            }
-            var ignorecase_tr_repr = ignorecase_tr.SerializeToString();
-
-            sw.WriteLine("//for InvariantCulture");
-            sw.WriteLine("public const string s_IgnoreCaseBDD_inv_repr =");
-            sw.Write('"');
-            sw.Write(ignorecase_inv_repr);
-            sw.WriteLine("\";");
-            sw.WriteLine("//for cultures az az-Cyrl az-Cyrl-AZ az-Latn az-Latn-AZ tr tr-CY tr-TR");
-            sw.WriteLine("public const string s_IgnoreCaseBDD_tr_repr =");
-            sw.Write('"');
-            sw.Write(ignorecase_tr_repr);
-            sw.WriteLine("\";");
-            sw.WriteLine("//for all other cultures including en-US");
             sw.WriteLine("public const string s_IgnoreCaseBDD_repr =");
             sw.Write('"');
             sw.Write(ignorecase_repr);

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -93,7 +93,7 @@ namespace System.Text.RegularExpressions.Tests
         /// This test is to make sure that the generated IgnoreCaseRelation table for DFA does not need to be updated.
         /// It would need to be updated/regenerated if this test fails.
         /// </summary>
-        //[OuterLoop("May take several seconds due to large number of cultures tested")]
+        [OuterLoop("May take several seconds due to large number of cultures tested")]
         [Fact]
         public void TestIgnoreCaseRelation()
         {
@@ -137,7 +137,7 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
-        //[OuterLoop("May take tens of seconds")]
+        [OuterLoop("May take tens of seconds")]
         [Fact]
         public void TestIgnoreCaseRelationBorderCasesInDFAmode()
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -44,7 +44,7 @@ namespace System.Text.RegularExpressions.Tests
                 char c = (char)i;
                 char cU = char.ToUpper(c);
                 char cL = char.ToLower(c);
-                //Turkish i without dot is only considered case-sensitive in tr and az languages
+                // Turkish i without dot is only considered case-sensitive in tr and az languages
                 if (treatedAsCaseInsensitive.Contains(c) ||
                     (c == Turkish_i_withoutDot && culture.TwoLetterISOLanguageName != "tr" && culture.TwoLetterISOLanguageName != "az"))
                     continue;
@@ -97,8 +97,8 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void TestIgnoreCaseRelation()
         {
-            //these 22 characters are considered case-insensitive by regex, while they are case-sensitive outside regex
-            //but they are only case-sensitive in an asymmmetrical way: tolower(c)=c, tolower(toupper(c)) != c
+            // these 22 characters are considered case-insensitive by regex, while they are case-sensitive outside regex
+            // but they are only case-sensitive in an asymmmetrical way: tolower(c)=c, tolower(toupper(c)) != c
             HashSet<char> treatedAsCaseInsensitive =
                  new("\u00B5\u017F\u0345\u03C2\u03D0\u03D1\u03D5\u03D6\u03F0\u03F1\u03F5\u1C80\u1C81\u1C82\u1C83\u1C84\u1C85\u1C86\u1C87\u1C88\u1E9B\u1FBE");
             foreach (char c in treatedAsCaseInsensitive)
@@ -110,15 +110,15 @@ namespace System.Text.RegularExpressions.Tests
 
             Assert.False(Regex.IsMatch(Turkish_i_withoutDot.ToString(), "i", RegexOptions.IgnoreCase));
 
-            //as baseline it is assumed the the invariant culture does not change
+            // as baseline it is assumed the the invariant culture does not change
             var inv_table = ComputeIgnoreCaseTable(CultureInfo.InvariantCulture, treatedAsCaseInsensitive);
             var cultures = System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes.AllCultures);
-            //expected difference between invariant and tr or az culture
+            // expected difference between invariant and tr or az culture
             string tr_diff = string.Format("I:Ii/I{0},i:Ii/i{1},{1}:{1}/i{1},{0}:{0}/I{0}", Turkish_i_withoutDot, Turkish_I_withDot);
-            //expected differnce between invariant and other cultures including the default en-US
+            // expected differnce between invariant and other cultures including the default en-US
             string default_diff = string.Format("I:Ii/Ii{0},i:Ii/Ii{0},{0}:{0}/Ii{0}", Turkish_I_withDot);
-            //the expected difference between invariant culture and all other cultures is only for i,I,Turkish_I_withDot,Turkish_i_withoutDot
-            //differentiate based on the TwoLetterISOLanguageName only (232 cases instead of 812)
+            // the expected difference between invariant culture and all other cultures is only for i,I,Turkish_I_withDot,Turkish_i_withoutDot
+            // differentiate based on the TwoLetterISOLanguageName only (232 cases instead of 812)
             List<CultureInfo> testcultures = new();
             HashSet<string> done = new();
             for (int i = 0; i < cultures.Length; i++)
@@ -129,10 +129,10 @@ namespace System.Text.RegularExpressions.Tests
                 var table = ComputeIgnoreCaseTable(culture, treatedAsCaseInsensitive);
                 string diff = GetDiff(inv_table, table);
                 if (culture.TwoLetterISOLanguageName == "tr" || culture.TwoLetterISOLanguageName == "az")
-                    //tr or az alphabet
+                    // tr or az alphabet
                     Assert.Equal(tr_diff, diff);
                 else
-                    //all other alphabets are treated the same as en-US
+                    // all other alphabets are treated the same as en-US
                     Assert.Equal(default_diff, diff);
             }
         }
@@ -141,8 +141,8 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void TestIgnoreCaseRelationBorderCasesInDFAmode()
         {
-            //these 22 characters are considered case-insensitive by regex, while they are case-sensitive outside regex
-            //but they are only case-sensitive in an asymmmetrical way: tolower(c)=c, tolower(toupper(c)) != c
+            // these 22 characters are considered case-insensitive by regex, while they are case-sensitive outside regex
+            // but they are only case-sensitive in an asymmmetrical way: tolower(c)=c, tolower(toupper(c)) != c
             HashSet<char> treatedAsCaseInsensitive =
                  new("\u00B5\u017F\u0345\u03C2\u03D0\u03D1\u03D5\u03D6\u03F0\u03F1\u03F5\u1C80\u1C81\u1C82\u1C83\u1C84\u1C85\u1C86\u1C87\u1C88\u1E9B\u1FBE");
             foreach (char c in treatedAsCaseInsensitive)
@@ -157,7 +157,7 @@ namespace System.Text.RegularExpressions.Tests
             Assert.True(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | DFA));
             Assert.False(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | DFA | RegexOptions.CultureInvariant));
 
-            //Turkish i without dot is not considered case-sensitive in the default en-US culture
+            // Turkish i without dot is not considered case-sensitive in the default en-US culture
             treatedAsCaseInsensitive.Add(Turkish_i_withoutDot);
 
             List<char> caseSensitiveChars = new();
@@ -165,7 +165,7 @@ namespace System.Text.RegularExpressions.Tests
                 if (!treatedAsCaseInsensitive.Contains(c) && char.ToUpper(c) != char.ToLower(c))
                     caseSensitiveChars.Add(c);
 
-            //test all case-sensitive characters exhaustively in DFA mode
+            // test all case-sensitive characters exhaustively in DFA mode
             foreach (char c in caseSensitiveChars)
                 Assert.True(Regex.IsMatch(char.ToUpper(c).ToString() + char.ToLower(c).ToString(),
                     c.ToString() + c.ToString(), RegexOptions.IgnoreCase | DFA));

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -30,7 +30,7 @@ namespace System.Text.RegularExpressions.Tests
         private const char Kelvin_sign = '\u212A';
 
         /// <summary>
-        /// Maps each character c to the set of all of its equivalent characters if case is ingored or null if c in case-insensitive
+        /// Maps each character c to the set of all of its equivalent characters if case is ignored or null if c in case-insensitive
         /// </summary>
         /// <param name="culture">ignoring case wrt this culture</param>
         /// <param name="treatedAsCaseInsensitive">characters that are otherwise case-sensitive but not in a regex</param>


### PR DESCRIPTION
Testing across all cultures that the only relevant special handling is required for the letters are i, I, and the Turkish i's, \u0130 and \u0131,
This test should catch any changes made to ordinal table of ignoring case of special characters that may depend on culture in the future.