### PR TITLE
Implement Control Flow Guard annotations

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Windows.props
@@ -19,6 +19,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <CppLibCreator>lib</CppLibCreator>
     <FullRuntimeName>Runtime</FullRuntimeName>
     <FullRuntimeName Condition="'$(ServerGarbageCollection)' != ''">Runtime.ServerGC</FullRuntimeName>
+    <FullRuntimeName Condition="'$(ControlFlowGuard)' == 'Guard'">Runtime.ServerGC.GuardCF</FullRuntimeName>
     <EntryPointSymbol Condition="'$(EntryPointSymbol)' == ''">wmainCRTStartup</EntryPointSymbol>
     <LinkerSubsystem Condition="'$(OutputType)' == 'WinExe' and '$(LinkerSubsystem)' == ''">WINDOWS</LinkerSubsystem>
     <LinkerSubsystem Condition="'$(OutputType)' == 'Exe' and '$(LinkerSubsystem)' == ''">CONSOLE</LinkerSubsystem>
@@ -76,6 +77,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Condition="'$(OutputType)' == 'WinExe' or '$(OutputType)' == 'Exe'" Include="/ENTRY:$(EntryPointSymbol)" />
       <LinkerArg Condition="$(NativeLib) == 'Shared'" Include="/INCLUDE:CoreRT_StaticInitialization" />
       <LinkerArg Include="/NATVIS:&quot;$(MSBuildThisFileDirectory)CoreRTNatVis.natvis&quot;" />
+      <LinkerArg Condition="'$(ControlFlowGuard)' == 'Guard'" Include="/guard:cf" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' != 'Debug'">

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -260,6 +260,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
       <IlcArg Condition="$(NoWarn) != ''" Include='--nowarn:"$([MSBuild]::Escape($(NoWarn)))"' />
       <IlcArg Condition="$(TrimmerSingleWarn) == 'true'" Include="--singlewarn" />
+      <IlcArg Condition="'$(ControlFlowGuard)' == 'Guard' and '$(TargetOS)' == 'windows'" Include="--guard:cf" />
       <IlcArg Include="@(_IlcRootedAssemblies->'--root:%(Identity)')" />
       <IlcArg Include="@(_IlcConditionallyRootedAssemblies->'--conditionalroot:%(Identity)')" />
       <IlcArg Include="@(_IlcNoSingleWarnAssemblies->'--nosinglewarnassembly:%(Filename)')" />

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -26,6 +26,12 @@ add_library(Runtime.ServerGC STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOU
 
 target_compile_definitions(Runtime.ServerGC PRIVATE -DFEATURE_SVR_GC)
 
+if (CLR_CMAKE_TARGET_WIN32)
+  add_library(Runtime.ServerGC.GuardCF STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM} ${SERVER_GC_SOURCES} ${RUNTIME_ARCH_ASM_OBJECTS})
+  target_compile_definitions(Runtime.ServerGC.GuardCF PRIVATE -DFEATURE_SVR_GC)
+  target_compile_options(Runtime.ServerGC.GuardCF PRIVATE /guard:cf)
+endif (CLR_CMAKE_TARGET_WIN32)
+
 # Get the current list of definitions
 get_compile_definitions(DEFINITIONS)
 
@@ -66,6 +72,12 @@ add_custom_target(
 
 add_dependencies(Runtime RuntimeAsmHelpers)
 add_dependencies(Runtime.ServerGC RuntimeAsmHelpers)
+if (CLR_CMAKE_TARGET_WIN32)
+  add_dependencies(Runtime.ServerGC.GuardCF RuntimeAsmHelpers)
+endif (CLR_CMAKE_TARGET_WIN32)
 
 install_static_library(Runtime aotsdk nativeaot)
 install_static_library(Runtime.ServerGC aotsdk nativeaot)
+if (CLR_CMAKE_TARGET_WIN32)
+  install_static_library(Runtime.ServerGC.GuardCF aotsdk nativeaot)
+endif (CLR_CMAKE_TARGET_WIN32)

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -29,7 +29,7 @@ target_compile_definitions(Runtime.ServerGC PRIVATE -DFEATURE_SVR_GC)
 if (CLR_CMAKE_TARGET_WIN32)
   add_library(Runtime.ServerGC.GuardCF STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOURCES} ${RUNTIME_SOURCES_ARCH_ASM} ${SERVER_GC_SOURCES} ${RUNTIME_ARCH_ASM_OBJECTS})
   target_compile_definitions(Runtime.ServerGC.GuardCF PRIVATE -DFEATURE_SVR_GC)
