### PR TITLE
Implement IDynamicInterfaceCastable

### DIFF
--- a/src/coreclr/nativeaot/Bootstrap/main.cpp
+++ b/src/coreclr/nativeaot/Bootstrap/main.cpp
@@ -111,6 +111,8 @@ extern "C" void AppendExceptionStackFrame();
 extern "C" void GetSystemArrayEEType();
 extern "C" void OnFirstChanceException();
 extern "C" void OnUnhandledException();
+extern "C" void IDynamicCastableIsInterfaceImplemented();
+extern "C" void IDynamicCastableGetInterfaceImplementation();
 
 typedef void(*pfn)();
 
@@ -123,6 +125,8 @@ static const pfn c_classlibFunctions[] = {
     &GetSystemArrayEEType,
     &OnFirstChanceException,
     &OnUnhandledException,
+    &IDynamicCastableIsInterfaceImplemented,
+    &IDynamicCastableGetInterfaceImplementation,
 };
 
 #ifndef _countof

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/IDynamicInterfaceCastableSupport.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/IDynamicInterfaceCastableSupport.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime;
+using System.Runtime.InteropServices;
+
+namespace Internal.Runtime
+{
+    static unsafe class IDynamicCastableSupport
+    {
+        [RuntimeExport("IDynamicCastableIsInterfaceImplemented")]
+        internal static bool IDynamicCastableIsInterfaceImplemented(IDynamicInterfaceCastable instance, MethodTable* interfaceType, bool throwIfNotImplemented)
+        {
+            return instance.IsInterfaceImplemented(new RuntimeTypeHandle(new EETypePtr(interfaceType)), throwIfNotImplemented);
+        }
+
+        [RuntimeExport("IDynamicCastableGetInterfaceImplementation")]
+        internal static IntPtr IDynamicCastableGetInterfaceImplementation(IDynamicInterfaceCastable instance, MethodTable* interfaceType, ushort slot)
+        {
+            RuntimeTypeHandle handle = instance.GetInterfaceImplementation(new RuntimeTypeHandle(new EETypePtr(interfaceType)));
+            EETypePtr implType = handle.ToEETypePtr();
+            if (implType.IsNull)
+            {
+                ThrowInvalidCastException(instance, interfaceType);
+            }
+            if (!implType.IsInterface)
+            {
+                ThrowInvalidOperationException(implType);
+            }
+            IntPtr result = RuntimeImports.RhResolveDispatchOnType(implType, new EETypePtr(interfaceType), slot);
+            if (result == IntPtr.Zero)
+            {
+                IDynamicCastableGetInterfaceImplementationFailure(instance, interfaceType, implType);
+            }
+            return result;
+        }
+
+        private static void ThrowInvalidCastException(object instance, MethodTable* interfaceType)
+        {
+            throw new InvalidCastException(SR.Format(SR.InvalidCast_FromTo, instance.GetType(), Type.GetTypeFromEETypePtr(new EETypePtr(interfaceType))));
+        }
+
+        private static void ThrowInvalidOperationException(EETypePtr resolvedImplType)
+        {
+            throw new InvalidOperationException(SR.Format(SR.IDynamicInterfaceCastable_NotInterface, Type.GetTypeFromEETypePtr(resolvedImplType)));
+        }
+
+        private static void IDynamicCastableGetInterfaceImplementationFailure(object instance, MethodTable* interfaceType, EETypePtr resolvedImplType)
+        {
+            if (resolvedImplType.DispatchMap == IntPtr.Zero)
+                throw new InvalidOperationException(SR.Format(SR.IDynamicInterfaceCastable_MissingImplementationAttribute, Type.GetTypeFromEETypePtr(resolvedImplType), nameof(DynamicInterfaceCastableImplementationAttribute)));
+
+            bool implementsInterface = false;
+            var interfaces = resolvedImplType.Interfaces;
+            for (int i = 0; i < interfaces.Count; i++)
+            {
+                if (interfaces[i] == new EETypePtr(interfaceType))
+                {
+                    implementsInterface = true;
+                    break;
+                }
+            }
+
+            if (!implementsInterface)
+                throw new InvalidOperationException(SR.Format(SR.IDynamicInterfaceCastable_DoesNotImplementRequested, Type.GetTypeFromEETypePtr(resolvedImplType), Type.GetTypeFromEETypePtr(new EETypePtr(interfaceType))));
+
+            throw new EntryPointNotFoundException();
+        }
+    }
+}

