### PR TITLE
NativeAOT-LLVM: store ref locals on shadow stack

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -48,7 +48,7 @@ enum class LocalVarLocation
     ShadowStack
 };
 
-// local vars that don't need to be on the shadow stack
+// Helper for unifying vars that do and don't need to be on the shadow stack.
 struct LocalVar
 {
     Value* llvmValue;

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -55,7 +55,7 @@ struct LocalVar
     LocalVarLocation location;
 
     LocalVar(LocalVarLocation location, Value* llvmValue) : llvmValue(llvmValue), location(location) {}
-    virtual Value* getValue(llvm::IRBuilder<>& builder)
+    Value* getValue(llvm::IRBuilder<>& builder)
     {
         return location == LocalVarLocation::LlvmStack ? llvmValue : builder.CreateLoad(llvmValue);
     }

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -42,7 +42,7 @@ struct SpilledExpressionEntry
     CorInfoType m_CorInfoType;
 };
 
-enum LocalVarLocation
+enum class LocalVarLocation
 {
     LlvmStack,
     ShadowStack


### PR DESCRIPTION
This PR pushes reference type locals on to the shadow stack.  The LLVM clrjit supports conservative GC only, so any GC references need to go on the shadow stack.  This change also allows these lclVars to be used across different blocks which is coming in another PR.