### PR TITLE
Bug fix of dfa lazy dot star

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexBuilder.cs
@@ -284,18 +284,10 @@ namespace System.Text.RegularExpressions.SRM
                 else
                     return this.eagerEmptyLoop;
             }
-            else if (lower == 0 && upper == int.MaxValue && regex.kind == SymbolicRegexKind.Singleton && this.solver.AreEquivalent(this.solver.True, regex.set))
+            else if (!isLazy && lower == 0 && upper == int.MaxValue && regex.kind == SymbolicRegexKind.Singleton && this.solver.AreEquivalent(this.solver.True, regex.set))
             {
                 return this.dotStar;
             }
-            //else if (lower == upper && lower < 3)
-            //{
-            //    // unwind a fixed length loop of low bound into a concatenation
-            //    var elems = new SymbolicRegexNode<S>[lower];
-            //    for (int i = 0; i < lower; i++)
-            //        elems[i] = regex;
-            //    return MkConcat(elems, toplevel);
-            //}
             else
             {
                 var loop = SymbolicRegexNode<S>.MkLoop(this, regex, lower, upper, isLazy);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -350,13 +350,13 @@ namespace System.Text.RegularExpressions.SRM
 
         #region various properties
         /// <summary>
-        /// Returns true if this is equivalent to .*
+        /// Returns true if this is equivalent to .* (the node must be eager also)
         /// </summary>
         public bool IsDotStar
         {
             get
             {
-                return this.IsStar && this.left.kind == SymbolicRegexKind.Singleton &&
+                return this.IsStar && this.left.kind == SymbolicRegexKind.Singleton && !IsLazy &&
                     this.builder.solver.AreEquivalent(this.builder.solver.True, this.left.set);
             }
         }
@@ -1018,10 +1018,6 @@ namespace System.Text.RegularExpressions.SRM
                                 var deriv = builder.MkConcat(step, star);
                                 return deriv;
                             }
-                            //else if (IsMaybe)
-                            //{
-                            //    return step;
-                            //}
                             else
                             {
                                 int newupper = (upper == int.MaxValue ? int.MaxValue : upper - 1);

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -254,7 +254,6 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Fact]
-        [ActiveIssue("incorrect replacement in DFA mode involving Devanagari matra characters")]
         public void Replace_MatchEvaluator_Test_DFA_Matra()
         {
             // Regression test carried over from above to DFA mode:

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -66,7 +66,7 @@ namespace System.Text.RegularExpressions.Tests
         [Theory]
         [InlineData(DFA, "e.g:abc", @"\B\W*?", true, 5, 0)]
         [ActiveIssue("bug with use of startset finding no match while there is an empty match")]
-        public void TestLazyLoops_AvtiveIssue(RegexOptions options, string input, string pattern, bool success, int index, int length)
+        public void TestLazyLoops_ActiveIssue(RegexOptions options, string input, string pattern, bool success, int index, int length)
         {
             Match m = Regex.Match(input, pattern, options);
             Assert.Equal(success, m.Success);

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -29,40 +29,6 @@ namespace System.Text.RegularExpressions.Tests
         private const char Turkish_i_withoutDot = '\u0131';
         private const char Kelvin_sign = '\u212A';
 
-        [Fact]
-        [ActiveIssue(@"inconsitent treatement of \u200c and \u200d in \w vs \b")]
-        public void TestBoundary()
-        {
-            Assert.True(Regex.IsMatch(" AB\u200cCD ", @"\b\w+\b"));
-            Assert.True(Regex.IsMatch(" AB\u200dCD ", @"\b\w+\b"));
-        }
-
-        /// <summary>
-        /// Same test as above but it succeeds in DFA mode because \u200c and \u200d are not in \w
-        /// and in DFA mode \b is treated equivalently to (?<!\w)(?=\w)|(?<=\w)(?!\w)
-        /// </summary>
-        [Fact]
-        public void TestBoundary_DFA()
-        {
-            Assert.True(Regex.IsMatch(" AB\u200cCD ", @"\b\w+\b", RegexSRMTests.DFA));
-            Assert.True(Regex.IsMatch(" AB\u200dCD ", @"\b\w+\b", RegexSRMTests.DFA));
-        }
-
-        /// <summary>
-        /// Test that \w has the same meaning in DFA mode as in non-DFA mode
-        /// </summary>
-        [Fact]
-        public void TestWordchar()
-        {
-            var w1 = new Regex(@"\w", RegexOptions.None);
-            var w2 = new Regex(@"\w", DFA);
-            var ambiguous = new List<char>();
-            for (char c = '\0'; c < '\uFFFF'; c++)
-                if (w1.IsMatch(c.ToString()) != w2.IsMatch(c.ToString()))
-                    ambiguous.Add(c);
-            Assert.Empty(ambiguous);
-        }
-
         /// <summary>
         /// Specific cases that are very slow/difficult with backtracking but fast/easy without backtracking
         /// </summary>

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -48,25 +48,13 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { options, "digits:0123456789", @"\W.*?\b", true, 6, 1 };
                 yield return new object[] { options, "e.g:abc", @"\B.*?\B", true, 5, 0 };
                 yield return new object[] { options, "e.g:abc", @"\B\W+?", false, 0, 0 };
+                yield return new object[] { options, "e.g:abc", @"\B\W*?", true, 5, 0 };
             }
-            yield return new object[] { RegexOptions.Singleline, "e.g:abc", @"\B\W*?", true, 5, 0 };
-            yield return new object[] { RegexOptions.Compiled | RegexOptions.Singleline, "e.g:abc", @"\B\W*?", true, 5, 0 };
         }
 
         [Theory]
         [MemberData(nameof(TestLazyLoops_Data))]
         public void TestLazyLoops(RegexOptions options, string input, string pattern, bool success, int index, int length)
-        {
-            Match m = Regex.Match(input, pattern, options);
-            Assert.Equal(success, m.Success);
-            Assert.Equal(index, m.Index);
-            Assert.Equal(length, m.Length);
-        }
-
-        [Theory]
-        [InlineData(DFA, "e.g:abc", @"\B\W*?", true, 5, 0)]
-        [ActiveIssue("bug with use of startset finding no match while there is an empty match")]
-        public void TestLazyLoops_ActiveIssue(RegexOptions options, string input, string pattern, bool success, int index, int length)
         {
             Match m = Regex.Match(input, pattern, options);
             Assert.Equal(success, m.Success);

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -49,6 +49,10 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { options, "e.g:abc", @"\B.*?\B", true, 5, 0 };
                 yield return new object[] { options, "e.g:abc", @"\B\W+?", false, 0, 0 };
                 yield return new object[] { options, "e.g:abc", @"\B\W*?", true, 5, 0 };
+
+                //while not lazy loops themselves, variants of the prior case that should give same results here
+                yield return new object[] { options, "e.g:abc", @"\B\W*", true, 5, 0 };
+                yield return new object[] { options, "e.g:abc", @"\B\W?", true, 5, 0 };
             }
         }
 


### PR DESCRIPTION
Fixed bug of .*? being treated as .* in DFA mode that came up testing of Replace and was related to and fixed an active issue.
Added more unit tests for lazy loops that then discovered another active issue that needs to be fixed where an empty match exists
and where there is no start-set and match fails for DFA (perhaps related to use of lazy loops, but it is not clear if that is so).