### PR TITLE
Fix pointer type validation

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.Validation.cs
@@ -71,12 +71,6 @@ namespace ILCompiler
 
                 if (parameterizedType.IsArray)
                 {
-                    if (parameterType.IsFunctionPointer)
-                    {
-                        // Arrays of function pointers are not currently supported
-                        ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
-                    }
-
                     LayoutInt elementSize = parameterType.GetElementSize();
                     if (!elementSize.IsIndeterminate && elementSize.AsInt >= ushort.MaxValue)
                     {
@@ -101,7 +95,13 @@ namespace ILCompiler
             }
             else if (type.IsFunctionPointer)
             {
-                ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+                var functionPointer = ((FunctionPointerType)type).Signature;
+                ((CompilerTypeSystemContext)type.Context).EnsureLoadableType(functionPointer.ReturnType);
+
+                foreach (TypeDesc param in functionPointer)
+                {
+                    ((CompilerTypeSystemContext)type.Context).EnsureLoadableType(param);
+                }
             }
             else
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -76,6 +76,12 @@ namespace ILCompiler.DependencyAnalysis
             _hasConditionalDependenciesFromMetadataManager = factory.MetadataManager.HasConditionalDependenciesDueToEETypePresence(type);
 
             factory.TypeSystemContext.EnsureLoadableType(type);
+
+            // We don't have a representation for function pointers right now
+            if (WithoutParameterizeTypes(type).IsFunctionPointer)
+                ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, type);
+
+            static TypeDesc WithoutParameterizeTypes(TypeDesc t) => t is ParameterizedType pt ? WithoutParameterizeTypes(pt.ParameterType) : t;
         }
         
         protected bool MightHaveInterfaceDispatchMap(NodeFactory factory)


### PR DESCRIPTION
CsWinRT was triggering the validation for a `sizeof(delegate*<blah>)` statement because we validate everything seen by the JIT.

Consider function pointer types valid, but still throw if we try to make an EEType.