### PR TITLE
Rename RegexOptions.DFA to RegexOptions.NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/libraries/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -241,7 +241,7 @@ namespace System.Text.RegularExpressions
         RightToLeft = 64,
         ECMAScript = 256,
         CultureInvariant = 512,
-        DFA = 1024,
+        NonBacktracking = 1024,
     }
     public enum RegexParseError
     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -96,7 +96,7 @@ namespace System.Text.RegularExpressions
             ValidateOptions(options);
             ValidateMatchTimeout(matchTimeout);
 
-            _useSRM = (options & RegexOptions.DFA) != 0;
+            _useSRM = (options & RegexOptions.NonBacktracking) != 0;
             if (_useSRM)
             {
                 // Ignore Compiled flag if DFA is used
@@ -132,7 +132,7 @@ namespace System.Text.RegularExpressions
             // This construction fails and throws a NotSupportedException
             // if constructs that are not compatible with DFA are being used in the pattern.
             if (_useSRM)
-                _srm = InitializeSRM(tree.Root, roptions & ~RegexOptions.DFA, matchTimeout, culture);
+                _srm = InitializeSRM(tree.Root, roptions & ~RegexOptions.NonBacktracking, matchTimeout, culture);
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace System.Text.RegularExpressions
 #if DEBUG
                              RegexOptions.Debug |
 #endif
-                             RegexOptions.DFA |
+                             RegexOptions.NonBacktracking |
                              RegexOptions.CultureInvariant)) != 0))
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.options);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -381,7 +381,7 @@ namespace System.Text.RegularExpressions
 
             // the conversion to atomic is incompatible with DFA mode
             // because it may introduce atomic loops that are not supported in DFA mode
-            if ((node.Options & RegexOptions.DFA) != 0)
+            if ((node.Options & RegexOptions.NonBacktracking) != 0)
             {
                 return;
             }
@@ -558,7 +558,7 @@ namespace System.Text.RegularExpressions
         {
             // this work is incompatible with and unnecessary in DFA mode
             // because atomic loops are not supported in DFA mode
-            if ((Options & RegexOptions.DFA) != 0)
+            if ((Options & RegexOptions.NonBacktracking) != 0)
             {
                 return this;
             }
@@ -861,7 +861,7 @@ namespace System.Text.RegularExpressions
                             }
 
                             prev.Type = Set;
