### PR TITLE
Include canonical forms of types involved in GVM dispatch

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -73,14 +73,6 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            // Generated type contains generic virtual methods that will get added to the GVM tables
-            if (TypeGVMEntriesNode.TypeNeedsGVMTableEntries(_type))
-            {
-                dependencyList.Add(new DependencyListEntry(factory.TypeGVMEntries(_type.GetTypeDefinition()), "Type with generic virtual methods"));
-
-                AddDependenciesForUniversalGVMSupport(factory, _type, ref dependencyList);
-            }
-
             // Ask the metadata manager if we have any dependencies due to reflectability.
             factory.MetadataManager.GetDependenciesDueToReflectability(ref dependencyList, factory, _type);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -502,6 +502,18 @@ namespace ILCompiler.DependencyAnalysis
                 // vtable information for things like IEnumerator<List<__Canon>>.
                 foreach (TypeDesc intface in _type.RuntimeInterfaces)
                     dependencies.Add(factory.VTable(intface), "Interface vtable slice");
+
+                // Generated type contains generic virtual methods that will get added to the GVM tables
+                if (TypeGVMEntriesNode.TypeNeedsGVMTableEntries(_type))
+                {
+                    dependencies.Add(new DependencyListEntry(factory.TypeGVMEntries(_type.GetTypeDefinition()), "Type with generic virtual methods"));
+
+                    AddDependenciesForUniversalGVMSupport(factory, _type, ref dependencies);
+
+                    TypeDesc canonicalType = _type.ConvertToCanonForm(CanonicalFormKind.Specific);
+                    if (canonicalType != _type)
+                        dependencies.Add(factory.ConstructedTypeSymbol(canonicalType), "Type with generic virtual methods");
+                }
             }
 
             if (factory.CompilationModuleGroup.PresenceOfEETypeImpliesAllMethodsOnType(_type))


### PR DESCRIPTION
The GVM analysis within the compiler assumes we can do analysis on top of canonical forms and we get analysis holes if the canonical form doesn't exist at compile time.

GVM dispatch at runtime might end up building new types as well, so the extra template isn't strictly just bloat but I do admit there's some laziness in just throwing the extra template in to fix the problem.

This wasn't hittable outside reflection-free mode because we generate canonical forms of everything outside reflection-free mode anyway.

As I was looking for a place to put this in, I realized the `TypeNeedsGVMTableEntries` logic needs to run on canonical types as well (those are not `ConstructedEETypeNode`), so I moved it to a common spot. That part was not necessary to fix the reported problem, but it provides a convenient spot to put the canonical type dependency.

Fixes #1473.