### PR TITLE
Include canonical EETypes in GVM analysis

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -121,6 +121,69 @@ namespace ILCompiler.DependencyAnalysis
 
         protected virtual bool EmitVirtualSlotsAndInterfaces => false;
 
+        public override bool InterestingForDynamicDependencyAnalysis
+        {
+            get
+            {
+                if (!EmitVirtualSlotsAndInterfaces)
+                    return false;
+
+                if (_type.IsInterface)
+                    return _type.HasGenericVirtualMethods();
+
+                if (_type.IsDefType)
+                {
+                    // First, check if this type has any GVM that overrides a GVM on a parent type. If that's the case, this makes
+                    // the current type interesting for GVM analysis (i.e. instantiate its overriding GVMs for existing GVMDependenciesNodes
+                    // of the instantiated GVM on the parent types).
+                    foreach (var method in _type.GetAllVirtualMethods())
+                    {
+                        Debug.Assert(method.IsVirtual);
+
+                        if (method.HasInstantiation)
+                        {
+                            MethodDesc slotDecl = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method);
+                            if (slotDecl != method)
+                                return true;
+                        }
+                    }
+
+                    // Second, check if this type has any GVMs that implement any GVM on any of the implemented interfaces. This would
+                    // make the current type interesting for dynamic dependency analysis to that we can instantiate its GVMs.
+                    foreach (DefType interfaceImpl in _type.RuntimeInterfaces)
+                    {
+                        foreach (var method in interfaceImpl.GetAllVirtualMethods())
+                        {
+                            Debug.Assert(method.IsVirtual);
+
+                            if (method.HasInstantiation)
+                            {
+                                // We found a GVM on one of the implemented interfaces. Find if the type implements this method. 
+                                // (Note, do this comparision against the generic definition of the method, not the specific method instantiation
+                                MethodDesc genericDefinition = method.GetMethodDefinition();
+                                MethodDesc slotDecl = _type.ResolveInterfaceMethodTarget(genericDefinition);
+                                if (slotDecl != null)
+                                {
+                                    // If the type doesn't introduce this interface method implementation (i.e. the same implementation
+                                    // already exists in the base type), do not consider this type interesting for GVM analysis just yet.
+                                    //
+                                    // We need to limit the number of types that are interesting for GVM analysis at all costs since
+                                    // these all will be looked at for every unique generic virtual method call in the program.
+                                    // Having a long list of interesting types affects the compilation throughput heavily.
+                                    if (slotDecl.OwningType == _type ||
+                                        _type.BaseType.ResolveInterfaceMethodTarget(genericDefinition) != slotDecl)
+                                    {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                return false;
+            }
+        }
+
         internal bool HasOptionalFields
         {
             get { return _optionalFieldsBuilder.IsAtLeastOneFieldUsed(); }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -141,6 +141,11 @@ namespace ILCompiler.DependencyAnalysis
                     potentialOverrideType.ConvertToCanonForm(CanonicalFormKind.Specific) != potentialOverrideType)
                     continue;
 
+                // Similarly, if the type is canonical but this method instantiation isn't, don't mix them.
+                if (!_method.IsSharedByGenericInstantiations &&
+                    potentialOverrideType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                    continue;
+
                 if (potentialOverrideType.IsInterface)
                 {
                     if (methodOwningType.HasSameTypeDefinition(potentialOverrideType) && (potentialOverrideType != methodOwningType))
@@ -187,7 +192,7 @@ namespace ILCompiler.DependencyAnalysis
                             if (overrideTypeCur == methodOwningType)
                                 break;
 
-                            overrideTypeCur = overrideTypeCur.BaseType;
+                            overrideTypeCur = overrideTypeCur.BaseType?.NormalizeInstantiation();
                         }
                         while (overrideTypeCur != null);
 


### PR DESCRIPTION
We might no longer have all the concrete EETypes to do analysis - need to include the canonical EETypes we have in the system. The main part of the change is the move of `InterestingForDynamicDependencyAnalysis` from `ConstructedEETypeNode` to `EETypeNode` and limiting it so that it only applies to Constructed and Canonical EETypes (that's the new if at the beginning).

The rest is just mopping up after the change.

Fixes #1372