-                            prev.Str = prevCharClass.ToStringClass((Options & RegexOptions.DFA) != 0);
+                            prev.Str = prevCharClass.ToStringClass((Options & RegexOptions.NonBacktracking) != 0);
                         }
                         else if (at.Type == Nothing)
                         {
@@ -1329,7 +1329,7 @@ namespace System.Text.RegularExpressions
         {
             // the conversion to atomic is incompatible with DFA mode
             // because it may introduce atomic loops that are not supported in DFA mode
-            if ((Options & RegexOptions.DFA) != 0)
+            if ((Options & RegexOptions.NonBacktracking) != 0)
             {
                 return;
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -19,7 +19,7 @@ namespace System.Text.RegularExpressions
 #endif
         ECMAScript              = 0x0100, // "e"
         CultureInvariant        = 0x0200,
-        DFA                     = 0x0400,
+        NonBacktracking         = 0x0400,
 
         // RegexCompiler internally uses 0x80000000 for its own internal purposes.
         // If such a value ever needs to be added publicly, RegexCompiler will need

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -323,7 +323,7 @@ namespace System.Text.RegularExpressions
                         goto ContinueOuterScan;
 
                     case '[':
-                        AddUnitSet(ScanCharClass(UseOptionI(), scanOnly: false)!.ToStringClass((_options & RegexOptions.DFA) != 0));
+                        AddUnitSet(ScanCharClass(UseOptionI(), scanOnly: false)!.ToStringClass((_options & RegexOptions.NonBacktracking) != 0));
                         break;
 
                     case '(':
@@ -1207,7 +1207,7 @@ namespace System.Text.RegularExpressions
                         cc.AddLowercase(_culture);
                     }
 
-                    return new RegexNode(RegexNode.Set, _options, cc.ToStringClass((_options & RegexOptions.DFA) != 0));
+                    return new RegexNode(RegexNode.Set, _options, cc.ToStringClass((_options & RegexOptions.NonBacktracking) != 0));
 
                 default:
                     return ScanBasicBackslash(scanOnly);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -120,7 +120,7 @@ namespace System.Text.RegularExpressions
             if (!replRef.TryGetTarget(out repl) || !repl.Pattern.Equals(replacement))
             {
                 repl = RegexParser.ParseReplacement(replacement, roptions, caps, capsize, capnames);
-                if (repl.HasGroups && ((roptions & RegexOptions.DFA) != 0))
+                if (repl.HasGroups && ((roptions & RegexOptions.NonBacktracking) != 0))
                     throw new NotSupportedException(SRM.Regex._DFA_incompatible_with + "replacement pattern with substitutions");
 
                 replRef.SetTarget(repl);

--- a/src/libraries/System.Text.RegularExpressions/tests/AttRegexTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/AttRegexTests.cs
@@ -72,9 +72,6 @@ namespace System.Text.RegularExpressions.Tests
 {
     public class AttRegexTests
     {
-
-        private static RegexOptions DFA = (RegexOptions)0x400;
-
         [Theory]
 
         // basic.dat
@@ -376,10 +373,17 @@ namespace System.Text.RegularExpressions.Tests
                 input = "";
             }
 
-            foreach (RegexOptions options in new[] { DFA, DFA | RegexOptions.Multiline, RegexOptions.None, RegexOptions.Compiled })
+            var allOptions = new List<RegexOptions>() { RegexOptions.None, RegexOptions.Compiled };
+            if (PlatformDetection.IsNetCore)
+            {
+                allOptions.Add(RegexHelpers.RegexOptionNonBacktracking);
+                allOptions.Add(RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Multiline);
+            }
+
+            foreach (RegexOptions options in allOptions)
             {
                 string captures = nondfa_captures;
-                bool dfa_mode = ((options & DFA) != 0);
+                bool dfa_mode = ((options & RegexHelpers.RegexOptionNonBacktracking) != 0);
                 if (dfa_mode && dfa_match != null)
                     //dfa_match value overrides the expected result in DFA mode
                     captures = dfa_match;

--- a/src/libraries/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/MatchCollectionTests.cs
@@ -2,16 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
 {
     public static partial class MatchCollectionTests
     {
+        public static IEnumerable<object[]> NoneCompiledBacktracking()
+        {
+            yield return new object[] { RegexOptions.None };
+            yield return new object[] { RegexOptions.Compiled };
+            if (PlatformDetection.IsNetCore)
+            {
+                yield return new object[] { RegexHelpers.RegexOptionNonBacktracking };
+            }
+        }
+
         [Theory]
-        [InlineData(RegexOptions.None)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexSRMTests.DFA)]
+        [MemberData(nameof(NoneCompiledBacktracking))]
         public static void GetEnumerator(RegexOptions options)
         {
             Regex regex = new Regex("e", options);
@@ -32,9 +41,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [InlineData(RegexOptions.None)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexSRMTests.DFA)]
+        [MemberData(nameof(NoneCompiledBacktracking))]
         public static void GetEnumerator_Invalid(RegexOptions options)
         {
             Regex regex = new Regex("e", options);
@@ -61,9 +68,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [InlineData(RegexOptions.None)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexSRMTests.DFA)]
+        [MemberData(nameof(NoneCompiledBacktracking))]
         public static void Item_Get_InvalidIndex_ThrowsArgumentOutOfRangeException(RegexOptions options)
         {
             Regex regex = new Regex("e", options);
@@ -73,9 +78,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [InlineData(RegexOptions.None)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexSRMTests.DFA)]
+        [MemberData(nameof(NoneCompiledBacktracking))]
         public static void ICollection_Properties(RegexOptions options)
         {
             Regex regex = new Regex("e", options);
@@ -88,35 +91,31 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [InlineData(0, RegexOptions.None)]
-        [InlineData(5, RegexOptions.None)]
-        [InlineData(0, RegexOptions.Compiled)]
-        [InlineData(5, RegexOptions.Compiled)]
-        [InlineData(0, RegexSRMTests.DFA)]
-        [InlineData(5, RegexSRMTests.DFA)]
-        public static void ICollection_CopyTo(int index, RegexOptions options)
+        [MemberData(nameof(NoneCompiledBacktracking))]
+        public static void ICollection_CopyTo(RegexOptions options)
         {
-            Regex regex = new Regex("e", options);
-            MatchCollection matches = regex.Matches("dotnet");
-            ICollection collection = matches;
-
-            Match[] copy = new Match[collection.Count + index];
-            collection.CopyTo(copy, index);
-
-            for (int i = 0; i < index; i++)
+            foreach (int index in new[] { 0, 5 })
             {
-                Assert.Null(copy[i]);
-            }
-            for (int i = index; i < copy.Length; i++)
-            {
-                Assert.Same(matches[i - index], copy[i]);
+                Regex regex = new Regex("e", options);
+                MatchCollection matches = regex.Matches("dotnet");
+                ICollection collection = matches;
+
+                Match[] copy = new Match[collection.Count + index];
+                collection.CopyTo(copy, index);
+
+                for (int i = 0; i < index; i++)
+                {
+                    Assert.Null(copy[i]);
+                }
+                for (int i = index; i < copy.Length; i++)
+                {
+                    Assert.Same(matches[i - index], copy[i]);
+                }
             }
         }
 
         [Theory]
-        [InlineData(RegexOptions.None)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexSRMTests.DFA)]
+        [MemberData(nameof(NoneCompiledBacktracking))]
         public static void ICollection_CopyTo_Invalid(RegexOptions options)
         {
             Regex regex = new Regex("e", options);

--- a/src/libraries/System.Text.RegularExpressions/tests/MonoRegexTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/MonoRegexTests.cs
@@ -53,8 +53,6 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(expected, result);
         }
 
-        private static RegexOptions DFA = (RegexOptions)0x400;
-
         public static IEnumerable<object[]> RegexTestCasesWithOptions()
         {
             foreach (object[] obj in RegexTestCases())
@@ -64,26 +62,29 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { obj[0], RegexOptions.Compiled | (RegexOptions)obj[1], obj[2], obj[3] };
                 yield return new object[] { obj[0], RegexOptions.Compiled | RegexOptions.CultureInvariant | (RegexOptions)obj[1], obj[2], obj[3] };
 
-                #region DFA option
-                //for the DFA option, skip the tests that use nonsupported options 
-                //or if the optional 5th arguments says "DFAINCOMPATIBLE" that applies
-                //when the following are being used in the pattern:
-                //backreferences, (negative/positive) lookahead, (negative/positive) lookbehind, atomic, \G
-                if ((((RegexOptions)obj[1] & (RegexOptions.ECMAScript | RegexOptions.RightToLeft)) != 0) ||
-                    (obj.Length > 4 && obj[4].Equals("DFAINCOMPATIBLE")))
-                    continue;
+                if (PlatformDetection.IsNetCore)
+                {
+                    #region DFA option
+                    //for the DFA option, skip the tests that use nonsupported options 
+                    //or if the optional 5th arguments says "DFAINCOMPATIBLE" that applies
+                    //when the following are being used in the pattern:
+                    //backreferences, (negative/positive) lookahead, (negative/positive) lookbehind, atomic, \G
+                    if ((((RegexOptions)obj[1] & (RegexOptions.ECMAScript | RegexOptions.RightToLeft)) != 0) ||
+                        (obj.Length > 4 && obj[4].Equals("DFAINCOMPATIBLE")))
+                        continue;
 
-                //add the DFA specific tests
-                //group i values for i>0 are not generated in DFA mode and are removed
-                //-- thus the string beyond the first ')' when the test succeeds is removed in obj[3]
-                string expected_result = (string)obj[3];
-                int j = expected_result.IndexOf(')');
-                if (j > 0)
-                    expected_result = expected_result.Substring(0, j + 1);
+                    //add the DFA specific tests
+                    //group i values for i>0 are not generated in DFA mode and are removed
+                    //-- thus the string beyond the first ')' when the test succeeds is removed in obj[3]
+                    string expected_result = (string)obj[3];
+                    int j = expected_result.IndexOf(')');
+                    if (j > 0)
+                        expected_result = expected_result.Substring(0, j + 1);
 
-                yield return new object[] { obj[0], DFA | (RegexOptions)obj[1], obj[2], expected_result };
-                yield return new object[] { obj[0], DFA | (RegexOptions)obj[1] | RegexOptions.CultureInvariant, obj[2], expected_result };
-                #endregion
+                    yield return new object[] { obj[0], RegexHelpers.RegexOptionNonBacktracking | (RegexOptions)obj[1], obj[2], expected_result };
+                    yield return new object[] { obj[0], RegexHelpers.RegexOptionNonBacktracking | (RegexOptions)obj[1] | RegexOptions.CultureInvariant, obj[2], expected_result };
+                    #endregion
+                }
             }
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -367,6 +367,7 @@ namespace System.Text.RegularExpressions.Tests
             // Options are invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1), TimeSpan.FromSeconds(1)));
+
             // 0x400 is new DFA mode that is now valid, 0x800 is still invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x800));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x800, TimeSpan.FromSeconds(1)));

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -107,20 +107,25 @@ namespace System.Text.RegularExpressions.Tests
 
         public static IEnumerable<object[]> Replace_String_TestData_DFA()
         {
-            yield return new object[] { @"a", "bbbb", "c", RegexSRMTests.DFA, 4, 3, "bbbb" };
-            yield return new object[] { @"", "   ", "123", RegexSRMTests.DFA, 4, 0, "123 123 123 123" };
-            yield return new object[] { "icrosoft", "MiCrOsOfT", "icrosoft", RegexOptions.IgnoreCase | RegexSRMTests.DFA, 9, 0, "Microsoft" };
-            yield return new object[] { "dog", "my dog has fleas", "CAT", RegexOptions.IgnoreCase | RegexSRMTests.DFA, 16, 0, "my CAT has fleas" };
-            yield return new object[] { "a", "aaaaa", "b", RegexSRMTests.DFA, 2, 0, "bbaaa" };
-            yield return new object[] { "a", "aaaaa", "b", RegexSRMTests.DFA, 2, 3, "aaabb" };
+            if (PlatformDetection.IsNetFramework)
+            {
+                yield break;
+            }
+
+            yield return new object[] { @"a", "bbbb", "c", RegexHelpers.RegexOptionNonBacktracking, 4, 3, "bbbb" };
+            yield return new object[] { @"", "   ", "123", RegexHelpers.RegexOptionNonBacktracking, 4, 0, "123 123 123 123" };
+            yield return new object[] { "icrosoft", "MiCrOsOfT", "icrosoft", RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking, 9, 0, "Microsoft" };
+            yield return new object[] { "dog", "my dog has fleas", "CAT", RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking, 16, 0, "my CAT has fleas" };
+            yield return new object[] { "a", "aaaaa", "b", RegexHelpers.RegexOptionNonBacktracking, 2, 0, "bbaaa" };
+            yield return new object[] { "a", "aaaaa", "b", RegexHelpers.RegexOptionNonBacktracking, 2, 3, "aaabb" };
 
             // Stress
-            yield return new object[] { ".", new string('a', 1000), "b", RegexSRMTests.DFA, 1000, 0, new string('b', 1000) };
+            yield return new object[] { ".", new string('a', 1000), "b", RegexHelpers.RegexOptionNonBacktracking, 1000, 0, new string('b', 1000) };
 
             // Undefined groups
-            yield return new object[] { "([a_z])(.+)", "abc", "$3", RegexSRMTests.DFA, 3, 0, "$3" };
-            yield return new object[] { @"(?<256>cat)\s*(?<512>dog)", "slkfjsdcat dogkljeah", "STARTcat$2048$1024dogEND", RegexSRMTests.DFA, 20, 0, "slkfjsdSTARTcat$2048$1024dogENDkljeah" };
-            yield return new object[] { @"(?<cat>cat)\s*(?<dog>dog)", "slkfjsdcat dogkljeah", "START${catTWO}dogcat${dogTWO}END", RegexSRMTests.DFA, 20, 0, "slkfjsdSTART${catTWO}dogcat${dogTWO}ENDkljeah" };
+            yield return new object[] { "([a_z])(.+)", "abc", "$3", RegexHelpers.RegexOptionNonBacktracking, 3, 0, "$3" };
+            yield return new object[] { @"(?<256>cat)\s*(?<512>dog)", "slkfjsdcat dogkljeah", "STARTcat$2048$1024dogEND", RegexHelpers.RegexOptionNonBacktracking, 20, 0, "slkfjsdSTARTcat$2048$1024dogENDkljeah" };
+            yield return new object[] { @"(?<cat>cat)\s*(?<dog>dog)", "slkfjsdcat dogkljeah", "START${catTWO}dogcat${dogTWO}END", RegexHelpers.RegexOptionNonBacktracking, 20, 0, "slkfjsdSTART${catTWO}dogcat${dogTWO}ENDkljeah" };
         }
 
         [Theory]
@@ -197,21 +202,26 @@ namespace System.Text.RegularExpressions.Tests
         }
         public static IEnumerable<object[]> Replace_MatchEvaluator_TestData_DFA()
         {
-            yield return new object[] { "a", "bbbb", new MatchEvaluator(match => "uhoh"), RegexSRMTests.DFA, 4, 0, "bbbb" };
-            yield return new object[] { "(Big|Small)", "Big mountain", new MatchEvaluator(MatchEvaluator1), RegexSRMTests.DFA, 12, 0, "Huge mountain" };
-            yield return new object[] { "(Big|Small)", "Small village", new MatchEvaluator(MatchEvaluator1), RegexSRMTests.DFA, 13, 0, "Tiny village" };
+            if (PlatformDetection.IsNetFramework)
+            {
+                yield break;
+            }
+
+            yield return new object[] { "a", "bbbb", new MatchEvaluator(match => "uhoh"), RegexHelpers.RegexOptionNonBacktracking, 4, 0, "bbbb" };
+            yield return new object[] { "(Big|Small)", "Big mountain", new MatchEvaluator(MatchEvaluator1), RegexHelpers.RegexOptionNonBacktracking, 12, 0, "Huge mountain" };
+            yield return new object[] { "(Big|Small)", "Small village", new MatchEvaluator(MatchEvaluator1), RegexHelpers.RegexOptionNonBacktracking, 13, 0, "Tiny village" };
 
             if ("i".ToUpper() == "I")
             {
-                yield return new object[] { "(Big|Small)", "bIG horse", new MatchEvaluator(MatchEvaluator1), RegexOptions.IgnoreCase | RegexSRMTests.DFA, 9, 0, "Huge horse" };
+                yield return new object[] { "(Big|Small)", "bIG horse", new MatchEvaluator(MatchEvaluator1), RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking, 9, 0, "Huge horse" };
             }
 
-            yield return new object[] { "(Big|Small)", "sMaLl dog", new MatchEvaluator(MatchEvaluator1), RegexOptions.IgnoreCase | RegexSRMTests.DFA, 9, 0, "Tiny dog" };
+            yield return new object[] { "(Big|Small)", "sMaLl dog", new MatchEvaluator(MatchEvaluator1), RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking, 9, 0, "Tiny dog" };
 
-            yield return new object[] { ".+", "XSP_TEST_FAILURE", new MatchEvaluator(MatchEvaluator2), RegexSRMTests.DFA, 16, 0, "SUCCESS" };
-            yield return new object[] { "[abcabc]", "abcabc", new MatchEvaluator(MatchEvaluator3), RegexSRMTests.DFA, 6, 0, "ABCABC" };
-            yield return new object[] { "[abcabc]", "abcabc", new MatchEvaluator(MatchEvaluator3), RegexSRMTests.DFA, 3, 0, "ABCabc" };
-            yield return new object[] { "[abcabc]", "abcabc", new MatchEvaluator(MatchEvaluator3), RegexSRMTests.DFA, 3, 2, "abCABc" };
+            yield return new object[] { ".+", "XSP_TEST_FAILURE", new MatchEvaluator(MatchEvaluator2), RegexHelpers.RegexOptionNonBacktracking, 16, 0, "SUCCESS" };
+            yield return new object[] { "[abcabc]", "abcabc", new MatchEvaluator(MatchEvaluator3), RegexHelpers.RegexOptionNonBacktracking, 6, 0, "ABCABC" };
+            yield return new object[] { "[abcabc]", "abcabc", new MatchEvaluator(MatchEvaluator3), RegexHelpers.RegexOptionNonBacktracking, 3, 0, "ABCabc" };
+            yield return new object[] { "[abcabc]", "abcabc", new MatchEvaluator(MatchEvaluator3), RegexHelpers.RegexOptionNonBacktracking, 3, 2, "abCABc" };
         }
 
         [Theory]
@@ -253,6 +263,7 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(expected, new Regex(pattern, options).Replace(input, evaluator, count, start));
         }
 
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Doesn't support NonBacktracking")]
         [Fact]
         public void Replace_MatchEvaluator_Test_DFA_Matra()
         {
@@ -262,14 +273,22 @@ namespace System.Text.RegularExpressions.Tests
             string boldInput = "\u092f\u0939 \u0915\u0930 \u0935\u0939 \u0915\u0930\u0947\u0902 \u0939\u0948\u0964";
             string boldExpected = "\u092f\u0939 <b>\u0915\u0930</b> \u0935\u0939 <b>\u0915\u0930\u0947\u0902</b> \u0939\u0948\u0964";
             string pattern = @"\u0915\u0930.*?\b";
-            var re = new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.Singleline | RegexSRMTests.DFA);
+            var re = new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.Singleline | RegexHelpers.RegexOptionNonBacktracking);
             Assert.Equal(boldExpected, re.Replace(boldInput, new MatchEvaluator(MatchEvaluatorBold)));
         }
 
+        public static IEnumerable<object[]> NoneCompiledBacktracking()
+        {
+            yield return new object[] { RegexOptions.None };
+            yield return new object[] { RegexOptions.Compiled };
+            if (PlatformDetection.IsNetCore)
+            {
+                yield return new object[] { RegexHelpers.RegexOptionNonBacktracking };
+            }
+        }
+
         [Theory]
-        [InlineData(RegexOptions.None)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexSRMTests.DFA)]
+        [MemberData(nameof(NoneCompiledBacktracking))]
         public void Replace_NoMatch(RegexOptions options)
         {
             string input = "";
@@ -278,9 +297,7 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [InlineData(RegexOptions.None)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexSRMTests.DFA)]
+        [MemberData(nameof(NoneCompiledBacktracking))]
         public void Replace_MatchEvaluator_UniqueMatchObjects(RegexOptions options)
         {
             const string Input = "abcdefghijklmnopqrstuvwxyz";
@@ -301,10 +318,8 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         [Theory]
-        [InlineData(RegexOptions.None)]
+        [MemberData(nameof(NoneCompiledBacktracking))]
         [InlineData(RegexOptions.RightToLeft)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexSRMTests.DFA)]
         public void Replace_MatchEvaluatorReturnsNullOrEmpty(RegexOptions options)
         {
             string result = Regex.Replace("abcde", @"[abcd]", (Match match) => {
@@ -375,8 +390,11 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startat", () => new Regex("pattern").Replace("input", "replacement", 0, 6));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startat", () => new Regex("pattern").Replace("input", new MatchEvaluator(MatchEvaluator1), 0, 6));
 
-            // Substitutions not supported in DFA mode
-            Assert.Throws<NotSupportedException>(() => new Regex("pattern", RegexSRMTests.DFA).Replace("input", "$0", -1));
+            if (PlatformDetection.IsNetCore)
+            {
+                // Substitutions not supported in DFA mode
+                Assert.Throws<NotSupportedException>(() => new Regex("pattern", RegexHelpers.RegexOptionNonBacktracking).Replace("input", "$0", -1));
+            }
         }
 
         public static string MatchEvaluator1(Match match) => match.Value.ToLower() == "big" ? "Huge": "Tiny";
@@ -397,8 +415,9 @@ namespace System.Text.RegularExpressions.Tests
 
         public static IEnumerable<object[]> TestReplaceCornerCases_TestData()
         {
-            foreach (var options in new RegexOptions[] { RegexSRMTests.DFA, RegexOptions.None, RegexOptions.Compiled })
+            foreach (object[] data in NoneCompiledBacktracking())
             {
+                RegexOptions options = (RegexOptions)data[0];
                 yield return new object[] { "[ab]+", "012aaabb34bba56", "###", 0, "012aaabb34bba56", options };
                 yield return new object[] { "[ab]+", "012aaabb34bba56", "###", -1, "012###34###56", options };
                 yield return new object[] { @"\b", "Hello World!", "#", 2, "#Hello# World!", options };
@@ -419,8 +438,9 @@ namespace System.Text.RegularExpressions.Tests
 
         public static IEnumerable<object[]> TestReplaceWithSubstitution_TestData()
         {
-            foreach (var options in new RegexOptions[] { RegexSRMTests.DFA, RegexOptions.None, RegexOptions.Compiled })
+            foreach (object[] data in NoneCompiledBacktracking())
             {
+                RegexOptions options = (RegexOptions)data[0];
                 yield return new object[] { @"(\$\d+):(\d+)", "it costs $500000:55 I think", "$$???:${2}", "it costs $???:55 I think", options };
                 yield return new object[] { @"(\d+)([a-z]+)", "---12345abc---", "$2$1", "---abc12345---", options };
             }
@@ -429,7 +449,7 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(TestReplaceWithSubstitution_TestData))]
         private void TestReplaceWithSubstitution(string pattern, string input, string replacement, string expectedoutput, RegexOptions opt)
         {
-            if (opt == RegexSRMTests.DFA)
+            if (opt == RegexHelpers.RegexOptionNonBacktracking)
             {
                 Assert.Throws<NotSupportedException>(() => Regex.Replace(input, pattern, replacement, opt));
                 Assert.Throws<NotSupportedException>(() => new Regex(pattern, opt).Replace(input, replacement, -1));
@@ -445,9 +465,10 @@ namespace System.Text.RegularExpressions.Tests
 
         public static IEnumerable<object[]> TestReplaceWithToUpperMatchEvaluator_TestData()
         {
-            foreach (var opt in new RegexOptions[] { RegexSRMTests.DFA, RegexOptions.None, RegexOptions.Compiled })
+            foreach (object[] data in NoneCompiledBacktracking())
             {
-                yield return new object[] { @"(\bis\b)", "this is it", "this IS it", opt };
+                RegexOptions options = (RegexOptions)data[0];
+                yield return new object[] { @"(\bis\b)", "this is it", "this IS it", options };
             }
         }
         [Theory]

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Tests.Common.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Tests.Common.cs
@@ -1,11 +1,27 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Xunit;
+
 namespace System.Text.RegularExpressions.Tests
 {
     public static class RegexHelpers
     {
         public const string DefaultMatchTimeout_ConfigKeyName = "REGEX_DEFAULT_MATCH_TIMEOUT";
+
+        /// <summary>RegexOptions.NonBacktracking.</summary>
+        /// <remarks>Defined here to be able to reference the value by name even on .NET Framework test builds.</remarks>
+        public const RegexOptions RegexOptionNonBacktracking = (RegexOptions)0x400;
+
+        public const RegexOptions RegexOptionDebug = (RegexOptions)0x80;
+
+        static RegexHelpers()
+        {
+            if (PlatformDetection.IsNetCore)
+            {
+                Assert.Equal(RegexOptionNonBacktracking, Enum.Parse(typeof(RegexOptions), "NonBacktracking"));
+            }
+        }
 
         public static bool IsDefaultCount(string input, RegexOptions options, int count)
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.IO;
 using Xunit;
-using Xunit.Abstractions;
 using System.Diagnostics;
 using System.Reflection;
 
@@ -69,8 +68,6 @@ namespace System.Text.RegularExpressions.Tests
         /// Output directory for generated dgml files.
         /// </summary>
         private const string dgmloutdirectory = tmpWorkingDir + @"dgml\";
-
-        private static RegexOptions DFA = (RegexOptions)0x400;
 
         private static MethodInfo _Deserialize = typeof(Regex).GetMethod("Deserialize", BindingFlags.NonPublic | BindingFlags.Static);
         private static Regex Deserialize(string s) => _Deserialize.Invoke(null, new object[] { s }) as Regex;
@@ -195,7 +192,7 @@ namespace System.Text.RegularExpressions.Tests
         {
             string rawregex = @"\bis\w*\b";
             //string rawregex = And(".*[0-9].*", ".*[A-Z].*");
-            Regex re = new Regex(rawregex, DFA | RegexOptions.Singleline);
+            Regex re = new Regex(rawregex, RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
             ViewDGML(re);
             ViewDGML(re, inReverse: true);
             ViewDGML(re, addDotStar: true);
@@ -205,7 +202,7 @@ namespace System.Text.RegularExpressions.Tests
         {
             Regex reC = new Regex(rawregex, RegexOptions.Compiled, new TimeSpan(0, 0, 10));
             Regex reN = new Regex(rawregex, RegexOptions.None, new TimeSpan(0, 0, 10));
-            Regex reD = new Regex(rawregex, DFA);
+            Regex reD = new Regex(rawregex, RegexHelpers.RegexOptionNonBacktracking);
             Match mC;
             Match mN;
             Match mD;
@@ -251,7 +248,7 @@ namespace System.Text.RegularExpressions.Tests
             int k = rawregexes.Length;
             //construct
             var sw = Stopwatch.StartNew();
-            var rs = Array.ConvertAll(rawregexes, s => new Regex(s, DFA, new TimeSpan(0,0,1)));
+            var rs = Array.ConvertAll(rawregexes, s => new Regex(s, RegexHelpers.RegexOptionNonBacktracking, new TimeSpan(0,0,1)));
             int totConstrTime = (int)sw.ElapsedMilliseconds;
             //-------
             //serialize

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -23,8 +23,6 @@ namespace System.Text.RegularExpressions.Tests
 #endif
         }
 
-        internal const RegexOptions DFA = (RegexOptions)0x400;
-
         private const char Turkish_I_withDot = '\u0130';
         private const char Turkish_i_withoutDot = '\u0131';
         private const char Kelvin_sign = '\u212A';
@@ -38,7 +36,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"(?i:(\()((?<a>\w+(\.\w+)*)(,(?<a>\w+(\.\w+)*)*)?)(\)))", "some.text(this.is,the.match)", 1)]
         private void TestDifficultCasesForBacktracking(string pattern, string input, int matchcount)
         {
-            var regex = new Regex(pattern, DFA);
+            var regex = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking);
             List<Match> matches = new List<Match>();
             var match = regex.Match(input);
             while (match.Success)
@@ -63,7 +61,7 @@ namespace System.Text.RegularExpressions.Tests
             random.NextBytes(buffer);
             var input = new string(Array.ConvertAll(buffer, b => (b <= 0x7F ? 'a' : 'b')));
             input += input_suffix;
-            Regex re = new Regex(pattern, DFA | RegexOptions.Singleline);
+            Regex re = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
             Match m = re.Match(input);
             Assert.True(m.Success);
             Assert.Equal(buffer.Length, m.Index);
@@ -190,13 +188,13 @@ namespace System.Text.RegularExpressions.Tests
             {
                 char cU = char.ToUpper(c);
                 Assert.NotEqual(c, cU);
-                Assert.False(Regex.IsMatch(c.ToString(), cU.ToString(), RegexOptions.IgnoreCase | DFA));
+                Assert.False(Regex.IsMatch(c.ToString(), cU.ToString(), RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking));
             }
 
-            Assert.False(Regex.IsMatch(Turkish_i_withoutDot.ToString(), "i", RegexOptions.IgnoreCase | DFA));
-            Assert.True(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | DFA));
-            Assert.True(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | DFA));
-            Assert.False(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | DFA | RegexOptions.CultureInvariant));
+            Assert.False(Regex.IsMatch(Turkish_i_withoutDot.ToString(), "i", RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking));
+            Assert.True(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking));
+            Assert.True(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking));
+            Assert.False(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking | RegexOptions.CultureInvariant));
 
             // Turkish i without dot is not considered case-sensitive in the default en-US culture
             treatedAsCaseInsensitive.Add(Turkish_i_withoutDot);
@@ -209,7 +207,7 @@ namespace System.Text.RegularExpressions.Tests
             // test all case-sensitive characters exhaustively in DFA mode
             foreach (char c in caseSensitiveChars)
                 Assert.True(Regex.IsMatch(char.ToUpper(c).ToString() + char.ToLower(c).ToString(),
-                    c.ToString() + c.ToString(), RegexOptions.IgnoreCase | DFA));
+                    c.ToString() + c.ToString(), RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking));
         }
 
         [Theory]
