### PR TITLE
Disable COM specific marshalers on Unix

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -266,7 +266,10 @@ namespace Internal.TypeSystem.Interop
                                 return MarshallerKind.CBool;
 
                             case NativeTypeKind.VariantBool:
-                                return MarshallerKind.VariantBool;
+                                if (type.Context.Target.IsWindows)
+                                    return MarshallerKind.VariantBool;
+                                else
+                                    return MarshallerKind.Invalid;
 
                             default:
                                 return MarshallerKind.Invalid;
@@ -580,12 +583,18 @@ namespace Internal.TypeSystem.Interop
             {
                 if (nativeType == NativeTypeKind.AsAny)
                     return isAnsi ? MarshallerKind.AsAnyA : MarshallerKind.AsAnyW;
-                else if ((isField && nativeType == NativeTypeKind.Default)
-                    || nativeType == NativeTypeKind.Intf
-                    || nativeType == NativeTypeKind.IUnknown)
-                    return MarshallerKind.ComInterface;
                 else
-                    return MarshallerKind.Variant;
+                if (type.Context.Target.IsWindows)
+                {
+                    if ((isField && nativeType == NativeTypeKind.Default)
+                        || nativeType == NativeTypeKind.Intf
+                        || nativeType == NativeTypeKind.IUnknown)
+                        return MarshallerKind.ComInterface;
+                    else
+                        return MarshallerKind.Variant;
+                }
+                else
+                    return MarshallerKind.Invalid;
             }
             else if (InteropTypes.IsStringBuilder(context, type))
             {
@@ -641,7 +650,10 @@ namespace Internal.TypeSystem.Interop
             }
             else if (type.IsInterface)
             {
-                return MarshallerKind.ComInterface;
+                if (type.Context.Target.IsWindows)
+                    return MarshallerKind.ComInterface;
+                else
+                    return MarshallerKind.Invalid;
             }
             else
                 return MarshallerKind.Invalid;

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -266,7 +266,7 @@ namespace Internal.TypeSystem.Interop
                                 return MarshallerKind.CBool;
 
                             case NativeTypeKind.VariantBool:
-                                if (type.Context.Target.IsWindows)
+                                if (context.Target.IsWindows)
                                     return MarshallerKind.VariantBool;
                                 else
                                     return MarshallerKind.Invalid;
@@ -584,7 +584,7 @@ namespace Internal.TypeSystem.Interop
                 if (nativeType == NativeTypeKind.AsAny)
                     return isAnsi ? MarshallerKind.AsAnyA : MarshallerKind.AsAnyW;
                 else
-                if (type.Context.Target.IsWindows)
+                if (context.Target.IsWindows)
                 {
                     if ((isField && nativeType == NativeTypeKind.Default)
                         || nativeType == NativeTypeKind.Intf
@@ -650,7 +650,7 @@ namespace Internal.TypeSystem.Interop
             }
             else if (type.IsInterface)
             {
-                if (type.Context.Target.IsWindows)
+                if (context.Target.IsWindows)
                     return MarshallerKind.ComInterface;
                 else
                     return MarshallerKind.Invalid;


### PR DESCRIPTION
Match CoreCLR behavior and prevent compiler from crashing