### PR TITLE
misc srm updates

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -24,8 +24,24 @@ namespace System.Text.RegularExpressions.Tests
             //ViewSampleRegexInDGML();
             //TestRunPerformance();
             //RegenerateUnicodeTables();
+            //string b = @"((?<=\w)(?!\w)|(?<!\w)(?=\w))"; //word-border anchor
+            //string b1 = @"((?<=\w)(?=\W)|(?<=\W)(?=\w))";
+            //TestLookaround(string.Format(@"{0}\w+{0}",b), "one two three", 3);
+            //TestLookaround(string.Format(@"{0}\w+{0}", b1), "one two three", 1);
         }
 
+        private void TestLookaround(string pattern, string input, int matchcount)
+        {
+            var regex = new Regex(pattern);
+            List<Match> matches = new List<Match>();
+            var match = regex.Match(input);
+            while (match.Success)
+            {
+                matches.Add(match);
+                match = match.NextMatch();
+            }
+            Assert.Equal(matchcount, matches.Count);
+        }
 
         private const string experimentDirectory = @"\\maku1\experiments\";
 

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -29,6 +29,23 @@ namespace System.Text.RegularExpressions.Tests
         private const char Turkish_i_withoutDot = '\u0131';
         private const char Kelvin_sign = '\u212A';
 
+        [Theory]
+        [InlineData("((?:0*)+?(?:.*)+?)?", "0a", 2)]
+        [InlineData("(?:(?:0?)+?(?:a?)+?)?", "0a", 2)]
+        [InlineData(@"(?i:(\()((?<a>\w+(\.\w+)*)(,(?<a>\w+(\.\w+)*)*)?)(\)))", "some.text(this.is,the.match)", 1)]
+        private void TestDifficultCasesForBacktracking(string pattern, string input, int matchcount)
+        {
+            var regex = new Regex(pattern, DFA);
+            List<Match> matches = new List<Match>();
+            var match = regex.Match(input);
+            while (match.Success)
+            {
+                matches.Add(match);
+                match = match.NextMatch();
+            }
+            Assert.Equal(matchcount, matches.Count);
+        }
+
         [Fact]
         public void TestNFAmode()
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -47,6 +47,18 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Fact]
+        public void TestMixedLazyEagerCounting()
+        {
+            string pattern = "z(a{0,5}|a{0,10}?)";
+            var input = "xyzaaaaaaaaaxyz";
+            Regex re = new Regex(pattern, DFA);
+            Match m = re.Match(input);
+            Assert.True(m.Success);
+            Assert.Equal(2, m.Index);
+            Assert.Equal(6, m.Length);
+        }
+
+        [Fact]
         public void TestNFAmode()
         {
             string rawregex = "a.{20}$";


### PR DESCRIPTION
Fixed a representation issue with mixed lazy/eager loops by moving lazy flag to key in the multiset dictionary so that lazy and eager loops are kept separate.

Added a unit test to test correct behavior (this test failed before that). 
Added also a couple of unrelated unit tests to test nonterminating cases from the discussion of 
dotnet/runtime/ issue #43314. To confirm that in DFA mode they all terminate.

Cleaned/simplified multiset code. The code was too verbose and repetitive, simplified the code through some refactoring.

