### PR TITLE
More cleanup for Regex SRM

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/BooleanClassifier.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/BooleanClassifier.cs
@@ -39,7 +39,7 @@ namespace System.Text.RegularExpressions.SRM
         internal static BooleanClassifier Create(CharSetSolver solver, BDD domain)
         {
             var ascii = new bool[128];
-            for (int i = 0; i < 128; i++)
+            for (int i = 0; i < ascii.Length; i++)
             {
                 ascii[i] = domain.Contains(i);
             }
@@ -98,7 +98,7 @@ namespace System.Text.RegularExpressions.SRM
                 }
             }
 
-            throw new ArgumentException($"{nameof(BooleanClassifier.Deserialize)} invalid '{nameof(input)}' parameter");
+            throw new ArgumentOutOfRangeException(nameof(input));
         }
         #endregion
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Classifier.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Classifier.cs
@@ -103,7 +103,7 @@ namespace System.Text.RegularExpressions.SRM
             int firstEnd = input.IndexOf(',');
             if (firstEnd == -1 || input.Slice(firstEnd + 1).IndexOf(',') != -1)
             {
-                throw new ArgumentException($"{nameof(Classifier.Deserialize)} invalid '{nameof(input)}' parameter");
+                throw new ArgumentOutOfRangeException(nameof(input));
             }
 
             int[] precomp = Base64.DecodeIntArray(input[..firstEnd]);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/Regex.cs
