### PR TITLE
Fix casing of build configurations

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -68,7 +68,7 @@ stages:
         jobParameters:
           timeoutInMinutes: 100
           testGroup: innerloop
-          buildArgs: -s nativeaot+libs+nativeaot.packages -lc release -rc debug
+          buildArgs: -s nativeaot+libs+nativeaot.packages -lc Release -rc Debug
           extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
 
   #
@@ -85,7 +85,7 @@ stages:
         jobParameters:
           timeoutInMinutes: 100
           testGroup: innerloop
-          buildArgs: -s nativeaot+libs+nativeaot.packages -lc release -rc checked
+          buildArgs: -s nativeaot+libs+nativeaot.packages -lc Release -rc Checked
           extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
 
   #
@@ -106,7 +106,7 @@ stages:
         timeoutInMinutes: 100
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         testGroup: innerloop
-        buildArgs: -s nativeaot.objwriter+nativeaot+libs+nativeaot.packages -c release
+        buildArgs: -s nativeaot.objwriter+nativeaot+libs+nativeaot.packages -c Release
         extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
         extraStepsParameters:
           uploadIntermediateArtifacts: ${{ variables.isOfficialBuild }}

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -15,8 +15,10 @@ steps:
 - ${{ if ne(parameters.archType, 'arm64') }}:
 
   - ${{ if eq(parameters.buildConfig, 'Release') }}:
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -c Release
+      displayName: Build libraries tests
     - script: $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -c Release -test
-      displayName: Build and run libraries tests
+      displayName: Run libraries tests
 
   # Build coreclr native test output
   - ${{ if eq(parameters.osGroup, 'windows') }}:


### PR DESCRIPTION
I cannot repro the CI failures in libraries tests locally, but it seems like we're rebuilding a bunch of things (besides the tests) when `libs.tests -test` is passed and the culprit appears to be the release/Release mismatch.