### PR TITLE
Garbage collect unused runtime imports/exports

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -101,16 +101,6 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern IntPtr RhpHandleAlloc(object value, GCHandleType type);
 
-        // Allocate dependent handle.
-        [RuntimeImport(Redhawk.BaseName, "RhpHandleAllocDependent")]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern IntPtr RhpHandleAllocDependent(object primary, object secondary);
-
-        // Allocate variable handle.
-        [RuntimeImport(Redhawk.BaseName, "RhpHandleAllocVariable")]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern IntPtr RhpHandleAllocVariable(object value, uint type);
-
         [RuntimeImport(Redhawk.BaseName, "RhHandleGet")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern object RhHandleGet(IntPtr handle);
@@ -156,10 +146,6 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern unsafe void RhpCopyObjectContents(object objDest, object objSrc);
 
-        [RuntimeImport(Redhawk.BaseName, "RhpCompareObjectContents")]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern bool RhpCompareObjectContentsAndPadding(object obj1, object obj2);
-
         [RuntimeImport(Redhawk.BaseName, "RhpAssignRef")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern unsafe void RhpAssignRef(ref object address, object obj);
@@ -192,10 +178,6 @@ namespace System.Runtime
         [RuntimeImport(Redhawk.BaseName, "RhpEHEnumNext")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern unsafe bool RhpEHEnumNext(void* pEHEnum, void* pEHClause);
-
-        [RuntimeImport(Redhawk.BaseName, "RhpGetSealedVirtualSlot")]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe IntPtr RhpGetSealedVirtualSlot(MethodTable* pEEType, ushort slot);
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetDispatchCellInfo")]
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -232,21 +214,6 @@ namespace System.Runtime
         //
         // Miscellaneous helpers.
         //
-
-        // Get the rarely used (optional) flags of an MethodTable. If they're not present 0 will be returned.
-        [RuntimeImport(Redhawk.BaseName, "RhpGetEETypeRareFlags")]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe uint RhpGetEETypeRareFlags(MethodTable* pEEType);
-
-        // Retrieve the offset of the value embedded in a Nullable<T>.
-        [RuntimeImport(Redhawk.BaseName, "RhpGetNullableEETypeValueOffset")]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe byte RhpGetNullableEETypeValueOffset(MethodTable* pEEType);
-
-        // Retrieve the target type T in a Nullable<T>.
-        [RuntimeImport(Redhawk.BaseName, "RhpGetNullableEEType")]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe MethodTable* RhpGetNullableEEType(MethodTable* pEEType);
 
         [RuntimeImport(Redhawk.BaseName, "RhpCallCatchFunclet")]
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
@@ -132,11 +132,6 @@ COOP_PINVOKE_HELPER(void, RhUnregisterGcCallout, (GcRestrictedCalloutKind eKind,
     RestrictedCallouts::UnregisterGcCallout(eKind, pCallout);
 }
 
-COOP_PINVOKE_HELPER(Boolean, RhIsPromoted, (OBJECTREF obj))
-{
-    return GCHeapUtilities::GetGCHeap()->IsPromoted(obj) ? Boolean_true : Boolean_false;
-}
-
 COOP_PINVOKE_HELPER(int32_t, RhGetLohCompactionMode, ())
 {
     return GCHeapUtilities::GetGCHeap()->GetLOHCompactionMode();

--- a/src/coreclr/nativeaot/Runtime/HandleTableHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/HandleTableHelpers.cpp
@@ -61,23 +61,3 @@ COOP_PINVOKE_HELPER(void, RhUnregisterRefCountedHandleCallback, (void * pCallout
 {
     RestrictedCallouts::UnregisterRefCountedHandleCallback(pCallout, pTypeFilter);
 }
-
-COOP_PINVOKE_HELPER(OBJECTHANDLE, RhpHandleAllocVariable, (Object * pObject, uint32_t type))
-{
-    return GCHandleUtilities::GetGCHandleManager()->GetGlobalHandleStore()->CreateHandleWithExtraInfo(pObject, HNDTYPE_VARIABLE, (void*)((uintptr_t)type));
-}
-
-COOP_PINVOKE_HELPER(uint32_t, RhHandleGetVariableType, (OBJECTHANDLE handle))
-{
-    return GetVariableHandleType(handle);
-}
-
-COOP_PINVOKE_HELPER(void, RhHandleSetVariableType, (OBJECTHANDLE handle, uint32_t type))
-{
-    UpdateVariableHandleType(handle, type);
-}
-
-COOP_PINVOKE_HELPER(uint32_t, RhHandleCompareExchangeVariableType, (OBJECTHANDLE handle, uint32_t oldType, uint32_t newType))
-{
-    return CompareExchangeVariableHandleType(handle, oldType, newType);
-}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -236,19 +236,6 @@ namespace System.Runtime
             return h;
         }
 
-        // Allocate variable handle with its initial type.
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhpHandleAllocVariable")]
-        private static extern IntPtr RhpHandleAllocVariable(object value, uint type);
-
-        internal static IntPtr RhHandleAllocVariable(object value, uint type)
-        {
-            IntPtr h = RhpHandleAllocVariable(value, type);
-            if (h == IntPtr.Zero)
-                throw new OutOfMemoryException();
-            return h;
-        }
-
         // Free handle.
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhHandleFree")]
@@ -284,22 +271,6 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhHandleSetDependentSecondary")]
         internal static extern void RhHandleSetDependentSecondary(IntPtr handle, object secondary);
 
-        // Get the handle type associated with a variable handle.
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhHandleGetVariableType")]
-        internal static extern uint RhHandleGetVariableType(IntPtr handle);
-
-        // Set the handle type associated with a variable handle.
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhHandleSetVariableType")]
-        internal static extern void RhHandleSetVariableType(IntPtr handle, uint type);
-
-        // Conditionally and atomically set the handle type associated with a variable handle if the current
-        // type is the one specified. Returns the previous handle type.
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhHandleCompareExchangeVariableType")]
-        internal static extern uint RhHandleCompareExchangeVariableType(IntPtr handle, uint oldType, uint newType);
-
         //
         // calls to runtime for type equality checks
         //
@@ -332,9 +303,6 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_IsInstanceOfClass")]
         private  static unsafe extern object IsInstanceOfClass(MethodTable* pTargetType, object obj);
-
-        internal static unsafe object IsInstanceOfClass(EETypePtr pTargetType, object obj)
-            => IsInstanceOfClass(pTargetType.ToPointer(), obj);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhTypeCast_IsInstanceOfInterface")]
@@ -508,10 +476,6 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhUnregisterRefCountedHandleCallback")]
         internal static extern void RhUnregisterRefCountedHandleCallback(IntPtr pCalloutMethod, EETypePtr pTypeFilter);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhIsPromoted")]
-        internal static extern bool RhIsPromoted(object obj);
 
         //
         // Blob support


### PR DESCRIPTION
Noticed while I was looking at thunk pools.

There's a couple more around restricted callouts, but I assume we're going to need that for ComWrappers lifetime tracking at some point.