### PR TITLE
Collection tests for dfa

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
@@ -53,7 +53,7 @@ namespace System.Text.RegularExpressions
         /// <param name="hideStateInfo">if true then hide state info</param>
         /// <param name="addDotStar">if true then pretend that there is a .* at the beginning</param>
         /// <param name="inReverse">if true then unwind the regex backwards (addDotStar is then ignored)</param>
-        /// <param name="onlyDFAinfo">if true then compute and save only genral DFA info</param>
+        /// <param name="onlyDFAinfo">if true then compute and save only general DFA info</param>
         /// <param name="writer">dgml output is written here</param>
         /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
         internal void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.SRM.cs
@@ -92,6 +92,7 @@ namespace System.Text.RegularExpressions
         /// Generates two files IgnoreCaseRelation.cs and UnicodeCategoryRanges.cs for the namespace System.Text.RegularExpressions.SRM.Unicode
         /// in the given directory path. Only avaliable in DEBUG mode.
         /// </summary>
+        [Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage(Justification = "Debug only")]
         internal static void GenerateUnicodeTables(string path)
         {
             SRM.Unicode.IgnoreCaseRelationGenerator.Generate("System.Text.RegularExpressions.SRM.Unicode", "IgnoreCaseRelation", path);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -172,7 +172,30 @@ namespace System.Text.RegularExpressions
 
             var state = (segments: SegmentStringBuilder.Create(), evaluator, prevat: 0, input, count);
 
-            if (!regex.RightToLeft)
+            if (regex._useSRM)
+            {
+                Match match = regex.Match(input, startat, input.Length - startat);
+                if (!match.Success)
+                    return input;
+
+                while (match.Success)
+                {
+                    if (state.prevat < match.Index)
+                        state.segments.Add(state.input.AsMemory(state.prevat, match.Index - state.prevat));
+                    state.prevat = match.Index + match.Length;
+                    state.segments.Add(state.evaluator(match).AsMemory());
+
+                    if (state.count > 0) state.count -= 1;
+                    if (state.count == 0) break;
+
+                    match = match.NextMatch();
+                }
+
+                // final segment
+                if (state.prevat < input.Length)
+                    state.segments.Add(state.input.AsMemory(state.prevat, input.Length - state.prevat));
+            }
+            else if (!regex.RightToLeft)
             {
                 regex.Run(input, startat, ref state, static (ref (SegmentStringBuilder segments, MatchEvaluator evaluator, int prevat, string input, int count) state, Match match) =>
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -102,7 +102,7 @@ namespace System.Text.RegularExpressions
                 // Ignore Compiled flag if DFA is used
                 // this is to make sure the pattern is not being compiled as well as being used in SRM
                 options = options & ~RegexOptions.Compiled;
-            } 
+            }
             this.pattern = pattern;
             internalMatchTimeout = matchTimeout;
             roptions = options;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -96,6 +96,12 @@ namespace System.Text.RegularExpressions
             ValidateOptions(options);
             ValidateMatchTimeout(matchTimeout);
 
+            _useSRM = (options & RegexOptions.DFA) != 0;
+            if (_useSRM)
+                // Ignore Compiled flag if DFA is used
+                // this is to make sure the pattern is not being compiled as well as being used in SRM
+                options = options & ~RegexOptions.Compiled;
+
             this.pattern = pattern;
             internalMatchTimeout = matchTimeout;
             roptions = options;
@@ -113,24 +119,19 @@ namespace System.Text.RegularExpressions
             // Extract the relevant information
             capnames = tree.CapNames;
             capslist = tree.CapsList;
+            // code related info is relevant in DFA mode only regarding caps
+            // that are used in RegexReplacement to check absense of subtitutions
+            _code = RegexWriter.Write(tree);
+            caps = _code.Caps;
+            capsize = _code.CapSize;
+
+            InitializeReferences();
 
             // If SRM is used then construct the SMR.Regex matcher.
             // This construction fails and throws a NotSupportedException
             // if constructs that are not compatible with DFA are being used in the pattern.
-            _useSRM = (options & RegexOptions.DFA) != 0;
             if (_useSRM)
-            {
                 _srm = InitializeSRM(tree.Root, roptions & ~RegexOptions.DFA, matchTimeout, culture);
-            }
-            else
-            {
-                // code related info is only set in non-DFA mode
-                _code = RegexWriter.Write(tree);
-                caps = _code.Caps;
-                capsize = _code.CapSize;
-            }
-
-            InitializeReferences();
         }
 
         /// <summary>
