### PR TITLE
Fix assembly on ARM32

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
@@ -7,16 +7,16 @@
     .global RhpGcPoll2
 
     LEAF_ENTRY RhpGcPoll
-        ; @todo: I'm assuming it's not OK to trash any register here. If that's not true we can optimize the
-        ; push/pops out of this fast path.
+        // @todo: I'm assuming it's not OK to trash any register here. If that's not true we can optimize the
+        // push/pops out of this fast path.
         push        {r0}
         ldr         r0, =RhpTrapThreads
         ldr         r0, [r0]
         tst         r0, #TrapThreadsFlags_TrapThreads
-        bne         %0
+        bne         LOCAL_LABEL(RhpGcPollRareCall)
         pop         {r0}
         bx          lr
-0
+LOCAL_LABEL(RhpGcPollRareCall):
         pop         {r0}
         b           RhpGcPollRare
     LEAF_END RhpGcPoll

--- a/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
@@ -7,18 +7,11 @@
     .global RhpGcPoll2
 
     LEAF_ENTRY RhpGcPoll
-        // @todo: I'm assuming it's not OK to trash any register here. If that's not true we can optimize the
-        // push/pops out of this fast path.
-        push        {r0}
         ldr         r0, =RhpTrapThreads
         ldr         r0, [r0]
-        tst         r0, #TrapThreadsFlags_TrapThreads
-        bne         LOCAL_LABEL(RhpGcPollRareCall)
-        pop         {r0}
+        cmp         r0, #TrapThreadsFlags_None
+        bne         RhpGcPollRare
         bx          lr
-LOCAL_LABEL(RhpGcPollRareCall):
-        pop         {r0}
-        b           RhpGcPollRare
     LEAF_END RhpGcPoll
 
     NESTED_ENTRY RhpGcPollRare, _TEXT, NoHandler

--- a/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
@@ -1,20 +1,2 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-
-#include <unixasmmacros.inc>
-#include "AsmOffsets.inc"
-
-    .global RhpGcPoll2
-
-    LEAF_ENTRY RhpGcPoll
-        PREPARE_EXTERNAL_VAR_INDIRECT_W RhpTrapThreads, 0
-        cbnz    w0, RhpGcPollRare // TrapThreadsFlags_None = 0
-        ret
-    LEAF_END RhpGcPoll
-
-    NESTED_ENTRY RhpGcPollRare, _TEXT, NoHandler
-        PUSH_COOP_PINVOKE_FRAME x0
-        bl RhpGcPoll2
-        POP_COOP_PINVOKE_FRAME
-        ret
-    NESTED_END RhpGcPollRare

--- a/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
+++ b/src/coreclr/nativeaot/Runtime/arm/GcProbe.S
@@ -1,2 +1,29 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+#include <unixasmmacros.inc>
+#include "AsmOffsets.inc"
+
+    .global RhpGcPoll2
+
+    LEAF_ENTRY RhpGcPoll
+        ; @todo: I'm assuming it's not OK to trash any register here. If that's not true we can optimize the
+        ; push/pops out of this fast path.
+        push        {r0}
+        ldr         r0, =RhpTrapThreads
+        ldr         r0, [r0]
+        tst         r0, #TrapThreadsFlags_TrapThreads
+        bne         %0
+        pop         {r0}
+        bx          lr
+0
+        pop         {r0}
+        b           RhpGcPollRare
+    LEAF_END RhpGcPoll
+
+    NESTED_ENTRY RhpGcPollRare, _TEXT, NoHandler
+        PUSH_COOP_PINVOKE_FRAME r0
+        bl RhpGcPoll2
+        POP_COOP_PINVOKE_FRAME
+        bx           lr
+    NESTED_END RhpGcPollRare

--- a/src/coreclr/nativeaot/Runtime/arm/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/arm/GcProbe.asm
@@ -344,18 +344,11 @@ __PPF_ThreadReg SETS "r2"
     NESTED_END RhpGcProbe
 
     LEAF_ENTRY RhpGcPoll
-        ; @todo: I'm assuming it's not OK to trash any register here. If that's not true we can optimize the
-        ; push/pops out of this fast path.
-        push        {r0}
         ldr         r0, =RhpTrapThreads
         ldr         r0, [r0]
         tst         r0, #TrapThreadsFlags_TrapThreads
-        bne         %0
-        pop         {r0}
+        bne         RhpGcPollRare
         bx          lr
-0
-        pop         {r0}
-        b           RhpGcPollRare
     LEAF_END RhpGcPoll
 
     NESTED_ENTRY RhpGcPollRare


### PR DESCRIPTION
When I copy over that file, I do not realize that these 2 functions do not compile properly

So far left following
- Produce libObjWriter.so for ARM
- Rewrite RhGetRuntimeHelperForType in C# as per this discussion https://github.com/dotnet/runtimelab/pull/1294#issuecomment-874430938