### PR TITLE
Fix name of the RhpStackProbe

### DIFF
--- a/src/coreclr/nativeaot/Runtime/i386/MiscStubs.S
+++ b/src/coreclr/nativeaot/Runtime/i386/MiscStubs.S
@@ -5,7 +5,7 @@
 #include <unixasmmacros.inc>
 
 // *********************************************************************/
-// JIT_StackProbe
+// RphStackProbe
 //
 // Purpose:
 //   the helper will access ("probe") a word on each page of the stack
@@ -17,7 +17,7 @@
 // NOTE: On Linux we must advance the stack pointer as we probe - it is not allowed to access 65535 bytes below esp.
 //
 #define PAGE_SIZE 0x1000
-NESTED_ENTRY JIT_StackProbe, _TEXT, NoHandler
+NESTED_ENTRY RphStackProbe, _TEXT, NoHandler
     // On entry:
     //   eax - the lowest address of the stack frame being allocated (i.e. [InitialSp - FrameSize])
     //
@@ -39,4 +39,4 @@ LOCAL_LABEL(ProbeLoop):
     EPILOG_END
     ret
 
-NESTED_END JIT_StackProbe, _TEXT
+NESTED_END RhpStackProbe, _TEXT

--- a/src/coreclr/nativeaot/Runtime/i386/MiscStubs.S
+++ b/src/coreclr/nativeaot/Runtime/i386/MiscStubs.S
@@ -5,7 +5,7 @@
 #include <unixasmmacros.inc>
 
 // *********************************************************************/
-// RphStackProbe
+// RhpStackProbe
 //
 // Purpose:
 //   the helper will access ("probe") a word on each page of the stack
@@ -17,7 +17,7 @@
 // NOTE: On Linux we must advance the stack pointer as we probe - it is not allowed to access 65535 bytes below esp.
 //
 #define PAGE_SIZE 0x1000
-NESTED_ENTRY RphStackProbe, _TEXT, NoHandler
+NESTED_ENTRY RhpStackProbe, _TEXT, NoHandler
     // On entry:
     //   eax - the lowest address of the stack frame being allocated (i.e. [InitialSp - FrameSize])
     //


### PR DESCRIPTION
When looking for #1458, I found this naming discrepancies. I assume that's just some rename happens over time