### PR TITLE
Speed up StElemRef if there's no covariance

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Object.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Object.cs
@@ -45,6 +45,9 @@ namespace System
             }
         }
 
+        [Runtime.CompilerServices.Intrinsic]
+        internal static extern MethodTable* MethodTableOf<T>();
+
         internal EETypePtr EETypePtr
         {
             get

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.CoreRT.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Object.CoreRT.cs
@@ -38,6 +38,9 @@ namespace System
         }
 #endif
 
+        [Runtime.CompilerServices.Intrinsic]
+        internal static extern MethodTable* MethodTableOf<T>();
+
         [Intrinsic]
         public Type GetType()
         {

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Object.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Object.cs
@@ -56,6 +56,9 @@ namespace System
             }
         }
 
+        [Runtime.CompilerServices.Intrinsic]
+        internal static extern MethodTable* MethodTableOf<T>();
+
         [StructLayout(LayoutKind.Sequential)]
         private class RawData
         {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.Intrinsics.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.Intrinsics.cs
@@ -98,6 +98,7 @@ namespace Internal.JitInterface
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Ctor, ".ctor", "System", "ByReference`1");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_ByReference_Value, "get_Value", "System", "ByReference`1");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "EETypePtrOf", "System", "EETypePtr");
+            table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "MethodTableOf", "System", "Object");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "DefaultConstructorOf", "System", "Activator");
             table.Add(CorInfoIntrinsics.CORINFO_INTRINSIC_GetRawHandle, "AllocatorOf", "System", "Activator");
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -1240,12 +1240,13 @@ namespace Internal.IL
 
         private bool IsEETypePtrOf(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name == "EETypePtrOf" && method.Instantiation.Length == 1)
+            if (method.IsIntrinsic && (method.Name == "EETypePtrOf" || method.Name == "MethodTableOf") && method.Instantiation.Length == 1)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    return owningType.Name == "EETypePtr" && owningType.Namespace == "System";
+                    return (owningType.Name == "EETypePtr" && owningType.Namespace == "System")
+                        || (owningType.Name == "Object" && owningType.Namespace == "System");
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1546,6 +1546,7 @@ namespace Internal.JitInterface
             switch (method.Name)
             {
                 case "EETypePtrOf":
+                case "MethodTableOf":
                     ComputeLookup(ref pResolvedToken, method.Instantiation[0], ReadyToRunHelperId.TypeHandle, ref pResult.lookup);
                     break;
                 case "DefaultConstructorOf":


### PR DESCRIPTION
Makes storing into arrays 40% faster if there's no covariance.

I added `Object.MethodTableOf<T>` because `EETypePtrOf<T>` was causing a spill into a temporary and was messing up codegen and we'll want this for #232 anyway. I wanted to add `MethodTable.Of<T>`, but `Object` has a property named `MethodTable` and that was breaking the pattern. So it's on `Object`. Oh well.