### PR TITLE
Srm unit test edits

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -48,11 +48,16 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
-        public static IEnumerable<object[]> Matches_TestData()
+        public static IEnumerable<object[]> Matches_TestData_NonBacktracking() =>
+            PlatformDetection.IsNetFramework ? RegexHelpers.NoTestData() : Matches_TestData_WithOptions(RegexHelpers.RegexOptionNonBacktracking);   
+
+        public static IEnumerable<object[]> Matches_TestData() => Matches_TestData_WithOptions(RegexOptions.None);   
+
+        private static IEnumerable<object[]> Matches_TestData_WithOptions(RegexOptions options)
         {
             yield return new object[]
             {
-                "[0-9]", "12345asdfasdfasdfljkhsda67890", RegexOptions.None,
+                "[0-9]", "12345asdfasdfasdfljkhsda67890", options,
                 new CaptureData[]
                 {
                     new CaptureData("1", 0, 1),
@@ -70,7 +75,7 @@ namespace System.Text.RegularExpressions.Tests
 
             yield return new object[]
             {
-                "[a-z0-9]+", "[token1]? GARBAGEtoken2GARBAGE ;token3!", RegexOptions.None,
+                "[a-z0-9]+", "[token1]? GARBAGEtoken2GARBAGE ;token3!", options,
                 new CaptureData[]
                 {
                     new CaptureData("token1", 1, 6),
@@ -91,7 +96,7 @@ namespace System.Text.RegularExpressions.Tests
 
             yield return new object[]
             {
-                @"\b\w*\b", "handling words of various lengths", RegexOptions.None,
+                @"\b\w*\b", "handling words of various lengths", options,
                 new CaptureData[]
                 {
                     new CaptureData("handling", 0, 8),
@@ -109,7 +114,7 @@ namespace System.Text.RegularExpressions.Tests
 
             yield return new object[]
             {
-                @"\b\w{2}\b", "handling words of various lengths", RegexOptions.None,
+                @"\b\w{2}\b", "handling words of various lengths", options,
                 new CaptureData[]
                 {
                     new CaptureData("of", 15, 2),
@@ -118,7 +123,7 @@ namespace System.Text.RegularExpressions.Tests
 
             yield return new object[]
             {
-                @"\w{6,}", "handling words of various lengths", RegexOptions.None,
+                @"\w{6,}", "handling words of various lengths", options,
                 new CaptureData[]
                 {
                     new CaptureData("handling", 0, 8),
@@ -127,19 +132,23 @@ namespace System.Text.RegularExpressions.Tests
                 }
             };
 
-            yield return new object[]
+            // RegexOptions.RightToLeft is not supported with NonBacktracking
+            if (options != RegexHelpers.RegexOptionNonBacktracking)
             {
-                @"foo\d+", "0123456789foo4567890foo1foo  0987", RegexOptions.RightToLeft,
+                yield return new object[]
+                {
+                @"foo\d+", "0123456789foo4567890foo1foo  0987", options | RegexOptions.RightToLeft,
                 new CaptureData[]
                 {
                     new CaptureData("foo1", 20, 4),
                     new CaptureData("foo4567890", 10, 10),
                 }
-            };
+                };
+            }
 
             yield return new object[]
             {
-                "[a-z]", "a", RegexOptions.None,
+                "[a-z]", "a", options,
                 new CaptureData[]
                 {
                     new CaptureData("a", 0, 1)
@@ -148,7 +157,7 @@ namespace System.Text.RegularExpressions.Tests
 
             yield return new object[]
             {
-                "[a-z]", "a1bc", RegexOptions.None,
+                "[a-z]", "a1bc", options,
                 new CaptureData[]
                 {
                     new CaptureData("a", 0, 1),
@@ -158,29 +167,33 @@ namespace System.Text.RegularExpressions.Tests
             };
 
             // Alternation construct
-            yield return new object[]
+            // General conditional statements (?(A)B|C) are not supported with NonBacktracking
+            if (options != RegexHelpers.RegexOptionNonBacktracking)
             {
-                "(?(A)A123|C789)", "A123 B456 C789", RegexOptions.None,
+                yield return new object[]
+                {
+                "(?(A)A123|C789)", "A123 B456 C789", options,
                 new CaptureData[]
                 {
                     new CaptureData("A123", 0, 4),
                     new CaptureData("C789", 10, 4),
                 }
-            };
+                };
 
-            yield return new object[]
-            {
-                "(?(A)A123|C789)", "A123 B456 C789", RegexOptions.None,
+                yield return new object[]
+                {
+                "(?(A)A123|C789)", "A123 B456 C789", options,
                 new CaptureData[]
                 {
                     new CaptureData("A123", 0, 4),
                     new CaptureData("C789", 10, 4),
                 }
-            };
+                };
+            }
 
             yield return new object[]
             {
-                "(?:ab|cd|ef|gh|i)j", "abj    cdj  efj           ghjij", RegexOptions.None,
+                "(?:ab|cd|ef|gh|i)j", "abj    cdj  efj           ghjij", options,
                 new CaptureData[]
                 {
                     new CaptureData("abj", 0, 3),
@@ -194,12 +207,12 @@ namespace System.Text.RegularExpressions.Tests
             // Using ^ with multiline
             yield return new object[]
             {
-                "^", "", RegexOptions.Multiline,
+                "^", "", options | RegexOptions.Multiline,
                 new[] { new CaptureData("", 0, 0) }
             };
             yield return new object[]
             {
-                "^", "\n\n\n", RegexOptions.Multiline,
+                "^", "\n\n\n", options | RegexOptions.Multiline,
                 new[]
                 {
                     new CaptureData("", 0, 0),
@@ -210,7 +223,7 @@ namespace System.Text.RegularExpressions.Tests
             };
             yield return new object[]
             {
-                "^abc", "abc\nabc \ndef abc \nab\nabc", RegexOptions.Multiline,
+                "^abc", "abc\nabc \ndef abc \nab\nabc", options | RegexOptions.Multiline,
                 new[]
                 {
                     new CaptureData("abc", 0, 3),
@@ -220,7 +233,7 @@ namespace System.Text.RegularExpressions.Tests
             };
             yield return new object[]
             {
-                @"^\w{5}", "abc\ndefg\n\nhijkl\n", RegexOptions.Multiline,
+                @"^\w{5}", "abc\ndefg\n\nhijkl\n", options | RegexOptions.Multiline,
                 new[]
                 {
                     new CaptureData("hijkl", 10, 5),
@@ -228,7 +241,7 @@ namespace System.Text.RegularExpressions.Tests
             };
             yield return new object[]
             {
-                @"^.*$", "abc\ndefg\n\nhijkl\n", RegexOptions.Multiline,
+                @"^.*$", "abc\ndefg\n\nhijkl\n", options | RegexOptions.Multiline,
                 new[]
                 {
                     new CaptureData("abc", 0, 3),
@@ -236,24 +249,29 @@ namespace System.Text.RegularExpressions.Tests
                     new CaptureData("", 9, 0),
                     new CaptureData("hijkl", 10, 5),
                     new CaptureData("", 16, 0),
-                }
-            };
-            yield return new object[]
-            {
-                @"^.*$", "abc\ndefg\n\nhijkl\n", RegexOptions.Multiline | RegexOptions.RightToLeft,
-                new[]
-                {
-                    new CaptureData("", 16, 0),
-                    new CaptureData("hijkl", 10, 5),
-                    new CaptureData("", 9, 0),
-                    new CaptureData("defg", 4, 4),
-                    new CaptureData("abc", 0, 3),
                 }
             };
 
+            // RegexOptions.RightToLeft is not supported with NonBacktracking
+            if (options != RegexHelpers.RegexOptionNonBacktracking)
+            {
+                yield return new object[]
+                {
+                @"^.*$", "abc\ndefg\n\nhijkl\n", options | RegexOptions.Multiline | RegexOptions.RightToLeft,
+                new[]
+                {
+                    new CaptureData("", 16, 0),
+                    new CaptureData("hijkl", 10, 5),
+                    new CaptureData("", 9, 0),
+                    new CaptureData("defg", 4, 4),
+                    new CaptureData("abc", 0, 3),
+                }
+                };
+            }
+
             yield return new object[]
             {
-                ".*", "abc", RegexOptions.None,
+                ".*", "abc", options,
                 new[]
                 {
                     new CaptureData("abc", 0, 3),
@@ -266,7 +284,7 @@ namespace System.Text.RegularExpressions.Tests
                 // .NET Framework missing fix in https://github.com/dotnet/runtime/pull/1075
                 yield return new object[]
                 {
-                    @"[a -\-\b]", "a #.", RegexOptions.None,
+                    @"[a -\-\b]", "a #.", options,
                     new CaptureData[]
                     {
                         new CaptureData("a", 0, 1),
@@ -275,10 +293,13 @@ namespace System.Text.RegularExpressions.Tests
                     }
                 };
 
-                // .NET Framework missing fix in https://github.com/dotnet/runtime/pull/993
-                yield return new object[]
+                // RegexOptions.ECMAScript is not supported with NonBacktracking
+                if (options != RegexHelpers.RegexOptionNonBacktracking)
                 {
-                    "[^]", "every", RegexOptions.ECMAScript,
+                    // .NET Framework missing fix in https://github.com/dotnet/runtime/pull/993
+                    yield return new object[]
+                    {
+                    "[^]", "every", options | RegexOptions.ECMAScript,
                     new CaptureData[]
                     {
                         new CaptureData("e", 0, 1),
@@ -287,11 +308,13 @@ namespace System.Text.RegularExpressions.Tests
                         new CaptureData("r", 3, 1),
                         new CaptureData("y", 4, 1),
                     }
-                };
+                    };
+                }
             }
         }
 
         [Theory]
+        [MemberData(nameof(Matches_TestData_NonBacktracking))]
         [MemberData(nameof(Matches_TestData))]
         [MemberData(nameof(RegexCompilationHelper.TransformRegexOptions), nameof(Matches_TestData), 2, MemberType = typeof(RegexCompilationHelper))]
         public void Matches(string pattern, string input, RegexOptions options, CaptureData[] expected)
@@ -368,7 +391,7 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1), TimeSpan.FromSeconds(1)));
 
-            // 0x400 is new DFA mode that is now valid, 0x800 is still invalid
+            // 0x400 is new NonBacktracking mode that is now valid, 0x800 is still invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x800));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x800, TimeSpan.FromSeconds(1)));
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Tests.Common.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Tests.Common.cs
@@ -62,6 +62,8 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { options };
             }
         }
+
+        public static IEnumerable<object[]> NoTestData() { yield break; }
     }
 
     public class CaptureData

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Tests.Common.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Tests.Common.cs
@@ -64,6 +64,15 @@ namespace System.Text.RegularExpressions.Tests
         }
 
         public static IEnumerable<object[]> NoTestData() { yield break; }
+
+
+        public static Regex CreateRegexInCulture(string pattern, RegexOptions options, Globalization.CultureInfo culture)
+        {
+            using (new System.Tests.ThreadCultureChange(culture))
+            {
+                return new Regex(pattern, options);
+            }
+        }
     }
 
     public class CaptureData

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.UnicodeChar.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.UnicodeChar.Tests.cs
@@ -12,19 +12,8 @@ namespace System.Text.RegularExpressions.Tests
     {
         private const int MaxUnicodeRange = 2 << 15;
 
-        public static IEnumerable<object[]> RegexUnicodeChar_TestData()
-        {
-            if (!PlatformDetection.IsNetFramework)
-            {
-                yield return new object[] { RegexHelpers.RegexOptionNonBacktracking };
-            }
-
-            yield return new object[] { RegexOptions.None };
-            yield return new object[] { RegexOptions.Compiled };
-        }
-
         [Theory]
-        [MemberData(nameof(RegexUnicodeChar_TestData))]
+        [MemberData(nameof(RegexHelpers.RegexOptions_TestData), MemberType = typeof(RegexHelpers))]
         public void RegexUnicodeChar(RegexOptions options)
         {
             // Regex engine is Unicode aware now for the \w and \d character classes

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Tests;
@@ -10,11 +11,19 @@ namespace System.Text.RegularExpressions.Tests
 {
     public class RegexCultureTests
     {
+        public static IEnumerable<object[]> CharactersComparedOneByOne_AnchoredPattern_TestData()
+        {
+            foreach (RegexOptions options in RegexHelpers.RegexOptionsExtended())
+            {
+                yield return new object[] { "^aa$", "aA", "da-DK", options, false };
+                yield return new object[] { "^aA$", "aA", "da-DK", options, true };
+                yield return new object[] { "^aa$", "aA", "da-DK", options | RegexOptions.IgnoreCase, true };
+                yield return new object[] { "^aA$", "aA", "da-DK", options | RegexOptions.IgnoreCase, true };
+            }
+        }
+
         [Theory]
-        [InlineData("^aa$", "aA", "da-DK", RegexOptions.None, false)]
-        [InlineData("^aA$", "aA", "da-DK", RegexOptions.None, true)]
-        [InlineData("^aa$", "aA", "da-DK", RegexOptions.IgnoreCase, true)]
-        [InlineData("^aA$", "aA", "da-DK", RegexOptions.IgnoreCase, true)]
+        [MemberData(nameof(CharactersComparedOneByOne_AnchoredPattern_TestData))]
         public void CharactersComparedOneByOne_AnchoredPattern(string pattern, string input, string culture, RegexOptions options, bool expected)
         {
             // Regex compares characters one by one.  If that changes, it could impact the behavior of
@@ -29,11 +38,18 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
+
+        public static IEnumerable<object[]> CharactersComparedOneByOne_Invariant_TestData()
+        {
+            foreach (RegexOptions options in RegexHelpers.RegexOptionsExtended())
+            {
+                yield return new object[] { options };
+                yield return new object[] { options | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant };
+            }
+        }
+
         [Theory]
-        [InlineData(RegexOptions.None)]
-        [InlineData(RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
-        [InlineData(RegexOptions.Compiled)]
-        [InlineData(RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+        [MemberData(nameof(CharactersComparedOneByOne_Invariant_TestData))]
         public void CharactersComparedOneByOne_Invariant(RegexOptions options)
         {
             // Regex compares characters one by one.  If that changes, it could impact the behavior of

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -173,7 +173,7 @@ namespace System.Text.RegularExpressions.Tests
             Assert.True(turkishRegex.IsMatch(input.ToUpper(turkish)));
         }
 
-        [ActiveIssue("Incorrect handling of IgnoreCase over intervals in Turkish Culture")]
+        [ActiveIssue("Incorrect handling of IgnoreCase over intervals in Turkish Culture, https://github.com/dotnet/runtime/issues/58958")]
         [Fact]
         public void TurkishCulture_Handling_Of_IgnoreCase()
         {
@@ -263,7 +263,7 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(match_expected, match.Value);
         }
 
-        [ActiveIssue("Incorrect result of match in complied mode in Invariant culture")]
+        [ActiveIssue("Incorrect result of match in complied mode in Invariant culture, https://github.com/dotnet/runtime/issues/58956")]
         [Fact]
         public void Match_InvariantCulture_None_vs_Compiled()
         {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -172,5 +172,35 @@ namespace System.Text.RegularExpressions.Tests
             Assert.False(turkishRegex.IsMatch(input.ToUpperInvariant()));
             Assert.True(turkishRegex.IsMatch(input.ToUpper(turkish)));
         }
+
+        [ActiveIssue("Incorrect handling of IgnoreCase over intervals in Turkish Culture")]
+        [Fact]
+        public void TurkishCulture_Handling_Of_IgnoreCase()
+        {
+            var turkish = new CultureInfo("tr-TR");
+            string input = "I\u0131\u0130i";
+            string pattern = "[H-J][\u0131-\u0140][\u0120-\u0130][h-j]";
+
+            Regex regex = Create(pattern, turkish, RegexOptions.IgnoreCase)[0];
+
+            // The pattern must trivially match the input because all of the letters fall in the given intervals
+            // Ignoring case can only add more letters here -- not REMOVE letters
+            Assert.True(regex.IsMatch(input));
+        }
+
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Doesn't support NonBacktracking")]
+        [Fact]
+        public void TurkishCulture_Handling_Of_IgnoreCase_NonBacktracking()
+        {
+            var turkish = new CultureInfo("tr-TR");
+            string input = "I\u0131\u0130i";
+            string pattern = "[H-J][\u0131-\u0140][\u0120-\u0130][h-j]";
+
+            Regex regex = Create(pattern, turkish, RegexOptions.IgnoreCase | RegexHelpers.RegexOptionNonBacktracking)[0];
+
+            // The pattern must trivially match the input because all of the letters fall in the given intervals
+            // Ignoring case can only add more letters here -- not REMOVE letters
+            Assert.True(regex.IsMatch(input));
+        }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -83,20 +83,30 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
+        public static IEnumerable<object[]> TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture_TestData()
+        {
+            // TODO:  foreach (RegexOptions options in RegexHelpers.RegexOptionsExtended())
+            // this currently fails for NonBacktracking, although all the culture support is there
+            foreach (RegexOptions options in new RegexOptions[] { RegexOptions.None })
+            {
+                yield return new object[] { 2, options };
+                yield return new object[] { 256, options };
+            }
+        }
+
         /// <summary>
         /// See https://en.wikipedia.org/wiki/Dotted_and_dotless_I
         /// </summary>
         [Theory]
-        [InlineData(2)]
-        [InlineData(256)]
+        [MemberData(nameof(TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture_TestData))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/56407", TestPlatforms.Android)]
-        public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture(int length)
+        public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture(int length, RegexOptions options)
         {
             var turkish = new CultureInfo("tr-TR");
             string input = string.Concat(Enumerable.Repeat("I\u0131\u0130i", length / 2));
 
-            Regex[] cultInvariantRegex = Create(input, CultureInfo.InvariantCulture, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-            Regex[] turkishRegex = Create(input, turkish, RegexOptions.IgnoreCase);
+            Regex[] cultInvariantRegex = Create(input, CultureInfo.InvariantCulture, options | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            Regex[] turkishRegex = Create(input, turkish, options | RegexOptions.IgnoreCase);
 
             // same input and regex does match so far so good
             Assert.All(cultInvariantRegex, rex => Assert.True(rex.IsMatch(input)));

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -250,57 +250,6 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(match, m.Value);
         }
 
-        [Theory]
-        [InlineData("(?i:I)", "xy\u0131ab", "", "", "\u0131")]
-        [InlineData("(?i:iI+)", "abcIIIxyz", "III", "III", "")]
-        [InlineData("(?i:iI+)", "abcIi\u0130xyz", "Ii\u0130", "Ii", "")]
-        [InlineData("(?i:iI+)", "abcI\u0130ixyz", "I\u0130i", "", "")]
-        [InlineData("(?i:iI+)", "abc\u0130IIxyz", "\u0130II", "II", "\u0130II")]
-        [InlineData("(?i:iI+)", "abc\u0130\u0131Ixyz", "", "", "\u0130\u0131I")]
-        [InlineData("(?i:iI+)", "abc\u0130Iixyz", "\u0130Ii", "Ii", "\u0130I")]
-        [InlineData("(?i:[^IJKLM]I)", "ii\u0130i\u0131ab", "", "\u0130i", "i\u0131")]
-        public void TestOfCulturesInSRM(string pattern, string input, string match_en_expected, string match_in_expected, string match_tr_expected)
-        {
-            CultureInfo tr_culture = new CultureInfo("tr");
-            CultureInfo savedCulture = CultureInfo.CurrentCulture;
-            CultureInfo.CurrentCulture = tr_culture;
-            //this will treat i=\u0130 and I=\u0131 but i!=I
-            Regex r_tr = new Regex(pattern, RegexOptions.NonBacktracking);
-            Regex r_tr_ = new Regex(pattern, RegexOptions.None);
-            var s = r_tr.Match(input).Value;
-            var s_ = r_tr_.Match(input).Value;
-            CultureInfo.CurrentCulture = savedCulture;
-            Assert.Equal(s, s_);
-            //this will treat i=I and i!=\u0130 and I!=\u131
-            Regex r_in = new Regex(pattern, RegexOptions.NonBacktracking | RegexOptions.CultureInvariant);
-            //this is the default for e-US culture where
-            //i=I=\u130 but I!=\u0131 
-            Regex r_en = new Regex(pattern, RegexOptions.NonBacktracking);
-
-            TestOfCulturesInSRM_(r_en, r_in, r_tr, input, match_en_expected, match_in_expected, match_tr_expected);
-
-            //validate that the correct results are maintained through serialization
-            TestOfCulturesInSRM_(SerDeser(r_en), SerDeser(r_in), SerDeser(r_tr), input, match_en_expected, match_in_expected, match_tr_expected);
-        }
-
-        private static Regex SerDeser(Regex r) => Deserialize(Serialize(r));
-
-        private void TestOfCulturesInSRM_(Regex r_en, Regex r_in, Regex r_tr, string input,
-            string match_en_expected, string match_in_expected, string match_tr_expected)
-        {
-            var match_en = r_en.Match(input);
-            var match_in = r_in.Match(input);
-            var match_tr = r_tr.Match(input);
-
-            Assert.Equal(match_en_expected != string.Empty, match_en.Success);
-            Assert.Equal(match_in_expected != string.Empty, match_in.Success);
-            Assert.Equal(match_tr_expected != string.Empty, match_tr.Success);
-
-            Assert.Equal(match_en_expected, match_en.Value);
-            Assert.Equal(match_in_expected, match_in.Value);
-            Assert.Equal(match_tr_expected, match_tr.Value);
-        }
-
         [Fact]
         public void TestAltOrderIndependence()
         {


### PR DESCRIPTION
Lifted more unit test to also handle NonBacktracking, including most Culture tests and all MultiMatching test (only excluding cases that are not supported with NonBacktracking).
Currently investigating a failing case for Turkish i, that should clearly be working because it is specifically supported in NonBacktracking mode, but it seems that some culture option is not being propagated correctly. 