### PR TITLE
fixed deep recursion crash in SRM

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -379,6 +379,10 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public string GroupNameFromNumber(int i)
         {
+            //in DFA mode there is a single top level group 0
+            if (_useSRM)
+                return (i == 0 ? "0" : string.Empty);
+
             if (capslist is null)
             {
                 return (uint)i < (uint)capsize ?
@@ -398,6 +402,10 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public int GroupNumberFromName(string name)
         {
+            //in DFA mode there is a single top level group 0
+            if (_useSRM)
+                return (name ==  "0" ? 0 : -1);
+
             if (name is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.name);

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.GetGroupNames.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.GetGroupNames.Tests.cs
@@ -114,13 +114,31 @@ namespace System.Text.RegularExpressions.Tests
                 new int[] { 0, 15 },
                 new string[] { "Ryan Byington", "Byington" }
             };
+
+            yield return new object[]
+            {
+                "(?'15'\\S+)\\s(?'15'\\S+)", "Ryan Byington",
+                new string[] { "0" },
+                new int[] { 0 },
+                new string[] { "Ryan Byington" },
+                RegexSRMTests.DFA
+            };
+
+            yield return new object[]
+            {
+                "(?<first_name>\\S+)\\s(?<last_name>\\S+)", "Ryan Byington",
+                new string[] { "0" },
+                new int[] { 0 },
+                new string[] { "Ryan Byington" },
+                RegexSRMTests.DFA
+            };
         }
 
         [Theory]
         [MemberData(nameof(GroupNamesAndNumbers_TestData))]
-        public void GroupNamesAndNumbers(string pattern, string input, string[] expectedNames, int[] expectedNumbers, string[] expectedGroups)
+        public void GroupNamesAndNumbers(string pattern, string input, string[] expectedNames, int[] expectedNumbers, string[] expectedGroups, RegexOptions options = RegexOptions.None)
         {
-            Regex regex = new Regex(pattern);
+            Regex regex = new Regex(pattern, options);
             Match match = regex.Match(input);
             Assert.True(match.Success);
 
@@ -145,24 +163,30 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
+        [InlineData("(f)(oo)", 1, RegexSRMTests.DFA)]
+        [InlineData("(f)(oo)", -1, RegexSRMTests.DFA)]
+        [InlineData("(f)(oo)", 2, RegexSRMTests.DFA)]
         [InlineData("foo", 1)]
         [InlineData("foo", -1)]
         [InlineData("(?<first_name>\\S+)\\s(?<last_name>\\S+)", -1)]
         [InlineData("(?<first_name>\\S+)\\s(?<last_name>\\S+)", 3)]
         [InlineData(@"((?<256>abc)\d+)?(?<16>xyz)(.*)", -1)]
-        public void GroupNameFromNumber_InvalidIndex_ReturnsEmptyString(string pattern, int index)
+        public void GroupNameFromNumber_InvalidIndex_ReturnsEmptyString(string pattern, int index, RegexOptions options = RegexOptions.None)
         {
-            Assert.Same(string.Empty, new Regex(pattern).GroupNameFromNumber(index));
+            Assert.Same(string.Empty, new Regex(pattern, options).GroupNameFromNumber(index));
         }
 
         [Theory]
+        [InlineData("(f)(oo)", "no-such-name", RegexSRMTests.DFA)]
+        [InlineData("(f)(oo)", "1", RegexSRMTests.DFA)]
+        [InlineData("(f)(oo)", "2", RegexSRMTests.DFA)]
         [InlineData("foo", "no-such-name")]
         [InlineData("foo", "1")]
         [InlineData("(?<first_name>\\S+)\\s(?<last_name>\\S+)", "no-such-name")]
         [InlineData("(?<first_name>\\S+)\\s(?<last_name>\\S+)", "FIRST_NAME")]
-        public void GroupNumberFromName_InvalidName_ReturnsMinusOne(string pattern, string name)
+        public void GroupNumberFromName_InvalidName_ReturnsMinusOne(string pattern, string name, RegexOptions options = RegexOptions.None)
         {
-            Assert.Equal(-1, new Regex(pattern).GroupNumberFromName(name));
+            Assert.Equal(-1, new Regex(pattern, options).GroupNumberFromName(name));
         }
 
         [Fact]

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.GetGroupNames.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.GetGroupNames.Tests.cs
@@ -9,10 +9,11 @@ namespace System.Text.RegularExpressions.Tests
     public class GetGroupNamesTests
     {
         [Theory]
-        [InlineData("(?<first_name>\\S+)\\s(?<last_name>\\S+)", new string[] { "0", "first_name", "last_name" })]
-        public void GetGroupNames(string pattern, string[] expectedGroupNames)
+        [InlineData("(?<first_name>\\S+)\\s(?<last_name>\\S+)", RegexOptions.None, new string[] { "0", "first_name", "last_name" })]
+        [InlineData("(?<first_name>\\S+)\\s(?<last_name>\\S+)", RegexSRMTests.DFA, new string[] { "0" })]
+        public void GetGroupNames(string pattern, RegexOptions options, string[] expectedGroupNames)
         {
-            Regex regex = new Regex(pattern);
+            Regex regex = new Regex(pattern, options);
             Assert.Equal(expectedGroupNames, regex.GetGroupNames());
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -1002,12 +1002,15 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(?>a*).", RegexOptions.None, "atomic" };
         }
 
-        [Fact]
-        public void StressTestSymbolicRegexConversion()
+        [Theory]
+        [InlineData(RegexOptions.None)]
+        [InlineData(RegexOptions.Compiled)]
+        [InlineData(DFA)]
+        public void StressTestDeepNestingOfConcat(RegexOptions options)
         {
             string pattern = string.Concat(Enumerable.Repeat("([a-z]", 1000).Concat(Enumerable.Repeat(")", 1000)));
             string input = string.Concat(Enumerable.Repeat("abcde", 200));
-            var re = new Regex(pattern, DFA);
+            var re = new Regex(pattern, options);
             Assert.True(re.IsMatch(input));
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -1001,5 +1001,14 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"\G(\w+\s?\w*),?", RegexOptions.None, "contiguous matches" };
             yield return new object[] { @"(?>a*).", RegexOptions.None, "atomic" };
         }
+
+        [Fact]
+        public void StressTestSymbolicRegexConversion()
+        {
+            string pattern = string.Concat(Enumerable.Repeat("([a-z]", 1000).Concat(Enumerable.Repeat(")", 1000)));
+            string input = string.Concat(Enumerable.Repeat("abcde", 200));
+            var re = new Regex(pattern, DFA);
+            Assert.True(re.IsMatch(input));
+        }
     }
 }


### PR DESCRIPTION
Conversion of deeply nested concatenations of RegexNodes to Symbolic Regexes was handled poorly/naively and caused crash (most probably out-of-stack-memory) when pattern has nested concats inside captures, say 1000-fold deep as in the added unit test. Discovered this by lifting over a related stress test that was used for Replace (but that initially failed earlier and used substitutions, so was out of scope because of the focus on substitutions), but now revisited and fixed the core issue behind the earlier crash.

Also added a cache for already created predicates from internal strings representing intervals and character classes, that in this unit test below gets called 1000x but exposed again the problem of repeated nontrivial computations that were not cached. This should improve construction time considerably for larger patterns. The cache itself is local to a regex matcher and should not be a concern.

Added the unit test StressTestSymbolicRegexConversion (this test would have crashed earlier).