@@ -221,7 +219,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("(ab|a|bcd|c)*d*", "ababcd", "0,6", "0,6")]       //same result with different order of choices
         public void TestAlternationOrderIndependenceInEagerLoop(string pattern, string input, string dfamatch, string nondfamatch)
         {
-            Regex r1 = new Regex(pattern, DFA);
+            Regex r1 = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking);
             Regex r1_ = new Regex(pattern);
             var m1 = r1.Match(input);
             var m1_ = r1_.Match(input);
@@ -250,7 +248,7 @@ namespace System.Text.RegularExpressions.Tests
             Match m_ = re_.Match(input);
             Assert.True(m_.Success);
             Assert.Equal(positions[0], m_.Index);
-            Regex re = new Regex(pattern, options | DFA);
+            Regex re = new Regex(pattern, options | RegexHelpers.RegexOptionNonBacktracking);
             Match m = re.Match(input);
             Assert.True(m.Success);
             Assert.Equal(positions[0], m.Index);
@@ -283,7 +281,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("(a\\Bb|a\\bb)", RegexOptions.None, "ab", true, "ab", 0)]
         public void TestAnchorPruning(string pattern, RegexOptions options, string input, bool success, string match, int index)
         {
-            Regex re = new Regex(pattern, options | DFA);
+            Regex re = new Regex(pattern, options | RegexHelpers.RegexOptionNonBacktracking);
             Match m = re.Match(input);
             Assert.Equal(success, m.Success);
             Assert.Equal(match, m.Value);
@@ -297,7 +295,7 @@ namespace System.Text.RegularExpressions.Tests
         public void TestConjunctionOverCounting(string conjunct1, string conjunct2, string input, bool success, string match)
         {
             string pattern = And(conjunct1, conjunct2);
-            Regex re = new Regex(pattern, DFA);
+            Regex re = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking);
             Match m = re.Match(input);
             Assert.Equal(success, m.Success);
             Assert.Equal(match, m.Value);
@@ -309,7 +307,7 @@ namespace System.Text.RegularExpressions.Tests
         public void TestDisjunctionOverCounting(string disjunct1, string disjunct2, string input, bool success, string match)
         {
             string pattern = disjunct1 + "|" + disjunct2;
-            Regex re = new Regex(pattern, DFA);
+            Regex re = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking);
             Match m = re.Match(input);
             Assert.Equal(success, m.Success);
             Assert.Equal(match, m.Value);
@@ -330,7 +328,7 @@ namespace System.Text.RegularExpressions.Tests
         public void TestOfCaseInsensitiveCornerCasesInSRM(string pattern, string input, bool success, string match_expected)
         {
             Regex r_ = new Regex(pattern);
-            Regex r = new Regex(pattern, DFA);
+            Regex r = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking);
             //RegexExperiment.ViewDGML(r);
             var m = r.Match(input);
             var m_ = r_.Match(input);
@@ -355,17 +353,17 @@ namespace System.Text.RegularExpressions.Tests
             CultureInfo savedCulture = CultureInfo.CurrentCulture;
             CultureInfo.CurrentCulture = tr_culture;
             //this will treat i=\u0130 and I=\u0131 but i!=I
-            Regex r_tr = new Regex(pattern, DFA);
+            Regex r_tr = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking);
             Regex r_tr_ = new Regex(pattern, RegexOptions.None);
             var s = r_tr.Match(input).Value;
             var s_ = r_tr_.Match(input).Value;
             CultureInfo.CurrentCulture = savedCulture;
             Assert.Equal(s, s_);
             //this will treat i=I and i!=\u0130 and I!=\u131
