### PR TITLE
lifted all Groups.Tests also to consider NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -6,6 +6,12 @@ using System.Globalization;
 using System.Tests;
 using Xunit;
 
+using System.IO;
+using Xunit.Abstractions;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+
 namespace System.Text.RegularExpressions.Tests
 {
     public class RegexGroupTests
@@ -502,12 +508,13 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"^(([d-f]*)|([c-e]*))$", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "", "dddeeeccceee" } };
             yield return new object[] { null, @"^(([c-e]*)|([d-f]*))$", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
 
-            yield return new object[] { null, @"(([a-d]*)|([a-z]*))", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", "" } };
-            yield return new object[] { null, @"(([d-f]*)|([c-e]*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeee", "dddeee", "dddeee", "" } };
+            // Different match in NonBackTracking when order of alternations does not matter
+            yield return new object[] { null, @"(([a-d]*)|([a-z]*))", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", "" }, "aaabbbcccdddeeefff" }; // <-- Nonbacktracking match same as for "(([a-z]*)|([a-d]*))"
+            yield return new object[] { null, @"(([d-f]*)|([c-e]*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeee", "dddeee", "dddeee", "" }, "dddeeeccceee" }; // <-- Nonbacktracking match same as for "(([c-e]*)|([d-f]*))"
             yield return new object[] { null, @"(([c-e]*)|([d-f]*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
 
-            yield return new object[] { null, @"(([a-d]*)|(.*))", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", "" } };
-            yield return new object[] { null, @"(([d-f]*)|(.*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeee", "dddeee", "dddeee", "" } };
+            yield return new object[] { null, @"(([a-d]*)|(.*))", "aaabbbcccdddeeefff", RegexOptions.None, new string[] { "aaabbbcccddd", "aaabbbcccddd", "aaabbbcccddd", "" }, "aaabbbcccdddeeefff" }; // <-- Nonbacktracking match same as for ".*"
+            yield return new object[] { null, @"(([d-f]*)|(.*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeee", "dddeee", "dddeee", "" }, "dddeeeccceee" }; // <-- Nonbacktracking match same as for ".*"
             yield return new object[] { null, @"(([c-e]*)|(.*))", "dddeeeccceee", RegexOptions.None, new string[] { "dddeeeccceee", "dddeeeccceee", "dddeeeccceee", "" } };
 
             // \p{Pi} (Punctuation Initial quote) \p{Pf} (Punctuation Final quote)
@@ -769,7 +776,8 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @"(?s).*(?-s)[1a]", "\n\n\n\n1", RegexOptions.None, new string[] { "\n\n\n\n1" } };
             yield return new object[] { null, @".*|.*|.*", "", RegexOptions.None, new string[] { "" } };
             yield return new object[] { null, @".*123|abc", "abc\n123", RegexOptions.None, new string[] { "abc" } };
-            yield return new object[] { null, @".*123|abc", "abc\n123", RegexOptions.Singleline, new string[] { "abc\n123" } };
+            yield return new object[] { null, @".*123|abc", "abc\n123", RegexOptions.Singleline, new string[] { "abc\n123" }, "abc" }; // <-- Nonbacktracking match same as for "abc|.*123"
+            yield return new object[] { null, @"abc|.*123", "abc\n123", RegexOptions.Singleline, new string[] { "abc" } };
             yield return new object[] { null, @".*", "\n", RegexOptions.None, new string[] { "" } };
             yield return new object[] { null, @".*\n", "\n", RegexOptions.None, new string[] { "\n" } };
             yield return new object[] { null, @".*", "\n", RegexOptions.Singleline, new string[] { "\n" } };
@@ -777,7 +785,8 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { null, @".*", "abc", RegexOptions.None, new string[] { "abc" } };
             yield return new object[] { null, @".*abc", "abc", RegexOptions.None, new string[] { "abc" } };
             yield return new object[] { null, @".*abc|ghi", "ghi", RegexOptions.None, new string[] { "ghi" } };
