### PR TITLE
Implement TryResolveConstraintMethodApprox

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
@@ -181,6 +181,7 @@ namespace Internal.TypeSystem
 
             // Interface method may or may not be fully canonicalized here.
             // It would be canonical on the CoreCLR side so canonicalize here to keep the algorithms similar.
+            Instantiation methodInstantiation = interfaceMethod.Instantiation;
             interfaceMethod = interfaceMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
             // 1. Find the (possibly generic) method that would implement the
@@ -305,9 +306,9 @@ namespace Internal.TypeSystem
 
             // We've resolved the method, ignoring its generic method arguments
             // If the method is a generic method then go and get the instantiated descriptor
-            if (interfaceMethod.HasInstantiation)
+            if (methodInstantiation.Length != 0)
             {
-                method = method.MakeInstantiatedMethod(interfaceMethod.Instantiation);
+                method = method.MakeInstantiatedMethod(methodInstantiation);
             }
 
             Debug.Assert(method != null);

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
@@ -280,7 +280,8 @@ namespace Internal.TypeSystem
             }
             else if (genInterfaceMethod.IsVirtual)
             {
-                method = canonType.FindVirtualFunctionTargetMethodOnObjectType(genInterfaceMethod);
+                MethodDesc targetMethod = interfaceType.FindMethodOnTypeWithMatchingTypicalMethod(genInterfaceMethod);
+                method = constrainedType.FindVirtualFunctionTargetMethodOnObjectType(targetMethod);
             }
             else
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
@@ -179,15 +179,18 @@ namespace Internal.TypeSystem
                 return null;
             }
 
-            // Non-virtual methods called through constraints simply resolve to the specified method without constraint resolution.
-            if (!interfaceMethod.IsVirtual)
-            {
-                return null;
-            }
+            // Interface method may or may not be fully canonicalized here.
+            // It would be canonical on the CoreCLR side so canonicalize here to keep the algorithms similar.
+            interfaceMethod = interfaceMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
-            MethodDesc method;
+            // 1. Find the (possibly generic) method that would implement the
+            // constraint if we were making a call on a boxed value type.
+
+            TypeDesc canonType = constrainedType.ConvertToCanonForm(CanonicalFormKind.Specific);
+            TypeSystemContext context = constrainedType.Context;
 
             MethodDesc genInterfaceMethod = interfaceMethod.GetMethodDefinition();
