### PR TITLE
Include a couple more native layout dependencies

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.NativeLayout.cs
@@ -212,6 +212,18 @@ namespace ILCompiler.DependencyAnalysis
             // of just necessary. (Which is what the actual templates signatures will ensure)
             public IEnumerable<IDependencyNode> TemplateConstructableTypes(TypeDesc type)
             {
+                // Array types are the only parameterized types that have templates
+                if (type.IsSzArray && !type.IsArrayTypeWithoutGenericInterfaces())
+                {
+                    TypeDesc arrayCanonicalType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
+
+                    // Add a dependency on the template for this type, if the canonical type should be generated into this binary.
+                    if (arrayCanonicalType.IsCanonicalSubtype(CanonicalFormKind.Any) && !_factory.NecessaryTypeSymbol(arrayCanonicalType).RepresentsIndirectionCell)
+                    {
+                        yield return _factory.NativeLayout.TemplateTypeLayout(arrayCanonicalType);
+                    }
+                }
+
                 while (type.IsParameterizedType)
                 {
                     type = ((ParameterizedType)type).ParameterType;


### PR DESCRIPTION
In the same spirit as #1321 and #1332.

The concern is that if we ever end up in situations where we only generate canonical code and not a single dictionary that matches it, we might miss artifacts required by native layout at runtime.

The above situation can happen with lazy generic virtual methods (that we would like to enable soon) or with lazy generics in general (nice to have in the future).

I'm finding all of these places by running an aggressive mode where only native artifacts the compiler considers necessary receive template layout. (The compiler currently generates template layout for everything generic, which tends to paper over deficiencies like this.)

I verified this is a no-size-diff change for a basic WebAPI app (modulo reordering things), but it fixes issues for the aggressive mode where previously we would miss artifacts in the middle of type building.