### PR TITLE
Fix compilation of libunwind on ARM

### DIFF
--- a/src/coreclr/nativeaot/libunwind/src/Unwind-EHABI.cpp
+++ b/src/coreclr/nativeaot/libunwind/src/Unwind-EHABI.cpp
@@ -91,9 +91,11 @@ _Unwind_Reason_Code ProcessDescriptors(
       case Descriptor::LU32:
         descriptor = getNextWord(descriptor, &length);
         descriptor = getNextWord(descriptor, &offset);
+        break;
       case Descriptor::LU16:
         descriptor = getNextNibble(descriptor, &length);
         descriptor = getNextNibble(descriptor, &offset);
+        break;
       default:
         assert(false);
         return _URC_FAILURE;


### PR DESCRIPTION
This is last issue which prevent compilation on ARM. 
So far, I have crash when publish, but that's on .NET 6 Preview 5 I hope. ILC not even running yet. 