### PR TITLE
Delete CheckArrayElementType lookup support

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -502,9 +502,6 @@ namespace System.Runtime
 
                     return (IntPtr)(delegate*<EEType*, int, object>)&InternalCalls.RhpNewArray;
 
-                case RuntimeHelperKind.CheckArrayElementType:
-                    return (IntPtr)(delegate*<EEType*, object, void>)&TypeCast.CheckVectorElemAddr;
-
                 default:
                     Debug.Assert(false, "Unknown RuntimeHelperKind");
                     return IntPtr.Zero;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -197,11 +197,6 @@ namespace Internal.Runtime.Augments
                 throwing ? RuntimeHelperKind.CastClass : RuntimeHelperKind.IsInst);
         }
 
-        public static IntPtr GetCheckArrayElementTypeHelperForType(RuntimeTypeHandle type)
-        {
-            return RuntimeImports.RhGetRuntimeHelperForType(CreateEETypePtr(type), RuntimeHelperKind.CheckArrayElementType);
-        }
-
         public static IntPtr GetDispatchMapForType(RuntimeTypeHandle typeHandle)
         {
             return CreateEETypePtr(typeHandle).DispatchMap;

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
@@ -949,30 +949,6 @@ namespace Internal.Runtime.TypeLoader
             }
         }
 
-        private class CheckArrayElementTypeCell : GenericDictionaryCell
-        {
-            internal TypeDesc Type;
-
-            internal override void Prepare(TypeBuilder builder)
-            {
-                if (Type.IsCanonicalSubtype(CanonicalFormKind.Any))
-                    Environment.FailFast("Canonical types do not have EETypes");
-
-                builder.RegisterForPreparation(Type);
-            }
-
-            internal override IntPtr Create(TypeBuilder builder)
-            {
-                return RuntimeAugments.GetCheckArrayElementTypeHelperForType(builder.GetRuntimeTypeHandle(Type));
-            }
-
-            internal override unsafe IntPtr CreateLazyLookupCell(TypeBuilder builder, out IntPtr auxResult)
-            {
-                auxResult = builder.GetRuntimeTypeHandle(Type).ToIntPtr();
-                return Create(builder);
-            }
-        }
-
 #if FEATURE_UNIVERSAL_GENERICS
         private class CallingConventionConverterCell : GenericDictionaryCell
         {
@@ -1812,16 +1788,6 @@ namespace Internal.Runtime.TypeLoader
                         TypeLoaderLogger.WriteLine("AllocateArray on: " + type.ToString());
 
                         cell = new AllocateArrayCell { Type = type };
-                    }
-                    break;
-
-                case FixupSignatureKind.CheckArrayElementType:
-                    {
-                        var type = nativeLayoutInfoLoadContext.GetType(ref parser);
-
-                        TypeLoaderLogger.WriteLine("CheckArrayElementType on: " + type.ToString());
-
-                        cell = new CheckArrayElementTypeCell { Type = type };
                     }
                     break;
 

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormat.cs
@@ -90,7 +90,7 @@ namespace Internal.NativeFormat
         IsInst                      = 0x0e,
         CastClass                   = 0x0f,
         AllocateArray               = 0x10,
-        CheckArrayElementType       = 0x11,
+        // unused                   = 0x11,
         TypeSize                    = 0x12,
         FieldOffset                 = 0x13,
         CallingConventionConverter  = 0x14,

--- a/src/coreclr/tools/Common/Internal/Runtime/RuntimeConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/RuntimeConstants.cs
@@ -64,6 +64,5 @@ namespace Internal.Runtime
         IsInst,
         CastClass,
         AllocateArray,
-        CheckArrayElementType,
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -44,7 +44,6 @@ namespace ILCompiler.DependencyAnalysis
         IsInst,             // isinst helper
         CastClass,          // castclass helper
         AllocArray,         // the array allocator of a type
-        CheckArrayElementType, // check the array element type
         TypeSize,           // size of the type
         FieldOffset,        // field offset
         CallingConvention_NoInstParam,      // CallingConventionConverterThunk NO_INSTANTIATING_PARAM


### PR DESCRIPTION
This appears unused. It was introduced in 2014 for what I assume was lazy generic support in rhbind. ProjectX didn't need it for anything so likely won't be needed in NativeAOT either. This helper is always the same so I don't think we'll need to put it in a generic dictionary.