### PR TITLE
Add access violation location in ASM

### DIFF
--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -376,6 +376,10 @@ static uintptr_t UnwindSimpleHelperToCaller(
     pContext->SetSp(sp+sizeof(uintptr_t)); // pop the stack
 #elif defined(HOST_ARM) || defined(HOST_ARM64)
     uintptr_t adjustedFaultingIP = pContext->GetLr();
+#if defined(HOST_ARM)
+    if (InInterfaceDispatchHelper(faultingIP))
+        pContext->SetSp(pContext->GetSp()+2*sizeof(uintptr_t));
+#endif
 #else
     uintptr_t adjustedFaultingIP = 0; // initializing to make the compiler happy
     PORTABILITY_ASSERT("UnwindSimpleHelperToCaller");

--- a/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/EHHelpers.cpp
@@ -376,10 +376,6 @@ static uintptr_t UnwindSimpleHelperToCaller(
     pContext->SetSp(sp+sizeof(uintptr_t)); // pop the stack
 #elif defined(HOST_ARM) || defined(HOST_ARM64)
     uintptr_t adjustedFaultingIP = pContext->GetLr();
-#if defined(HOST_ARM)
-    if (InInterfaceDispatchHelper(faultingIP))
-        pContext->SetSp(pContext->GetSp()+2*sizeof(uintptr_t));
-#endif
 #else
     uintptr_t adjustedFaultingIP = 0; // initializing to make the compiler happy
     PORTABILITY_ASSERT("UnwindSimpleHelperToCaller");

--- a/src/coreclr/nativeaot/Runtime/arm/StubDispatch.S
+++ b/src/coreclr/nativeaot/Runtime/arm/StubDispatch.S
@@ -12,7 +12,7 @@
 // Macro that generates a stub consuming a cache with the given number of entries.
 .macro DEFINE_INTERFACE_DISPATCH_STUB entries
 
-LEAF_ENTRY RhpInterfaceDispatch\entries, _TEXT
+NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT
         // r12 currently contains the indirection cell address. But we need more scratch registers and
         // we may A/V on a null this. Both of these suggest we need a real prolog and epilog.
         PROLOG_PUSH {r1-r2}
@@ -21,6 +21,7 @@ LEAF_ENTRY RhpInterfaceDispatch\entries, _TEXT
         ldr         r2, [r12, #OFFSETOF__InterfaceDispatchCell__m_pCache]
 
         // Load the EEType from the object instance in r0.
+        ALTERNATE_ENTRY RhpInterfaceDispatchAVLocation\entries
         ldr         r1, [r0]
 
         CurrentOffset = OFFSETOF__InterfaceDispatchCache__m_rgEntries
@@ -57,7 +58,7 @@ LOCAL_LABEL(99_\entries):
         EPILOG_POP  {r2}
         EPILOG_BRANCH_REG r12
 
-LEAF_END RhpInterfaceDispatch\entries, _TEXT
+NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT
 
 .endm // DEFINE_INTERFACE_DISPATCH_STUB
 

--- a/src/coreclr/nativeaot/Runtime/arm/StubDispatch.S
+++ b/src/coreclr/nativeaot/Runtime/arm/StubDispatch.S
@@ -12,7 +12,7 @@
 // Macro that generates a stub consuming a cache with the given number of entries.
 .macro DEFINE_INTERFACE_DISPATCH_STUB entries
 
-NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT
+NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT, NoHandler
         // r12 currently contains the indirection cell address. But we need more scratch registers and
         // we may A/V on a null this. Both of these suggest we need a real prolog and epilog.
         PROLOG_PUSH {r1-r2}
@@ -58,7 +58,7 @@ LOCAL_LABEL(99_\entries):
         EPILOG_POP  {r2}
         EPILOG_BRANCH_REG r12
 
-NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT
+NESTED_END RhpInterfaceDispatch\entries, _TEXT
 
 .endm // DEFINE_INTERFACE_DISPATCH_STUB
 

--- a/src/coreclr/nativeaot/Runtime/arm/StubDispatch.S
+++ b/src/coreclr/nativeaot/Runtime/arm/StubDispatch.S
@@ -14,8 +14,9 @@
 
 NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT, NoHandler
         // r12 currently contains the indirection cell address. But we need more scratch registers and
-        // we may A/V on a null this. Both of these suggest we need a real prolog and epilog.
-        PROLOG_PUSH {r1-r2}
+        // we may A/V on a null this. Store r1 and r2 in red zone.
+        str         r1, [sp, #-8]
+        str         r2, [sp, #-4]
 
         // r12 currently holds the indirection cell address. We need to get the cache structure instead.
         ldr         r2, [r12, #OFFSETOF__InterfaceDispatchCell__m_pCache]
@@ -43,7 +44,8 @@ NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT, NoHandler
         // Point r12 to the indirection cell using the back pointer in the cache block
         ldr         r12, [r2, #OFFSETOF__InterfaceDispatchCache__m_pCell]
 
-        EPILOG_POP  {r1-r2}
+        ldr         r1, [sp, #-8]
+        ldr         r2, [sp, #-4]
         b           C_FUNC(RhpInterfaceDispatchSlow)
 
         // Common epilog for cache hits. Have to out of line it here due to limitation on the number of
@@ -52,10 +54,10 @@ LOCAL_LABEL(99_\entries):
         // R2 contains address of the cache block. We store it in the red zone in case the target we jump
         // to needs it.
         // R12 contains the target address to jump to
-        EPILOG_POP  {r1}
-        // The red zone is only 8 bytes long, so we have to store r2 into it between the pops.
-        str         r2, [sp, #-4]
-        EPILOG_POP  {r2}
+        ldr         r1, [sp, #-8]
+        // We have to store R2 with address of the cache block into red zone before restoring original r2.
+        str         r2, [sp, #-8]
+        ldr         r2, [sp, #-4]
         EPILOG_BRANCH_REG r12
 
 NESTED_END RhpInterfaceDispatch\entries, _TEXT


### PR DESCRIPTION
That location used in `InInterfaceDispatchHelper` to check for possible NRE
See #1424