@@ -147,9 +148,6 @@ namespace System.Text.RegularExpressions
             // TBD: this could also be supported easily, but is not of priority right now
             if ((options & RegexOptions.ECMAScript) != 0)
                 throw new NotSupportedException(SRM.Regex._DFA_incompatible_with + RegexOptions.ECMAScript);
-            // TBD: this will eventually be supported
-            if ((options & RegexOptions.Compiled) != 0)
-                throw new NotSupportedException(SRM.Regex._DFA_incompatible_with + RegexOptions.Compiled);
 
             return SRM.Regex.Create(rootNode, options, matchTimeout, culture);
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -120,7 +120,7 @@ namespace System.Text.RegularExpressions
             capnames = tree.CapNames;
             capslist = tree.CapsList;
             // code related info is relevant in DFA mode only regarding caps
-            // that are used in RegexReplacement to check absense of subtitutions
+            // that are used in RegexReplacement to check absence of subtitutions
             _code = RegexWriter.Write(tree);
             caps = _code.Caps;
             capsize = _code.CapSize;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -110,9 +110,9 @@ namespace System.Text.RegularExpressions
             // Parse the input
             RegexTree tree = RegexParser.Parse(pattern, roptions, culture ?? ((options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture));
 
-            // if SRM is used then construct the SMR.Regex matcher
-            // this construction fails and throws a NotSupportedException
-            // if unsupported constructs are being used in the original regex
+            // If SRM is used then construct the SMR.Regex matcher.
+            // This construction fails and throws a NotSupportedException
+            // if constructs that are not compatible with DFA are being used in the original regex.
             _useSRM = (options & RegexOptions.DFA) != 0;
             if (_useSRM)
             {
@@ -126,9 +126,9 @@ namespace System.Text.RegularExpressions
                 _code = RegexWriter.Write(tree);
                 caps = _code.Caps;
                 capsize = _code.CapSize;
-
-                InitializeReferences();
             }
+
+            InitializeReferences();
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -98,10 +98,11 @@ namespace System.Text.RegularExpressions
 
             _useSRM = (options & RegexOptions.DFA) != 0;
             if (_useSRM)
+            {
                 // Ignore Compiled flag if DFA is used
                 // this is to make sure the pattern is not being compiled as well as being used in SRM
                 options = options & ~RegexOptions.Compiled;
-
+            } 
             this.pattern = pattern;
             internalMatchTimeout = matchTimeout;
             roptions = options;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -110,9 +110,13 @@ namespace System.Text.RegularExpressions
             // Parse the input
             RegexTree tree = RegexParser.Parse(pattern, roptions, culture ?? ((options & RegexOptions.CultureInvariant) != 0 ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture));
 
+            // Extract the relevant information
+            capnames = tree.CapNames;
+            capslist = tree.CapsList;
+
             // If SRM is used then construct the SMR.Regex matcher.
             // This construction fails and throws a NotSupportedException
-            // if constructs that are not compatible with DFA are being used in the original regex.
+            // if constructs that are not compatible with DFA are being used in the pattern.
             _useSRM = (options & RegexOptions.DFA) != 0;
             if (_useSRM)
             {
@@ -120,9 +124,7 @@ namespace System.Text.RegularExpressions
             }
             else
             {
-                // Extract the relevant information
-                capnames = tree.CapNames;
-                capslist = tree.CapsList;
+                // code related info is only set in non-DFA mode
                 _code = RegexWriter.Write(tree);
                 caps = _code.Caps;
                 capsize = _code.CapSize;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -105,6 +105,7 @@ namespace System.Text.RegularExpressions
             var parser = new RegexParser(pattern, options, culture, caps, capsize, capnames, stackalloc int[OptionStackDefaultSize]);
 
             RegexNode root = parser.ScanReplacement();
+
             var regexReplacement = new RegexReplacement(pattern, root, caps);
             parser.Dispose();
 

--- a/src/libraries/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
@@ -10,6 +10,7 @@ namespace System.Text.RegularExpressions.Tests
     {
         [Theory]
         [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexSRMTests.DFA)]
         public static void GetEnumerator(RegexOptions options)
         {
@@ -32,6 +33,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexSRMTests.DFA)]
         public static void GetEnumerator_Invalid(RegexOptions options)
         {
@@ -60,6 +62,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexSRMTests.DFA)]
         public static void Item_Get_InvalidIndex_ThrowsArgumentOutOfRangeException(RegexOptions options)
         {
@@ -71,6 +74,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexSRMTests.DFA)]
         public static void ICollection_Properties(RegexOptions options)
         {
@@ -86,6 +90,8 @@ namespace System.Text.RegularExpressions.Tests
         [Theory]
         [InlineData(0, RegexOptions.None)]
         [InlineData(5, RegexOptions.None)]
+        [InlineData(0, RegexOptions.Compiled)]
+        [InlineData(5, RegexOptions.Compiled)]
         [InlineData(0, RegexSRMTests.DFA)]
         [InlineData(5, RegexSRMTests.DFA)]
         public static void ICollection_CopyTo(int index, RegexOptions options)
@@ -109,6 +115,7 @@ namespace System.Text.RegularExpressions.Tests
 
         [Theory]
         [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexSRMTests.DFA)]
         public static void ICollection_CopyTo_Invalid(RegexOptions options)
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
@@ -8,10 +8,12 @@ namespace System.Text.RegularExpressions.Tests
 {
     public static partial class MatchCollectionTests
     {
-        [Fact]
-        public static void GetEnumerator()
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexSRMTests.DFA)]
+        public static void GetEnumerator(RegexOptions options)
         {
-            Regex regex = new Regex("e");
+            Regex regex = new Regex("e", options);
             MatchCollection matches = regex.Matches("dotnet");
             IEnumerator enumerator = matches.GetEnumerator();
             for (int i = 0; i < 2; i++)
@@ -28,10 +30,12 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
-        [Fact]
-        public static void GetEnumerator_Invalid()
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexSRMTests.DFA)]
+        public static void GetEnumerator_Invalid(RegexOptions options)
         {
-            Regex regex = new Regex("e");
+            Regex regex = new Regex("e", options);
             MatchCollection matches = regex.Matches("dotnet");
             IEnumerator enumerator = matches.GetEnumerator();
 
@@ -54,19 +58,23 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal("t", collection[1].ToString());
         }
 
