### PR TITLE
Fix handling diamond case in GVMs

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.GVMResolution.cs
@@ -148,14 +148,20 @@ namespace Internal.Runtime.TypeLoader
 
                 MethodNameAndSignature targetMethodNameAndSignature = null;
                 RuntimeTypeHandle targetTypeHandle = default;
+                bool isDefaultInterfaceMethodImplementation;
 
                 if (nameAndSigToken != SpecialGVMInterfaceEntry.Diamond && nameAndSigToken != SpecialGVMInterfaceEntry.Reabstraction)
                 {
                     targetMethodNameAndSignature = GetMethodNameAndSignatureFromNativeReader(nativeLayoutReader, module.Handle, nameAndSigToken);
                     targetTypeHandle = extRefs.GetRuntimeTypeHandleFromIndex(entryParser.GetUnsigned());
+                    isDefaultInterfaceMethodImplementation = RuntimeAugments.IsInterface(targetTypeHandle);
 #if GVM_RESOLUTION_TRACE
                     Debug.WriteLine("    Searching for GVM implementation on targe type = " + GetTypeNameDebug(targetTypeHandle));
 #endif
+                }
+                else
+                {
+                    isDefaultInterfaceMethodImplementation = true;
                 }
 
                 uint numIfaceImpls = entryParser.GetUnsigned();
@@ -171,7 +177,7 @@ namespace Internal.Runtime.TypeLoader
                     uint numIfaceSigs = entryParser.GetUnsigned();
 
                     if (!openTargetTypeHandle.Equals(implementingTypeHandle)
-                        || defaultMethods != RuntimeAugments.IsInterface(targetTypeHandle))
+                        || defaultMethods != isDefaultInterfaceMethodImplementation)
                     {
                         // Skip over signatures data
                         for (uint l = 0; l < numIfaceSigs; l++)


### PR DESCRIPTION
`targetTypeHandle` would be null if there's no destination.

Fixes two of the default interface methods tests in the Pri-0 test suite.