-            yield return new object[] { null, @".*abc|.*ghi", "abcghi", RegexOptions.None, new string[] { "abc" } };
+            yield return new object[] { null, @".*abc|.*ghi", "abcghi", RegexOptions.None, new string[] { "abc" }, "abcghi" }; // <-- Nonbacktracking match same as for ".*ghi|.*abc"
+            yield return new object[] { null, @".*ghi|.*abc", "abcghi", RegexOptions.None, new string[] { "abcghi" } };
             yield return new object[] { null, @".*abc|.*ghi", "bcghi", RegexOptions.None, new string[] { "bcghi" } };
             yield return new object[] { null, @".*abc|.+c", " \n   \n   bc", RegexOptions.None, new string[] { "   bc" } };
             yield return new object[] { null, @".*abc", "12345 abc", RegexOptions.None, new string[] { "12345 abc" } };
@@ -905,7 +914,7 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(Groups_CustomCulture_TestData_AzeriLatin))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/56407", TestPlatforms.Android)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/36900", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
-        public void Groups(string cultureName, string pattern, string input, RegexOptions options, string[] expectedGroups)
+        public void Groups(string cultureName, string pattern, string input, RegexOptions options, string[] expectedGroups, string altMatch = null)
         {
             if (cultureName is null)
             {
@@ -917,16 +926,39 @@ namespace System.Text.RegularExpressions.Tests
             {
                 Groups(pattern, input, options, expectedGroups);
                 Groups(pattern, input, RegexOptions.Compiled | options, expectedGroups);
+                // Alternative altMatch when order of alternations matters in backtracking but order does not matter in NonBacktracking mode
+                // Also in NonBacktracking there is only a single top-level match, which is expectedGroups[0] when altMatch is null
+                Groups(pattern, input, RegexHelpers.RegexOptionNonBacktracking | options, new string[] { altMatch == null ? expectedGroups[0] : altMatch });
             }
 
             static void Groups(string pattern, string input, RegexOptions options, string[] expectedGroups)
             {
-                Regex regex = new Regex(pattern, options);
+                Regex regex;
+                if ((options & RegexHelpers.RegexOptionNonBacktracking) != 0)
+                {
+                    if (pattern.Contains("?(cat)"))
+                        // General if-then-else construct is not supported and uses the ?(cat) condition in the tests
+                        // TODO: The constructor will throw NotSupportedException so this check will become obsolete
+                        return;
+                    try
+                    {
+                        regex = new Regex(pattern, options);
+                    }
+                    catch (NotSupportedException)
+                    {
+                        // Some constructs are not suppoted in NonBacktracking mode, such as: if-then-else, lookaround, and backreferences
+                        return;
+                    }
+                }
+                else
+                {
+                    regex = new Regex(pattern, options);
+                }
                 Match match = regex.Match(input);
-                Assert.True(match.Success);
 
-                Assert.Equal(expectedGroups.Length, match.Groups.Count);
+                Assert.True(match.Success);
                 Assert.Equal(expectedGroups[0], match.Value);
+                Assert.Equal(expectedGroups.Length, match.Groups.Count);
 
                 int[] groupNumbers = regex.GetGroupNumbers();
                 string[] groupNames = regex.GetGroupNames();

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -6,12 +6,6 @@ using System.Globalization;
 using System.Tests;
 using Xunit;
 
-using System.IO;
-using Xunit.Abstractions;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.Serialization;
-
 namespace System.Text.RegularExpressions.Tests
 {
     public class RegexGroupTests

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -48,8 +48,9 @@ namespace System.Text.RegularExpressions.Tests
             genUnicode.Invoke(null, new object[] { s_tmpWorkingDir });
         }
 
-        [ConditionalTheory(nameof(Enabled))]
-        [InlineData(@"((?<=\w)(?!\w)|(?<!\w)(?=\w))", 3)] // word-border anchor
+        [Theory]
+        [InlineData(@"\b", 3)]
+        [InlineData(@"((?<=\w)(?!\w)|(?<!\w)(?=\w))", 3)] // similar to word-border anchor
         [InlineData(@"((?<=\w)(?=\W)|(?<=\W)(?=\w))", 1)]
         public void TestLookaround(string pattern, int expectedCount)
         {


### PR DESCRIPTION
All groups tests successfully lifted to the NonBacktracking option as an additional case (totalling essentially over 600 new individual cases, but each case still falls under an old test -- btw. this is also true for Compiled  -- just added NonBacktracking in the same way that Compiled was added, which resulted in a very small edit actually)

Had to explicitly single out some cases that use conditionals for now (a few tests that use "?(cat)" as a test).  Once the parser will throw NotSupportedException this check can(should) be omitted. This is a fairly small and not-so-important todo item, as nothing much will really change as far as the involved logic of the tests is concerned.