### PR TITLE
Prevent crash on ARM32

### DIFF
--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -188,11 +188,11 @@ void Compiler::unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat)
 
     for (regNumber regNum = isFloat ? REG_FP_FIRST : REG_FIRST; regNum < REG_COUNT;
 #if TARGET_ARM
-         regNum = isFloat ? REG_NEXT(REG_NEXT(regNum)) : REG_NEXT(regNum),
+         regNum = isFloat ? REG_NEXT(REG_NEXT(regNum)) : REG_NEXT(regNum), regBit <<= isFloat ? 2 : 1
 #else
-         regNum = REG_NEXT(regNum),
+         regNum = REG_NEXT(regNum), regBit <<= 1
 #endif
-         regBit <<= 1)
+         )
     {
         if (regBit > regMask)
         {

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -188,7 +188,7 @@ void Compiler::unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat)
 
     for (regNumber regNum = isFloat ? REG_FP_FIRST : REG_FIRST; regNum < REG_COUNT;
 #if TARGET_ARM
-         regNum = isFloat ? ((regNumber)((unsigned)(regNum) + 2)) : REG_NEXT(regNum),
+         regNum = isFloat ? REG_NEXT(REG_NEXT(regNum)) : REG_NEXT(regNum),
 #else
          regNum = REG_NEXT(regNum),
 #endif

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -187,7 +187,12 @@ void Compiler::unwindPushPopMaskCFI(regMaskTP regMask, bool isFloat)
     regMaskTP regBit = isFloat ? genRegMask(REG_FP_FIRST) : 1;
 
     for (regNumber regNum = isFloat ? REG_FP_FIRST : REG_FIRST; regNum < REG_COUNT;
-         regNum           = REG_NEXT(regNum), regBit <<= 1)
+#if TARGET_ARM
+         regNum = isFloat ? ((regNumber)((unsigned)(regNum) + 2)) : REG_NEXT(regNum),
+#else
+         regNum = REG_NEXT(regNum),
+#endif
+         regBit <<= 1)
     {
         if (regBit > regMask)
         {

--- a/src/coreclr/jit/unwindarm.cpp
+++ b/src/coreclr/jit/unwindarm.cpp
@@ -71,100 +71,52 @@ short Compiler::mapRegNumToDwarfReg(regNumber reg)
             dwarfReg = 15;
             break;
         case REG_F0:
-            dwarfReg = 64;
-            break;
-        case REG_F1:
-            dwarfReg = 65;
+            dwarfReg = 256;
             break;
         case REG_F2:
-            dwarfReg = 66;
-            break;
-        case REG_F3:
-            dwarfReg = 67;
+            dwarfReg = 257;
             break;
         case REG_F4:
-            dwarfReg = 68;
-            break;
-        case REG_F5:
-            dwarfReg = 69;
+            dwarfReg = 258;
             break;
         case REG_F6:
-            dwarfReg = 70;
-            break;
-        case REG_F7:
-            dwarfReg = 71;
+            dwarfReg = 259;
             break;
         case REG_F8:
-            dwarfReg = 72;
-            break;
-        case REG_F9:
-            dwarfReg = 73;
+            dwarfReg = 260;
             break;
         case REG_F10:
-            dwarfReg = 74;
-            break;
-        case REG_F11:
-            dwarfReg = 75;
+            dwarfReg = 261;
             break;
         case REG_F12:
-            dwarfReg = 76;
-            break;
-        case REG_F13:
-            dwarfReg = 77;
+            dwarfReg = 262;
             break;
         case REG_F14:
-            dwarfReg = 78;
-            break;
-        case REG_F15:
-            dwarfReg = 79;
+            dwarfReg = 263;
             break;
         case REG_F16:
-            dwarfReg = 80;
-            break;
-        case REG_F17:
-            dwarfReg = 81;
+            dwarfReg = 264;
             break;
         case REG_F18:
-            dwarfReg = 82;
-            break;
-        case REG_F19:
-            dwarfReg = 83;
+            dwarfReg = 265;
             break;
         case REG_F20:
-            dwarfReg = 84;
-            break;
-        case REG_F21:
-            dwarfReg = 85;
+            dwarfReg = 266;
             break;
         case REG_F22:
-            dwarfReg = 86;
-            break;
-        case REG_F23:
-            dwarfReg = 87;
+            dwarfReg = 267;
             break;
         case REG_F24:
-            dwarfReg = 88;
-            break;
-        case REG_F25:
-            dwarfReg = 89;
+            dwarfReg = 268;
             break;
         case REG_F26:
-            dwarfReg = 90;
-            break;
-        case REG_F27:
-            dwarfReg = 91;
+            dwarfReg = 269;
             break;
         case REG_F28:
-            dwarfReg = 92;
-            break;
-        case REG_F29:
-            dwarfReg = 93;
+            dwarfReg = 270;
             break;
         case REG_F30:
-            dwarfReg = 94;
-            break;
-        case REG_F31:
-            dwarfReg = 95;
+            dwarfReg = 271;
             break;
         default:
             noway_assert(!"unexpected REG_NUM");

--- a/src/coreclr/tools/aot/ObjWriter/debugInfo/dwarf/dwarfGen.cpp
+++ b/src/coreclr/tools/aot/ObjWriter/debugInfo/dwarf/dwarfGen.cpp
@@ -300,7 +300,7 @@ static int GetRegOpSize(int DwarfRegNum) {
   }
 }
 
-static void EmitBreg(MCObjectStreamer* Streamer, int DwarfRegNum) {
+static void EmitBreg(MCObjectStreamer* Streamer, int DwarfRegNum, StringRef bytes) {
   if (DwarfRegNum <= 31) {
     Streamer->EmitIntValue(DwarfRegNum + dwarf::DW_OP_breg0, 1);
   }
@@ -308,6 +308,18 @@ static void EmitBreg(MCObjectStreamer* Streamer, int DwarfRegNum) {
     Streamer->EmitIntValue(dwarf::DW_OP_bregx, 1);
     Streamer->EmitULEB128IntValue(DwarfRegNum);
   }
+  Streamer->EmitBytes(bytes);
+}
+
+static void EmitBreg(MCObjectStreamer* Streamer, int DwarfRegNum, int value) {
+  if (DwarfRegNum <= 31) {
+    Streamer->EmitIntValue(DwarfRegNum + dwarf::DW_OP_breg0, 1);
+  }
+  else {
+    Streamer->EmitIntValue(dwarf::DW_OP_bregx, 1);
+    Streamer->EmitULEB128IntValue(DwarfRegNum);
+  }
+  Streamer->EmitSLEB128IntValue(value);
 }
 
 static void EmitReg(MCObjectStreamer* Streamer, int DwarfRegNum) {
@@ -349,8 +361,7 @@ static void EmitVarLocation(MCObjectStreamer *Streamer,
         } else {
           Streamer->EmitULEB128IntValue(Len);
         }
-        EmitBreg(Streamer, DwarfRegNum);
-        Streamer->EmitSLEB128IntValue(0);
+        EmitBreg(Streamer, DwarfRegNum, 0);
       } else {
         Len = GetRegOpSize(DwarfRegNum);
         if (IsLocList) {
@@ -385,8 +396,7 @@ static void EmitVarLocation(MCObjectStreamer *Streamer,
         } else {
           Streamer->EmitULEB128IntValue(Len);
         }
-        EmitBreg(Streamer, DwarfBaseRegNum);
-        Streamer->EmitBytes(OffsetRepr);
+        EmitBreg(Streamer, DwarfBaseRegNum, OffsetRepr);
         Streamer->EmitIntValue(dwarf::DW_OP_deref, 1);
       } else {
         Len = OffsetRepr.size() + GetRegOpSize(DwarfBaseRegNum);
@@ -395,8 +405,7 @@ static void EmitVarLocation(MCObjectStreamer *Streamer,
         } else {
           Streamer->EmitULEB128IntValue(Len);
         }
-        EmitBreg(Streamer, DwarfBaseRegNum);
-        Streamer->EmitBytes(OffsetRepr);
+        EmitBreg(Streamer, DwarfBaseRegNum, OffsetRepr);
       }
 
       break;
@@ -451,13 +460,11 @@ static void EmitVarLocation(MCObjectStreamer *Streamer,
         Streamer->EmitIntValue(dwarf::DW_OP_piece, 1);
         Streamer->EmitULEB128IntValue(TargetPointerSize);
 
-        EmitBreg(Streamer, DwarfBaseRegNum);
-        Streamer->EmitBytes(OffsetRepr);
+        EmitBreg(Streamer, DwarfBaseRegNum, OffsetRepr);
         Streamer->EmitIntValue(dwarf::DW_OP_piece, 1);
         Streamer->EmitULEB128IntValue(TargetPointerSize);
       } else {
-        EmitBreg(Streamer, DwarfBaseRegNum);
-        Streamer->EmitBytes(OffsetRepr);
+        EmitBreg(Streamer, DwarfBaseRegNum, OffsetRepr);
         Streamer->EmitIntValue(dwarf::DW_OP_piece, 1);
         Streamer->EmitULEB128IntValue(TargetPointerSize);
 


### PR DESCRIPTION
This change has 2 parts, one which is JIT part and likely require submission to runtime.
I keep that change here to give full scope of changes. Will extract if everything would be fine.
JIT for ARM now start numering floating point registers starting from 256

Second part is DWARF generation
In order to produce DWARF I made following changes
- Account for register numbers more then 31, by use DW_OP_bregx and DW_OP_regx for large regnum
- Combine VLT_FPSTK and VLT_STK handling.

See #1388