### PR TITLE
Improve GVM lookup failure message in type loader

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
@@ -513,13 +513,13 @@ namespace Internal.Runtime.TypeLoader
                         var sb = new System.Text.StringBuilder();
                         sb.AppendLine("Generic virtual method pointer lookup failure.");
                         sb.AppendLine();
-                        sb.AppendLine("Declaring type handle: " + declaringType.LowLevelToStringRawEETypeAddress());
-                        sb.AppendLine("Target type handle: " + targetTypeHandle.LowLevelToStringRawEETypeAddress());
+                        sb.AppendLine("Declaring type: " + RuntimeAugments.GetLastResortString(declaringType));
+                        sb.AppendLine("Target type: " + RuntimeAugments.GetLastResortString(targetTypeHandle));
                         sb.AppendLine("Method name: " + targetMethodNameAndSignature.Name);
                         sb.AppendLine("Instantiation:");
                         for (int i = 0; i < genericArguments.Length; i++)
                         {
-                            sb.AppendLine("  Argument " + i.LowLevelToString() + ": " + genericArguments[i].LowLevelToStringRawEETypeAddress());
+                            sb.AppendLine("  Argument " + i.LowLevelToString() + ": " + RuntimeAugments.GetLastResortString(genericArguments[i]));
                         }
 
                         Environment.FailFast(sb.ToString());


### PR DESCRIPTION
In favor of https://github.com/dotnet/runtimelab/issues/1372#issuecomment-893239032

Not sure it's in a correct way.