### PR TITLE
Drop unnescessary suffix 2 from Rhp functions

### DIFF
--- a/src/coreclr/nativeaot/Runtime/amd64/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/PInvoke.asm
@@ -178,28 +178,6 @@ NESTED_END RhpReversePInvokeAttachOrTrapThread, _TEXT
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; RhpReversePInvokeReturn
-;;
-;; IN:  RCX: address of reverse pinvoke frame
-;;
-;; TRASHES:  RCX, RDX, R10, R11
-;;
-;; PRESERVES: RAX (return value)
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-LEAF_ENTRY RhpReversePInvokeReturn, _TEXT
-        mov         rdx, [rcx + 8]  ; get Thread pointer
-        mov         rcx, [rcx + 0]  ; get previous M->U transition frame
-
-        mov         [rdx + OFFSETOF__Thread__m_pTransitionFrame], rcx
-        cmp         [RhpTrapThreads], TrapThreadsFlags_None
-        jne         RhpWaitForSuspend
-        ret
-LEAF_END RhpReversePInvokeReturn, _TEXT
-
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
 ;; RhpPInvoke
 ;;
 ;; IN:  RCX: address of pinvoke frame

--- a/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/arm/PInvoke.asm
@@ -120,34 +120,4 @@ NoAbort
         NESTED_END RhpReversePInvokeTrapThread
 
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; RhpReversePInvokeReturn
-;;
-;; IN:  r3: address of reverse pinvoke frame
-;;                  0: save slot for previous M->U transition frame
-;;                  4: save slot for thread pointer to avoid re-calc in epilog sequence
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-        LEAF_ENTRY RhpReversePInvokeReturn
-
-        ldr         r2, [r3, #4]    ; get Thread pointer
-        ldr         r3, [r3, #0]    ; get previous M->U transition frame
-
-        str         r3, [r2, #OFFSETOF__Thread__m_pTransitionFrame]
-        dmb
-
-        ldr         r3, =RhpTrapThreads
-        ldr         r3, [r3]
-        tst         r3, #TrapThreadsFlags_TrapThreads
-        bne         RareTrapThread
-
-        bx          lr
-
-RareTrapThread
-        b           RhpWaitForSuspend
-
-        LEAF_END RhpReversePInvokeReturn
-
-
         end

--- a/src/coreclr/nativeaot/Runtime/i386/PInvoke.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/PInvoke.asm
@@ -113,28 +113,5 @@ Done:
         ret
 _RhpWaitForGC endp
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; RhpReversePInvokeReturn
-;;
-;; IN:  ECX: address of reverse pinvoke frame
-;;                  0: save slot for previous M->U transition frame
-;;                  4: save slot for thread pointer to avoid re-calc in epilog sequence
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-FASTCALL_FUNC RhpReversePInvokeReturn, 0
-        push        edx         ; save return value
-
-        mov         edx, [ecx + 4]  ; get Thread pointer
-        mov         ecx, [ecx + 0]  ; get previous M->U transition frame
-
-        mov         [edx + OFFSETOF__Thread__m_pTransitionFrame], ecx
-        test        [RhpTrapThreads], TrapThreadsFlags_TrapThreads
-        pop         edx         ; restore return value
-        jnz         _RhpWaitForSuspend
-        ret
-
-FASTCALL_ENDFUNC
-
 
         end

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -1394,8 +1394,7 @@ EXTERN_C NOINLINE void FASTCALL RhpReversePInvokeAttachOrTrapThread2(ReversePInv
 // PInvoke
 //
 
-// Standard calling convention variant of RhpReversePInvoke
-COOP_PINVOKE_HELPER(void, RhpReversePInvoke2, (ReversePInvokeFrame * pFrame))
+COOP_PINVOKE_HELPER(void, RhpReversePInvoke, (ReversePInvokeFrame * pFrame))
 {
     Thread * pCurThread = ThreadStore::RawGetCurrentThread();
     pFrame->m_savedThread = pCurThread;
@@ -1405,8 +1404,7 @@ COOP_PINVOKE_HELPER(void, RhpReversePInvoke2, (ReversePInvokeFrame * pFrame))
     RhpReversePInvokeAttachOrTrapThread2(pFrame);
 }
 
-// Standard calling convention variant of RhpReversePInvokeReturn
-COOP_PINVOKE_HELPER(void, RhpReversePInvokeReturn2, (ReversePInvokeFrame * pFrame))
+COOP_PINVOKE_HELPER(void, RhpReversePInvokeReturn, (ReversePInvokeFrame * pFrame))
 {
     pFrame->m_savedThread->InlineReversePInvokeReturn(pFrame);
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/JitHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/JitHelper.cs
@@ -236,10 +236,10 @@ namespace ILCompiler
                     break;
 
                 case ReadyToRunHelper.ReversePInvokeEnter:
-                    mangledName = "RhpReversePInvoke2";
+                    mangledName = "RhpReversePInvoke";
                     break;
                 case ReadyToRunHelper.ReversePInvokeExit:
-                    mangledName = "RhpReversePInvokeReturn2";
+                    mangledName = "RhpReversePInvokeReturn";
                     break;
 
                 case ReadyToRunHelper.CheckCastAny:


### PR DESCRIPTION
Rename RhpReversePInvokeReturn2 and RhpReversePInvoke2