--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -655,6 +655,14 @@ namespace Internal.Runtime
             }
         }
 
+        internal bool IsIDynamicInterfaceCastable
+        {
+            get
+            {
+                return ((_usFlags & (ushort)EETypeFlags.IDynamicInterfaceCastableFlag) != 0);
+            }
+        }
+
         internal bool IsValueType
         {
             get

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CachedInterfaceDispatch.cs
@@ -29,7 +29,17 @@ namespace System.Runtime
             IntPtr pTargetCode = RhResolveDispatchWorker(pObject, (void*)pCell, ref cellInfo);
             if (pTargetCode != IntPtr.Zero)
             {
-                return InternalCalls.RhpUpdateDispatchCellCache(pCell, pTargetCode, pObject.MethodTable, ref cellInfo);
+                // We don't update the dispatch cell cache if this is IDynamicInterfaceCastable because this
+                // scenario is by-design dynamic. There is no guarantee that another instance with the same MethodTable
+                // as the one we just resolved would do the resolution the same way. We will need to ask again.
+                if (!pObject.MethodTable->IsIDynamicInterfaceCastable)
+                {
+                    return InternalCalls.RhpUpdateDispatchCellCache(pCell, pTargetCode, pObject.MethodTable, ref cellInfo);
+                }
+                else
+                {
+                    return pTargetCode;
+                }
             }
 
             // "Valid method implementation was not found."
@@ -93,12 +103,22 @@ namespace System.Runtime
 
             if (cellInfo.CellType == DispatchCellType.InterfaceAndSlot)
             {
-                // Type whose DispatchMap is used.
+                // Type whose DispatchMap is used. Usually the same as the above but for types which implement IDynamicInterfaceCastable
+                // we may repeat this process with an alternate type.
                 MethodTable* pResolvingInstanceType = pInstanceType;
 
                 IntPtr pTargetCode = DispatchResolve.FindInterfaceMethodImplementationTarget(pResolvingInstanceType,
                                                                               cellInfo.InterfaceType.ToPointer(),
                                                                               cellInfo.InterfaceSlot);
+                if (pTargetCode == IntPtr.Zero && pInstanceType->IsIDynamicInterfaceCastable)
+                {
+                    // Dispatch not resolved through normal dispatch map, try using the IDynamicInterfaceCastable
+                    // This will either give us the appropriate result, or throw.
+                    var pfnGetInterfaceImplementation = (delegate*<object, MethodTable*, ushort, IntPtr>)
+                        pInstanceType->GetClasslibFunction(ClassLibFunctionId.IDynamicCastableGetInterfaceImplementation);
+                    pTargetCode = pfnGetInterfaceImplementation(pObject, cellInfo.InterfaceType.ToPointer(), cellInfo.InterfaceSlot);
+                    Diagnostics.Debug.Assert(pTargetCode != IntPtr.Zero);
+                }
                 return pTargetCode;
             }
             else if (cellInfo.CellType == DispatchCellType.VTableOffset)

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.cs
@@ -142,7 +142,7 @@ namespace System.Runtime
         private static void OnFirstChanceExceptionViaClassLib(object exception)
         {
             IntPtr pOnFirstChanceFunction =
-                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType((IntPtr)exception.MethodTable, ClassLibFunctionId.OnFirstChance);
+                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(exception.MethodTable, ClassLibFunctionId.OnFirstChance);
 
             if (pOnFirstChanceFunction == IntPtr.Zero)
             {
@@ -162,7 +162,7 @@ namespace System.Runtime
         private static void OnUnhandledExceptionViaClassLib(object exception)
         {
             IntPtr pOnUnhandledExceptionFunction =
-                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType((IntPtr)exception.MethodTable, ClassLibFunctionId.OnUnhandledException);
+                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(exception.MethodTable, ClassLibFunctionId.OnUnhandledException);
 
             if (pOnUnhandledExceptionFunction == IntPtr.Zero)
             {
@@ -283,12 +283,12 @@ namespace System.Runtime
         // Given an ExceptionID and an MethodTable address, get an exception object of a type that the module containing
         // the given address will understand. This finds the classlib-defined GetRuntimeException function and asks
         // it for the exception object.
-        internal static Exception GetClasslibExceptionFromEEType(ExceptionIDs id, IntPtr pEEType)
+        internal static Exception GetClasslibExceptionFromEEType(ExceptionIDs id, MethodTable* pEEType)
         {
             // Find the classlib function that will give us the exception object we want to throw. This
             // is a RuntimeExport function from the classlib module, and is therefore managed-callable.
             IntPtr pGetRuntimeExceptionFunction = IntPtr.Zero;
-            if (pEEType != IntPtr.Zero)
+            if (pEEType != null)
             {
                 pGetRuntimeExceptionFunction = (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(pEEType, ClassLibFunctionId.GetRuntimeException);
             }
@@ -310,7 +310,7 @@ namespace System.Runtime
                 FailFastViaClasslib(
                     RhFailFastReason.ClassLibDidNotTranslateExceptionID,
                     null,
-                    pEEType);
+                    (IntPtr)pEEType);
             }
 
             return e;

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -42,6 +42,8 @@ namespace System.Runtime
         GetSystemArrayEEType = 5,
         OnFirstChance = 6,
         OnUnhandledException = 7,
+        IDynamicCastableIsInterfaceImplemented = 8,
+        IDynamicCastableGetInterfaceImplementation = 9,
     }
 
     internal static class InternalCalls
@@ -213,7 +215,7 @@ namespace System.Runtime
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetClasslibFunctionFromEEType")]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe void* RhpGetClasslibFunctionFromEEType(IntPtr pEEType, ClassLibFunctionId id);
+        internal static extern unsafe void* RhpGetClasslibFunctionFromEEType(MethodTable* pEEType, ClassLibFunctionId id);
 
         //
         // StackFrameIterator

--- a/src/coreclr/nativeaot/Runtime/ICodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/ICodeManager.h
@@ -107,6 +107,8 @@ enum class ClasslibFunctionId
     GetSystemArrayEEType = 5,
     OnFirstChanceException = 6,
     OnUnhandledException = 7,
+    IDynamicCastableIsInterfaceImplemented = 8,
+    IDynamicCastableGetInterfaceImplementation = 9,
 };
 
 enum class AssociatedDataFlags : unsigned char

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3148,6 +3148,15 @@
   <data name="Encoding_UTF7_Disabled" xml:space="preserve">
     <value>Support for UTF-7 is disabled. See {0} for more information.</value>
   </data>
+  <data name="IDynamicInterfaceCastable_DoesNotImplementRequested" xml:space="preserve">
+    <value>Type '{0}' returned by IDynamicInterfaceCastable does not implement the requested interface '{1}'.</value>
+  </data>
+  <data name="IDynamicInterfaceCastable_MissingImplementationAttribute" xml:space="preserve">
+    <value>Type '{0}' returned by IDynamicInterfaceCastable does not have the attribute '{1}'.</value>
+  </data>
+  <data name="IDynamicInterfaceCastable_NotInterface" xml:space="preserve">
+    <value>Type '{0}' returned by IDynamicInterfaceCastable is not an interface.</value>
+  </data>
   <data name="NotSupported_BodyRemoved" xml:space="preserve">
     <value>The body of this method was removed by the AOT compiler because it's not callable.</value>
   </data>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -370,6 +370,9 @@
     <Compile Include="$(CompilerCommonPath)\Internal\Runtime\CanonTypeKind.cs">
       <Link>Internal\Runtime\CanonTypeKind.cs</Link>
     </Compile>
+    <Compile Include="$(AotCommonPath)\Internal\Runtime\IDynamicInterfaceCastableSupport.cs">
+      <Link>Internal\Runtime\IDynamicInterfaceCastableSupport.cs</Link>
+    </Compile>
     <Compile Include="$(AotCommonPath)\Internal\Runtime\MethodTable.cs">
       <Link>Internal\Runtime\MethodTable.cs</Link>
     </Compile>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/InvokeUtils.cs
@@ -89,6 +89,13 @@ namespace System
                 if (RuntimeImports.AreTypesAssignable(srcEEType, dstEEType))
                     return srcObject;
 
+                if (dstEEType.IsInterface)
+                {
+                    if (srcObject is Runtime.InteropServices.IDynamicInterfaceCastable castable
+                        && castable.IsInterfaceImplemented(new RuntimeTypeHandle(dstEEType), throwIfNotImplemented: false))
+                        return srcObject;
+                }
+
                 object dstObject;
                 Exception exception = ConvertOrWidenPrimitivesEnumsAndPointersIfPossible(srcObject, srcEEType, dstEEType, semantics, out dstObject);
                 if (exception == null)

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/TypeCast.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/TypeLoader/TypeCast.cs
@@ -210,6 +210,7 @@ namespace Internal.Reflection.Execution
 
         //
         // Determines if a value of the source type can be assigned to a location of the target type.
+        // It does not handle IDynamicInterfaceCastable, and cannot since we do not have an actual object instance here.
         // This routine assumes that the source type is boxed, i.e. a value type source is presumed to be
         // compatible with Object and ValueType and an enum source is additionally compatible with Enum.
         //

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LazyVtableResolverThunk.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/LazyVtableResolverThunk.cs
@@ -717,7 +717,7 @@ namespace Internal.Runtime.TypeLoader
                     methodAddress = RuntimeAugments.ResolveDispatchOnType(instanceType.GetRuntimeTypeHandle(),
                                                                           targetMethod.OwningType.GetRuntimeTypeHandle(),
                                                                           interfaceSlot);
-                    Debug.Assert(methodAddress != IntPtr.Zero);
+                    Debug.Assert(methodAddress != IntPtr.Zero); // TODO! This should happen for IDynamicInterfaceCastable dispatch...
                     return true;
                 }
                 else
@@ -758,7 +758,7 @@ namespace Internal.Runtime.TypeLoader
                                                                           targetMethod.OwningType.GetRuntimeTypeHandle(),
                                                                           interfaceSlot);
 
-                    Debug.Assert(methodAddress != IntPtr.Zero);
+                    Debug.Assert(methodAddress != IntPtr.Zero); // TODO! This should happen for IDynamicInterfaceCastable dispatch...
                     return true;
                 }
             }

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -567,5 +567,11 @@ namespace ILCompiler
         {
             return method.IsPInvoke && (method is Internal.IL.Stubs.PInvokeTargetNativeMethod);
         }