@@ -96,12 +96,14 @@ namespace System.Text.RegularExpressions.SRM
         {
             string[] fragments = input.Split(TopLevelSeparator);
             if (fragments.Length != 15)
-                throw new ArgumentException($"{nameof(Regex.Deserialize)} error", nameof(input));
+            {
+                throw new ArgumentOutOfRangeException(nameof(input));
+            }
 
             try
             {
                 BVAlgebraBase alg = BVAlgebraBase.Deserialize(fragments[1]);
-                Debug.Assert(alg is BV64Algebra || alg is BVAlgebra);
+                Debug.Assert(alg is BV64Algebra or BVAlgebra);
                 IMatcher matcher = alg is BV64Algebra bv64 ?
                     new SymbolicRegexMatcher<ulong>(bv64, fragments) :
                     new SymbolicRegexMatcher<BV>((BVAlgebra)alg, fragments);
@@ -109,7 +111,7 @@ namespace System.Text.RegularExpressions.SRM
             }
             catch (Exception e)
             {
-                throw new ArgumentException($"{nameof(Regex.Deserialize)} error", nameof(input), e);
+                throw new ArgumentOutOfRangeException(nameof(input), e);
             }
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexInfo.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-
 namespace System.Text.RegularExpressions.SRM
 {
     /// <summary>Misc information of structural properties of a <see cref="SymbolicRegexNode{S}"/> that is computed bottom up.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexNode.cs
@@ -1,13 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace System.Text.RegularExpressions.SRM
 {
@@ -519,39 +517,23 @@ namespace System.Text.RegularExpressions.SRM
             return node;
         }
 
-        internal static SymbolicRegexNode<S> MkOr(SymbolicRegexBuilder<S> builder, SymbolicRegexSet<S> alts)
-        {
-            if (alts.IsNothing)
-                return builder._nothing;
-
-            if (alts.IsEverything)
-                return builder._dotStar;
-
-            if (alts.IsSingleton)
-                return alts.GetSingletonElement();
-
-            return new SymbolicRegexNode<S>(builder, SymbolicRegexKind.Or, null, null, -1, -1, default, null, alts)
+        internal static SymbolicRegexNode<S> MkOr(SymbolicRegexBuilder<S> builder, SymbolicRegexSet<S> alts) =>
+            alts.IsNothing ? builder._nothing :
+            alts.IsEverything ? builder._dotStar :
+            alts.IsSingleton ? alts.GetSingletonElement() :
+            new SymbolicRegexNode<S>(builder, SymbolicRegexKind.Or, null, null, -1, -1, default, null, alts)
             {
                 _info = SymbolicRegexInfo.Or(GetInfos(alts))
             };
-        }
 
-        internal static SymbolicRegexNode<S> MkAnd(SymbolicRegexBuilder<S> builder, SymbolicRegexSet<S> alts)
-        {
-            if (alts.IsNothing)
-                return builder._nothing;
-
-            if (alts.IsEverything)
-                return builder._dotStar;
-
-            if (alts.IsSingleton)
-                return alts.GetSingletonElement();
-
-            return new SymbolicRegexNode<S>(builder, SymbolicRegexKind.And, null, null, -1, -1, default, null, alts)
+        internal static SymbolicRegexNode<S> MkAnd(SymbolicRegexBuilder<S> builder, SymbolicRegexSet<S> alts) =>
+            alts.IsNothing ? builder._nothing :
+            alts.IsEverything ? builder._dotStar :
+            alts.IsSingleton ? alts.GetSingletonElement() :
+            new SymbolicRegexNode<S>(builder, SymbolicRegexKind.And, null, null, -1, -1, default, null, alts)
             {
                 _info = SymbolicRegexInfo.And(GetInfos(alts))
             };
-        }
 
         private static SymbolicRegexInfo[] GetInfos(SymbolicRegexNode<S>[] nodes)
         {
@@ -1139,6 +1121,8 @@ namespace System.Text.RegularExpressions.SRM
         /// </summary>
         public S[] ComputeMinterms()
         {
+            Debug.Assert(typeof(S).IsAssignableTo(typeof(IComparable)));
+
             HashSet<S> predicates = GetPredicates();
             Debug.Assert(predicates.Count != 0);
 
@@ -1150,17 +1134,8 @@ namespace System.Text.RegularExpressions.SRM
             }
             Debug.Assert(i == predicatesArray.Length);
 
-            var mt = new List<S>();
-            foreach ((bool[], S) pair in _builder._solver.GenerateMinterms(predicatesArray))
-            {
-                mt.Add(pair.Item2);
-            }
-
-            if (mt[0] is IComparable)
-            {
-                mt.Sort();
-            }
-
+            List<S> mt = _builder._solver.GenerateMinterms(predicatesArray);
+            mt.Sort();
             return mt.ToArray();
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/SymbolicRegexSet.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -194,17 +193,10 @@ namespace System.Text.RegularExpressions.SRM
                 other.ExceptWith(others1);
             }
 
-            if (other.Count == 0 && loops.Count == 0)
-            {
-                return kind == SymbolicRegexKind.Or ?
-                    builder._emptySet :
-                    builder._fullSet;
-            }
-
-            return new SymbolicRegexSet<S>(builder, kind, other, loops)
-            {
-                _watchdog = watchdog
-            };
+            return
+                other.Count != 0 || loops.Count != 0 ? new SymbolicRegexSet<S>(builder, kind, other, loops) { _watchdog = watchdog } :
+                kind == SymbolicRegexKind.Or ? builder._emptySet :
+                builder._fullSet;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             static void AddLoopElement(
@@ -388,7 +380,8 @@ namespace System.Text.RegularExpressions.SRM
             Debug.Assert(IsSingleton);
 
             Enumerator e = GetEnumerator();
-            e.MoveNext();
+            bool success = e.MoveNext();
+            Debug.Assert(success);
             return e.Current;
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BDD.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BDD.cs
@@ -187,7 +187,7 @@ namespace System.Text.RegularExpressions.SRM
         /// </summary>
         public override bool Equals(object? obj) =>
             obj is BDD bdd &&
-            (this == bdd || Ordinal == bdd.Ordinal && One == bdd.One && Zero == bdd.Zero);
+            (this == bdd || (Ordinal == bdd.Ordinal && One == bdd.One && Zero == bdd.Zero));
 
         /// <summary>
         /// Returns a topologically sorted array of all the nodes (other than True or False) in this BDD

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BDDAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BDDAlgebra.cs
@@ -246,6 +246,7 @@ namespace System.Text.RegularExpressions.SRM
                     if (a == b)
                         return a;
                     break;
+
                 case BoolOp.Xor:
                     if (a == False)
                         return b;
@@ -258,6 +259,7 @@ namespace System.Text.RegularExpressions.SRM
                     if (b == True)
                         return CreateNot_rec(a);
                     break;
+
                 default:
                     Debug.Fail("Unhandled binary BoolOp case");
                     break;
@@ -475,10 +477,8 @@ namespace System.Text.RegularExpressions.SRM
         /// Generate all non-overlapping Boolean combinations of a set of BDDs.
         /// </summary>
         /// <param name="sets">the BDDs to create the minterms for</param>
-        /// <returns>
-        /// tuples of booleans indicating which of the input sets are true in the minterm and the BDD for the minterm
-        /// </returns>
-        public IEnumerable<(bool[], BDD)> GenerateMinterms(params BDD[] sets) => _mintermGen.GenerateMinterms(sets);
+        /// <returns>BDDs for the minterm</returns>
+        public List<BDD> GenerateMinterms(params BDD[] sets) => _mintermGen.GenerateMinterms(sets);
 
         /// <summary>
         /// Make a set containing all integers whose bits up to maxBit equal n.
@@ -674,12 +674,11 @@ namespace System.Text.RegularExpressions.SRM
         #endregion
 
         /// <summary>
-        /// Throws NotSupportedException.
-        /// Can be overwridden in a derived algebra.
         /// The returned integer must be nonegative
         /// and will act as the combined terminal in a multi-terminal BDD.
+        /// May throw NotSupportedException.
         /// </summary>
-        public virtual int CombineTerminals(BoolOp op, int terminal1, int terminal2) => throw new NotSupportedException($"{nameof(CombineTerminals)}:{op}");
+        public abstract int CombineTerminals(BoolOp op, int terminal1, int terminal2);
 
         /// <summary>
         /// Replace the True node in the BDD by a non-Boolean terminal.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BV.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/BV.cs
@@ -48,7 +48,7 @@ namespace System.Text.RegularExpressions.SRM
                 if (value)
                 {
                     //set the j'th bit of the k'th block to 1
-                    _blocks[k] |= (1ul << j);
+                    _blocks[k] |= 1ul << j;
                 }
                 else
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/CharSetSolver.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace System.Text.RegularExpressions.SRM
@@ -280,10 +278,9 @@ namespace System.Text.RegularExpressions.SRM
                 if (Or(s_or_d, pred) == s_or_d)
                 {
                     //check first if this is purely ascii range for digits
-                    if (And(pred, s).Equals(s) && And(pred, nonasciiDigit).IsEmpty)
-                        return $"[\\s{RepresentRanges(ToRanges(And(pred, asciiDigit)), checkSingletonComlement: false)}]";
-
-                    return $"[\\s\\d-[{RepresentSet(And(s_or_d, Not(pred)))}]]";
+                    return And(pred, s).Equals(s) && And(pred, nonasciiDigit).IsEmpty ?
+                        $"[\\s{RepresentRanges(ToRanges(And(pred, asciiDigit)), checkSingletonComlement: false)}]" :
+                        $"[\\s\\d-[{RepresentSet(And(s_or_d, Not(pred)))}]]";
                 }
                 //---
                 // s|wD
@@ -368,5 +365,7 @@ namespace System.Text.RegularExpressions.SRM
         }
 
         private static bool IsSingletonRange(Tuple<uint, uint>[] ranges) => ranges.Length == 1 && ranges[0].Item1 == ranges[0].Item2;
+
+        public override int CombineTerminals(BoolOp op, int terminal1, int terminal2) => throw new NotSupportedException();
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/IBooleanAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/IBooleanAlgebra.cs
@@ -85,8 +85,8 @@ namespace System.Text.RegularExpressions.SRM
         /// If n=0 return Tuple({},True)
         /// </summary>
         /// <param name="constraints">array of constraints</param>
-        /// <returns>Booolean combinations that are satisfiable</returns>
-        IEnumerable<(bool[], T)> GenerateMinterms(params T[] constraints);
+        /// <returns>constraints that are satisfiable</returns>
+        List<T> GenerateMinterms(params T[] constraints);
 
         /// <summary>
         /// Serialize the predicate as a nonempty string only using characters in the Base64 subset [0-9a-zA-Z/+.]

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/MintermGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/algebras/MintermGenerator.cs
@@ -7,20 +7,18 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Text.RegularExpressions.SRM
 {
-    /// <summary>
-    /// Provides a generic implementation for minterm generation over a given Boolean Algebra. The minterms for a set of
-    /// predicates are all their non-overlapping, satisfiable Boolean combinations. For example if the predicates are
-    /// [0-9] and [0-4], then there are three minterms: [0-4], [5-9] and [^0-9]. Notably, there is no minterm
-    /// corresponding to "[0-9] and not [0-4]", since that is unsatisfiable.
-    /// </summary>
+    /// <summary>Provides a generic implementation for minterm generation over a given Boolean Algebra.</summary>
     /// <typeparam name="TPredicate">type of predicates</typeparam>
+    /// <remarks>
+    /// The minterms for a set of predicates are all their non-overlapping, satisfiable Boolean combinations. For example,
+    /// if the predicates are [0-9] and [0-4], then there are three minterms: [0-4], [5-9] and [^0-9]. Notably, there is no
+    /// minterm corresponding to "[0-9] and not [0-4]", since that is unsatisfiable.
+    /// </remarks>
     internal sealed class MintermGenerator<TPredicate> where TPredicate : notnull
     {
         private readonly IBooleanAlgebra<TPredicate> _algebra;
 
-        /// <summary>
-        /// Constructs a minterm generator for a given Boolean Algebra.
-        /// </summary>
+        /// <summary>Constructs a minterm generator for a given Boolean Algebra.</summary>
         /// <param name="algebra">given Boolean Algebra</param>
         public MintermGenerator(IBooleanAlgebra<TPredicate> algebra)
         {
@@ -31,80 +29,44 @@ namespace System.Text.RegularExpressions.SRM
         }
 
         /// <summary>
-        /// Given an array of predidates {p_1, p_2, ..., p_n} where n>=0.
-        /// Enumerate all satisfiable Boolean combinations Tuple({b_1, b_2, ..., b_n}, p)
+        /// Given an array of predidates {p_1, p_2, ..., p_n} where n>=0,
+        /// enumerate all satisfiable Boolean combinations Tuple({b_1, b_2, ..., b_n}, p)
         /// where p is satisfiable and equivalent to p'_1 &amp; p'_2 &amp; ... &amp; p'_n,
-        /// where p'_i = p_i if b_i = true and p'_i is Not(p_i) otherwise.
-        /// If n=0 return Tuple({},True).
+        /// where p'_i = p_i if b_i = true and p'_i is Not(p_i). Otherwise, if n=0
+        /// return Tuple({},True).
         /// </summary>
         /// <param name="preds">array of predicates</param>
         /// <returns>all minterms of the given predicate sequence</returns>
-        public IEnumerable<(bool[], TPredicate)> GenerateMinterms(params TPredicate[] preds)
+        public List<TPredicate> GenerateMinterms(params TPredicate[] preds)
         {
             if (preds.Length == 0)
             {
-                yield return (Array.Empty<bool>(), _algebra.True);
-                yield break;
+                return new List<TPredicate> { _algebra.True };
             }
 
             // The minterms will be solved using non-equivalent predicates, i.e., the equivalence classes of preds. The
             // following code maps each predicate to an equivalence class and also stores for each equivalence class the
             // predicates belonging to it, so that a valuation for the original predicates may be reconstructed.
 
-            // all the equivalence classes
-            var equivClasses = new List<TPredicate>();
-            // mapping from equivalcence classes to their members' indices
-            var classIndices = new Dictionary<EquivalenceClass, int>();
-            var memberLists = new List<List<int>>();
+            var tree = new PartitionTree(_algebra);
 
+            var seen = new HashSet<EquivalenceClass>();
             for (int i = 0; i < preds.Length; i++)
             {
-                // use a wrapper that overloads Equals to be logical equivalence as the key
-                EquivalenceClass equiv = CreateEquivalenceClass(preds[i]);
-                if (!classIndices.TryGetValue(equiv, out int classIndex))
+                // Use a wrapper that overloads Equals to be logical equivalence as the key
+                if (seen.Add(new EquivalenceClass(_algebra, preds[i])))
                 {
-                    // if no equivalence class exists yet create a new index
-                    classIndex = classIndices.Count;
-                    classIndices[equiv] = classIndex;
-                    equivClasses.Add(preds[i]);
-                    memberLists.Add(new List<int>());
+                    // Push each equivalence class into the partition tree
+                    tree.Refine(preds[i]);
                 }
-                // add the index of the input predicate to its equivalence class
-                memberLists[classIndex].Add(i);
             }
 
-            var tree = new PartitionTree<TPredicate>(_algebra);
-            // push each equivalence class into the partition tree
-            foreach (TPredicate x in equivClasses)
-            {
-                tree.Refine(x);
-            }
-
-            // iterate through all minterms as the leaves of the partition tree
-            foreach (PartitionTree<TPredicate> leaf in tree.GetLeaves())
-            {
-                // reconstruct a valuation of the original predicates for each minterm
-                bool[] characteristic = new bool[preds.Length];
-                // the path enumerates all the indices of all equivalence classes that are true in the minterm
-                foreach (int k in leaf.GetPath())
-                {
-                    // for each equivalence class mark all of its members as true
-                    foreach (int n in memberLists[k])
-                    {
-                        characteristic[n] = true;
-                    }
-                }
-
-                yield return (characteristic, leaf._pred);
-            }
+            // Return all minterms as the leaves of the partition tree
+            return tree.GetLeafPredicates();
         }
 
-        private EquivalenceClass CreateEquivalenceClass(TPredicate set) => new EquivalenceClass(_algebra, set);
-
-        /// <summary>
-        /// Wraps a predicate as an equivalence class object whose Equals method is Equivalence checking
-        /// </summary>
-        private struct EquivalenceClass
+        /// <summary>Wraps a predicate as an equivalence class object whose Equals method is equivalence checking.</summary>
+        private readonly struct EquivalenceClass
         {
             private readonly TPredicate _set;
             private readonly IBooleanAlgebra<TPredicate> _algebra;
@@ -119,187 +81,168 @@ namespace System.Text.RegularExpressions.SRM
 
             public override bool Equals([NotNullWhen(true)] object? obj) => obj is EquivalenceClass ec && _algebra.AreEquivalent(_set, ec._set);
         }
-    }
 
-    /// <summary>
-    /// A partition tree for efficiently solving minterms. Predicates are pushed into the tree with Refine(), which
-    /// creates leaves in the tree for all satisfiable and non-overlapping combinations with any previously pushed
-    /// predicates. At the end of the process the minterms can be read from the paths to the leaves of the tree.
-    ///
-    /// The valuations of the predicates are represented as follows. Given a path a^-1, a^0, a^1, ..., a^n, predicate
-    /// p^i is true in the corresponding minterm if and only if a^i is the left child of a^i-1.
-    ///
-    /// This class assumes that all predicates passed to Refine() are non-equivalent.
-    /// </summary>
-    internal sealed class PartitionTree<TPredicate>
-    {
-        private readonly PartitionTree<TPredicate>? _parent;
-        private readonly int _index;
-        internal readonly TPredicate _pred;
-        private readonly IBooleanAlgebra<TPredicate> _solver;
-        private PartitionTree<TPredicate>? _left;
-        private PartitionTree<TPredicate>? _right; // complement
-
-        /// <summary>
-        /// Create the root of the partition tree. Nodes below this will be indexed starting from 0. The initial
-        /// predicate is true.
-        /// </summary>
-        internal PartitionTree(IBooleanAlgebra<TPredicate> solver)
+        /// <summary>A partition tree for efficiently solving minterms.</summary>
+        /// <remarks>
+        /// Predicates are pushed into the tree with Refine(), which creates leaves in the tree for all satisfiable
+        /// and non-overlapping combinations with any previously pushed predicates. At the end of the process the
+        /// minterms can be read from the paths to the leaves of the tree.
+        ///
+        /// The valuations of the predicates are represented as follows. Given a path a^-1, a^0, a^1, ..., a^n, predicate
+        /// p^i is true in the corresponding minterm if and only if a^i is the left child of a^i-1.
+        ///
+        /// This class assumes that all predicates passed to Refine() are non-equivalent.
+        /// </remarks>
+        private sealed class PartitionTree
         {
-            _solver = solver;
-            _index = -1;
-            _parent = null;
-            _pred = solver.True;
-            _left = null;
-            _right = null;
-        }
+            internal readonly TPredicate _pred;
+            private readonly IBooleanAlgebra<TPredicate> _solver;
+            private PartitionTree? _left;
+            private PartitionTree? _right; // complement
 
-        private PartitionTree(IBooleanAlgebra<TPredicate> solver, int depth, PartitionTree<TPredicate> parent, TPredicate pred, PartitionTree<TPredicate>? left, PartitionTree<TPredicate>? right)
-        {
-            _solver = solver;
-            _parent = parent;
-            _index = depth;
-            _pred = pred;
-            _left = left;
-            _right = right;
-        }
+            /// <summary>Create the root of the partition tree.</summary>
+            /// <remarks>Nodes below this will be indexed starting from 0. The initial predicate is true.</remarks>
+            internal PartitionTree(IBooleanAlgebra<TPredicate> solver) : this(solver, solver.True, null, null) { }
 
-        internal void Refine(TPredicate other)
-        {
-            if (_left == null && _right == null)
+            private PartitionTree(IBooleanAlgebra<TPredicate> solver, TPredicate pred, PartitionTree? left, PartitionTree? right)
             {
-                // if this is a leaf node create left and/or right children for the new predicate
-                TPredicate thisAndOther = _solver.And(_pred, other);
-                if (_solver.IsSatisfiable(thisAndOther))
+                _solver = solver;
+                _pred = pred;
+                _left = left;
+                _right = right;
+            }
+
+            internal void Refine(TPredicate other)
+            {
+                if (_left is null && _right is null)
                 {
-                    // the predicates overlap, now check if this is contained in other
-                    TPredicate thisMinusOther = _solver.And(_pred, _solver.Not(other));
-                    if (_solver.IsSatisfiable(thisMinusOther))
+                    // If this is a leaf node create left and/or right children for the new predicate
+                    TPredicate thisAndOther = _solver.And(_pred, other);
+                    if (_solver.IsSatisfiable(thisAndOther))
                     {
-                        // this is not contained in other, both children are needed
-                        _left = new PartitionTree<TPredicate>(_solver, _index + 1, this, thisAndOther, null, null);
-                        // the right child corresponds to a conjunction with a negation, which matches thisMinusOther
-                        _right = new PartitionTree<TPredicate>(_solver, _index + 1, this, thisMinusOther, null, null);
+                        // The predicates overlap, now check if this is contained in other
+                        TPredicate thisMinusOther = _solver.And(_pred, _solver.Not(other));
+                        if (_solver.IsSatisfiable(thisMinusOther))
+                        {
+                            // This is not contained in other, both children are needed
+                            _left = new PartitionTree(_solver, thisAndOther, null, null);
+
+                            // The right child corresponds to a conjunction with a negation, which matches thisMinusOther
+                            _right = new PartitionTree(_solver, thisMinusOther, null, null);
+                        }
+                        else // [[this]] subset of [[other]]
+                        {
+                            // Other implies this, so populate the left child with this
+                            _left = new PartitionTree(_solver, _pred, null, null);
+                        }
                     }
-                    else // [[this]] subset of [[other]]
+                    else // [[this]] subset of [[not(other)]]
                     {
-                        // other implies this, so populate the left child with this
-                        _left = new PartitionTree<TPredicate>(_solver, _index + 1, this, _pred, null, null);
+                        // negation of other implies this, so populate the right child with this
+                        _right = new PartitionTree(_solver, _pred, null, null); //other must be false
                     }
                 }
-                else // [[this]] subset of [[not(other)]]
+                else if (_left is null)
                 {
-                    // negation of other implies this, so populate the right child with this
-                    _right = new PartitionTree<TPredicate>(_solver, _index + 1, this, _pred, null, null); //other must be false
+                    // No choice has to be made here, refine the single child that exists
+                    _right!.Refine(other);
                 }
-            }
-            else if (_left == null)
-            {
-                // no choice has to be made here, refine the single child that exists
-                _right!.Refine(other);
-            }
-            else if (_right == null)
-            {
-                // no choice has to be made here, refine the single child that exists
-                _left!.Refine(other);
-            }
-            else
-            {
-                TPredicate thisAndOther = _solver.And(_pred, other);
-                if (_solver.IsSatisfiable(thisAndOther))
+                else if (_right is null)
                 {
-                    // other is satisfiable in this subtree
-                    TPredicate thisMinusOther = _solver.And(_pred, _solver.Not(other));
-                    if (_solver.IsSatisfiable(thisMinusOther))
+                    // No choice has to be made here, refine the single child that exists
+                    _left!.Refine(other);
+                }
+                else
+                {
+                    TPredicate thisAndOther = _solver.And(_pred, other);
+                    if (_solver.IsSatisfiable(thisAndOther))
                     {
-                        // but other does not imply this whole subtree, refine both children
-                        _left.Refine(other);
-                        _right.Refine(other);
+                        // Other is satisfiable in this subtree
+                        TPredicate thisMinusOther = _solver.And(_pred, _solver.Not(other));
+                        if (_solver.IsSatisfiable(thisMinusOther))
+                        {
+                            // But other does not imply this whole subtree, refine both children
+                            _left.Refine(other);
+                            _right.Refine(other);
+                        }
+                        else // [[this]] subset of [[other]]
+                        {
+                            // And other implies the whole subtree, include it in all minterms under here
+                            _left.ExtendLeft();
+                            _right.ExtendLeft();
+                        }
                     }
-                    else // [[this]] subset of [[other]]
+                    else // [[this]] subset of [[not(other)]]
                     {
-                        // and other implies the whole subtree, include it in all minterms under here
-                        _left.ExtendLeft();
-                        _right.ExtendLeft();
+                        // Other is not satisfiable in this subtree, include its negation in all minterms under here
+                        _left.ExtendRight();
+                        _right.ExtendRight();
                     }
                 }
-                else // [[this]] subset of [[not(other)]]
+            }
+
+            /// <summary>
+            /// Include the next predicate in all minterms under this node. Assumes the next predicate implies the predicate
+            /// of this node.
+            /// </summary>
+            private void ExtendLeft()
+            {
+                if (_left is null && _right is null)
                 {
-                    // other is not satisfiable in this subtree, include its negation in all minterms under here
-                    _left.ExtendRight();
-                    _right.ExtendRight();
+                    _left = new PartitionTree(_solver, _pred, null, null);
+                }
+                else
+                {
+                    _left?.ExtendLeft();
+                    _right?.ExtendLeft();
                 }
             }
-        }
 
-        /// <summary>
-        /// Include the next predicate in all minterms under this node. Assumes the next predicate implies the predicate
-        /// of this node.
-        /// </summary>
-        private void ExtendLeft()
-        {
-            if (_left == null && _right == null)
+            /// <summary>
+            /// Include the negation of next predicate in all minterms under this node. Assumes the negation of the next
+            /// predicate implies the predicate of this node.
+            /// </summary>
+            private void ExtendRight()
             {
-                _left = new PartitionTree<TPredicate>(_solver, _index + 1, this, _pred, null, null);
-            }
-            else
-            {
-                Debug.Assert(_left is not null || _right is not null);
-                _left?.ExtendLeft();
-                _right?.ExtendLeft();
-            }
-        }
-
-        /// <summary>
-        /// Include the negation of next predicate in all minterms under this node. Assumes the negation of the next
-        /// predicate implies the predicate of this node.
-        /// </summary>
-        private void ExtendRight()
-        {
-            if (_left == null && _right == null)
-            {
-                _right = new PartitionTree<TPredicate>(_solver, _index + 1, this, _pred, null, null);
-            }
-            else
-            {
-                Debug.Assert(_left is not null || _right is not null);
-                _left?.ExtendRight();
-                _right?.ExtendRight();
-            }
-        }
-
-        /// <summary>
-        /// Enumerate all predicates included in this minterm in their non-negated form.
-        /// </summary>
-        internal IEnumerable<int> GetPath()
-        {
-            for (PartitionTree<TPredicate> curr = this; curr._parent != null; curr = curr._parent)
-            {
-                if (curr._parent._left == curr) //curr is the left child of its parent
+                if (_left is null && _right is null)
                 {
-                    yield return curr._index;
+                    _right = new PartitionTree(_solver, _pred, null, null);
+                }
+                else
+                {
+                    _left?.ExtendRight();
+                    _right?.ExtendRight();
                 }
             }
-        }
 
-        /// <summary>
-        /// Enumerate all of the leaves in the tree.
-        /// </summary>
-        internal IEnumerable<PartitionTree<TPredicate>> GetLeaves()
-        {
-            if (_left == null && _right == null)
+            /// <summary>Get the predicates from all of the leaves in the tree.</summary>
+            internal List<TPredicate> GetLeafPredicates()
             {
-                yield return this;
-            }
-            else
-            {
-                if (_left != null)
-                    foreach (PartitionTree<TPredicate> leaf in _left.GetLeaves())
-                        yield return leaf;
+                var leaves = new List<TPredicate>();
 
-                if (_right != null)
-                    foreach (PartitionTree<TPredicate> leaf in _right.GetLeaves())
-                        yield return leaf;
+                var stack = new Stack<PartitionTree>();
+                stack.Push(this);
+                while (stack.TryPop(out PartitionTree? node))
+                {
+                    if (node._left is null && node._right is null)
+                    {
+                        leaves.Add(node._pred);
+                    }
+                    else
+                    {
+                        if (node._left is not null)
+                        {
+                            stack.Push(node._left);
+                        }
+
+                        if (node._right is not null)
+                        {
+                            stack.Push(node._right);
+                        }
+                    }
+                }
+
+                return leaves;
             }
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/IgnoreCaseTransformer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/IgnoreCaseTransformer.cs
@@ -73,8 +73,6 @@ namespace System.Text.RegularExpressions.SRM.Unicode
                     // In the default (en-US) culture: Turkish_I_withDot = i = I
                     // In the invariant culture: i = I, while Turkish_I_withDot is case-insensitive
                     BDD tr_I_withdot_BDD = _solver.CharConstraint(Turkish_I_WithDot);
-                    BDD i_BDD = _solver.CharConstraint('i');
-                    BDD I_BDD = _solver.CharConstraint('I');
 
                     // Since Turkish_I_withDot is case-insensitive in invariant culture, remove it from the default (en-US culture) table.
                     BDD inv_table = _solver.And(_ignoreCaseRel_Default, _solver.Not(tr_I_withdot_BDD));

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/UnicodeCategoryRangesGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/unicode/UnicodeCategoryRangesGenerator.cs
@@ -43,9 +43,9 @@ namespace {namespacename}
         {
             int maxChar = 0xFFFF;
             var catMap = new Dictionary<UnicodeCategory, Ranges>();
-            for (int c = 0; c < 30; c++)
+            foreach (UnicodeCategory c in Enum.GetValues<UnicodeCategory>())
             {
-                catMap[(UnicodeCategory)c] = new Ranges();
+                catMap[c] = new Ranges();
             }
 
             Ranges whitespace = new Ranges();
@@ -65,9 +65,9 @@ namespace {namespacename}
             }
 
             //generate bdd reprs for each of the category ranges
-            BDD[] catBDDs = new BDD[30];
+            BDD[] catBDDs = new BDD[catMap.Count];
             CharSetSolver bddb = new CharSetSolver();
-            for (int c = 0; c < 30; c++)
+            for (int c = 0; c < catBDDs.Length; c++)
                 catBDDs[c] = bddb.CreateBddForIntRanges(catMap[(UnicodeCategory)c].ranges);
 
             BDD whitespaceBdd = bddb.CreateBddForIntRanges(whitespace.ranges);
@@ -77,7 +77,7 @@ namespace {namespacename}
             sw.WriteLine("        /// <summary>Serialized BDD representations of all the Unicode categories.</summary>");
             sw.WriteLine("        public static readonly string[] AllCategoriesSerializedBDD = new string[]");
             sw.WriteLine("        {");
-            for (int i = 0; i < 30; i++)
+            for (int i = 0; i < catBDDs.Length; i++)
             {
                 sw.WriteLine("            // {0}({1}):", (UnicodeCategory)i, i);
                 sw.Write("            \"");

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/StringUtility.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/srm/utils/StringUtility.cs
@@ -52,9 +52,9 @@ namespace System.Text.RegularExpressions.SRM
                 '\v' => @"\v",
                 '\f' => @"\f",
                 '\n' => @"\n",
-                _ when code >= 0x20 && code <= 0x7E => c.ToString(),
+                _ when code is >= 0x20 and <= 0x7E => c.ToString(),
                 _ when code <= 0xFF => $"\\x{code:X2}",
-                _  => $"\\u{code:X4}",
+                _ => $"\\u{code:X4}",
             };
         }
     }


### PR DESCRIPTION
- Change GenerateMinterms to only return BDD, not a tuple; the bool[] was never used, so we don't need to exert energy creating it.
- Avoid recursion in MintermGenerator.GetLeaves
- Remove some dead code in GetIgnoreCaseRel
- Change exceptions for not supported to use NotSupported rather than NotImplemented
- Remove some unused parameters/fields
- Remove some more bounds checking by iterating from 0 to arr.Length rather than to a const
- Make a few properties into auto-props
- Clean up some naming and use of braces
- Make some types nested where they're only used by one consumer
- Make some structs readonly
- Remove more unused usings
- Clean up some exception throwing