-  target_compile_options(Runtime.ServerGC.GuardCF PRIVATE /guard:cf)
+  target_compile_options(Runtime.ServerGC.GuardCF PRIVATE $<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:/guard:cf>)
 endif (CLR_CMAKE_TARGET_WIN32)
 
 # Get the current list of definitions

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 using Internal.JitInterface;
 
 namespace ILCompiler
@@ -21,6 +23,7 @@ namespace ILCompiler
         protected bool _methodBodyFolding;
         protected bool _singleThreaded;
         protected InstructionSetSupport _instructionSetSupport;
+        protected SecurityMitigationOptions _mitigationOptions;
 
         partial void InitializePartial()
         {
@@ -76,6 +79,12 @@ namespace ILCompiler
             return this;
         }
 
+        public CompilationBuilder UseSecurityMitigationOptions(SecurityMitigationOptions options)
+        {
+            _mitigationOptions = options;
+            return this;
+        }
+
         public CompilationBuilder UseMethodBodyFolding(bool enable)
         {
             _methodBodyFolding = enable;
@@ -105,5 +114,11 @@ namespace ILCompiler
         {
             return new ILScannerBuilder(_context, compilationGroup ?? _compilationGroup, _nameMangler, GetILProvider(), GetPreinitializationManager());
         }
+    }
+
+    [Flags]
+    public enum SecurityMitigationOptions
+    {
+        ControlFlowGuardAnnotations = 0x0001,
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -70,6 +70,9 @@ namespace ILCompiler
             if (_debugInformationProvider is not NullDebugInformationProvider)
                 options |= ObjectWritingOptions.GenerateDebugInfo;
 
+            if ((_compilationOptions & RyuJitCompilationOptions.ControlFlowGuardAnnotations) != 0)
+                options |= ObjectWritingOptions.ControlFlowGuard;
+
             ObjectWriter.EmitObject(outputFile, nodes, NodeFactory, options, dumper);
         }
 
@@ -214,5 +217,6 @@ namespace ILCompiler
     {
         MethodBodyFolding = 0x1,
         SingleThreadedCompilation = 0x2,
+        ControlFlowGuardAnnotations = 0x4,
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -110,6 +110,9 @@ namespace ILCompiler
             if (_singleThreaded)
                 options |= RyuJitCompilationOptions.SingleThreadedCompilation;
 
+            if ((_mitigationOptions & SecurityMitigationOptions.ControlFlowGuardAnnotations) != 0)
+                options |= RyuJitCompilationOptions.ControlFlowGuardAnnotations;
+
             var factory = new RyuJitNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider, GetPreinitializationManager());
 
             JitConfigProvider.Initialize(_context.Target, jitFlagBuilder.ToArray(), _ryujitOptions);


### PR DESCRIPTION
This is a set of changes required to enable control flow guard enforcement within the process. Control flow guard is a security mitigation feature that validates that indirect calls only land on addresses that are valid targets of indirect calls. It has two parts: identifying valid targets of indirect calls within the process, and checking whether target of indirect call is valid before dispatching to it.

This implements annotations and enforcement within the unmanaged parts of the NativeAOT runtime and the annotation-only part for the managed code. Enforcement will follow later.

Three kinds of changes:

* A new version of Runtime.lib that enables `/guard:cf` flag. This is in addition to the existing libraries since we don't want code to pay the perf penalty if CFG is not enabled.
* Annotating methods as valid CFG targets in the AOT compiler and object file writer.
* MSBuild support for new `<ControlFlowGuard>Guard</ControlFlowGuard>` property that enables all of this (passes a switch to the AOT compiler, selects the guarded version of runtime libraries to link with, and passes a switch to link.exe to enable CFG for the process).