+
+        public static bool IsDynamicInterfaceCastableImplementation(this MetadataType interfaceType)
+        {
+            Debug.Assert(interfaceType.IsInterface);
+            return interfaceType.HasCustomAttribute("System.Runtime.InteropServices", "DynamicInterfaceCastableImplementationAttribute");
+        }
     }
 }

--- a/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/MethodTable.Constants.cs
@@ -41,7 +41,10 @@ namespace Internal.Runtime
         /// </summary>
         HasPointersFlag = 0x0020,
 
-        // Unused = 0x0040,
+        /// <summary>
+        /// This type implements IDynamicInterfaceCastable to allow dynamic resolution of interface casts.
+        /// </summary>
+        IDynamicInterfaceCastableFlag = 0x0040,
 
         /// <summary>
         /// This type is generic and one or more of its type parameters is co- or contra-variant. This

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -740,7 +740,22 @@ namespace Internal.TypeSystem
             bool diamondCase = false;
             impl = null;
 
-            foreach (MetadataType runtimeInterface in currentType.RuntimeInterfaces)
+            DefType[] consideredInterfaces;
+            if (!currentType.IsInterface)
+            {
+                // If this is not an interface, only things on the interface list could provide
+                // default implementations.
+                consideredInterfaces = currentType.RuntimeInterfaces;
+            }
+            else
+            {
+                // If we're asking about an interface, include the interface in the list.
+                consideredInterfaces = new DefType[currentType.RuntimeInterfaces.Length + 1];
+                Array.Copy(currentType.RuntimeInterfaces, consideredInterfaces, currentType.RuntimeInterfaces.Length);
+                consideredInterfaces[consideredInterfaces.Length - 1] = currentType;
+            }
+
+            foreach (MetadataType runtimeInterface in consideredInterfaces)
             {
                 if (runtimeInterface == interfaceMethodOwningType)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -653,7 +653,12 @@ namespace ILCompiler.DependencyAnalysis
                 // to have the variant flag set (even if all the arguments are non-variant).
                 // This supports e.g. casting uint[] to ICollection<int>
                 flags |= (UInt16)EETypeFlags.GenericVarianceFlag;
-            }              
+            }
+
+            if (_type.IsIDynamicInterfaceCastable)
+            {
+                flags |= (UInt16)EETypeFlags.IDynamicInterfaceCastableFlag;
+            }
 
             ISymbolNode relatedTypeNode = GetRelatedTypeNode(factory);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -76,8 +76,18 @@ namespace ILCompiler.DependencyAnalysis
             if (!type.IsArray && !type.IsDefType)
                 return false;
 
