### PR TITLE
Stop running FileSystem tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -284,7 +284,6 @@
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" Condition="'$(TargetOS)' != 'OSX'" />
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" Condition="'$(__DistroRid)' != 'linux-musl-x64'"/>
     <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.Threading\tests\System.Threading.Tests.csproj" />
-    <ProjectExclusions Remove="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" Condition="'$(TargetOS)' != 'OSX'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I cannot repro the issue the CI is running into locally

The CI and official builds periodically fail with:

```
D:\workspace\_work\1\s\.dotnet\sdk\6.0.100-rc.1.21411.28\Microsoft.Common.CurrentVersion.targets(4606,5): error MSB3026: Could not copy "D:\workspace\_work\1\s\artifacts\obj\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll" to "D:\workspace\_work\1\s\artifacts\bin\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll". Beginning retry 1 in 1000ms. The requested operation cannot be performed on a file with a user-mapped section open. : 'D:\workspace\_work\1\s\artifacts\bin\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll'  [D:\workspace\_work\1\s\src\libraries\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj]
D:\workspace\_work\1\s\.dotnet\sdk\6.0.100-rc.1.21411.28\Microsoft.Common.CurrentVersion.targets(4606,5): error MSB3026: Could not copy "D:\workspace\_work\1\s\artifacts\obj\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll" to "D:\workspace\_work\1\s\artifacts\bin\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll". Beginning retry 2 in 1000ms. The requested operation cannot be performed on a file with a user-mapped section open. : 'D:\workspace\_work\1\s\artifacts\bin\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll'  [D:\workspace\_work\1\s\src\libraries\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj]
D:\workspace\_work\1\s\.dotnet\sdk\6.0.100-rc.1.21411.28\Microsoft.Common.CurrentVersion.targets(4606,5): error MSB3026: Could not copy "D:\workspace\_work\1\s\artifacts\obj\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll" to "D:\workspace\_work\1\s\artifacts\bin\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll". Beginning retry 3 in 1000ms. The requested operation cannot be performed on a file with a user-mapped section open. : 'D:\workspace\_work\1\s\artifacts\bin\System.Security.Principal.Windows\net6.0-windows-Release\System.Security.Principal.Windows.dll'  [D:\workspace\_work\1\s\src\libraries\System.Security.Principal.Windows\src\System.Security.Principal.Windows.csproj]
```

When running locally (build first, then `build libs.tests -test`) I cannot see a single write to System.Security.Principal.Windows.dll (i.e. it's not that I don't hit a race, it's up to date and there's no reason to build it even once - as I would expect).

The reference comes from the FileSystem test. So just removing this test for now to unblock official builds.