### PR TITLE
Use the repo-local NuGet.config with GetReferenceAssemblies so we can use pre-release ref packs reliably.

### DIFF
--- a/DllImportGenerator/DllImportGenerator.UnitTests/DllImportGenerator.UnitTests.csproj
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/DllImportGenerator.UnitTests.csproj
@@ -26,4 +26,8 @@
     <ProjectReference Include="..\Ancillary.Interop\Ancillary.Interop.csproj" />
     <ProjectReference Include="..\DllImportGenerator\DllImportGenerator.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+	<None Include="$(RepoRoot)/NuGet.config" Link="NuGet.config" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis.Testing;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
+++ b/DllImportGenerator/DllImportGenerator.UnitTests/TestUtils.cs
@@ -18,25 +18,6 @@ namespace DllImportGenerator.UnitTests
 {
     internal static class TestUtils
     {
-        private static string NuGetConfigPath { get; } = FindRepoNuGetConfig();
-
-        private static string FindRepoNuGetConfig()
-        {
-            ReadOnlySpan<char> assemblyLocation = typeof(TestUtils).Assembly.Location;
-            for (ReadOnlySpan<char> directory = Path.GetDirectoryName(assemblyLocation); !directory.IsEmpty; directory = Path.GetDirectoryName(directory))
-            {
-                string nugetConfigPath = Path.Join(directory, "NuGet.config");
-                if (File.Exists(nugetConfigPath))
-                {
-                    return nugetConfigPath;
-                }
-            }
-
-            Debug.Assert(false, "This repo should always contain a NuGet.config at the repo root.");
-
-            return string.Empty;
-        }
-
         /// <summary>
         /// Assert the pre-srouce generator compilation has only
         /// the expected failure diagnostics.
@@ -118,7 +99,7 @@ namespace DllImportGenerator.UnitTests
                         "Microsoft.NETCore.App.Ref",
                         "6.0.0-preview.6.21317.4"),
                     Path.Combine("ref", "net6.0"))
-                .WithNuGetConfigFilePath(NuGetConfigPath);
+                .WithNuGetConfigFilePath(Path.Combine(Path.GetDirectoryName(typeof(TestUtils).Assembly.Location)!, "NuGet.config"));
 
             // Include the assembly containing the new attribute and all of its references.
             // [TODO] Remove once the attribute has been added to the BCL

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
     <!-- Roslyn dependencies -->
     <CompilerPlatformVersion>3.10.0-3.21229.26</CompilerPlatformVersion>
-    <CompilerPlatformTestingVersion>1.0.1-beta1.20478.1</CompilerPlatformTestingVersion>
+    <CompilerPlatformTestingVersion>1.1.0</CompilerPlatformTestingVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3-beta1.21268.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <!-- Package dependencies -->
     <SystemCommandLineVersion>2.0.0-beta1.21118.1</SystemCommandLineVersion>


### PR DESCRIPTION
Fixes the issues around pulling down ref packs that we are seeing in #1374.

This will also enable us to start working on emitting code that uses NativeMemory.Alloc in some cases before Preview 7 comes out.