### PR TITLE
Fix SingleMethodCompilationModuleGroup

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -35,18 +35,17 @@ namespace ILCompiler
 
         public sealed override bool ContainsMethodDictionary(MethodDesc method)
         {
-            Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) != method);
-            return ContainsMethodBody(method, false);
+            return true;
         }
 
         public override bool ContainsType(TypeDesc type)
         {
-            return false;
+            return true;
         }
 
         public override bool ContainsTypeDictionary(TypeDesc type)
         {
-            return false;
+            return true;
         }
 
         public override bool ImportsMethod(MethodDesc method, bool unboxingStub)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -35,6 +35,7 @@ namespace ILCompiler
 
         public sealed override bool ContainsMethodDictionary(MethodDesc method)
         {
+            Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) != method);
             return true;
         }
 


### PR DESCRIPTION
Returning false from these results in various asserts/crashes before/after we do codegen.

The point of this is to make sure we only compile one method. Generating data structures is fine.