### PR TITLE
Don't generate artifacts for reflection-blocked things

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectableMethodNode.cs
@@ -30,6 +30,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
+            Debug.Assert(!factory.MetadataManager.IsReflectionBlocked(_method.GetTypicalMethodDefinition()));
+
             DependencyList dependencies = new DependencyList();
             factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencies, factory, _method);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
@@ -132,6 +132,11 @@ namespace ILCompiler
                 method = method.MakeInstantiatedMethod(inst);
             }
 
+            if (factory.MetadataManager.IsReflectionBlocked(method))
+            {
+                return false;
+            }
+
             dependencies ??= new DependencyList();
 
             try
@@ -167,6 +172,11 @@ namespace ILCompiler
                 field = field.Context.GetFieldForInstantiatedType(
                     field.GetTypicalFieldDefinition(),
                     ((MetadataType)owningType).MakeInstantiatedType(inst));
+            }
+
+            if (factory.MetadataManager.IsReflectionBlocked(field))
+            {
+                return false;
             }
 
             if (!TryGetDependenciesForReflectedType(ref dependencies, factory, field.OwningType, reason))
@@ -236,7 +246,12 @@ namespace ILCompiler
                 {
                     type = type.GetTypeDefinition();
                 }
-                
+
+                if (factory.MetadataManager.IsReflectionBlocked(type))
+                {
+                    return false;
+                }
+
                 dependencies ??= new DependencyList();
 
                 dependencies.Add(factory.MaximallyConstructableType(type), reason);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
@@ -42,7 +42,8 @@ namespace ILCompiler
 
         public void AddReflectionRoot(MethodDesc method, string reason)
         {
-            _rootAdder(_factory.ReflectableMethod(method), reason);
+            if (!_factory.MetadataManager.IsReflectionBlocked(method))
+                _rootAdder(_factory.ReflectableMethod(method), reason);
         }
 
         public void RootThreadStaticBaseForType(TypeDesc type, string reason)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -384,7 +384,9 @@ namespace ILCompiler
         public override void GetDependenciesDueToLdToken(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
             dependencies = dependencies ?? new DependencyList();
-            dependencies.Add(factory.ReflectableMethod(method), "LDTOKEN method");
+
+            if (!IsReflectionBlocked(method))
+                dependencies.Add(factory.ReflectableMethod(method), "LDTOKEN method");
         }
 
         protected override void GetDependenciesDueToMethodCodePresenceInternal(ref DependencyList dependencies, NodeFactory factory, MethodDesc method, MethodIL methodIL)


### PR DESCRIPTION
We can often end up in situations when the compiler decides we need to generate artifacts due to reflection (e.g. all methods on a type including those inherited from `System.Object`).

We would end up generating artifacts that we then reject in the appropriate mapping tables.

Optimized build (where such `ReflectedMethodNodes` would not be added as roots) can mostly mop up after this, but this still results in a cool 100 kB saving on an ASP.NET WebApi app (the extra method added to the graph could have caused new vtable slots to be needed, etc. that we can't get rid of afterwards anymore).