### PR TITLE
Do not throw when when see foreign type

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1340,6 +1340,10 @@ namespace ILCompiler
                             {
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Null array");
                             }
+                            else if (array.Value is ForeignTypeInstance)
+                            {
+                                return Status.Fail(methodIL.OwningMethod, opcode, "Foreign array");
+                            }
                             else
                             {
                                 ThrowHelper.ThrowInvalidProgramException();


### PR DESCRIPTION
Static fields from other types cannot be pre-initialized and this is wel-known case so do not throw.
Closes #1403