### PR TITLE
Fix invoking instance methods on interfaces

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionVirtualInvokeMapNode.cs
@@ -45,9 +45,6 @@ namespace ILCompiler.DependencyAnalysis
             if (!method.IsVirtual)
                 return false;
 
-            if (method.OwningType.IsInterface)
-                return true;
-
             if (method.IsFinal)
                 return false;
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -269,11 +269,13 @@ internal class ReflectionTest
         interface IFoo<T>
         {
             string Format(string s) => "IFoo<" + typeof(T) + ">::Format(" + s + ")";
+            sealed string InstanceMethod(string s) => "IFoo<" + typeof(T) + ">::InstanceMethod(" + s + ")";
         }
 
         interface IFoo
         {
             string Format(string s) => "IFoo::Format(" + s + ")";
+            sealed string InstanceMethod(string s) => "IFoo::InstanceMethod(" + s + ")";
         }
 
         interface IBar : IFoo
@@ -317,6 +319,18 @@ internal class ReflectionTest
             {
                 var result = (string)typeof(IFoo).GetMethod(nameof(IFoo.Format)).Invoke(new Foo(), new object[] { "abc" });
                 if (result != "IBar::Format(abc)")
+                    throw new Exception();
+            }
+
+            {
+                var result = (string)typeof(IFoo).GetMethod(nameof(IFoo.InstanceMethod)).Invoke(new Foo(), new object[] { "abc" });
+                if (result != "IFoo::InstanceMethod(abc)")
+                    throw new Exception();
+            }
+
+            {
+                var result = (string)typeof(IFoo<Enum>).GetMethod(nameof(IFoo<Enum>.InstanceMethod)).Invoke(new Foo(), new object[] { "abc" });
+                if (result != "IFoo<System.Enum>::InstanceMethod(abc)")
                     throw new Exception();
             }
         }


### PR DESCRIPTION
Non-virtual instance methods on interfaces need an instantiation argument. Also, stop assuming all interface methods are virtual.