### PR TITLE
Fix handling of constrained calls on ValueTypes

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9001,19 +9001,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
             }
             else
             {
-                // If the EE was able to resolve a constrained call, the instantiating parameter to use is the type
-                // by which the call was constrained with. We embed pConstrainedResolvedToken as the extra argument
-                // because pResolvedToken is an interface method and interface types make a poor generic context.
-                if (pConstrainedResolvedToken)
-                {
-                    instParam = impTokenToHandle(pConstrainedResolvedToken, &runtimeLookup, true /*mustRestoreHandle*/,
-                                                 false /* importParent */);
-                }
-                else
-                {
-                    instParam = impParentClassTokenToHandle(pResolvedToken, &runtimeLookup, true /*mustRestoreHandle*/);
-                }
-
+                instParam = impParentClassTokenToHandle(pResolvedToken, &runtimeLookup, true /*mustRestoreHandle*/);
                 if (instParam == nullptr)
                 {
                     assert(compDonotInline());
@@ -9396,7 +9384,7 @@ DONE:
 
     if ((sig->flags & CORINFO_SIGFLAG_FAT_CALL) != 0)
     {
-        assert(opcode == CEE_CALLI);
+        assert(opcode == CEE_CALLI || callInfo->kind == CORINFO_CALL_CODE_POINTER);
         addFatPointerCandidate(call->AsCall());
     }
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
@@ -770,17 +770,17 @@ namespace Internal.Runtime.TypeLoader
                 if (Method is NoMetadataMethodDesc)
                 {
                     // If the method does not have metadata, use the NameAndSignature property which should work in that case.
-                    if (!TypeLoaderEnvironment.Instance.IsStaticMethodSignature(Method.NameAndSignature.Signature))
-                        return false;
+                    if (TypeLoaderEnvironment.Instance.IsStaticMethodSignature(Method.NameAndSignature.Signature))
+                        return true;
                 }
                 else
                 {
                     // Otherwise, use the MethodSignature
-                    if (!Method.Signature.IsStatic)
-                        return false;
+                    if (Method.Signature.IsStatic)
+                        return true;
                 }
 
-                return true;
+                return Method.OwningType.IsValueType && !Method.UnboxingStub;
             }
 
             internal unsafe override IntPtr Create(TypeBuilder builder)
@@ -805,7 +805,9 @@ namespace Internal.Runtime.TypeLoader
 
                 if (Method.FunctionPointer != IntPtr.Zero)
                 {
-                    if (Method.Instantiation.Length > 0 || TypeLoaderEnvironment.Instance.IsStaticMethodSignature(MethodSignature))
+                    if (Method.Instantiation.Length > 0
+                        || TypeLoaderEnvironment.Instance.IsStaticMethodSignature(MethodSignature)
+                        || (Method.OwningType.IsValueType && !Method.UnboxingStub))
                     {
                         Debug.Assert(methodDictionary != IntPtr.Zero);
 #if SUPPORTS_NATIVE_METADATA_TYPE_LOADING

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -525,7 +525,11 @@ namespace Internal.IL
                 // We have the canonical version of the method - find the runtime determined version.
                 // This is simplified because we know the method is on a valuetype.
                 Debug.Assert(targetMethod.OwningType.IsValueType);
-                MethodDesc targetOfLookup = _compilation.TypeSystemContext.GetMethodForRuntimeDeterminedType(targetMethod.GetTypicalMethodDefinition(), (RuntimeDeterminedType)_constrained);
+                MethodDesc targetOfLookup;
+                if (_constrained.IsRuntimeDeterminedType)
+                    targetOfLookup = _compilation.TypeSystemContext.GetMethodForRuntimeDeterminedType(targetMethod.GetTypicalMethodDefinition(), (RuntimeDeterminedType)_constrained);
+                else
+                    targetOfLookup = _compilation.TypeSystemContext.GetMethodForInstantiatedType(targetMethod.GetTypicalMethodDefinition(), (InstantiatedType)_constrained);
                 if (targetOfLookup.HasInstantiation)
                 {
                     targetOfLookup = targetOfLookup.MakeInstantiatedMethod(runtimeDeterminedMethod.Instantiation);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -530,7 +530,7 @@ namespace Internal.IL
                 {
                     targetOfLookup = targetOfLookup.MakeInstantiatedMethod(runtimeDeterminedMethod.Instantiation);
                 }
-                Debug.Assert(targetOfLookup.GetCanonMethodTarget(CanonicalFormKind.Specific) == targetMethod);
+                Debug.Assert(targetOfLookup.GetCanonMethodTarget(CanonicalFormKind.Specific) == targetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific));
                 _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.MethodEntry, targetOfLookup), reason);
             }
             else if (directCall)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1141,7 +1141,7 @@ namespace Internal.JitInterface
                     var methodToGetInstantiation = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
                     targetOfLookup = targetOfLookup.MakeInstantiatedMethod(methodToGetInstantiation.Instantiation);
                 }
