### PR TITLE
Refresh code shared with IL Linker

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Logger.cs
+++ b/src/coreclr/tools/Common/Compiler/Logger.cs
@@ -80,7 +80,9 @@ namespace ILCompiler
                 }
             }
 
-            MessageOrigin messageOrigin = new MessageOrigin(origin.OwningMethod, document, lineNumber, null);
+            MethodDesc warnedMethod = CompilerGeneratedState.GetUserDefinedMethodForCompilerGeneratedMember(origin.OwningMethod) ?? origin.OwningMethod;
+
+            MessageOrigin messageOrigin = new MessageOrigin(warnedMethod, document, lineNumber, null);
             LogWarning(text, code, messageOrigin, subcategory);
         }
 
@@ -102,6 +104,8 @@ namespace ILCompiler
 
             if (origin.MemberDefinition is MethodDesc method)
             {
+                method = CompilerGeneratedState.GetUserDefinedMethodForCompilerGeneratedMember(method) ?? method;
+
                 var ecmaMethod = method.GetTypicalMethodDefinition() as EcmaMethod;
                 suppressions = ecmaMethod?.GetDecodedCustomAttributes("System.Diagnostics.CodeAnalysis", "UnconditionalSuppressMessageAttribute");
             }

--- a/src/coreclr/tools/Common/Compiler/Logging/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/CompilerGeneratedState.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler.Logging
+{
+    // Currently this is implemented using heuristics
+    public class CompilerGeneratedState
+    {
+        private static bool HasRoslynCompilerGeneratedName(DefType type) =>
+            type.Name.Contains('<') || (type.ContainingType != null && HasRoslynCompilerGeneratedName(type.ContainingType));
+
+        public static MethodDesc GetUserDefinedMethodForCompilerGeneratedMember(MethodDesc sourceMember)
+        {
+            var compilerGeneratedType = sourceMember.OwningType.GetTypeDefinition() as EcmaType;
+            if (compilerGeneratedType == null)
+                return null;
+
+            // Only handle async or iterator state machine
+            // So go to the declaring type and check if it's compiler generated (as a perf optimization)
+            if (!HasRoslynCompilerGeneratedName(compilerGeneratedType) || compilerGeneratedType.ContainingType == null)
+                return null;
+
+            // Now go to its declaring type and search all methods to find the one which points to the type as its
+            // state machine implementation.
+            foreach (EcmaMethod method in compilerGeneratedType.ContainingType.GetMethods())
+            {
+                var decodedAttribute = method.GetDecodedCustomAttribute("System.Runtime.CompilerServices", "AsyncIteratorStateMachineAttribute")
+                    ?? method.GetDecodedCustomAttribute("System.Runtime.CompilerServices", "AsyncStateMachineAttribute")
+                    ?? method.GetDecodedCustomAttribute("System.Runtime.CompilerServices", "IteratorStateMachineAttribute");
+
+                if (!decodedAttribute.HasValue)
+                    continue;
+
+                if (decodedAttribute.Value.FixedArguments.Length != 1
+                    || decodedAttribute.Value.FixedArguments[0].Value is not TypeDesc stateMachineType)
+                    continue;
+
+                if (stateMachineType == compilerGeneratedType)
+                    return method;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/coreclr/tools/Common/Compiler/Logging/MessageContainer.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/MessageContainer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Text;
 using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -89,32 +90,78 @@ namespace ILCompiler.Logging
             if (context.IsWarningSuppressed(code, origin))
                 return null;
 
-            if (subcategory == MessageSubCategory.AotAnalysis || subcategory == MessageSubCategory.TrimAnalysis)
-            {
-                var declaringType = origin.MemberDefinition switch
-                {
-                    TypeDesc type => type,
-                    MethodDesc method => method.OwningType,
-                    FieldDesc field => field.OwningType,
-#if !READYTORUN
-                    PropertyPseudoDesc property => property.OwningType,
-                    EventPseudoDesc @event => @event.OwningType,
-#endif
-                    _ => null,
-                };
-
-                ModuleDesc declaringAssembly = (declaringType as MetadataType)?.Module;
-                Debug.Assert(declaringAssembly != null);
-                if (declaringAssembly != null && context.IsSingleWarn(declaringAssembly, subcategory))
-                {
-                    return null;
-                }
-            }
+            if (TryLogSingleWarning(context, code, origin, subcategory))
+                return null;
 
             if (context.IsWarningAsError(code))
                 return new MessageContainer(MessageCategory.WarningAsError, text, code, subcategory, origin);
 
             return new MessageContainer(MessageCategory.Warning, text, code, subcategory, origin);
+        }
+
+        private static bool TryLogSingleWarning(Logger context, int code, MessageOrigin origin, string subcategory)
+        {
+            if (subcategory != MessageSubCategory.AotAnalysis && subcategory != MessageSubCategory.TrimAnalysis)
+                return false;
+
+            var declaringType = origin.MemberDefinition switch
+            {
+                TypeDesc type => type,
+                MethodDesc method => method.OwningType,
+                FieldDesc field => field.OwningType,
+#if !READYTORUN
+                PropertyPseudoDesc property => property.OwningType,
+                EventPseudoDesc @event => @event.OwningType,
+#endif
+                _ => null,
+            };
+
+            ModuleDesc declaringAssembly = (declaringType as MetadataType)?.Module;
+            Debug.Assert(declaringAssembly != null);
+            if (declaringAssembly == null)
+                return false;
+
+            // Any IL2026 warnings left in an assembly with an IsTrimmable attribute are considered intentional
+            // and should not be collapsed, so that the user-visible RUC message gets printed.
+            if (code == 2026 && IsTrimmableAssembly(declaringAssembly))
+                return false;
+
+            if (context.IsSingleWarn(declaringAssembly, subcategory))
+                return true;
+
+            return false;
+        }
+
+        private static bool IsTrimmableAssembly(ModuleDesc assembly)
+        {
+            if (assembly is EcmaAssembly ecmaAssembly)
+            {   
+                foreach (var attribute in ecmaAssembly.GetDecodedCustomAttributes("System.Reflection", "AssemblyMetadataAttribute"))
+                {
+                    if (attribute.FixedArguments.Length != 2)
+                        continue;
+
+                    if (!attribute.FixedArguments[0].Type.IsString
+                        || ((string)(attribute.FixedArguments[0].Value)).Equals("IsTrimmable", StringComparison.Ordinal))
+                        continue;
+
+                    if (!attribute.FixedArguments[1].Type.IsString)
+                        continue;
+
+                    string value = (string)attribute.FixedArguments[1].Value;
+
+                    if (value.Equals("True", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        //LogWarning($"Invalid AssemblyMetadata(\"IsTrimmable\", \"{args[1].Value}\") attribute in assembly '{assembly.Name.Name}'. Value must be \"True\"", 2102, GetAssemblyLocation(assembly));
+                    }
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/coreclr/tools/Common/Compiler/Logging/MessageOrigin.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/MessageOrigin.cs
@@ -55,7 +55,7 @@ namespace ILCompiler.Logging
 
 #if false
         public bool Equals(MessageOrigin other) =>
-            (FileName, MemberDefinition, SourceLine, SourceColumn) == (other.FileName, other.MemberDefinition, other.SourceLine, other.SourceColumn);
+            (FileName, MemberDefinition, SourceLine, SourceColumn, ILOffset) == (other.FileName, other.MemberDefinition, other.SourceLine, other.SourceColumn, other.ILOffset);
 
         public override bool Equals(object obj) => obj is MessageOrigin messageOrigin && Equals(messageOrigin);
         public override int GetHashCode() => (FileName, MemberDefinition, SourceLine, SourceColumn).GetHashCode();
@@ -66,8 +66,15 @@ namespace ILCompiler.Logging
         {
             if (MemberDefinition != null && other.MemberDefinition != null)
             {
-                return (MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, MemberDefinition.DeclaringType?.Name, MemberDefinition?.Name).CompareTo
-                    ((other.MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, other.MemberDefinition.DeclaringType?.Name, other.MemberDefinition?.Name));
+                TypeDefinition thisTypeDef = (MemberDefinition as TypeDefinition) ?? MemberDefinition.DeclaringType;
+				TypeDefinition otherTypeDef = (other.MemberDefinition as TypeDefinition) ?? other.MemberDefinition.DeclaringType;
+				int result = (thisTypeDef?.Module?.Assembly?.Name?.Name, thisTypeDef?.Name, MemberDefinition?.Name).CompareTo
+					((otherTypeDef?.Module?.Assembly?.Name?.Name, otherTypeDef?.Name, other.MemberDefinition?.Name));
+				if (result != 0)
+					return result;
+				if (ILOffset != null && other.ILOffset != null)
+					return ILOffset.Value.CompareTo (other.ILOffset);
+				return ILOffset == null ? (other.ILOffset == null ? 0 : 1) : -1;
             }
             else if (MemberDefinition == null && other.MemberDefinition == null)
             {

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/CompilerGeneratedState.cs
@@ -1,0 +1,94 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace Mono.Linker
+{
+	// Currently this is implemented using heuristics
+	public class CompilerGeneratedState
+	{
+		readonly LinkContext _context;
+		readonly Dictionary<TypeDefinition, MethodDefinition> _compilerGeneratedTypeToUserCodeMethod;
+		readonly HashSet<TypeDefinition> _typesWithPopulatedCache;
+
+		public CompilerGeneratedState (LinkContext context)
+		{
+			_context = context;
+			_compilerGeneratedTypeToUserCodeMethod = new Dictionary<TypeDefinition, MethodDefinition> ();
+			_typesWithPopulatedCache = new HashSet<TypeDefinition> ();
+		}
+
+		static bool HasRoslynCompilerGeneratedName (TypeDefinition type) =>
+			type.Name.Contains ('<') || (type.DeclaringType != null && HasRoslynCompilerGeneratedName (type.DeclaringType));
+
+		void PopulateCacheForType (TypeDefinition type)
+		{
+			// Avoid repeat scans of the same type
+			if (!_typesWithPopulatedCache.Add (type))
+				return;
+
+			foreach (MethodDefinition method in type.Methods) {
+				if (!method.HasCustomAttributes)
+					continue;
+
+				foreach (var attribute in method.CustomAttributes) {
+					if (attribute.AttributeType.Namespace != "System.Runtime.CompilerServices")
+						continue;
+
+					switch (attribute.AttributeType.Name) {
+					case "AsyncIteratorStateMachineAttribute":
+					case "AsyncStateMachineAttribute":
+					case "IteratorStateMachineAttribute":
+						TypeDefinition stateMachineType = GetFirstConstructorArgumentAsType (attribute);
+						if (stateMachineType != null) {
+							if (!_compilerGeneratedTypeToUserCodeMethod.TryAdd (stateMachineType, method)) {
+								var alreadyAssociatedMethod = _compilerGeneratedTypeToUserCodeMethod[stateMachineType];
+								_context.LogWarning (
+									$"Methods '{method.GetDisplayName ()}' and '{alreadyAssociatedMethod.GetDisplayName ()}' are both associated with state machine type '{stateMachineType.GetDisplayName ()}'. This is currently unsupported and may lead to incorrectly reported warnings.",
+									2107,
+									new MessageOrigin (method),
+									MessageSubCategory.TrimAnalysis);
+							}
+						}
+
+						break;
+					}
+				}
+			}
+		}
+
+		static TypeDefinition GetFirstConstructorArgumentAsType (CustomAttribute attribute)
+		{
+			if (!attribute.HasConstructorArguments)
+				return null;
+
+			return attribute.ConstructorArguments[0].Value as TypeDefinition;
+		}
+
+		public MethodDefinition GetUserDefinedMethodForCompilerGeneratedMember (IMemberDefinition sourceMember)
+		{
+			if (sourceMember == null)
+				return null;
+
+			TypeDefinition compilerGeneratedType = (sourceMember as TypeDefinition) ?? sourceMember.DeclaringType;
+			if (_compilerGeneratedTypeToUserCodeMethod.TryGetValue (compilerGeneratedType, out MethodDefinition userDefinedMethod))
+				return userDefinedMethod;
+
+			// Only handle async or iterator state machine
+			// So go to the declaring type and check if it's compiler generated (as a perf optimization)
+			if (!HasRoslynCompilerGeneratedName (compilerGeneratedType) || compilerGeneratedType.DeclaringType == null)
+				return null;
+
+			// Now go to its declaring type and search all methods to find the one which points to the type as its
+			// state machine implementation.
+			PopulateCacheForType (compilerGeneratedType.DeclaringType);
+			if (_compilerGeneratedTypeToUserCodeMethod.TryGetValue (compilerGeneratedType, out userDefinedMethod))
+				return userDefinedMethod;
+
+			return null;
+		}
+	}
+}

--- a/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageOrigin.cs
+++ b/src/coreclr/tools/Common/Compiler/Logging/ReferenceSource/MessageOrigin.cs
@@ -15,10 +15,20 @@ namespace Mono.Linker
 #nullable enable
 		public string? FileName { get; }
 		public IMemberDefinition? MemberDefinition { get; }
+
+		readonly IMemberDefinition _suppressionContextMember;
+		public IMemberDefinition? SuppressionContextMember { get => _suppressionContextMember ?? MemberDefinition; }
 #nullable disable
 		public int SourceLine { get; }
 		public int SourceColumn { get; }
 		public int? ILOffset { get; }
+
+		const int HiddenLineNumber = 0xfeefee;
+
+		public MessageOrigin (IMemberDefinition memberDefinition)
+			: this (memberDefinition, null)
+		{
+		}
 
 		public MessageOrigin (string fileName, int sourceLine = 0, int sourceColumn = 0)
 		{
@@ -26,13 +36,20 @@ namespace Mono.Linker
 			SourceLine = sourceLine;
 			SourceColumn = sourceColumn;
 			MemberDefinition = null;
+			_suppressionContextMember = null;
 			ILOffset = null;
 		}
 
-		public MessageOrigin (IMemberDefinition memberDefinition, int? ilOffset = null)
+		public MessageOrigin (IMemberDefinition memberDefinition, int? ilOffset)
+			: this (memberDefinition, ilOffset, null)
+		{
+		}
+
+		public MessageOrigin (IMemberDefinition memberDefinition, int? ilOffset, IMemberDefinition suppressionContextMember)
 		{
 			FileName = null;
 			MemberDefinition = memberDefinition;
+			_suppressionContextMember = suppressionContextMember;
 			SourceLine = 0;
 			SourceColumn = 0;
 			ILOffset = ilOffset;
@@ -47,6 +64,14 @@ namespace Mono.Linker
 				var offset = ILOffset ?? 0;
 				SequencePoint correspondingSequencePoint = method.DebugInformation.SequencePoints
 					.Where (s => s.Offset <= offset)?.Last ();
+
+				// If the warning comes from hidden line (compiler generated code typically)
+				// search for any sequence point with non-hidden line number and report that as a best effort.
+				if (correspondingSequencePoint.StartLine == HiddenLineNumber) {
+					correspondingSequencePoint = method.DebugInformation.SequencePoints
+						.Where (s => s.StartLine != HiddenLineNumber)?.FirstOrDefault ();
+				}
+
 				if (correspondingSequencePoint != null) {
 					fileName = correspondingSequencePoint.Document.Url;
 					sourceLine = correspondingSequencePoint.StartLine;
@@ -70,7 +95,7 @@ namespace Mono.Linker
 		}
 
 		public bool Equals (MessageOrigin other) =>
-			(FileName, MemberDefinition, SourceLine, SourceColumn) == (other.FileName, other.MemberDefinition, other.SourceLine, other.SourceColumn);
+			(FileName, MemberDefinition, SourceLine, SourceColumn, ILOffset) == (other.FileName, other.MemberDefinition, other.SourceLine, other.SourceColumn, other.ILOffset);
 
 		public override bool Equals (object obj) => obj is MessageOrigin messageOrigin && Equals (messageOrigin);
 		public override int GetHashCode () => (FileName, MemberDefinition, SourceLine, SourceColumn).GetHashCode ();
@@ -80,8 +105,17 @@ namespace Mono.Linker
 		public int CompareTo (MessageOrigin other)
 		{
 			if (MemberDefinition != null && other.MemberDefinition != null) {
-				return (MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, MemberDefinition.DeclaringType?.Name, MemberDefinition?.Name).CompareTo
-					((other.MemberDefinition.DeclaringType?.Module?.Assembly?.Name?.Name, other.MemberDefinition.DeclaringType?.Name, other.MemberDefinition?.Name));
+				TypeDefinition thisTypeDef = (MemberDefinition as TypeDefinition) ?? MemberDefinition.DeclaringType;
+				TypeDefinition otherTypeDef = (other.MemberDefinition as TypeDefinition) ?? other.MemberDefinition.DeclaringType;
+				int result = (thisTypeDef?.Module?.Assembly?.Name?.Name, thisTypeDef?.Name, MemberDefinition?.Name).CompareTo
+					((otherTypeDef?.Module?.Assembly?.Name?.Name, otherTypeDef?.Name, other.MemberDefinition?.Name));
+				if (result != 0)
+					return result;
+
+				if (ILOffset != null && other.ILOffset != null)
+					return ILOffset.Value.CompareTo (other.ILOffset);
+
+				return ILOffset == null ? (other.ILOffset == null ? 0 : 1) : -1;
 			} else if (MemberDefinition == null && other.MemberDefinition == null) {
 				if (FileName != null && other.FileName != null) {
 					return string.Compare (FileName, other.FileName);

--- a/src/coreclr/tools/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/MarshalAsDescriptor.cs
@@ -26,6 +26,7 @@ namespace Internal.TypeSystem
         LPTStr = 0x16,        // Ptr to OS preferred (SBCS/Unicode) string
         ByValTStr = 0x17,     // OS preferred (SBCS/Unicode) inline string (only valid in structs)
         IUnknown = 0x19,
+        IDispatch = 0x1a,
         Struct = 0x1b,
         Intf = 0x1c,
         SafeArray = 0x1d,

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -230,7 +230,7 @@ namespace ILCompiler.Dataflow
                     {
                         // Already know that there's a non-empty annotation on a field which is not System.Type/String and we're about to ignore it
                         _logger.LogWarning(
-                            $"Field '{field.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'",
+                            $"Field '{field.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.",
                             2097, field, subcategory: MessageSubCategory.TrimAnalysis);
                         continue;
                     }
@@ -305,8 +305,8 @@ namespace ILCompiler.Dataflow
                             if (returnAnnotation != DynamicallyAccessedMemberTypes.None && !IsTypeInterestingForDataflow(signature.ReturnType))
                             {
                                 _logger.LogWarning(
-                                    $"Return parameter of method '{method.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'",
-                                    2098, method, subcategory: MessageSubCategory.TrimAnalysis);
+                                    $"Return type of method '{method.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.",
+                                    2106, method, subcategory: MessageSubCategory.TrimAnalysis);
                             }
                         }
                         else
@@ -318,7 +318,7 @@ namespace ILCompiler.Dataflow
                             if (!IsTypeInterestingForDataflow(signature[parameter.SequenceNumber - 1]))
                             {
                                 _logger.LogWarning(
-                                    $"Parameter #{parameter.SequenceNumber} of method '{method.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'",
+                                    $"Parameter #{parameter.SequenceNumber} of method '{method.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to parameters of type 'System.Type' or 'System.String'.",
                                     2098, method, subcategory: MessageSubCategory.TrimAnalysis);
                                 continue;
                             }
@@ -376,7 +376,7 @@ namespace ILCompiler.Dataflow
                     if (!IsTypeInterestingForDataflow(property.Signature.ReturnType))
                     {
                         _logger.LogWarning(
-                            $"Property '{property.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'",
+                            $"Property '{property.GetDisplayName()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.",
                             2099, property, subcategory: MessageSubCategory.TrimAnalysis);
                         continue;
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/FlowAnnotations.cs
@@ -120,7 +120,7 @@ namespace Mono.Linker.Dataflow
 					return (DynamicallyAccessedMemberTypes) (int) attribute.ConstructorArguments[0].Value;
 				else
 					_context.LogWarning (
-						$"Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute' doesn't have the required number of parameters specified",
+						$"Attribute 'System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute' doesn't have the required number of parameters specified.",
 						2028, locationMember ?? (provider as IMemberDefinition));
 			}
 			return DynamicallyAccessedMemberTypes.None;
@@ -144,7 +144,7 @@ namespace Mono.Linker.Dataflow
 					if (!IsTypeInterestingForDataflow (field.FieldType)) {
 						// Already know that there's a non-empty annotation on a field which is not System.Type/String and we're about to ignore it
 						_context.LogWarning (
-							$"Field '{field.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'",
+							$"Field '{field.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to fields of type 'System.Type' or 'System.String'.",
 							2097, field, subcategory: MessageSubCategory.TrimAnalysis);
 						continue;
 					}
@@ -209,8 +209,12 @@ namespace Mono.Linker.Dataflow
 						paramAnnotations[i + offset] = pa;
 					}
 
-					DynamicallyAccessedMemberTypes returnAnnotation = IsTypeInterestingForDataflow (method.ReturnType) ?
-						GetMemberTypesForDynamicallyAccessedMembersAttribute (method.MethodReturnType, method) : DynamicallyAccessedMemberTypes.None;
+					DynamicallyAccessedMemberTypes returnAnnotation = GetMemberTypesForDynamicallyAccessedMembersAttribute (method.MethodReturnType, method);
+					if (returnAnnotation != DynamicallyAccessedMemberTypes.None && !IsTypeInterestingForDataflow (method.ReturnType)) {
+						_context.LogWarning (
+							$"Return type of method '{method.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.",
+							2106, method, subcategory: MessageSubCategory.TrimAnalysis);
+					}
 
 					DynamicallyAccessedMemberTypes[] genericParameterAnnotations = null;
 					if (method.HasGenericParameters) {
@@ -253,7 +257,7 @@ namespace Mono.Linker.Dataflow
 
 					if (!IsTypeInterestingForDataflow (property.PropertyType)) {
 						_context.LogWarning (
-							$"Property '{property.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'",
+							$"Property '{property.GetDisplayName ()}' has 'DynamicallyAccessedMembersAttribute', but that attribute can only be applied to properties of type 'System.Type' or 'System.String'.",
 							2099, property, subcategory: MessageSubCategory.TrimAnalysis);
 						continue;
 					}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/ReflectionPatternContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReferenceSource/ReflectionPatternContext.cs
@@ -25,21 +25,22 @@ namespace Mono.Linker.Dataflow
 		bool _patternReported;
 #endif
 
-		public IMemberDefinition Source { get; private set; }
-		public IMetadataTokenProvider MemberWithRequirements { get; private set; }
-		public Instruction Instruction { get; private set; }
-		public bool ReportingEnabled { get; private set; }
+		public MessageOrigin Origin { get; init; }
+		public IMemberDefinition Source { get => Origin.MemberDefinition; }
+		public IMetadataTokenProvider MemberWithRequirements { get; init; }
+		public Instruction Instruction { get; init; }
+		public bool ReportingEnabled { get; init; }
 
 		public ReflectionPatternContext (
 			LinkContext context,
 			bool reportingEnabled,
-			IMemberDefinition source,
+			in MessageOrigin origin,
 			IMetadataTokenProvider memberWithRequirements,
 			Instruction instruction = null)
 		{
 			_context = context;
 			ReportingEnabled = reportingEnabled;
-			Source = source;
+			Origin = origin;
 			MemberWithRequirements = memberWithRequirements;
 			Instruction = instruction;
 
@@ -92,7 +93,7 @@ namespace Mono.Linker.Dataflow
 #endif
 
 			if (ReportingEnabled)
-				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (Source, Instruction, MemberWithRequirements, message, messageCode);
+				_context.ReflectionPatternRecorder.UnrecognizedReflectionAccessPattern (Origin, Source, Instruction, MemberWithRequirements, message, messageCode);
 		}
 
 		public void Dispose ()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -23,6 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Common\Compiler\Logging\CompilerGeneratedState.cs">
+      <Link>Compiler\Logging\CompilerGeneratedState.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\Compiler\Logging\MessageContainer.cs">
       <Link>Compiler\Logging\MessageContainer.cs</Link>
     </Compile>


### PR DESCRIPTION
Main highlights:

* Warn on COM usage (fixes #670)
* Don't collapse warnings from IsTrimmable assemblies
* Handling of some compiler generated code: RequiresUnreferencedCode and UnconditionallySuppressMessage gets propagated to the async/yield state machines, plus we report warnings on user methods.