+            // Interfaces don't have a dispatch map because we dispatch them based on the
+            // dispatch map of the implementing class.
+            // The only exception are IDynamicInterfaceCastable scenarios that dispatch
+            // using the interface dispatch map.
+            // We generate the dispatch map irrespective of whether the interface actually
+            // implements any methods (we don't run the for loop below) so that at runtime
+            // we can distinguish between "the interface returned by IDynamicInterfaceCastable
+            // wasn't marked as [DynamicInterfaceCastableImplementation]" and "we couldn't find an
+            // implementation". We don't want to use the custom attribute for that at runtime because
+            // that's reflection and this should work without reflection.
             if (type.IsInterface)
-                return false;
+                return ((MetadataType)type).IsDynamicInterfaceCastableImplementation();
 
             TypeDesc declType = type.GetClosestDefType();
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -109,8 +109,11 @@ namespace ILCompiler.DependencyAnalysis
 
             _sealedVTableEntries = new List<SealedVTableEntry>();
 
-            // If this is an interface, we're done. They don't have any slots.
-            if (_type.IsInterface)
+            // Interfaces don't have any virtual slots with the exception of interfaces that provide
+            // IDynamicInterfaceCastable implementation.
+            // Normal interface don't need one because the dispatch is done at the class level.
+            // For IDynamicInterfaceCastable, we don't have an implementing class.
+            if (_type.IsInterface && !((MetadataType)_type).IsDynamicInterfaceCastableImplementation())
                 return true;
 
             IReadOnlyList<MethodDesc> virtualSlots = factory.VTable(declType).Slots;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VirtualMethodCallHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VirtualMethodCallHelper.cs