+            MethodDesc method = null;
             if (genInterfaceMethod.OwningType.IsInterface)
             {
                 // Sometimes (when compiling shared generic code)
@@ -199,15 +202,84 @@ namespace Internal.TypeSystem
                 // at least one of them will be)
 
                 // Enumerate all potential interface instantiations
+                int potentialMatchingInterfaces = 0;
+                foreach (DefType potentialInterfaceType in canonType.RuntimeInterfaces)
+                {
+                    if (potentialInterfaceType.ConvertToCanonForm(CanonicalFormKind.Specific) ==
+                        interfaceType.ConvertToCanonForm(CanonicalFormKind.Specific))
+                    {
+                        potentialMatchingInterfaces++;
+                        MethodDesc potentialInterfaceMethod = genInterfaceMethod;
+                        if (potentialInterfaceMethod.OwningType != potentialInterfaceType)
+                        {
+                            potentialInterfaceMethod = context.GetMethodForInstantiatedType(
+                                potentialInterfaceMethod.GetTypicalMethodDefinition(), (InstantiatedType)potentialInterfaceType);
+                        }
 
-                // TODO: this code assumes no shared generics
-                Debug.Assert(interfaceType == interfaceMethod.OwningType);
+                        method = canonType.ResolveInterfaceMethodToVirtualMethodOnType(potentialInterfaceMethod);
 
-                method = constrainedType.ResolveInterfaceMethodToVirtualMethodOnType(genInterfaceMethod);
+                        // See code:#TryResolveConstraintMethodApprox_DoNotReturnParentMethod
+                        if (method != null && !method.OwningType.IsValueType)
+                        {
+                            // We explicitly wouldn't want to abort if we found a default implementation.
+                            // The above resolution doesn't consider the default methods.
+                            Debug.Assert(!method.OwningType.IsInterface);
+                            return null;
+                        }
+                    }
+                }
+
+                Debug.Assert(potentialMatchingInterfaces != 0);
+
+                if (potentialMatchingInterfaces > 1)
+                {
+                    // We have more potentially matching interfaces
+                    Debug.Assert(interfaceType.HasInstantiation);
+
+                    bool isExactMethodResolved = false;
+
+                    if (!interfaceType.IsCanonicalSubtype(CanonicalFormKind.Any) &&
+                        !interfaceType.IsGenericDefinition &&
+                        !constrainedType.IsCanonicalSubtype(CanonicalFormKind.Any) &&
+                        !constrainedType.IsGenericDefinition)
+                    {
+                        // We have exact interface and type instantiations (no generic variables and __Canon used
+                        // anywhere)
+                        if (constrainedType.CanCastTo(interfaceType))
+                        {
+                            // We can resolve to exact method
+                            MethodDesc exactInterfaceMethod = context.GetMethodForInstantiatedType(
+                                genInterfaceMethod.GetTypicalMethodDefinition(), (InstantiatedType)interfaceType);
+                            method = constrainedType.ResolveVariantInterfaceMethodToVirtualMethodOnType(exactInterfaceMethod);
+                            isExactMethodResolved = method != null;
+                        }
+                    }
+
+                    if (!isExactMethodResolved)
+                    {
+                        // We couldn't resolve the interface statically
+                        // Notify the caller that it should use runtime lookup
+                        // Note that we can leave pMD incorrect, because we will use runtime lookup
+                        forceRuntimeLookup = true;
+                    }
+                }
+                else
+                {
+                    // If we can resolve the interface exactly then do so (e.g. when doing the exact
+                    // lookup at runtime, or when not sharing generic code).
+                    if (constrainedType.CanCastTo(interfaceType))
+                    {
+                        MethodDesc exactInterfaceMethod = genInterfaceMethod;
+                        if (genInterfaceMethod.OwningType != interfaceType)
+                            exactInterfaceMethod = context.GetMethodForInstantiatedType(
+                                genInterfaceMethod.GetTypicalMethodDefinition(), (InstantiatedType)interfaceType);
+                        method = canonType.ResolveVariantInterfaceMethodToVirtualMethodOnType(exactInterfaceMethod);
+                    }
+                }
             }
             else if (genInterfaceMethod.IsVirtual)
             {
-                method = constrainedType.FindVirtualFunctionTargetMethodOnObjectType(genInterfaceMethod);
+                method = canonType.FindVirtualFunctionTargetMethodOnObjectType(genInterfaceMethod);
             }
             else
             {
@@ -239,7 +311,6 @@ namespace Internal.TypeSystem
             }
 
             Debug.Assert(method != null);
-            //assert(!pMD->IsUnboxingStub());
 
             return method;
         }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1139,6 +1139,7 @@ namespace Internal.JitInterface
                     // use the ConstrainedMethodUseLookupResult dictionary entry so that the exact
                     // dispatch can be computed with the help of the generic dictionary.
                     // We fail the compilation here to avoid bad codegen. This is not actually an invalid program.
+                    // https://github.com/dotnet/runtimelab/issues/1431
                     ThrowHelper.ThrowInvalidProgramException();
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1131,6 +1131,17 @@ namespace Internal.JitInterface
                 // This is simplified because we know the method is on a valuetype.
                 Debug.Assert(targetMethod.OwningType.IsValueType);
                 TypeDesc runtimeDeterminedConstrainedType = (TypeDesc)GetRuntimeDeterminedObjectForToken(ref *pConstrainedResolvedToken);
+
+                if (forceUseRuntimeLookup)
+                {
+                    // The below logic would incorrectly resolve the lookup into the first match we found,
+                    // but there was a compile-time ambiguity due to shared code. The correct fix should
+                    // use the ConstrainedMethodUseLookupResult dictionary entry so that the exact
+                    // dispatch can be computed with the help of the generic dictionary.
+                    // We fail the compilation here to avoid bad codegen. This is not actually an invalid program.
+                    ThrowHelper.ThrowInvalidProgramException();
+                }
+
                 MethodDesc targetOfLookup;
                 if (runtimeDeterminedConstrainedType.IsRuntimeDeterminedType)
                     targetOfLookup = _compilation.TypeSystemContext.GetMethodForRuntimeDeterminedType(targetMethod.GetTypicalMethodDefinition(), (RuntimeDeterminedType)runtimeDeterminedConstrainedType);


### PR DESCRIPTION
I tried to implement the full behavior (that wouldn't throw from forceRuntimeLookup), but that started to be hairy (https://github.com/MichalStrehovsky/runtimelab/commit/7d632d43ddd1f5b21383c4123b924a5623d83b5e) so I'll leave it in a branch: the dictionary entries look different from what we would need (not fat pointers), we need to intern the ConstrainedCallInfo, and who knows what else is needed on top of what's in that commit.