-        [Fact]
-        public static void Item_Get_InvalidIndex_ThrowsArgumentOutOfRangeException()
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexSRMTests.DFA)]
+        public static void Item_Get_InvalidIndex_ThrowsArgumentOutOfRangeException(RegexOptions options)
         {
-            Regex regex = new Regex("e");
+            Regex regex = new Regex("e", options);
             MatchCollection matches = regex.Matches("dotnet");
             AssertExtensions.Throws<ArgumentOutOfRangeException>("i", () => matches[-1]);
             AssertExtensions.Throws<ArgumentOutOfRangeException>("i", () => matches[matches.Count]);
         }
 
-        [Fact]
-        public static void ICollection_Properties()
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexSRMTests.DFA)]
+        public static void ICollection_Properties(RegexOptions options)
         {
-            Regex regex = new Regex("e");
+            Regex regex = new Regex("e", options);
             MatchCollection matches = regex.Matches("dotnet");
             ICollection collection = matches;
 
@@ -76,11 +84,13 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [InlineData(0)]
-        [InlineData(5)]
-        public static void ICollection_CopyTo(int index)
+        [InlineData(0, RegexOptions.None)]
+        [InlineData(5, RegexOptions.None)]
+        [InlineData(0, RegexSRMTests.DFA)]
+        [InlineData(5, RegexSRMTests.DFA)]
+        public static void ICollection_CopyTo(int index, RegexOptions options)
         {
-            Regex regex = new Regex("e");
+            Regex regex = new Regex("e", options);
             MatchCollection matches = regex.Matches("dotnet");
             ICollection collection = matches;
 
@@ -97,10 +107,12 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
-        [Fact]
-        public static void ICollection_CopyTo_Invalid()
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexSRMTests.DFA)]
+        public static void ICollection_CopyTo_Invalid(RegexOptions options)
         {
-            Regex regex = new Regex("e");
+            Regex regex = new Regex("e", options);
             ICollection collection = regex.Matches("dotnet");
 
             // Array is null

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -88,7 +88,6 @@ namespace System.Text.RegularExpressions.Tests
             // DFA option is not supported together with these other options
             Assert.Throws<NotSupportedException>(() => new Regex("abc", RegexOptions.ECMAScript | RegexSRMTests.DFA));
             Assert.Throws<NotSupportedException>(() => new Regex("abc", RegexOptions.RightToLeft | RegexSRMTests.DFA));
-            Assert.Throws<NotSupportedException>(() => new Regex("abc", RegexOptions.Compiled | RegexSRMTests.DFA));
 
             // DFA option is not supported for these constructs
             Assert.Throws<NotSupportedException>(() => new Regex("(?=a)", RegexSRMTests.DFA));

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -19,6 +19,8 @@ namespace System.Text.RegularExpressions.Tests
     {
         public static IEnumerable<object[]> Ctor_TestData()
         {
+            yield return new object[] { "foo", RegexSRMTests.DFA, Regex.InfiniteMatchTimeout };
+            yield return new object[] { "foo", RegexSRMTests.DFA, new TimeSpan(1) };
             yield return new object[] { "foo", RegexOptions.None, Regex.InfiniteMatchTimeout };
             yield return new object[] { "foo", RegexOptions.RightToLeft, Regex.InfiniteMatchTimeout };
             yield return new object[] { "foo", RegexOptions.Compiled, Regex.InfiniteMatchTimeout };
@@ -56,6 +58,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
+        [InlineData(RegexSRMTests.DFA)]
         [InlineData(RegexOptions.None)]
         [InlineData(RegexOptions.Compiled)]
         public void CtorDebugInvoke(RegexOptions options)
@@ -65,7 +68,8 @@ namespace System.Text.RegularExpressions.Tests
             r = new Regex("[abc]def(ghi|jkl)", options | (RegexOptions)0x80 /*RegexOptions.Debug*/);
             Assert.False(r.Match("a").Success);
             Assert.True(r.Match("adefghi").Success);
-            Assert.Equal("123456789", r.Replace("123adefghi789", "456"));
+            string repl = r.Replace("123adefghi78bdefjkl9", "###");
+            Assert.Equal("123###78###9", repl);
 
             r = new Regex("(ghi|jkl)*ghi", options | (RegexOptions)0x80 /*RegexOptions.Debug*/);
             Assert.False(r.Match("jkl").Success);

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -85,6 +85,19 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public static void Ctor_Invalid()
         {
+            // DFA option is not supported together with these other options
+            Assert.Throws<NotSupportedException>(() => new Regex("abc", RegexOptions.ECMAScript | RegexSRMTests.DFA));
+            Assert.Throws<NotSupportedException>(() => new Regex("abc", RegexOptions.RightToLeft | RegexSRMTests.DFA));
+            Assert.Throws<NotSupportedException>(() => new Regex("abc", RegexOptions.Compiled | RegexSRMTests.DFA));
+
+            // DFA option is not supported for these constructs
+            Assert.Throws<NotSupportedException>(() => new Regex("(?=a)", RegexSRMTests.DFA));
+            Assert.Throws<NotSupportedException>(() => new Regex("(?!a)", RegexSRMTests.DFA));
+            Assert.Throws<NotSupportedException>(() => new Regex("(?<=a)", RegexSRMTests.DFA));
+            Assert.Throws<NotSupportedException>(() => new Regex("(?<!a)", RegexSRMTests.DFA));
+            Assert.Throws<NotSupportedException>(() => new Regex(@"(?(0)ab)", RegexSRMTests.DFA));
+            Assert.Throws<NotSupportedException>(() => new Regex(@"([ab])\1", RegexSRMTests.DFA));
+
             // Pattern is null
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => new Regex(null));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => new Regex(null, RegexOptions.None));

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -346,7 +346,7 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startat", () => new Regex("pattern").Replace("input", "replacement", 0, 6));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startat", () => new Regex("pattern").Replace("input", new MatchEvaluator(MatchEvaluator1), 0, 6));
 
-            // Sustitutions not supported in DFA mode
+            // Substitutions not supported in DFA mode
             Assert.Throws<NotSupportedException>(() => new Regex("pattern", RegexSRMTests.DFA).Replace("input", "$0", -1));
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -29,6 +29,32 @@ namespace System.Text.RegularExpressions.Tests
         private const char Turkish_i_withoutDot = '\u0131';
         private const char Kelvin_sign = '\u212A';
 
+        //[Theory]
+        //[InlineData(RegexOptions.None)]
+        //[InlineData(DFA)]
+        //public void TestBoundary(RegexOptions options)
+        //{
+        //    var W = new Regex(@"\W", options);
+        //    var b = new Regex(@"\b", options);
+        //    var ambiguous = new List<char>();
+        //    for (char c = '\0'; c < '\uFFFF'; c++)
+        //        if (W.IsMatch(c.ToString()) && b.IsMatch(c.ToString()))
+        //            ambiguous.Add(c);
+        //    Assert.Empty(ambiguous);
+        //}
+
+        //[Fact]
+        //public void TestWordchar()
+        //{
+        //    var w1 = new Regex(@"\w", RegexOptions.None);
+        //    var w2 = new Regex(@"\w", DFA);
+        //    var ambiguous = new List<char>();
+        //    for (char c = '\0'; c < '\uFFFF'; c++)
+        //        if (w1.IsMatch(c.ToString()) != w2.IsMatch(c.ToString()))
+        //            ambiguous.Add(c);
+        //    Assert.Empty(ambiguous);
+        //}
+
         [Theory]
         [InlineData("((?:0*)+?(?:.*)+?)?", "0a", 2)]
         [InlineData("(?:(?:0?)+?(?:a?)+?)?", "0a", 2)]

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -29,31 +29,32 @@ namespace System.Text.RegularExpressions.Tests
         private const char Turkish_i_withoutDot = '\u0131';
         private const char Kelvin_sign = '\u212A';
 
-        //[Theory]
-        //[InlineData(RegexOptions.None)]
-        //[InlineData(DFA)]
-        //public void TestBoundary(RegexOptions options)
-        //{
-        //    var W = new Regex(@"\W", options);
-        //    var b = new Regex(@"\b", options);
-        //    var ambiguous = new List<char>();
-        //    for (char c = '\0'; c < '\uFFFF'; c++)
-        //        if (W.IsMatch(c.ToString()) && b.IsMatch(c.ToString()))
-        //            ambiguous.Add(c);
-        //    Assert.Empty(ambiguous);
-        //}
+        [Fact]
+        [ActiveIssue(@"inconsitent treatement of \u200c and \u200d in \w vs \b")]
+        public void TestBoundary()
+        {
+            Assert.True(Regex.IsMatch(" AB\u200cCD ", @"\b\w+\b"));
+            Assert.True(Regex.IsMatch(" AB\u200dCD ", @"\b\w+\b"));
+        }
 
-        //[Fact]
-        //public void TestWordchar()
-        //{
-        //    var w1 = new Regex(@"\w", RegexOptions.None);
-        //    var w2 = new Regex(@"\w", DFA);
-        //    var ambiguous = new List<char>();
-        //    for (char c = '\0'; c < '\uFFFF'; c++)
-        //        if (w1.IsMatch(c.ToString()) != w2.IsMatch(c.ToString()))
-        //            ambiguous.Add(c);
-        //    Assert.Empty(ambiguous);
-        //}
+        [Fact]
+        public void TestBoundary_DFA()
+        {
+            Assert.True(Regex.IsMatch(" AB\u200cCD ", @"\b\w+\b", RegexSRMTests.DFA));
+            Assert.True(Regex.IsMatch(" AB\u200dCD ", @"\b\w+\b", RegexSRMTests.DFA));
+        }
+
+        [Fact]
+        public void TestWordchar()
+        {
+            var w1 = new Regex(@"\w", RegexOptions.None);
+            var w2 = new Regex(@"\w", DFA);
+            var ambiguous = new List<char>();
+            for (char c = '\0'; c < '\uFFFF'; c++)
+                if (w1.IsMatch(c.ToString()) != w2.IsMatch(c.ToString()))
+                    ambiguous.Add(c);
+            Assert.Empty(ambiguous);
+        }
 
         [Theory]
         [InlineData("((?:0*)+?(?:.*)+?)?", "0a", 2)]

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -23,7 +23,7 @@ namespace System.Text.RegularExpressions.Tests
 #endif
         }
 
-        internal static RegexOptions DFA = (RegexOptions)0x400;
+        internal const RegexOptions DFA = (RegexOptions)0x400;
 
         private const char Turkish_I_withDot = '\u0130';
         private const char Turkish_i_withoutDot = '\u0131';


### PR DESCRIPTION
Support for Regex.Replace in DFA mode. (this support was missing before)
Added some new unit tests for collections, replace and constructor.
Lifted old unit tests for ctor, replace, and collections to include DFA mode.
This is part of extending more unit tests to DFA mode.
Found and fixed a bug related to incorrect use of match length 
when match was not started from the beginning of the input.