### PR TITLE
Downgrade forced default constructor inclusion

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -65,7 +65,7 @@ namespace ILCompiler.DependencyAnalysis
             if (defaultCtor != null)
             {
                 dependencyList.Add(new DependencyListEntry(
-                    factory.ReflectableMethod(defaultCtor),
+                    factory.CanonicalEntrypoint(defaultCtor),
                     "DefaultConstructorNode"));
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -151,7 +151,7 @@ namespace ILCompiler.DependencyAnalysis
             if (defaultCtor != null)
             {
                 dependencyList.Add(new DependencyListEntry(
-                    factory.ReflectableMethod(defaultCtor), 
+                    factory.CanonicalEntrypoint(defaultCtor), 
                     "DefaultConstructorNode"));
             }
 


### PR DESCRIPTION
We force include the default constructor of a type whenever an EEType is created mostly to make sure `Activator.CreateInstance<T>` is going to work in dynamically created types. I think we should be able to get by without it, but we should at least start by not including the method as a reflectable method.

IL Linker doesn't guarantee `CreateInstance<T>` is going to work unless dataflow annotations match (CreateInstance annoying doesn't have a `new()` constraint but IL Linker requires that whatever is used in place of the T is either a concrete type or a T that has `new()` or a `DynamicallyAccessedMembers.PublicParameterlessConstructor` annotation).