### PR TITLE
NativeAOT: Only mark debugger step in/through points on Windows

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -58,7 +58,8 @@ namespace Internal.IL.Stubs.StartupCode
             ILEmitter emitter = new ILEmitter();
             ILCodeStream codeStream = emitter.NewCodeStream();
 
-            codeStream.MarkDebuggerStepThroughPoint();
+            if (Context.Target.IsWindows)
+                codeStream.MarkDebuggerStepThroughPoint();
 
             // Allow the class library to run explicitly ordered class constructors first thing in start-up.
             if (_libraryInitializers != null)
@@ -118,7 +119,8 @@ namespace Internal.IL.Stubs.StartupCode
                 codeStream.Emit(ILOpcode.call, emitter.NewToken(startup.GetKnownMethod("GetMainMethodArguments", null)));
             }
 
-            codeStream.MarkDebuggerStepInPoint();
+            if (Context.Target.IsWindows)
+                codeStream.MarkDebuggerStepInPoint();
             codeStream.Emit(ILOpcode.call, emitter.NewToken(_mainMethod));
 
             MethodDesc setLatchedExitCode = startup?.GetMethod("SetLatchedExitCode", null);
@@ -233,12 +235,14 @@ namespace Internal.IL.Stubs.StartupCode
                 ILEmitter emit = new ILEmitter();
                 ILCodeStream codeStream = emit.NewCodeStream();
 
-                codeStream.MarkDebuggerStepThroughPoint();
+                if (Context.Target.IsWindows)
+                    codeStream.MarkDebuggerStepThroughPoint();
 
                 for (int i = 0; i < Signature.Length; i++)
                     codeStream.EmitLdArg(i);
 
-                codeStream.MarkDebuggerStepInPoint();
+                if (Context.Target.IsWindows)
+                    codeStream.MarkDebuggerStepInPoint();
 
                 codeStream.Emit(ILOpcode.call, emit.NewToken(WrappedMethod));
 


### PR DESCRIPTION
Disabling the DebuggerSteppingHelpers on non-Windows fixes a bug where breakpoints were not working correctly with the Switch debugger. The helpers are only useful on Windows anyway, so this should be a safe change.