### PR TITLE
NativeAOT-LLVM: Reflection fix - add test and dependency for GetDependenciesDueToAccess

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -3,12 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Internal.TypeSystem;
 using ILCompiler;
 using LLVMSharp.Interop;
@@ -17,7 +14,6 @@ using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.LLVM;
 using Internal.IL.Stubs;
-using Internal.ReadyToRunConstants;
 using Internal.TypeSystem.Ecma;
 
 namespace Internal.IL

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -17,6 +17,7 @@ using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.LLVM;
 using Internal.IL.Stubs;
+using Internal.ReadyToRunConstants;
 using Internal.TypeSystem.Ecma;
 
 namespace Internal.IL
@@ -1801,6 +1802,8 @@ namespace Internal.IL
         {
             MethodDesc runtimeDeterminedMethod = (MethodDesc)_methodIL.GetObject(token);
             MethodDesc callee = (MethodDesc)_canonMethodIL.GetObject(token);
+            _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, callee);
+
             if (callee.IsIntrinsic)
             {
                 if (ImportIntrinsicCall(callee, runtimeDeterminedMethod))

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -4555,6 +4555,7 @@ namespace Internal.IL
 
         private LLVMValueRef GetFieldAddress(FieldDesc runtimeDeterminedField, FieldDesc field, bool isStatic)
         {
+            _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _dependencies, _compilation.NodeFactory, _canonMethodIL, field);
             if (field.IsStatic)
             {
                 //pop unused value

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -31,7 +31,6 @@
 
     <ItemGroup Condition="'$(TestBuildMode)' == 'nativeaot' and '$(TargetArchitecture)' == 'wasm'">
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\BasicThreading\BasicThreading.csproj" />
-      <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\DataFlow\DataFlow.csproj" />
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\HardwareIntrinsics\*.csproj" />
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\Delegates\Delegates.csproj" />
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\DynamicGenerics\DynamicGenerics.csproj" />

--- a/src/tests/nativeaot/SmokeTests/Dataflow/Dataflow.cs
+++ b/src/tests/nativeaot/SmokeTests/Dataflow/Dataflow.cs
@@ -14,6 +14,7 @@ class Program
     static int Main()
     {
         TestReturnValue.Run();
+        TestFieldAccess.Run();
         TestGetMethodEventFieldPropertyConstructor.Run();
         TestGetInterface.Run();
         TestInGenericCode.Run();
@@ -55,6 +56,26 @@ class Program
 
             GiveMePublicAndPrivate();
             Assert.Equal(2, typeof(PublicAndPrivate).CountConstructors());
+        }
+    }
+
+    class TestFieldAccess
+    {
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
+        static Type s_annotatedType;
+
+        static class TestClass
+        {
+            public static void UnusedButKeptMethod() { }
+        }
+
+        private static void SetField() => s_annotatedType = typeof(TestClass);
+
+        public static void Run()
+        {
+            SetField();
+
+            Assert.Equal(1, typeof(TestClass).CountPublicMethods());
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -373,6 +373,8 @@ internal static class Program
 
         TestBoolCompare();
 
+        TestGetDependenciesDueToAccess();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -3464,6 +3466,23 @@ internal static class Program
         bool expected = true;
         bool actual = true;
         EndTest(expected.Equals(actual));
+    }
+
+    public class BaseClass<T>
+    {
+        public virtual string GVMethod1<U>(T t, U u) { return "BaseClass.GVMethod1"; }
+    }
+
+    public class DerivedClass1<T> : BaseClass<T>
+    {
+        public override sealed string GVMethod1<U>(T t, U u) { return "DerivedClass1.GVMethod1"; }
+    }
+
+    static void TestGetDependenciesDueToAccess()
+    {
+        StartTest("Test GetDependenciesDueToAccess (MakeGenericMethod)");
+        MethodInfo gvm1 = typeof(DerivedClass1<string>).GetTypeInfo().GetDeclaredMethod("GVMethod1").MakeGenericMethod(typeof(string));
+        EndTest(gvm1.Invoke(new DerivedClass1<string>(), new[] { "", "" }) == "DerivedClass1.GVMethod1");
     }
 
     static ushort ReadUInt16()

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -373,8 +373,6 @@ internal static class Program
 
         TestBoolCompare();
 
-        TestGetDependenciesDueToAccess();
-
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -3466,23 +3464,6 @@ internal static class Program
         bool expected = true;
         bool actual = true;
         EndTest(expected.Equals(actual));
-    }
-
-    public class BaseClass<T>
-    {
-        public virtual string GVMethod1<U>(T t, U u) { return "BaseClass.GVMethod1"; }
-    }
-
-    public class DerivedClass1<T> : BaseClass<T>
-    {
-        public override sealed string GVMethod1<U>(T t, U u) { return "DerivedClass1.GVMethod1"; }
-    }
-
-    static void TestGetDependenciesDueToAccess()
-    {
-        StartTest("Test GetDependenciesDueToAccess (MakeGenericMethod)");
-        MethodInfo gvm1 = typeof(DerivedClass1<string>).GetTypeInfo().GetDeclaredMethod("GVMethod1").MakeGenericMethod(typeof(string));
-        EndTest(gvm1.Invoke(new DerivedClass1<string>(), new[] { "", "" }) == "DerivedClass1.GVMethod1");
     }
 
     static ushort ReadUInt16()


### PR DESCRIPTION
This PR adds a test and a fix for the missing GetDependenciesDueToAccess call.

From a visual comparison of ILScanner https://github.com/dotnet/runtimelab/blob/23feaa85546690e611531ee0d6113077f8d64708/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs#L682 to ILToLLVMImporter I also thought that there should be this dependency, `GVMLookupForSlot`, at https://github.com/dotnet/runtimelab/blob/23feaa85546690e611531ee0d6113077f8d64708/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs#L2186-L2189

```
            if (canonMethod.HasInstantiation)
            {
                exactContextNeedsRuntimeLookup = callee.IsSharedByGenericInstantiations;
                MethodDesc entryPoint = _compilation.TypeSystemContext.SystemModule.GetKnownType("System.Runtime", "TypeLoaderExports").GetKnownMethod("GVMLookupForSlot", null);
                _dependencies.Add(_compilation.NodeFactory.MethodEntrypoint(entryPoint), "LLVM GVM dependency");
            }
```

 But it's not currently present and nothing breaks, so interested if there is a test that might highlight this.