### PR TITLE
Fix more issues with native layout dependencies

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericMethodsTemplateMap.cs
@@ -51,21 +51,15 @@ namespace ILCompiler.DependencyAnalysis
             nativeSection.Place(hashtable);
 
 
-            foreach (MethodDesc method in factory.MetadataManager.GetCompiledMethods())
+            foreach (var methodEntryNode in factory.MetadataManager.GetTemplateMethodEntries())
             {
-                if (!IsEligibleToBeATemplate(method))
-                    continue;
-
-                var methodEntryNode = factory.NativeLayout.TemplateMethodEntry(method);
-
-                if (!methodEntryNode.Marked)
-                    continue;
-
                 // Method entry
                 Vertex methodEntry = methodEntryNode.SavedVertex;
 
                 // Method's native layout info
-                Vertex nativeLayout = factory.NativeLayout.TemplateMethodLayout(method).SavedVertex;
+                var layoutNode = factory.NativeLayout.TemplateMethodLayout(methodEntryNode.Method);
+                Debug.Assert(layoutNode.Marked);
+                Vertex nativeLayout = layoutNode.SavedVertex;
 
                 // Hashtable Entry
                 Vertex entry = nativeWriter.GetTuple(
@@ -73,7 +67,7 @@ namespace ILCompiler.DependencyAnalysis
                     nativeWriter.GetUnsignedConstant((uint)nativeLayout.VertexOffset));
 
                 // Add to the hash table, hashed by the containing type's hashcode
-                uint hashCode = (uint)method.GetHashCode();
+                uint hashCode = (uint)methodEntryNode.Method.GetHashCode();
                 hashtable.Append(hashCode, nativeSection.Place(entry));
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -58,6 +58,7 @@ namespace ILCompiler
         private HashSet<DefType> _typesWithDelegateMarshalling = new HashSet<DefType>();
         private HashSet<DefType> _typesWithStructMarshalling = new HashSet<DefType>();
         private HashSet<MethodDesc> _dynamicInvokeTemplates = new HashSet<MethodDesc>();
+        private HashSet<NativeLayoutTemplateMethodSignatureVertexNode> _templateMethodEntries = new HashSet<NativeLayoutTemplateMethodSignatureVertexNode>();
 
         internal NativeLayoutInfoNode NativeLayoutInfo { get; private set; }
         internal DynamicInvokeTemplateDataNode DynamicInvokeTemplateData { get; private set; }
@@ -232,6 +233,11 @@ namespace ILCompiler
             if (obj is DynamicInvokeTemplateNode dynamicInvokeTemplate)
             {
                 _dynamicInvokeTemplates.Add(dynamicInvokeTemplate.Method);
+            }
+
+            if (obj is NativeLayoutTemplateMethodSignatureVertexNode templateMethodEntry)
+            {
+                _templateMethodEntries.Add(templateMethodEntry);
             }
         }
 
@@ -698,6 +704,11 @@ namespace ILCompiler
         internal IEnumerable<MethodDesc> GetDynamicInvokeTemplateMethods()
         {
             return _dynamicInvokeTemplates;
+        }
+
+        internal IEnumerable<NativeLayoutTemplateMethodSignatureVertexNode> GetTemplateMethodEntries()
+        {
+            return _templateMethodEntries;
         }
 
         public bool IsReflectionBlocked(TypeDesc type)


### PR DESCRIPTION
This is in the same spirit as #1321.

Native layout wasn't properly declaring dependencies for type handles and method generic dictionaries.

The type handles case can be hit with the existing test coverage (need to turn off eager generic dictionary building for GVMs).

The generic dictionary case required a new test (again, can only be hit once we disable eager GVM dictionaries).

These are prerequisites for making GVM dictionaries fully lazy.