### PR TITLE
support for Regex.Split in NonBacktracking mode

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -109,7 +109,6 @@ namespace System.Text.RegularExpressions
                         break;
                     }
 
-                    // Omit the matched substring itself and find the next match
                     match = match.NextMatch();
                 }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -87,7 +87,36 @@ namespace System.Text.RegularExpressions
             count--;
             (List<string> results, int prevat, string input, int count) state = (results: new List<string>(), prevat: 0, input, count);
 
-            if (!regex.RightToLeft)
+            if (regex._srm is not null)
+            {
+                Match match = regex.Match(input, startat, input.Length - startat);
+                if (!match.Success)
+                {
+                    // If there is no match then return the input as the only part in the split
+                    return new[] { input };
+                }
+
+                while (match.Success)
+                {
+                    // Add the substring before the found match, this may be empty
+                    state.results.Add(state.input.Substring(state.prevat, match.Index - state.prevat));
+                    state.prevat = match.Index + match.Length;
+
+                    if (--state.count == 0)
+                    {
+                        // If the maximum number of allowed mathes is reached break the splitting
+                        // If the initial value of count is 0 or negative this value just keeps decreasing further
+                        break;
+                    }
+
+                    // Omit the matched substring itself and find the next match
+                    match = match.NextMatch();
+                }
+
+                // Add the final suffix that either did not contain any matches or was cut off due to max split count being reached, this may be empty
+                state.results.Add(state.input.Substring(state.prevat, input.Length - state.prevat));
+            }
+            else if (!regex.RightToLeft)
             {
                 regex.Run(input, startat, ref state, static (ref (List<string> results, int prevat, string input, int count) state, Match match) =>
                 {

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -922,7 +922,10 @@ namespace System.Text.RegularExpressions.Tests
                 Groups(pattern, input, RegexOptions.Compiled | options, expectedGroups);
                 // Alternative altMatch when order of alternations matters in backtracking but order does not matter in NonBacktracking mode
                 // Also in NonBacktracking there is only a single top-level match, which is expectedGroups[0] when altMatch is null
-                Groups(pattern, input, RegexHelpers.RegexOptionNonBacktracking | options, new string[] { altMatch == null ? expectedGroups[0] : altMatch });
+                if (!PlatformDetection.IsNetFramework)
+                {
+                    Groups(pattern, input, RegexHelpers.RegexOptionNonBacktracking | options, new string[] { altMatch == null ? expectedGroups[0] : altMatch });
+                }
             }
 
             static void Groups(string pattern, string input, RegexOptions options, string[] expectedGroups)

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Split.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Split.Tests.cs
@@ -57,7 +57,7 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { @"(?<=\G..)(?=..)", "aabbccdd", RegexOptions.None, 8, 0, new string[] { "aa", "bb", "cc", "dd" } };
         }
 
-        // Test data addjusted from Split_TestData for RegexOptions.NonBacktracking
+        // Test data adjusted from Split_TestData for RegexOptions.NonBacktracking
         public static IEnumerable<object[]> Split_TestData_NonBacktracking()
         {
             yield return new object[] { "", "", RegexHelpers.RegexOptionNonBacktracking, 0, 0, new string[] { "", "" } };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Split.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Split.Tests.cs
@@ -60,6 +60,11 @@ namespace System.Text.RegularExpressions.Tests
         // Test data adjusted from Split_TestData for RegexOptions.NonBacktracking
         public static IEnumerable<object[]> Split_TestData_NonBacktracking()
         {
+            if (PlatformDetection.IsNetFramework)
+            {
+                yield break;
+            }
+
             yield return new object[] { "", "", RegexHelpers.RegexOptionNonBacktracking, 0, 0, new string[] { "", "" } };
             yield return new object[] { "123", "abc", RegexHelpers.RegexOptionNonBacktracking, 3, 0, new string[] { "abc" } };
 
@@ -97,6 +102,11 @@ namespace System.Text.RegularExpressions.Tests
         {         
             foreach (var options in new RegexOptions[] { RegexHelpers.RegexOptionNonBacktracking, RegexOptions.None, RegexOptions.Compiled })
             {
+                if (PlatformDetection.IsNetFramework && options == RegexHelpers.RegexOptionNonBacktracking)
+                {
+                    yield break;
+                }
+
                 yield return new object[] { @"\b", "Hello World!", options, 3, 6, new string[] { "Hello ", "World", "!" } };
                 yield return new object[] { @"\b", "Hello World!", options, 0, 0, new string[] { "", "Hello", " ", "World", "!" } };
                 yield return new object[] { @"^", "Hello \nWorld!", options | RegexOptions.Multiline, 0, 0, new string[] { "", "Hello \n", "World!" } };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Split.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Split.Tests.cs
@@ -69,19 +69,16 @@ namespace System.Text.RegularExpressions.Tests
             yield return new object[] { ":", "kkk:lll:mmm:nnn:ooo", RegexHelpers.RegexOptionNonBacktracking, 0, 0, new string[] { "kkk", "lll", "mmm", "nnn", "ooo" } };
 
             // RegexOptions.NonBacktracking is similar to RegexOptions.ExplicitCapture when there are no explicit capture names because NonBacktracking does not support captures
-            // This is the reason for including the RegexOptions.ExplicitCapture options after the tests to check that the results are the same in this case
-            yield return new object[] { @"(\s)?(-)", "once -upon-a time", RegexHelpers.RegexOptionNonBacktracking, 17, 0, new string[] { "once", "upon", "a time" } };
-            yield return new object[] { @"(\s)?(-)", "once -upon-a time", RegexOptions.ExplicitCapture, 17, 0, new string[] { "once", "upon", "a time" } };
-            yield return new object[] { @"(\s)?(-)", "once upon a time", RegexHelpers.RegexOptionNonBacktracking, 16, 0, new string[] { "once upon a time" } };
-            yield return new object[] { @"(\s)?(-)", "once upon a time", RegexOptions.ExplicitCapture, 16, 0, new string[] { "once upon a time" } };
-            yield return new object[] { @"(\s)?(-)", "once - -upon- a- time", RegexHelpers.RegexOptionNonBacktracking, 21, 0, new string[] { "once", "", "upon", " a", " time" } };
-            yield return new object[] { @"(\s)?(-)", "once - -upon- a- time", RegexOptions.ExplicitCapture, 21, 0, new string[] { "once", "", "upon", " a", " time" } };
-            yield return new object[] { "a(.)c(.)e", "123abcde456aBCDe789", RegexHelpers.RegexOptionNonBacktracking, 19, 0, new string[] { "123", "456aBCDe789" } };
-            yield return new object[] { "a(.)c(.)e", "123abcde456aBCDe789", RegexOptions.ExplicitCapture, 19, 0, new string[] { "123", "456aBCDe789" } };
-            yield return new object[] { "a.c.e", "123abcde456aBCDe789", RegexHelpers.RegexOptionNonBacktracking, 19, 0, new string[] { "123", "456aBCDe789" } };
-            yield return new object[] { "a.c.e", "123abcde456aBCDe789", RegexOptions.ExplicitCapture, 19, 0, new string[] { "123", "456aBCDe789" } };
-            yield return new object[] { "a.c.e", "123abcde456aBCDe789", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.IgnoreCase, 19, 0, new string[] { "123", "456", "789" } };
-            yield return new object[] { "a.c.e", "123abcde456aBCDe789", RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase, 19, 0, new string[] { "123", "456", "789" } };
+            // This is the reason for including the RegexOptions.ExplicitCapture options also to check that the results are the same in this case
+            foreach (RegexOptions options in new[] { RegexHelpers.RegexOptionNonBacktracking, RegexOptions.ExplicitCapture })
+            {
+                yield return new object[] { @"(\s)?(-)", "once -upon-a time", options, 17, 0, new string[] { "once", "upon", "a time" } };
+                yield return new object[] { @"(\s)?(-)", "once upon a time", options, 16, 0, new string[] { "once upon a time" } };
+                yield return new object[] { @"(\s)?(-)", "once - -upon- a- time", options, 21, 0, new string[] { "once", "", "upon", " a", " time" } };
+                yield return new object[] { "a(.)c(.)e", "123abcde456aBCDe789", options, 19, 0, new string[] { "123", "456aBCDe789" } };
+                yield return new object[] { "a.c.e", "123abcde456aBCDe789", options, 19, 0, new string[] { "123", "456aBCDe789" } };
+                yield return new object[] { "a.c.e", "123abcde456aBCDe789", options | RegexOptions.IgnoreCase, 19, 0, new string[] { "123", "456", "789" } };
+            }
 
             // RegexOptions.NonBacktracking also ignores named captures as if they were not given
             yield return new object[] { "a(?<dot1>.)c(.)e", "123abcde456aBCDe789", RegexHelpers.RegexOptionNonBacktracking, 19, 0, new string[] { "123", "456aBCDe789" } };


### PR DESCRIPTION
Implemented `Split `for `NonBacktracking `mode. 
Lifted all `Split `unit tests to the `NonBacktracking  `mode (with some adjustments because captures are not supported).
Added some new tests for (`None`, `Compiled`, and `NonBacktracking`) to verify correct/same behavior of unusual cases involving Split based on anchors (such tests were missing before).