### PR TITLE
Don't copy custom attribute from Main to MainMethodWrapper

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -228,11 +228,6 @@ namespace Internal.IL.Stubs.StartupCode
                 }
             }
 
-            public override bool HasCustomAttribute(string attributeNamespace, string attributeName)
-            {
-                return WrappedMethod.HasCustomAttribute(attributeNamespace, attributeName);
-            }
-
             public override MethodIL EmitIL()
             {
                 ILEmitter emit = new ILEmitter();


### PR DESCRIPTION
Not sure why that was done. We would copy RequiresUnreferencedCode and crash later when we try to crack it open (this is not an `EcmaMethod`).