### PR TITLE
Fixes compilation error

### DIFF
--- a/src/coreclr/tools/Common/CommandLine/Enumerable.cs
+++ b/src/coreclr/tools/Common/CommandLine/Enumerable.cs
@@ -18,16 +18,6 @@ namespace Internal.CommandLine
             return Linq.Enumerable.Empty<T>();
         }
 
-        public static IEnumerable<U> Select<T, U>(this IEnumerable<T> values, Func<T, U> func)
-        {
-            Debug.Assert(values != null);
-
-            foreach (T value in values)
-            {
-                yield return func(value);
-            }
-        }
-
         public static IEnumerable<T> Where<T>(this IEnumerable<T> values, Func<T, bool> func)
         {
             Debug.Assert(values != null);
@@ -37,11 +27,6 @@ namespace Internal.CommandLine
                 if (func(value))
                     yield return value;
             }
-        }
-
-        public static IEnumerable<T> Concat<T>(this IEnumerable<T> first, IEnumerable<T> second)
-        {
-            return Linq.Enumerable.Concat(first, second);
         }
 
         public static bool All<T>(this IEnumerable<T> source, Func<T, bool> predicate)


### PR DESCRIPTION
after introduction of these functions to LINQ
This is requires bump of expected version in global.json

Closes #1334