-                Debug.Assert(targetOfLookup.GetCanonMethodTarget(CanonicalFormKind.Specific) == targetMethod);
+                Debug.Assert(targetOfLookup.GetCanonMethodTarget(CanonicalFormKind.Specific) == targetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific));
 
                 ComputeLookup(ref pResolvedToken,
                     targetOfLookup,

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1131,7 +1131,11 @@ namespace Internal.JitInterface
                 // This is simplified because we know the method is on a valuetype.
                 Debug.Assert(targetMethod.OwningType.IsValueType);
                 TypeDesc runtimeDeterminedConstrainedType = (TypeDesc)GetRuntimeDeterminedObjectForToken(ref *pConstrainedResolvedToken);
-                MethodDesc targetOfLookup = _compilation.TypeSystemContext.GetMethodForRuntimeDeterminedType(targetMethod.GetTypicalMethodDefinition(), (RuntimeDeterminedType)runtimeDeterminedConstrainedType);
+                MethodDesc targetOfLookup;
+                if (runtimeDeterminedConstrainedType.IsRuntimeDeterminedType)
+                    targetOfLookup = _compilation.TypeSystemContext.GetMethodForRuntimeDeterminedType(targetMethod.GetTypicalMethodDefinition(), (RuntimeDeterminedType)runtimeDeterminedConstrainedType);
+                else
+                    targetOfLookup = _compilation.TypeSystemContext.GetMethodForInstantiatedType(targetMethod.GetTypicalMethodDefinition(), (InstantiatedType)runtimeDeterminedConstrainedType);
                 if (targetOfLookup.HasInstantiation)
                 {
                     var methodToGetInstantiation = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -961,6 +961,7 @@ namespace Internal.JitInterface
             bool resolvedConstraint = false;
             bool forceUseRuntimeLookup = false;
             bool targetIsFatFunctionPointer = false;
+            bool useFatCallTransform = false;
 
             MethodDesc methodAfterConstraintResolution = method;
             if (constrainedType == null)
@@ -1115,6 +1116,36 @@ namespace Internal.JitInterface
                     pResult->codePointerOrStubLookup.constLookup =
                         CreateConstLookupToSymbol(_compilation.NodeFactory.FatFunctionPointer(targetMethod));
                 }
+            }
+            else if (directCall && resolvedConstraint && pResult->exactContextNeedsRuntimeLookup)
+            {
+                // We want to do a direct call to a shared method on a valuetype. We need to provide
+                // a generic context, but the JitInterface doesn't provide a way for us to do it from here.
+                // So we do the next best thing and ask RyuJIT to look up a fat pointer.
+
+                pResult->kind = CORINFO_CALL_KIND.CORINFO_CALL_CODE_POINTER;
+                pResult->codePointerOrStubLookup.constLookup.accessType = InfoAccessType.IAT_VALUE;
+                pResult->nullInstanceCheck = true;
+
+                // We have the canonical version of the method - find the runtime determined version.
+                // This is simplified because we know the method is on a valuetype.
+                Debug.Assert(targetMethod.OwningType.IsValueType);
+                TypeDesc runtimeDeterminedConstrainedType = (TypeDesc)GetRuntimeDeterminedObjectForToken(ref *pConstrainedResolvedToken);
+                MethodDesc targetOfLookup = _compilation.TypeSystemContext.GetMethodForRuntimeDeterminedType(targetMethod.GetTypicalMethodDefinition(), (RuntimeDeterminedType)runtimeDeterminedConstrainedType);
+                if (targetOfLookup.HasInstantiation)
+                {
+                    var methodToGetInstantiation = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+                    targetOfLookup = targetOfLookup.MakeInstantiatedMethod(methodToGetInstantiation.Instantiation);
+                }
+                Debug.Assert(targetOfLookup.GetCanonMethodTarget(CanonicalFormKind.Specific) == targetMethod);
+
+                ComputeLookup(ref pResolvedToken,
+                    targetOfLookup,
+                    ReadyToRunHelperId.MethodEntry,
+                    ref pResult->codePointerOrStubLookup);
+
+                targetIsFatFunctionPointer = true;
+                useFatCallTransform = true;
             }
             else if (directCall)
             {
@@ -1315,6 +1346,10 @@ namespace Internal.JitInterface
             targetIsFatFunctionPointer |= (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) != 0 && !(pResult->kind == CORINFO_CALL_KIND.CORINFO_CALL);
 
             Get_CORINFO_SIG_INFO(targetMethod, &pResult->sig, targetIsFatFunctionPointer);
+            if (useFatCallTransform)
+            {
+                pResult->sig.flags |= CorInfoSigInfoFlags.CORINFO_SIGFLAG_FAT_CALL;
+            }
 
             if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_VERIFICATION) != 0)
             {

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/GenericVirtualMethods.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/GenericVirtualMethods.cs
@@ -204,8 +204,7 @@ public static class GenericVirtualMethods
         Assert.AreEqual("Called GVMStructGeneric<object>.GVM<int>", igvmStructGenericOverObject.GVM<int>(54));
         Assert.AreEqual("Called GVMStructGeneric<object>.GVM<GVMDerivedClass>", igvmStructGenericOverObject.GVM<GVMDerivedClass>(testObject));
         Assert.AreEqual("Called GVMStructGeneric<object>.GVM<string>", igvmStructGenericOverObject.GVM<string>("testString"));
-        // https://github.com/dotnet/corert/issues/3608
-        // TestConstrainedCalls<GVMStructGeneric<object>>(new GVMStructGeneric<object>(), "Called GVMStructGeneric<object>.GVM<int>", "Called GVMStructGeneric<object>.GVM<GVMDerivedClass>", "Called GVMStructGeneric<object>.GVM<string>");
+        TestConstrainedCalls<GVMStructGeneric<object>>(new GVMStructGeneric<object>(), "Called GVMStructGeneric<object>.GVM<int>", "Called GVMStructGeneric<object>.GVM<GVMDerivedClass>", "Called GVMStructGeneric<object>.GVM<string>");
         TestConstrainedCalls<IInterfaceWithGVM>(new GVMStructGeneric<object>(), "Called GVMStructGeneric<object>.GVM<int>", "Called GVMStructGeneric<object>.GVM<GVMDerivedClass>", "Called GVMStructGeneric<object>.GVM<string>");
     }
 


### PR DESCRIPTION
* We weren't able to get a usable generic context to the method being invoked.
* Undoes https://github.com/dotnet/coreclr/pull/13577 that was papering over the issue, fixing this for non-generic methods, but leaving generic methods unfixed.
* The fix is similar to how CoreCLR handles this - on CoreCLR, we call a helper, get an instantiation thunk back, and invoke that.
* Since we don't have instantiation thunks in NativeAOT, we ask for a fat function pointer and perform a fat call.
* This is a bit less efficient than what we had in NativeAOT before this change (generic lookup for the context, and a direct call). We wouldn't be able to express the correct generic lookup sequence without a JitInterface change. What we get with this pull request is probably good enough.

Fixes #1357.
Fixes https://github.com/dotnet/corert/issues/3608 (which is the same issue, but in CoreRT repo)