### PR TITLE
Build Debug ObjWriter in Checked/Debug configurations

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -33,10 +33,10 @@
   <PropertyGroup>
     <ILCompilerVersion>6.0.0-preview.5.21222.2</ILCompilerVersion>
 
-    <_ObjWriterBuildType>$(Configuration)</_ObjWriterBuildType>
-    <_ObjWriterBuildType Condition="'$(_ObjWriterBuildType)' == 'Checked'">Debug</_ObjWriterBuildType>
+    <ObjWriterBuildType>$(Configuration)</ObjWriterBuildType>
+    <ObjWriterBuildType Condition="'$(ObjWriterBuildType)' == 'Checked'">Debug</ObjWriterBuildType>
 
-    <ObjWriterArtifactPath Condition="'$(TargetsWindows)' == 'true'">$(ArtifactsDir)llvm-project\llvm\build\$(TargetArchitecture)\$(_ObjWriterBuildType)\bin\$(LibPrefix)objwriter$(LibSuffix)</ObjWriterArtifactPath>
+    <ObjWriterArtifactPath Condition="'$(TargetsWindows)' == 'true'">$(ArtifactsDir)llvm-project\llvm\build\$(TargetArchitecture)\$(ObjWriterBuildType)\bin\$(LibPrefix)objwriter$(LibSuffix)</ObjWriterArtifactPath>
     <ObjWriterArtifactPath Condition="'$(TargetsWindows)' != 'true'">$(ArtifactsDir)llvm-project\llvm\build\$(TargetArchitecture)\lib\$(LibPrefix)objwriter$(LibSuffix)</ObjWriterArtifactPath>
 
     <!-- CoreDisTools are used in debugging visualizers. -->

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -33,7 +33,10 @@
   <PropertyGroup>
     <ILCompilerVersion>6.0.0-preview.5.21222.2</ILCompilerVersion>
 
-    <ObjWriterArtifactPath Condition="'$(TargetsWindows)' == 'true'">$(ArtifactsDir)llvm-project\llvm\build\$(TargetArchitecture)\Release\bin\$(LibPrefix)objwriter$(LibSuffix)</ObjWriterArtifactPath>
+    <_ObjWriterBuildType>$(Configuration)</_ObjWriterBuildType>
+    <_ObjWriterBuildType Condition="'$(_ObjWriterBuildType)' == 'Checked'">Debug</_ObjWriterBuildType>
+
+    <ObjWriterArtifactPath Condition="'$(TargetsWindows)' == 'true'">$(ArtifactsDir)llvm-project\llvm\build\$(TargetArchitecture)\$(_ObjWriterBuildType)\bin\$(LibPrefix)objwriter$(LibSuffix)</ObjWriterArtifactPath>
     <ObjWriterArtifactPath Condition="'$(TargetsWindows)' != 'true'">$(ArtifactsDir)llvm-project\llvm\build\$(TargetArchitecture)\lib\$(LibPrefix)objwriter$(LibSuffix)</ObjWriterArtifactPath>
 
     <!-- CoreDisTools are used in debugging visualizers. -->

--- a/src/coreclr/tools/aot/ObjWriter/objwriter.proj
+++ b/src/coreclr/tools/aot/ObjWriter/objwriter.proj
@@ -5,12 +5,12 @@
     <BuildScriptName Condition="'$(TargetOS)' == 'windows'">build.cmd</BuildScriptName>
     <BuildScriptName Condition="'$(TargetOS)' != 'windows'">build.sh</BuildScriptName>
 
-    <_ObjWriterBuildType>$(Configuration)</_ObjWriterBuildType>
-    <_ObjWriterBuildType Condition="'$(_ObjWriterBuildType)' == 'Checked'">Debug</_ObjWriterBuildType>
+    <ObjWriterBuildType>$(Configuration)</ObjWriterBuildType>
+    <ObjWriterBuildType Condition="'$(ObjWriterBuildType)' == 'Checked'">Debug</ObjWriterBuildType>
 
     <BuildArguments>"$(ArtifactsDir)" "$(RepoRoot)"</BuildArguments>
     <BuildArguments>$(BuildArguments) $(BuildArchitecture) $(TargetArchitecture)</BuildArguments>
-    <BuildArguments>$(BuildArguments) $(_ObjWriterBuildType) $(Compiler)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(ObjWriterBuildType) $(Compiler)</BuildArguments>
   </PropertyGroup>
 
   <Target Name="Build">

--- a/src/coreclr/tools/aot/ObjWriter/objwriter.proj
+++ b/src/coreclr/tools/aot/ObjWriter/objwriter.proj
@@ -5,9 +5,12 @@
     <BuildScriptName Condition="'$(TargetOS)' == 'windows'">build.cmd</BuildScriptName>
     <BuildScriptName Condition="'$(TargetOS)' != 'windows'">build.sh</BuildScriptName>
 
+    <_ObjWriterBuildType>$(Configuration)</_ObjWriterBuildType>
+    <_ObjWriterBuildType Condition="'$(_ObjWriterBuildType)' == 'Checked'">Debug</_ObjWriterBuildType>
+
     <BuildArguments>"$(ArtifactsDir)" "$(RepoRoot)"</BuildArguments>
     <BuildArguments>$(BuildArguments) $(BuildArchitecture) $(TargetArchitecture)</BuildArguments>
-    <BuildArguments>$(BuildArguments) Release $(Compiler)</BuildArguments>
+    <BuildArguments>$(BuildArguments) $(_ObjWriterBuildType) $(Compiler)</BuildArguments>
   </PropertyGroup>
 
   <Target Name="Build">


### PR DESCRIPTION
The asserts/checks are useful and we no longer hit issues with non-Release builds.