### PR TITLE
Make PropertyValue public

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -21,7 +21,13 @@ namespace System.Diagnostics.Tracing
     ///
     /// To get the value of a property quickly, use a delegate produced by <see cref="PropertyValue.GetPropertyGetter(PropertyInfo)"/>.
     /// </summary>
-    internal readonly unsafe struct PropertyValue
+#if CORERT
+    [CLSCompliant(false)]
+    public
+#else
+    internal
+#endif
+    readonly unsafe struct PropertyValue
     {
         /// <summary>
         /// Union of well-known value types, to avoid boxing those types.
@@ -206,7 +212,12 @@ namespace System.Diagnostics.Tracing
             return helper.GetPropertyGetter(property);
         }
 
-        private abstract class TypeHelper
+#if CORERT
+        public
+#else
+        private
+#endif
+        abstract class TypeHelper
         {
             public abstract Func<PropertyValue, PropertyValue> GetPropertyGetter(PropertyInfo property);
 
@@ -220,7 +231,12 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        private sealed class ReferenceTypeHelper<TContainer> : TypeHelper where TContainer : class?
+#if CORERT
+        public
+#else
+        private
+#endif
+        sealed class ReferenceTypeHelper<TContainer> : TypeHelper where TContainer : class?
         {
             private static Func<TContainer, TProperty> GetGetMethod<TProperty>(PropertyInfo property) =>
                 property.GetMethod!.CreateDelegate<Func<TContainer, TProperty>>();

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -23,7 +23,7 @@ namespace System.Diagnostics.Tracing
     /// </summary>
 #if CORERT
     [CLSCompliant(false)]
-    public
+    public // On CoreRT, this must be public to prevent it from getting reflection blocked.
 #else
     internal
 #endif
@@ -213,7 +213,7 @@ namespace System.Diagnostics.Tracing
         }
 
 #if CORERT
-        public
+        public // On CoreRT, this must be public to prevent it from getting reflection blocked.
 #else
         private
 #endif
@@ -232,7 +232,7 @@ namespace System.Diagnostics.Tracing
         }
 
 #if CORERT
-        public
+        public // On CoreRT, this must be public to prevent it from getting reflection blocked.
 #else
         private
 #endif


### PR DESCRIPTION
ReferenceTypeHelper is a target of reflection. Likely none of that worked at runtime because non-public details of corelib are blocked from reflection.

Noticed this by accident in the "generate template type metadata lazily" mode - I didn't subject the template type metadata to reflection blocking, and I was seeing extra template metadata for this compared to baseline. In the baseline, `ReferenceTypeHelper` is unusable with reflection completely - in the lazy mode, we generated unreachable template type metadata for it (and still blocked the reflection data).