@@ -92,6 +92,14 @@ namespace ILCompiler
 
         private static int GetNumberOfSlotsInCurrentType(NodeFactory factory, TypeDesc implType, bool countDictionarySlots)
         {
+            if (implType.IsInterface)
+            {
+                // We normally don't need to ask about vtable slots of interfaces. It's not wrong to ask
+                // that question, but we currently only ask it for IDynamicInterfaceCastable implementations.
+                Debug.Assert(((MetadataType)implType).IsDynamicInterfaceCastableImplementation());
+                return (implType.HasGenericDictionarySlot() && countDictionarySlots) ? 1 : 0;
+            }
+
             // Now compute the total number of vtable slots that would exist on the type
             int baseSlots = GetNumberOfBaseSlots(factory, implType, countDictionarySlots);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -416,7 +416,7 @@
       <Link>Common\EETypeOptionalFieldsBuilder.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\Internal\Runtime\EETypeBuilderHelpers.cs">
-      <Link>Common\MethodTable.cs</Link>
+      <Link>Common\EETypeBuilderHelpers.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\Internal\Runtime\InterfaceDispatchCellCachePointerFlags.cs">
       <Link>Common\InterfaceDispatchCellCachePointerFlags.cs</Link>

--- a/src/tests/nativeaot/SmokeTests/Interfaces/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/Interfaces/Interfaces.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 public class BringUpTest
 {
@@ -39,6 +40,7 @@ public class BringUpTest
         TestVariantInterfaceOptimizations.Run();
         TestSharedIntefaceMethods.Run();
         TestCovariantReturns.Run();
+        TestDynamicInterfaceCastable.Run();
 
         return Pass;
     }
@@ -730,6 +732,68 @@ public class BringUpTest
 
             IContravariantInterface<MySealedClass> i2 = new CoAndContravariantOverSealed();
             i2.DoContravariant(null);
+        }
+    }
+
+    class TestDynamicInterfaceCastable
+    {
+        class CastableClass<TInterface, TImpl> : IDynamicInterfaceCastable
+        {
+            RuntimeTypeHandle IDynamicInterfaceCastable.GetInterfaceImplementation(RuntimeTypeHandle interfaceType)
+                => interfaceType.Equals(typeof(TInterface).TypeHandle) ? typeof(TImpl).TypeHandle : default;
+            bool IDynamicInterfaceCastable.IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented)
+                => interfaceType.Equals(typeof(TInterface).TypeHandle);
+        }
+
+        interface IInterface
+        {
+            string GetCookie();
+        }
+
+        [DynamicInterfaceCastableImplementation]
+        interface IInterfaceCastableImpl : IInterface
+        {
+            string IInterface.GetCookie() => "IInterfaceCastableImpl";
+        }
+
+        interface IInterfaceImpl : IInterface
+        {
+            string IInterface.GetCookie() => "IInterfaceImpl";
+        }
+
+        [DynamicInterfaceCastableImplementation]
+        interface IInterfaceIndirectCastableImpl : IInterfaceImpl { }
+
+        public static void Run()
+        {
+            Console.WriteLine("Testing IDynamicInterfaceCastable...");
+
+            {
+                IInterface o = (IInterface)new CastableClass<IInterface, IInterfaceCastableImpl>();
+                if (o.GetCookie() != "IInterfaceCastableImpl")
+                    throw new Exception();
+            }
+
+            {
+                IInterface o = (IInterface)new CastableClass<IInterface, IInterfaceImpl>();
+                bool success = false;
+                try
+                {
+                    o.GetCookie();
+                }
+                catch (InvalidOperationException)
+                {
+                    success = true;
+                }
+                if (!success)
+                    throw new Exception();
+            }
+
+            {
+                IInterface o = (IInterface)new CastableClass<IInterface, IInterfaceIndirectCastableImpl>();
+                if (o.GetCookie() != "IInterfaceImpl")
+                    throw new Exception();
+            }
         }
     }
 }


### PR DESCRIPTION
Adds almost full support for IDynamicInterfaceCastable. The missing part is support for shared interface methods - we need to provide generic context somehow and instantiating stubs are not it because we don't have them.

I used https://github.com/dotnet/corert/pull/8103 as a blueprint, with a small difference - instead of hardcoding slot numbers into the MethodTable, I'm making runtime call into CoreLib so that we can call methods on `IDynamicInterfaceCastable` as usual. Being in the CoreLib makes various error handling easier too.

The implementation in the compiler is very straightforward:

* Allow `DynamicInterfaceCastableImplementation` interfaces to have a dispatch map.
* Allow `DynamicInterfaceCastableImplementation` to have a sealed vtable.
* Pretty much all that's needed.

At runtime, we consult the dispatch map to find the proper implementation, given an implementation interface.

Contributes to #162.