### PR TITLE
Fix annotations on custom attribute handling

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/NativeFormat/NativeFormatCustomAttributeData.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/NativeFormat/NativeFormatCustomAttributeData.cs
@@ -48,6 +48,8 @@ namespace System.Reflection.Runtime.CustomAttributes.NativeFormat
 
         public sealed override ConstructorInfo Constructor
         {
+            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
+                Justification = "Metadata generation ensures custom attribute constructors are resolvable.")]
             get
             {
                 MetadataReader reader = _reader;
@@ -196,7 +198,7 @@ namespace System.Reflection.Runtime.CustomAttributes.NativeFormat
             return customAttributeNamedArguments;
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2080:UnrecognizedReflectionPattern",
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
             Justification = "Metadata generation ensures fields/properties referenced from attributes are preserved.")]
         private static CustomAttributeNamedArgument CreateCustomAttributeNamedArgument(Type attributeType, string memberName, bool isField, CustomAttributeTypedArgument typedValue)
         {

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -84,9 +84,9 @@ namespace System.Reflection.Runtime.CustomAttributes
             }
         }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
-            Justification = "Metadata generation ensures custom attribute constructors are resolvable.")]
-        protected static ConstructorInfo ResolveAttributeConstructor(Type attributeType, Type[] parameterTypes)
+        protected static ConstructorInfo ResolveAttributeConstructor(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+            Type attributeType, Type[] parameterTypes)
         {
             int parameterCount = parameterTypes.Length;
             foreach (ConstructorInfo candidate in attributeType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/CustomAttributes/RuntimePseudoCustomAttributeData.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection.Runtime.General;
@@ -16,16 +17,14 @@ namespace System.Reflection.Runtime.CustomAttributes
     //
     internal sealed class RuntimePseudoCustomAttributeData : RuntimeCustomAttributeData
     {
-        public RuntimePseudoCustomAttributeData(Type attributeType, IList<CustomAttributeTypedArgument> constructorArguments, IList<CustomAttributeNamedArgument> namedArguments)
+        public RuntimePseudoCustomAttributeData(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+            Type attributeType, IList<CustomAttributeTypedArgument> constructorArguments)
         {
             _attributeType = attributeType;
             if (constructorArguments == null)
                 constructorArguments = Array.Empty<CustomAttributeTypedArgument>();
             _constructorArguments = new ReadOnlyCollection<CustomAttributeTypedArgument>(constructorArguments);
-            if (namedArguments == null)
-                namedArguments = Array.Empty<CustomAttributeNamedArgument>();
-            _namedArguments = new ReadOnlyCollection<CustomAttributeNamedArgument>(namedArguments);
-            return;
         }
 
         public sealed override Type AttributeType
@@ -68,13 +67,15 @@ namespace System.Reflection.Runtime.CustomAttributes
 
         internal sealed override IList<CustomAttributeNamedArgument> GetNamedArguments(bool throwIfMissingMetadata)
         {
-            return _namedArguments;
+            // Note: if we ever need to return non-empty named arguments, we need to ensure the reflection metadata for the
+            // corresponding fields/properties is kept (we might have to bump the dataflow annotation on _attributeType).
+            return Array.Empty<CustomAttributeNamedArgument>();
         }
 
         // Equals/GetHashCode no need to override (they just implement reference equality but desktop never unified these things.)
 
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         private readonly Type _attributeType;
         private readonly ReadOnlyCollection<CustomAttributeTypedArgument> _constructorArguments;
-        private readonly ReadOnlyCollection<CustomAttributeNamedArgument> _namedArguments;
     }
 }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/FieldInfos/RuntimeFieldInfo.cs
@@ -66,13 +66,13 @@ namespace System.Reflection.Runtime.FieldInfos
                 {
                     int offset = ExplicitLayoutFieldOffsetData;
                     CustomAttributeTypedArgument offsetArgument = new CustomAttributeTypedArgument(typeof(int), offset);
-                    yield return new RuntimePseudoCustomAttributeData(typeof(FieldOffsetAttribute), new CustomAttributeTypedArgument[] { offsetArgument }, null);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(FieldOffsetAttribute), new CustomAttributeTypedArgument[] { offsetArgument });
                 }
 
                 FieldAttributes attributes = Attributes;
                 if (0 != (attributes & FieldAttributes.NotSerialized))
                 {
-                    yield return new RuntimePseudoCustomAttributeData(typeof(NonSerializedAttribute), null, null);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(NonSerializedAttribute), null);
                 }
             }
         }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs
@@ -89,7 +89,7 @@ namespace System.Reflection.Runtime.MethodInfos
 
                 MethodImplAttributes implAttributes = _common.MethodImplementationFlags;
                 if (0 != (implAttributes & MethodImplAttributes.PreserveSig))
-                    yield return new RuntimePseudoCustomAttributeData(typeof(PreserveSigAttribute), null, null);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(PreserveSigAttribute), null);
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeFatMethodParameterInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/ParameterInfos/RuntimeFatMethodParameterInfo.cs
@@ -29,11 +29,11 @@ namespace System.Reflection.Runtime.ParameterInfos
 
                 ParameterAttributes attributes = Attributes;
                 if (0 != (attributes & ParameterAttributes.In))
-                    yield return new RuntimePseudoCustomAttributeData(typeof(InAttribute), null, null);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(InAttribute), null);
                 if (0 != (attributes & ParameterAttributes.Out))
-                    yield return new RuntimePseudoCustomAttributeData(typeof(OutAttribute), null, null);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(OutAttribute), null);
                 if (0 != (attributes & ParameterAttributes.Optional))
-                    yield return new RuntimePseudoCustomAttributeData(typeof(OptionalAttribute), null, null);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(OptionalAttribute), null);
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/RuntimeNamedTypeInfo.cs
@@ -45,10 +45,10 @@ namespace System.Reflection.Runtime.TypeInfos
 
                 TypeAttributes attributes = Attributes;
                 if (0 != (attributes & TypeAttributes.Import))
-                    yield return new RuntimePseudoCustomAttributeData(typeof(ComImportAttribute), null, null);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(ComImportAttribute), null);
 
                 if (0 != (attributes & TypeAttributes.Serializable))
-                    yield return new RuntimePseudoCustomAttributeData(typeof(SerializableAttribute), null, null);
+                    yield return new RuntimePseudoCustomAttributeData(typeof(SerializableAttribute), null);
             }
         }
 


### PR DESCRIPTION
We were lucking out that default constructors on synthetic attributes were kept. Hit this in a more aggressive compilation mode that was stripping them.