### PR TITLE
added nfa mode to SRM as a fallback when DFA state-space explodes

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
@@ -146,8 +146,7 @@ namespace System.Text.RegularExpressions.SRM
         /// If atom is False this means that this is \n and it is the last character of the input.
         /// </summary>
         /// <param name="atom">minterm corresponding to some input character or False corresponding to last \n</param>
-        /// <param name="antimirov">if true computes antimirov derivatives</param>
-        internal State<S> Next(S atom, bool antimirov)
+        internal State<S> Next(S atom)
         {
             var alg = Node.builder.solver;
             S WLpred = Node.builder.wordLetterPredicate;
@@ -176,7 +175,7 @@ namespace System.Text.RegularExpressions.SRM
             // combined character context
             uint context = CharKind.Context(PrevCharKind, nextCharKind);
             // compute the derivative of the node for the given context
-            SymbolicRegexNode<S> derivative = Node.MkDerivative(atom, context, antimirov);
+            SymbolicRegexNode<S> derivative = Node.MkDerivative(atom, context);
             // nextCharKind will be the PrevCharKind of the target state
             // use an existing state instead if one exists already
             // otherwise create a new new id for it

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
@@ -146,7 +146,7 @@ namespace System.Text.RegularExpressions.SRM
         /// If atom is False this means that this is \n and it is the last character of the input.
         /// </summary>
         /// <param name="atom">minterm corresponding to some input character or False corresponding to last \n</param>
-        /// <param name="antimirov">if true uses antimirov derivatives</param>
+        /// <param name="antimirov">if true computes antimirov derivatives</param>
         internal State<S> Next(S atom, bool antimirov)
         {
             var alg = Node.builder.solver;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/State.cs
@@ -146,7 +146,8 @@ namespace System.Text.RegularExpressions.SRM
         /// If atom is False this means that this is \n and it is the last character of the input.
         /// </summary>
         /// <param name="atom">minterm corresponding to some input character or False corresponding to last \n</param>
-        internal State<S> Next(S atom)
+        /// <param name="antimirov">if true uses antimirov derivatives</param>
+        internal State<S> Next(S atom, bool antimirov)
         {
             var alg = Node.builder.solver;
             S WLpred = Node.builder.wordLetterPredicate;
@@ -175,7 +176,7 @@ namespace System.Text.RegularExpressions.SRM
             // combined character context
             uint context = CharKind.Context(PrevCharKind, nextCharKind);
             // compute the derivative of the node for the given context
-            SymbolicRegexNode<S> derivative = Node.MkDerivative(atom, context);
+            SymbolicRegexNode<S> derivative = Node.MkDerivative(atom, context, antimirov);
             // nextCharKind will be the PrevCharKind of the target state
             // use an existing state instead if one exists already
             // otherwise create a new new id for it

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
@@ -959,7 +959,7 @@ namespace System.Text.RegularExpressions.SRM
         /// <summary>
         /// Make a state with given node and previous character context
         /// </summary>
-        public State<S> MkState(SymbolicRegexNode<S> node, uint prevCharKind, bool nfamode = false)
+        public State<S> MkState(SymbolicRegexNode<S> node, uint prevCharKind, bool antimirov = false)
         {
             //first prune the anchors in the node
             S WLpred = wordLetterPredicate;
@@ -973,8 +973,8 @@ namespace System.Text.RegularExpressions.SRM
             State<S> state;
             if (!stateCache.TryGetValue(s, out state))
             {
-                // do not cache powersets of states as states in nfa mode
-                if (nfamode && pruned_node.Kind == SymbolicRegexKind.Or)
+                // do not cache set of states as states in antimirov mode
+                if (antimirov && pruned_node.Kind == SymbolicRegexKind.Or)
                 {
                     s.Id = -1; // mark the Id as invalid
                     state = s;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
@@ -37,6 +37,11 @@ namespace System.Text.RegularExpressions.SRM
         internal S wordLetterPredicate;
         internal S newLinePredicate;
 
+        /// <summary>
+        /// Partition of the input space of predicates.
+        /// </summary>
+        internal S[] atoms;
+
         private Dictionary<S, SymbolicRegexNode<S>> singletonCache = new Dictionary<S, SymbolicRegexNode<S>>();
         // states that have been created
         internal HashSet<State<S>> stateCache = new HashSet<State<S>>();
@@ -44,7 +49,14 @@ namespace System.Text.RegularExpressions.SRM
         /// Maps state ids to states, initial capacity is 1024 states.
         /// Each time more states are needed the length is increased by 1024.
         /// </summary>
-        internal State<S>[] statearray = new State<S>[1024];
+        internal State<S>[] statearray;
+        internal State<S>[] delta;
+        private const int s_INITIALSTATELIMIT = 1024;
+
+        /// <summary>
+        /// K is the smallest k s.t. 2^k >= atoms.Length + 1
+        /// </summary>
+        internal int K;
 
         private SymbolicRegexBuilder()
         {
@@ -67,6 +79,19 @@ namespace System.Text.RegularExpressions.SRM
         /// </summary>
         internal SymbolicRegexBuilder(ICharAlgebra<S> solver) : this()
         {
+            // atoms = null if partition of the solver is undefined and returned as null
+            atoms = solver.GetPartition();
+            if (atoms == null)
+                K = -1;
+            else
+            {
+                statearray = new State<S>[s_INITIALSTATELIMIT];
+                // the extra slot with id atoms.Length is reserved for \Z (last occurrence of \n)
+                int k = 1;
+                while (atoms.Length >= (1 << k)) k += 1;
+                K = k;
+                delta = new State<S>[s_INITIALSTATELIMIT << K];
+            }
             InitilizeFields(solver);
         }
 
@@ -928,6 +953,52 @@ namespace System.Text.RegularExpressions.SRM
                 }
                 n = j + 1;
                 return nodes.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Make a state with given node and previous character context
+        /// </summary>
+        public State<S> MkState(SymbolicRegexNode<S> node, uint prevCharKind, bool nfamode = false)
+        {
+            //first prune the anchors in the node
+            S WLpred = wordLetterPredicate;
+            S startSet = node.GetStartSet();
+            //true if the startset of the node overlaps with some wordletter or the node can be nullable
+            bool contWithWL = (node.CanBeNullable || solver.IsSatisfiable(solver.MkAnd(WLpred, startSet)));
+            //true if the startset of the node overlaps with some nonwordletter or the node can be nullable
+            bool contWithNWL = (node.CanBeNullable || solver.IsSatisfiable(solver.MkAnd(solver.MkNot(WLpred), startSet)));
+            var pruned_node = node.PruneAnchors(prevCharKind, contWithWL, contWithNWL);
+            State<S> s = new State<S>(pruned_node, prevCharKind);
+            State<S> state;
+            if (!stateCache.TryGetValue(s, out state))
+            {
+                // do not cache powersets of states as states in nfa mode
+                if (nfamode && pruned_node.Kind == SymbolicRegexKind.Or)
+                {
+                    s.Id = -1; // mark the Id as invalid
+                    state = s;
+                }
+                else
+                    state = MakeNewState(s);
+            }
+            return state;
+        }
+
+        private State<S> MakeNewState(State<S> state)
+        {
+            lock (this)
+            {
+                state.Id = stateCache.Count;
+                stateCache.Add(state);
+                if (state.Id == statearray.Length)
+                {
+                    int newsize = statearray.Length + 1024;
+                    Array.Resize(ref statearray, newsize);
+                    Array.Resize(ref delta, newsize << K);
+                }
+                statearray[state.Id] = state;
+                return state;
             }
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
@@ -58,6 +58,12 @@ namespace System.Text.RegularExpressions.SRM
         /// </summary>
         internal int K;
 
+        /// <summary>
+        /// If true then delta is used in a mode where
+        /// each target state represents a set of states.
+        /// </summary>
+        internal bool antimirov;
+
         private SymbolicRegexBuilder()
         {
             this.epsilon = SymbolicRegexNode<S>.MkEpsilon(this);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -236,6 +236,8 @@ namespace System.Text.RegularExpressions.SRM
             }
         }
 
+        internal SymbolicRegexNode<S> ToANF() => throw new NotImplementedException();
+
         /// <summary>
         /// Converts a concatenation into an array,
         /// returns a non-concatenation in a singleton array.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -236,8 +236,6 @@ namespace System.Text.RegularExpressions.SRM
             }
         }
 
-        internal SymbolicRegexNode<S> ToANF() => throw new NotImplementedException();
-
         /// <summary>
         /// Converts a concatenation into an array,
         /// returns a non-concatenation in a singleton array.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -987,8 +987,9 @@ namespace System.Text.RegularExpressions.SRM
         /// </summary>
         /// <param name="elem">given element wrt which the derivative is taken</param>
         /// <param name="context">immediately surrounding character context that affects nullability of anchors</param>
+        /// <param name="antimirov">if true uses Antimirov derivatives</param>
         /// <returns></returns>
-        internal SymbolicRegexNode<S> MkDerivative(S elem, uint context)
+        internal SymbolicRegexNode<S> MkDerivative(S elem, uint context, bool antimirov)
         {
             if (this == builder.dotStar || this == builder.nothing)
                 return this;
@@ -1005,7 +1006,7 @@ namespace System.Text.RegularExpressions.SRM
                     case SymbolicRegexKind.Loop:
                         {
                             #region d(a, R*) = d(a,R)R*
-                            var step = left.MkDerivative(elem, context);
+                            var step = left.MkDerivative(elem, context, antimirov);
                             if (step == builder.nothing || upper == 0)
                             {
                                 return builder.nothing;
@@ -1038,10 +1039,17 @@ namespace System.Text.RegularExpressions.SRM
                     case SymbolicRegexKind.Concat:
                         {
                             #region d(a, AB) = d(a,A)B | (if A nullable then d(a,B))
-                            var first = builder.MkConcat(left.MkDerivative(elem, context), right);
+                            var leftd = left.MkDerivative(elem, context, antimirov);
+                            var first = builder.nothing;
+                            if (antimirov && leftd.kind == SymbolicRegexKind.Or)
+                                // push concatenations into the union
+                                foreach (var d in leftd.alts)
+                                    first = builder.MkOr(first, builder.MkConcat(d, right));
+                            else
+                                first = builder.MkConcat(leftd, right);
                             if (left.IsNullableFor(context))
                             {
-                                var second = right.MkDerivative(elem, context);
+                                var second = right.MkDerivative(elem, context, antimirov);
                                 var deriv = builder.MkOr2(first, second);
                                 return deriv;
                             }
@@ -1054,35 +1062,35 @@ namespace System.Text.RegularExpressions.SRM
                     case SymbolicRegexKind.Or:
                         {
                             #region d(a,A|B) = d(a,A)|d(a,B)
-                            var alts_deriv = alts.MkDerivative(elem, context);
+                            var alts_deriv = alts.MkDerivative(elem, context, antimirov);
                             return builder.MkOr(alts_deriv);
                             #endregion
                         }
                     case SymbolicRegexKind.And:
                         {
                             #region d(a,A & B) = d(a,A) & d(a,B)
-                            var derivs = alts.MkDerivative(elem, context);
+                            var derivs = alts.MkDerivative(elem, context, antimirov);
                             return builder.MkAnd(derivs);
                             #endregion
                         }
                     case SymbolicRegexKind.IfThenElse:
                         {
                             #region d(a,Ite(A,B,C)) = Ite(d(a,A),d(a,B),d(a,C))
-                            var condD = iteCond.MkDerivative(elem, context);
+                            var condD = iteCond.MkDerivative(elem, context, antimirov);
                             if (condD == builder.nothing)
                             {
-                                var rightD = right.MkDerivative(elem, context);
+                                var rightD = right.MkDerivative(elem, context, antimirov);
                                 return rightD;
                             }
                             else if (condD == builder.dotStar)
                             {
-                                var leftD = left.MkDerivative(elem, context);
+                                var leftD = left.MkDerivative(elem, context, antimirov);
                                 return leftD;
                             }
                             else
                             {
-                                var leftD = left.MkDerivative(elem, context);
-                                var rightD = right.MkDerivative(elem, context);
+                                var leftD = left.MkDerivative(elem, context, antimirov);
+                                var rightD = right.MkDerivative(elem, context, antimirov);
                                 var ite = builder.MkIfThenElse(condD, leftD, rightD);
                                 return ite;
                             }
@@ -2404,13 +2412,13 @@ namespace System.Text.RegularExpressions.SRM
             return elems;
         }
 
-        internal SymbolicRegexSet<S> MkDerivative(S elem, uint context)
-             => CreateMultiset(builder, MkDerivativesOfElems(elem, context), kind);
+        internal SymbolicRegexSet<S> MkDerivative(S elem, uint context, bool antimirov)
+             => CreateMultiset(builder, MkDerivativesOfElems(elem, context, antimirov), kind);
 
-        private IEnumerable<SymbolicRegexNode<S>> MkDerivativesOfElems(S elem, uint context)
+        private IEnumerable<SymbolicRegexNode<S>> MkDerivativesOfElems(S elem, uint context, bool antimirov)
         {
             foreach (var s in this)
-                yield return s.MkDerivative(elem, context);
+                yield return s.MkDerivative(elem, context, antimirov);
         }
 
         private IEnumerable<SymbolicRegexNode<T>> TransformElems<T>(SymbolicRegexBuilder<T> builderT, Func<S, T> predicateTransformer)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
@@ -208,7 +208,7 @@ namespace System.Text.RegularExpressions.SRM
 
         public BDD[] GetPartition()
         {
-            throw new NotSupportedException();
+            return null;
         }
 
         public string PrettyPrint(BDD pred)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
@@ -36,7 +36,7 @@ namespace System.Text.RegularExpressions.SRM.DGML
                 var q = stack.Pop();
                 foreach (var c in partition)
                 {
-                    var p = q.Next(c, false);
+                    var p = q.Next(c);
                     //check that p is not a dead-end
                     if (!p.IsNothing)
                     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
@@ -23,7 +23,7 @@ namespace System.Text.RegularExpressions.SRM.DGML
             uint startId = (inReverse ? (srm.Ar.info.StartsWithLineAnchor ? CharKind.StartStop : 0)
                                             : (srm.A.info.StartsWithLineAnchor ? CharKind.StartStop : 0));
             //inReverse only matters if Ar contains some line anchor
-            _q0 = State<S>.MkState(inReverse ? srm.Ar : (addDotStar ? srm.A1 : srm.A), startId);
+            _q0 = _builder.MkState(inReverse ? srm.Ar : (addDotStar ? srm.A1 : srm.A), startId);
             var stack = new Stack<State<S>>();
             stack.Push(_q0);
             _states.Add(_q0.Id);
@@ -69,7 +69,7 @@ namespace System.Text.RegularExpressions.SRM.DGML
 
         public string DescribeStartLabel() => "";
 
-        public string DescribeState(int state) => ViewState(_builder.statearray[state]);
+        public string DescribeState(int state) => _builder.statearray[state].DgmlView;
 
         public IEnumerable<int> GetStates() => _states;
 
@@ -78,16 +78,5 @@ namespace System.Text.RegularExpressions.SRM.DGML
         public IEnumerable<Move<S>> GetMoves() => _moves;
 
         private static string HTMLEncodeChars(string s) => s.Replace("&", "&amp;").Replace("\"", "&quot;").Replace("<", "&lt;").Replace(">", "&gt;");
-
-        private string ViewState(State<S> state)
-        {
-            string deriv = HTMLEncodeChars(state.Node.ToString());
-            string info = CharKind.PrettyPrint(state.PrevCharKind);
-            if (info != string.Empty)
-                info = string.Format("Previous: {0}&#13;", info);
-            if (deriv == string.Empty)
-                deriv = "()";
-            return string.Format("{0}{1}", info, deriv);
-        }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/dgml/RegexDFA.cs
@@ -36,7 +36,7 @@ namespace System.Text.RegularExpressions.SRM.DGML
                 var q = stack.Pop();
                 foreach (var c in partition)
                 {
-                    var p = q.Next(c);
+                    var p = q.Next(c, false);
                     //check that p is not a dead-end
                     if (!p.IsNothing)
                     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -162,10 +162,10 @@ namespace System.Text.RegularExpressions.SRM
         private const int s_STATEMAXBOUND = 10000;
 
         /// <summary>
-        /// If true then builder.delta is used in nfa mode where
+        /// If true then builder.delta is used in a mode where
         /// each target state represents a set of states.
         /// </summary>
-        private bool nfamode;
+        private bool antimirov;
 
         #region custom serialization/deserialization
         /// <summary>
@@ -415,7 +415,7 @@ namespace System.Text.RegularExpressions.SRM
             int atom_id = (c == 10 && i == input.Length - 1 && q.StartsWithLineAnchor ? builder.atoms.Length : dt.Find(c));
             // atom=False represents \Z
             S atom = atom_id == builder.atoms.Length ? builder.solver.False : builder.atoms[atom_id];
-            if (nfamode && q.Node.Kind == SymbolicRegexKind.Or)
+            if (antimirov && q.Node.Kind == SymbolicRegexKind.Or)
             {
                 SymbolicRegexNode<S> union = builder.nothing;
                 uint kind = 0;
@@ -460,11 +460,11 @@ namespace System.Text.RegularExpressions.SRM
                 else
                 {
                     // this is the only place in code where the Next method is called in the matcher
-                    p = q.Next(atom, nfamode);
+                    p = q.Next(atom, antimirov);
                     builder.delta[offset] = p;
-                    //switch to nfa mode if the maximum bound has been reached
+                    //switch to antimirov mode if the maximum bound has been reached
                     if (p.Id == s_STATEMAXBOUND)
-                        nfamode = true;
+                        antimirov = true;
                     return p;
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -460,7 +460,7 @@ namespace System.Text.RegularExpressions.SRM
                 else
                 {
                     // this is the only place in code where the Next method is called in the matcher
-                    p = q.Next(atom);
+                    p = q.Next(atom, nfamode);
                     builder.delta[offset] = p;
                     //switch to nfa mode if the maximum bound has been reached
                     if (p.Id == s_STATEMAXBOUND)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/matcher/SymbolicRegexMatcher.cs
@@ -161,12 +161,6 @@ namespace System.Text.RegularExpressions.SRM
 
         private const int s_STATEMAXBOUND = 10000;
 
-        /// <summary>
-        /// If true then builder.delta is used in a mode where
-        /// each target state represents a set of states.
-        /// </summary>
-        private bool antimirov;
-
         #region custom serialization/deserialization
         /// <summary>
         /// Append the custom format of this matcher into sb. All characters are in visible ASCII.
@@ -415,7 +409,7 @@ namespace System.Text.RegularExpressions.SRM
             int atom_id = (c == 10 && i == input.Length - 1 && q.StartsWithLineAnchor ? builder.atoms.Length : dt.Find(c));
             // atom=False represents \Z
             S atom = atom_id == builder.atoms.Length ? builder.solver.False : builder.atoms[atom_id];
-            if (antimirov && q.Node.Kind == SymbolicRegexKind.Or)
+            if (builder.antimirov && q.Node.Kind == SymbolicRegexKind.Or)
             {
                 SymbolicRegexNode<S> union = builder.nothing;
                 uint kind = 0;
@@ -460,11 +454,11 @@ namespace System.Text.RegularExpressions.SRM
                 else
                 {
                     // this is the only place in code where the Next method is called in the matcher
-                    p = q.Next(atom, antimirov);
+                    p = q.Next(atom);
                     builder.delta[offset] = p;
                     //switch to antimirov mode if the maximum bound has been reached
                     if (p.Id == s_STATEMAXBOUND)
-                        antimirov = true;
+                        builder.antimirov = true;
                     return p;
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -29,6 +29,22 @@ namespace System.Text.RegularExpressions.Tests
         private const char Turkish_i_withoutDot = '\u0131';
         private const char Kelvin_sign = '\u212A';
 
+        [Fact]
+        public void TestNFAmode()
+        {
+            string rawregex = "a.{20}$";
+            Random random = new Random(0);
+            byte[] buffer = new byte[50000];
+            random.NextBytes(buffer);
+            var input = new string(Array.ConvertAll(buffer, b => (b <= 0x7F ? 'a' : 'b')));
+            input += "a01234567890123456789";
+            Regex re = new Regex(rawregex, DFA | RegexOptions.Singleline);
+            Match m = re.Match(input);
+            Assert.True(m.Success);
+            Assert.Equal(buffer.Length, m.Index);
+            Assert.Equal(21, m.Length);
+        }
+
         /// <summary>
         /// Maps each character c to the set of all of its equivalent characters if case is ignored or null if c in case-insensitive
         /// </summary>

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -45,6 +45,22 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(21, m.Length);
         }
 
+        [Fact]
+        public void TestNFAmodeAntimirov()
+        {
+            string rawregex = "(a.{20}|a.{10})bc$";
+            Random random = new Random(0);
+            byte[] buffer = new byte[50000];
+            random.NextBytes(buffer);
+            var input = new string(Array.ConvertAll(buffer, b => (b <= 0x7F ? 'a' : 'b')));
+            input += "a01234567890123456789bc";
+            Regex re = new Regex(rawregex, DFA | RegexOptions.Singleline);
+            Match m = re.Match(input);
+            Assert.True(m.Success);
+            Assert.Equal(buffer.Length, m.Index);
+            Assert.Equal(23, m.Length);
+        }
+
         /// <summary>
         /// Maps each character c to the set of all of its equivalent characters if case is ignored or null if c in case-insensitive
         /// </summary>


### PR DESCRIPTION
Added a DFA state limit of 10000 that triggers NFA mode. Default DFA state space size is 1024 and this is increased by 1024 each time more states are needed to be stored. When 10000 state limit is reached then states are only added for non-union states. For example a regex (state) (.{10}$|.{7}$) becomes is treated as a union of two states .{10}$ and .{7}$. In NFA mode SRM works with unions that slows down the overall matching.

NFA mode is highly unlikely to happen but avoids running out of memory for large counters and long inputs of millions of characters when each input character may cause a new state.

The change does not affect the overall semantics of SRM.

Also refactored the code a bit so that handling of states and transitions (delta) happens in one place now (in the builder) instead of states in the builder and transitions in the matcher -- that caused the resizing logic of the corresponding arrays to be unintuitive and difficult to work with in particular to ensure thread-safety.
