### PR TITLE
fixed failing DGML test and turned back serialize-deserialize in DEBUG

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
@@ -61,9 +61,9 @@ namespace System.Text.RegularExpressions.SRM
         {
             var regex = new Regex(rootNode, options, matchTimeout, culture);
 #if DEBUG
-            //// Test the serialization roundtrip.
-            //// Effectively, here all tests in DEBUG mode are run with deserialized matchers, not the original ones.
-            //regex = Deserialize(regex.Serialize());
+            // Test the serialization roundtrip.
+            // Effectively, here all tests in DEBUG mode are run with deserialized matchers, not the original ones.
+            regex = Deserialize(regex.Serialize());
 #endif
             return regex;
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -466,11 +466,23 @@ namespace System.Text.RegularExpressions.Tests
         {
             StringWriter sw = new StringWriter();
             var re = new Regex(".*a+", RegexOptions.NonBacktracking | RegexOptions.Singleline);
+            RegexExperiment.ViewDGML(re, name : "TestDGMLGeneration");
             SaveDGML(re, sw);
             string str = sw.ToString();
             Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", str);
             Assert.Contains("DirectedGraph", str);
+#if DEBUG
+            // in debug mode re may be serialized and then deserialized internally 
+            // if that happens the predicate label .*a+ becomes .*[2]+
+            // the partition of characters in this regex is into two sets (in binary):
+            //   01 or [1] representing [^a]  (first part)
+            //   10 or [2] representinng 'a' (second part) which is where 2 comes from
+            //   (3rd part would be 100 = [4], 4th 1000 = [8] etc)
+            // '.' here is the union of all parts, i.e. 01 and 10 that is 11 (in binary internally) but printed as '.' also.
+            Assert.True(str.Contains(".*a+") || str.Contains(".*[2]+"));
+#else
             Assert.Contains(".*a+", str);
+#endif
         }
 
         [Fact]

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -471,7 +471,6 @@ namespace System.Text.RegularExpressions.Tests
             string str = sw.ToString();
             Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", str);
             Assert.Contains("DirectedGraph", str);
-#if DEBUG
             // in debug mode re may be serialized and then deserialized internally 
             // if that happens the predicate label .*a+ becomes .*[2]+
             // the partition of characters in this regex is into two sets (in binary):
@@ -480,9 +479,6 @@ namespace System.Text.RegularExpressions.Tests
             //   (3rd part would be 100 = [4], 4th 1000 = [8] etc)
             // '.' here is the union of all parts, i.e. 01 and 10 that is 11 (in binary internally) but printed as '.' also.
             Assert.True(str.Contains(".*a+") || str.Contains(".*[2]+"));
-#else
-            Assert.Contains(".*a+", str);
-#endif
         }
 
         [Fact]

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -466,7 +466,7 @@ namespace System.Text.RegularExpressions.Tests
         {
             StringWriter sw = new StringWriter();
             var re = new Regex(".*a+", RegexOptions.NonBacktracking | RegexOptions.Singleline);
-            RegexExperiment.ViewDGML(re, name : "TestDGMLGeneration");
+            // RegexExperiment.ViewDGML(re, name : "TestDGMLGeneration");
             SaveDGML(re, sw);
             string str = sw.ToString();
             Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", str);


### PR DESCRIPTION
One test was failing because when an SRM internal regex is serialized and then deserialized with the internal base64 coder the 
direct pretty-printing info of individual predicates and chars is lost and only preserved at an abstract level.
Relaxed the test to check this, and turned the serialization/deserializtion back on in DEBUG mode so that 
whenever an SRM internal regex is created it is run through the serialize/deserialize loop. 
The release build will of course not do that, 
so both forms (original one and ser-deser-version) are in fact being tested in the end.