-            Regex r_in = new Regex(pattern, DFA | RegexOptions.CultureInvariant);
+            Regex r_in = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking | RegexOptions.CultureInvariant);
             //this is the default for e-US culture where
             //i=I=\u130 but I!=\u0131 
-            Regex r_en = new Regex(pattern, DFA);
+            Regex r_en = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking);
 
             TestOfCulturesInSRM_(r_en, r_in, r_tr, input, match_en_expected, match_in_expected, match_tr_expected);
 
@@ -395,7 +393,7 @@ namespace System.Text.RegularExpressions.Tests
         public void TestAltOrderIndependence()
         {
             string rawregex = @"(the)\s*(0?[1-9]|[12][0-9]|3[01])";
-            var re = new Regex(rawregex, DFA);
+            var re = new Regex(rawregex, RegexHelpers.RegexOptionNonBacktracking);
             var reC = new Regex(rawregex, RegexOptions.Compiled);
             var input = "it is the 10:00 time";
             var re_match = re.Match(input);
@@ -406,7 +404,7 @@ namespace System.Text.RegularExpressions.Tests
             //----
             //equivalent regex as DFA
             string rawregex_alt = @"(the)\s*([12][0-9]|3[01]|0?[1-9])";
-            var re_alt = new Regex(rawregex_alt, DFA);
+            var re_alt = new Regex(rawregex_alt, RegexHelpers.RegexOptionNonBacktracking);
             var re_alt_match = re_alt.Match(input);
             Assert.Equal(re_match.Index, re_alt_match.Index);
             Assert.Equal(re_match.Value, re_alt_match.Value);
@@ -425,7 +423,7 @@ namespace System.Text.RegularExpressions.Tests
             //the input has 2^12 * 50 = 204800 characters
             string rawregex = @"[\\/]?[^\\/]*?(heythere|hej)[^\\/]*?$";
             Regex reC = new Regex(rawregex, RegexOptions.Compiled, new TimeSpan(0, 0, 1));
-            Regex re = new Regex(rawregex, DFA, new TimeSpan(0, 0, 0, 0, 100));
+            Regex re = new Regex(rawregex, RegexHelpers.RegexOptionNonBacktracking, new TimeSpan(0, 0, 0, 0, 100));
             //it takes over 4min with backtracking, so 1sec times out for sure
             Assert.Throws<RegexMatchTimeoutException>(() => { reC.Match(input); });
             //DFA needs less than 100ms
@@ -436,13 +434,13 @@ namespace System.Text.RegularExpressions.Tests
         /// Test that timeout is being checked in DFA mode.
         /// </summary>
         [Fact]
-        public void TestSRMTimeout() => TestSRMTimeout_(new Regex(@"a.{20}$", DFA, new TimeSpan(0, 0, 0, 0, 10)));
+        public void TestSRMTimeout() => TestSRMTimeout_(new Regex(@"a.{20}$", RegexHelpers.RegexOptionNonBacktracking, new TimeSpan(0, 0, 0, 0, 10)));
 
         /// <summary>
         /// Test that serialization preserves timeout information.
         /// </summary>
         [Fact]
-        public void TestSRMTimeoutAfterDeser() => TestSRMTimeout_(Deserialize(Serialize(new Regex(@"a.{20}$", DFA, new TimeSpan(0, 0, 0, 0, 10)))));
+        public void TestSRMTimeoutAfterDeser() => TestSRMTimeout_(Deserialize(Serialize(new Regex(@"a.{20}$", RegexHelpers.RegexOptionNonBacktracking, new TimeSpan(0, 0, 0, 0, 10)))));
 
         private void TestSRMTimeout_(Regex re)
         {
@@ -467,7 +465,7 @@ namespace System.Text.RegularExpressions.Tests
         public void TestDGMLGeneration()
         {
             StringWriter sw = new StringWriter();
-            var re = new Regex(".*a+", DFA | RegexOptions.Singleline);
+            var re = new Regex(".*a+", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
             SaveDGML(re, sw);
             string str = sw.ToString();
             Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", str);
@@ -478,7 +476,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void TestWordBoundary()
         {
-            var re = new Regex(@"\b\w+nn\b", DFA);
+            var re = new Regex(@"\b\w+nn\b", RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("both Anne and Ann are names that contain nn");
             Assert.True(match.Success);
             Assert.Equal<int>(14, match.Index);
@@ -490,7 +488,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void TestStartSet()
         {
-            var re = new Regex(@"\u221E|\u2713", DFA);
+            var re = new Regex(@"\u221E|\u2713", RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("infinity \u221E and checkmark \u2713 are contained here");
             Assert.True(match.Success);
             Assert.Equal<int>(9, match.Index);
@@ -520,7 +518,7 @@ namespace System.Text.RegularExpressions.Tests
             string[] rawregexes = new string[] {@"\b\d\w+nn\b", "An+e", "^this", "(?i:Jaan$)", @"\p{Sm}+" };
             int k = rawregexes.Length;
             //DFA versions
-            var rs = Array.ConvertAll(rawregexes, s => new Regex(s, DFA));
+            var rs = Array.ConvertAll(rawregexes, s => new Regex(s, RegexHelpers.RegexOptionNonBacktracking));
             //Compiled versions
             var rsC = Array.ConvertAll(rawregexes, s => new Regex(s, RegexOptions.Compiled));
             //serialize
@@ -549,7 +547,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void SRMPrefixBugFixTest()
         {
-            var re1 = new Regex("(a|ba)c", DFA);
+            var re1 = new Regex("(a|ba)c", RegexHelpers.RegexOptionNonBacktracking);
             var match1 = re1.Match("bac");
             Assert.True(match1.Success);
             Assert.Equal(0, match1.Index);
@@ -569,13 +567,13 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTestBorderAnchors1()
         {
-            var re1 = new Regex(@"\B x", DFA);
+            var re1 = new Regex(@"\B x", RegexHelpers.RegexOptionNonBacktracking);
             var match1 = re1.Match(" xx");
             Assert.True(match1.Success);
             Assert.Equal(0, match1.Index);
             Assert.Equal(2, match1.Length);
             //---
-            var re2 = new Regex(@"\bxx\b", DFA);
+            var re2 = new Regex(@"\bxx\b", RegexHelpers.RegexOptionNonBacktracking);
             var match2 = re2.Match(" zxx:xx");
             Assert.True(match2.Success);
             Assert.Equal(5, match2.Index);
@@ -585,7 +583,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTestBorderAnchors2()
         {
-            var re3 = new Regex(@"^abc*\B", RegexOptions.Multiline | DFA);
+            var re3 = new Regex(@"^abc*\B", RegexOptions.Multiline | RegexHelpers.RegexOptionNonBacktracking);
             var match3 = re3.Match("\nabcc \nabcccd\n");
             Assert.True(match3.Success);
             Assert.Equal(1, match3.Index);
@@ -599,7 +597,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTestBorderAnchors3()
         {
-            var re = new Regex(@"a$", RegexOptions.Multiline | DFA);
+            var re = new Regex(@"a$", RegexOptions.Multiline | RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("b\na");
             Assert.True(match.Success);
             Assert.Equal(2, match.Index);
@@ -609,7 +607,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTest()
         {
-            var re = new Regex(@"a+", DFA);
+            var re = new Regex(@"a+", RegexHelpers.RegexOptionNonBacktracking);
             var match1 = re.Match("xxxxxaaaaxxxxxxxxxxaaaaaa");
             Assert.True(match1.Success);
             Assert.Equal(5, match1.Index);
@@ -627,7 +625,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTestWithIgnoreCase()
         {
-            var re = new Regex(@"a+", DFA | RegexOptions.IgnoreCase);
+            var re = new Regex(@"a+", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.IgnoreCase);
             var match1 = re.Match("xxxxxaAAaxxxxxxxxxxaaaaAa");
             Assert.True(match1.Success);
             Assert.Equal(5, match1.Index);
@@ -645,7 +643,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTestNonASCII()
         {
-            var re = new Regex(@"\d\s\w+", DFA);
+            var re = new Regex(@"\d\s\w+", RegexHelpers.RegexOptionNonBacktracking);
             var match1 = re.Match("=====1\v\u212A4==========1\ta\u0130Aa");
             Assert.True(match1.Success);
             Assert.Equal(5, match1.Index);
@@ -663,7 +661,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTest_WhiteSpace()
         {
-            var re = new Regex(@"\s+", DFA);
+            var re = new Regex(@"\s+", RegexHelpers.RegexOptionNonBacktracking);
             var match1 = re.Match("===== \n\t\v\r ====");
             Assert.True(match1.Success);
             Assert.Equal(5, match1.Index);
@@ -674,7 +672,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTest_FFFF()
         {
-            var re = new Regex(@"(\uFFFE\uFFFF)+", DFA);
+            var re = new Regex(@"(\uFFFE\uFFFF)+", RegexHelpers.RegexOptionNonBacktracking);
             var match1 = re.Match("=====\uFFFE\uFFFF\uFFFE\uFFFF\uFFFE====");
             Assert.True(match1.Success);
             Assert.Equal(5, match1.Index);
@@ -685,7 +683,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void BasicSRMTest_NoPartition()
         {
-            var re = new Regex(@"(...)+", DFA | RegexOptions.Singleline);
+            var re = new Regex(@"(...)+", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
             var match1 = re.Match("abcdefgh");
             Assert.True(match1.Success);
             Assert.Equal(0, match1.Index);
@@ -706,7 +704,7 @@ namespace System.Text.RegularExpressions.Tests
             //"Me", 7: EnclosingMark
             //"Nd", 8: DecimalDigitNumber
             //"Nl", 9: LetterNumber
-            var re = new Regex(@"\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Mn}\p{Mc}\p{Me}\p{Nd}\p{Nl}", DFA);
+            var re = new Regex(@"\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Mn}\p{Mc}\p{Me}\p{Nd}\p{Nl}", RegexHelpers.RegexOptionNonBacktracking);
             //match contains the first character from each category
             string input = "=====Aa\u01C5\u02B0\u01BB\u0300\u0903\u04880\u16EE===";
             var match1 = re.Match(input);
@@ -730,7 +728,7 @@ namespace System.Text.RegularExpressions.Tests
             //"Co", 17: PrivateUse
             //"Pc", 18: ConnectorPunctuation
             //"Pd", 19: DashPunctuation
-            var re = new Regex(@"\p{No}\p{Zs}\p{Zl}\p{Zp}\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Pc}\p{Pd}", DFA);
+            var re = new Regex(@"\p{No}\p{Zs}\p{Zl}\p{Zp}\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Pc}\p{Pd}", RegexHelpers.RegexOptionNonBacktracking);
             //match contains the first character from each category
             string input = "=====\u00B2 \u2028\u2029\0\u0600\uD800\uE000_\u002D===";
             var match1 = re.Match(input);
@@ -754,7 +752,7 @@ namespace System.Text.RegularExpressions.Tests
             //"Sk", 27: ModifierSymbol
             //"So", 28: OtherSymbol
             //"Cn", 29: OtherNotAssigned
-            var re = new Regex(@"\p{Ps}\p{Pe}\p{Pi}\p{Pf}\p{Po}\p{Sm}\p{Sc}\p{Sk}\p{So}\p{Cn}", DFA);
+            var re = new Regex(@"\p{Ps}\p{Pe}\p{Pi}\p{Pf}\p{Po}\p{Sm}\p{Sc}\p{Sk}\p{So}\p{Cn}", RegexHelpers.RegexOptionNonBacktracking);
             //match contains the first character from each category
             string input = "=====()\xAB\xBB!+$^\xA6\u0378======";
             var match1 = re.Match(input);
@@ -768,7 +766,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void SRMTest_UnicodeCategories00to29()
         {
-            var re = new Regex(@"\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Mn}\p{Mc}\p{Me}\p{Nd}\p{Nl}\p{No}\p{Zs}\p{Zl}\p{Zp}\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Pc}\p{Pd}\p{Ps}\p{Pe}\p{Pi}\p{Pf}\p{Po}\p{Sm}\p{Sc}\p{Sk}\p{So}\p{Cn}", DFA);
+            var re = new Regex(@"\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Mn}\p{Mc}\p{Me}\p{Nd}\p{Nl}\p{No}\p{Zs}\p{Zl}\p{Zp}\p{Cc}\p{Cf}\p{Cs}\p{Co}\p{Pc}\p{Pd}\p{Ps}\p{Pe}\p{Pi}\p{Pf}\p{Po}\p{Sm}\p{Sc}\p{Sk}\p{So}\p{Cn}", RegexHelpers.RegexOptionNonBacktracking);
             //match contains the first character from each category
             string input = "=====Aa\u01C5\u02B0\u01BB\u0300\u0903\u04880\u16EE\xB2 \u2028\u2029\0\u0600\uD800\uE000_\x2D()\xAB\xBB!+$^\xA6\u0378======";
             var match1 = re.Match(input);
@@ -783,7 +781,7 @@ namespace System.Text.RegularExpressions.Tests
         public void SRMTest_BV()
         {
              //this will need a total of 68 parts, thus will use the general BV algebra instead of BV64 algebra
-            var re = new Regex(@"(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>:;@)+", DFA);
+            var re = new Regex(@"(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>:;@)+", RegexHelpers.RegexOptionNonBacktracking);
             string input = "=====abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>:;@abcdefg======";
             var match1 = re.Match(input);
             Assert.True(match1.Success);
@@ -802,7 +800,7 @@ namespace System.Text.RegularExpressions.Tests
             //pattern_WL = "ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ０１２３４５６７８９＜＞：；＆＠％！"
             string pattern_WL = new String(Array.ConvertAll(pattern_orig.ToCharArray(), c => (char)((int)c + 0xFF00 - 32)));
             string pattern = "(" + pattern_orig + "===" + pattern_WL + ")+";
-            var re = new Regex(pattern, DFA);
+            var re = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking);
             string input = "=====" + pattern_orig + "===" + pattern_WL + pattern_orig + "===" + pattern_WL + "===" + pattern_orig + "===" + pattern_orig;
             var match1 = re.Match(input); 
             Assert.True(match1.Success);
@@ -820,7 +818,7 @@ namespace System.Text.RegularExpressions.Tests
             //pattern_WL = "ａｂｃ"
             string pattern_WL = new String(Array.ConvertAll(pattern_orig.ToCharArray(), c => (char)((int)c + 0xFF00 - 32)));
             string pattern = "(" + pattern_orig + "===" + pattern_WL + ")+";
-            var re = new Regex(pattern, DFA | RegexOptions.IgnoreCase);
+            var re = new Regex(pattern, RegexHelpers.RegexOptionNonBacktracking | RegexOptions.IgnoreCase);
             string input = "=====" + pattern_orig.ToUpper() + "===" + pattern_WL + pattern_orig + "===" + pattern_WL.ToUpper() + "===" + pattern_orig + "===" + pattern_orig;
             var match1 = re.Match(input);
             Assert.True(match1.Success);
@@ -848,7 +846,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void SRMTest_ConjuctionIsMatch()
         {
-            var re = new Regex(And(".*a.*",".*b.*"), DFA | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+            var re = new Regex(And(".*a.*",".*b.*"), RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline | RegexOptions.IgnoreCase);
             bool ok = re.IsMatch("xxaaxxBxaa");
             Assert.True(ok);
             bool fail = re.IsMatch("xxaaxxcxaa");
@@ -859,7 +857,7 @@ namespace System.Text.RegularExpressions.Tests
         public void SRMTest_ConjuctionFindMatch()
         {
             // contains lower, upper, and a digit, and is between 2 and 4 characters long
-            var re = new Regex(And(".*[a-z].*", ".*[A-Z].*", ".*[0-9].*", ".{2,4}"), DFA | RegexOptions.Singleline);
+            var re = new Regex(And(".*[a-z].*", ".*[A-Z].*", ".*[0-9].*", ".{2,4}"), RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
             var match = re.Match("xxaac\n5Bxaa");
             Assert.True(match.Success);
             Assert.Equal(4, match.Index);
@@ -871,7 +869,7 @@ namespace System.Text.RegularExpressions.Tests
         {
             // contains lower, upper, and a digit, and is between 4 and 8 characters long, does not contain 2 consequtive digits
             var re = new Regex(And(".*[a-z].*", ".*[A-Z].*", ".*[0-9].*", ".{4,8}",
-                Not(".*(01|12|23|34|45|56|67|78|89).*")), DFA | RegexOptions.Singleline);
+                Not(".*(01|12|23|34|45|56|67|78|89).*")), RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
             var match = re.Match("xxaac12Bxaas3455");
             Assert.True(match.Success);
             Assert.Equal(6, match.Index);
@@ -882,20 +880,20 @@ namespace System.Text.RegularExpressions.Tests
         public void SRMTest_LazyLoopMatch()
         {
             //eager
-            var re = new Regex("a[0-9]+0", DFA);
+            var re = new Regex("a[0-9]+0", RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("ababca123000xyz");
             Assert.True(match.Success);
             Assert.Equal(5, match.Index);
             Assert.Equal(7, match.Length);
             //---
             //lazy
-            var reL = new Regex("a[0-9]+?0", DFA);
+            var reL = new Regex("a[0-9]+?0", RegexHelpers.RegexOptionNonBacktracking);
             var matchL = reL.Match("ababca123000xyz");
             Assert.True(matchL.Success);
             Assert.Equal(5, matchL.Index);
             Assert.Equal(5, matchL.Length);
             //lazy and eager combined
-            var re2 = new Regex("a[0-9]+?0|b[0-9]+0", DFA);
+            var re2 = new Regex("a[0-9]+?0|b[0-9]+0", RegexHelpers.RegexOptionNonBacktracking);
             var match21 = re2.Match("ababca123000xyzababcb123000xyz");
             //the first match starting with 'a' uses lazy loop
             Assert.True(match21.Success);
@@ -912,7 +910,7 @@ namespace System.Text.RegularExpressions.Tests
         public void SRMTest_NestedLazyLoop()
         {
             //read lazily blocks of 3 x's at a time
-            var re = new Regex("(x{3})+?", DFA);
+            var re = new Regex("(x{3})+?", RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("abcxxxxxxxxacacaca");
             Assert.True(match.Success);
             Assert.Equal(3, match.Index);
@@ -923,7 +921,7 @@ namespace System.Text.RegularExpressions.Tests
         public void SRMTest_NestedEagerLoop()
         {
             //read eagerly blocks of 3 x's at a time
-            var re = new Regex("(x{3})+", DFA);
+            var re = new Regex("(x{3})+", RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("abcxxxxxxxxacacaca");
             Assert.True(match.Success);
             Assert.Equal(3, match.Index);
@@ -933,7 +931,7 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void SRMTest_CountedLazyLoop()
         {
-            var re = new Regex("a[bcd]{4,5}?(.)", DFA);
+            var re = new Regex("a[bcd]{4,5}?(.)", RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("acdbcdbe");
             Assert.True(match.Success);
             Assert.Equal(0, match.Index);
@@ -945,7 +943,7 @@ namespace System.Text.RegularExpressions.Tests
         public void SRMTest_CountedLoop()
         {
             //eager matching of the loop must match 5 elements in the loop
-            var re = new Regex("a[bcd]{4,5}(.)", DFA);
+            var re = new Regex("a[bcd]{4,5}(.)", RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("acdbcdbe");
             Assert.True(match.Success);
             Assert.Equal(0, match.Index);
@@ -955,13 +953,13 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void SRMTest_NewLine()
         {
-            var re = new Regex("\n", DFA);
+            var re = new Regex("\n", RegexHelpers.RegexOptionNonBacktracking);
             var match = re.Match("\n");
             Assert.True(match.Success);
             Assert.Equal(0, match.Index);
             Assert.Equal(1, match.Length);
             //---
-            var re2 = new Regex("[^a]", DFA);
+            var re2 = new Regex("[^a]", RegexHelpers.RegexOptionNonBacktracking);
             var match2 = re2.Match("\n");
             Assert.True(match2.Success);
             Assert.Equal(0, match2.Index);
@@ -975,7 +973,7 @@ namespace System.Text.RegularExpressions.Tests
             string actual = string.Empty;
             try
             {
-                new Regex(pattern, options | DFA);
+                new Regex(pattern, options | RegexHelpers.RegexOptionNonBacktracking);
             }
             catch (Exception e)
             {

--- a/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/libraries/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -28,11 +28,9 @@
     <Compile Include="RegexCharacterSetTests.cs" />
     <Compile Include="RegexCompilationHelper.cs" />
     <Compile Include="RegexCultureTests.cs" />
-    <Compile Include="RegexExperiment.cs" />
     <Compile Include="RegexMatchTimeoutExceptionTests.cs" />
     <Compile Include="RegexParserTests.cs" />
     <Compile Include="RegexReductionTests.cs" />
-    <Compile Include="RegexSRMTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Compile Include="..\src\System\Text\RegularExpressions\RegexParseError.cs" Link="System\Text\RegularExpressions\RegexParseError.cs" />
@@ -50,6 +48,8 @@
     <Compile Include="PrecompiledRegexScenarioTest.cs" />
     <Compile Include="RegexCompilationInfoTests.cs" />
     <Compile Include="RegexGroupNameTests.cs" />
+    <Compile Include="RegexExperiment.cs" />
+    <Compile Include="RegexSRMTests.cs" />
     <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs" Link="Common\System\Diagnostics\DebuggerAttributes.cs" />
     <Compile Include="..\src\System\Text\RegularExpressions\RegexCharClass.MappingTable.cs" Link="System\Text\RegularExpressions\RegexCharClass.MappingTable.cs" />
   </ItemGroup>


### PR DESCRIPTION
And fix execution of tests on .NET Framework.