### PR TITLE
Call registerSymbol on potentially new symbols

### DIFF
--- a/src/coreclr/tools/aot/ObjWriter/objwriter.cpp
+++ b/src/coreclr/tools/aot/ObjWriter/objwriter.cpp
@@ -428,6 +428,7 @@ int ObjectWriter::EmitSymbolRef(const char *SymbolName,
   MCSymbolRefExpr::VariantKind Kind = MCSymbolRefExpr::VK_None;
 
   MCSymbol* Symbol = OutContext->getOrCreateSymbol(SymbolName);
+  Assembler->registerSymbol(*Symbol);
 
   if ((int)Flags & (int)SymbolRefFlags::SymbolRefFlags_AddressTakenFunction) {
     AddressTakenFunctions.insert(Symbol);


### PR DESCRIPTION
LLVM will call `registerSymbol` most of the time (because the first thing Asm does is calling visit on the passed expression), but `emitRelocDirective` doesn't.

We only call that one on ARM and AArch64 which makes this bug invisible everywhere else.