### PR TITLE
Srm update

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -250,6 +310,9 @@
     <value>contiguous matches (\\G)</value>
   </data>
   <data name="ExpressionDescription_AtomicSubexpressions" xml:space="preserve">
-    <value>atomic subexpressions (?> pattern)</value>
+    <value>atomic subexpressions (?&gt; pattern)</value>
+  </data>
+  <data name="ExpressionDescription_IfThenElse" xml:space="preserve">
+    <value>test conditional (?( test-pattern ) yes-pattern | no-pattern )</value>
   </data>
 </root>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -433,7 +433,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 return _builder.MkLoop(body, isLazy, node.M, node.N);
             }
 
-            // TODO: recognizing strictly only [] (RegexNode.Nothing), for example [0-[0]] would not be regonized
+            // TODO: recognizing strictly only [] (RegexNode.Nothing), for example [0-[0]] would not be recognized
             bool IsNothing(RegexNode node) => node.Type == RegexNode.Nothing || (node.Type == RegexNode.Set && ConvertSet(node).IsNothing);
 
             bool IsDotStar(RegexNode node) => node.Type == RegexNode.Setloop && Convert(node, false).IsDotStar;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -294,7 +294,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
                     throw new NotSupportedException(SR.Format(SR.NotSupported_NonBacktrackingConflictingExpression, node.Type switch
                     {
-                        RegexNode.Testgroup => SR.ExpressionDescription_IfThenElse,
+                        //RegexNode.Testgroup => SR.ExpressionDescription_IfThenElse,
                         RegexNode.Ref => SR.ExpressionDescription_Backreference,
                         RegexNode.Testref => SR.ExpressionDescription_Conditional,
                         RegexNode.Require => SR.ExpressionDescription_PositiveLookaround,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -294,7 +294,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
                     throw new NotSupportedException(SR.Format(SR.NotSupported_NonBacktrackingConflictingExpression, node.Type switch
                     {
-                        //RegexNode.Testgroup => SR.ExpressionDescription_IfThenElse,
+                        RegexNode.Testgroup => SR.ExpressionDescription_IfThenElse,
                         RegexNode.Ref => SR.ExpressionDescription_Backreference,
                         RegexNode.Testref => SR.ExpressionDescription_Conditional,
                         RegexNode.Require => SR.ExpressionDescription_PositiveLookaround,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -454,6 +454,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     conjuncts.Add(node.Child(0));
                     node = node.Child(1);
                 }
+
                 conjuncts.Add(node);
                 return true;
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -263,9 +263,6 @@ namespace System.Text.RegularExpressions.Symbolic
                 case RegexNode.Setlazy:
                     return ConvertSetloop(node, node.Type == RegexNode.Setlazy);
 
-                case RegexNode.Testgroup:
-                    return _builder.MkIfThenElse(Convert(node.Child(0), false), Convert(node.Child(1), false), Convert(node.Child(2), false));
-
                 // TBD: ECMA case intersect predicate with ascii range ?
                 case RegexNode.Boundary:
                 case RegexNode.ECMABoundary:
@@ -282,8 +279,22 @@ namespace System.Text.RegularExpressions.Symbolic
                     return _builder._nothing;
 
                 default:
+                    if (node.Type == RegexNode.Testgroup)
+                    {
+                        // Try to extract the special case representing complement or intersection
+                        if (IsComplementedNode(node))
+                        {
+                            return _builder.MkNot(Convert(node.Child(0), false));
+                        }
+                        List<RegexNode> conjuncts = new();
+                        if (TryGetIntersection(node, conjuncts))
+                        {
+                            return _builder.MkAnd(Array.ConvertAll(conjuncts.ToArray(), x => Convert(x, false)));
+                        }
+                    }
                     throw new NotSupportedException(SR.Format(SR.NotSupported_NonBacktrackingConflictingExpression, node.Type switch
                     {
+                        RegexNode.Testgroup => SR.ExpressionDescription_IfThenElse,
                         RegexNode.Ref => SR.ExpressionDescription_Backreference,
                         RegexNode.Testref => SR.ExpressionDescription_Conditional,
                         RegexNode.Require => SR.ExpressionDescription_PositiveLookaround,
@@ -421,6 +432,32 @@ namespace System.Text.RegularExpressions.Symbolic
                 SymbolicRegexNode<BDD> body = _builder.MkSingleton(moveCond);
                 return _builder.MkLoop(body, isLazy, node.M, node.N);
             }
+
+            // TODO: recognizing strictly only [] (RegexNode.Nothing), for example [0-[0]] would not be regonized
+            bool IsNothing(RegexNode node) => node.Type == RegexNode.Nothing || (node.Type == RegexNode.Set && ConvertSet(node).IsNothing);
+
+            bool IsDotStar(RegexNode node) => node.Type == RegexNode.Setloop && Convert(node, false).IsDotStar;
+
+            bool IsIntersect(RegexNode node) => node.Type == RegexNode.Testgroup && IsNothing(node.Child(2));
+
+            bool TryGetIntersection(RegexNode node, List<RegexNode> conjuncts)
+            {
+                if (!IsIntersect(node))
+                {
+                    return false;
+                }
+                conjuncts.Add(node.Child(0));
+                node = node.Child(1);
+                while (IsIntersect(node))
+                {
+                    conjuncts.Add(node.Child(0));
+                    node = node.Child(1);
+                }
+                conjuncts.Add(node);
+                return true;
+            }
+
+            bool IsComplementedNode(RegexNode node) => IsNothing(node.Child(1)) && IsDotStar(node.Child(2));
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -446,6 +446,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 {
                     return false;
                 }
+
                 conjuncts.Add(node.Child(0));
                 node = node.Child(1);
                 while (IsIntersect(node))

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -747,6 +747,7 @@ namespace System.Text.RegularExpressions.Symbolic
             lock (this)
             {
                 state.Id = _stateCache.Count;
+                int k = state.GetHashCode();
                 _stateCache.Add(state);
 
                 Debug.Assert(_statearray is not null);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -304,14 +304,11 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         /// <summary>
-        /// Make an if-then-else regex (?(cond)left|right),
-        /// or create it as conjuction if right is false
+        /// Make a complemented node
         /// </summary>
-        /// <param name="cond">condition</param>
-        /// <param name="left">true case</param>
-        /// <param name="right">false case</param>
+        /// <param name="node">node to be complemented</param>
         /// <returns></returns>
-        internal SymbolicRegexNode<TElement> MkIfThenElse(SymbolicRegexNode<TElement> cond, SymbolicRegexNode<TElement> left, SymbolicRegexNode<TElement> right) => SymbolicRegexNode<TElement>.MkIfThenElse(this, cond, left, right);
+        internal SymbolicRegexNode<TElement> MkNot(SymbolicRegexNode<TElement> node) => SymbolicRegexNode<TElement>.MkNot(this, node);
 
         internal SymbolicRegexNode<TElement> NormalizeGeneralLoops(SymbolicRegexNode<TElement> sr)
         {
@@ -494,12 +491,9 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
 
                 default:
-                    Debug.Assert(sr._kind == SymbolicRegexKind.IfThenElse);
-                    Debug.Assert(sr._iteCond is not null && sr._left is not null && sr._right is not null);
-                    return builderT.MkIfThenElse(
-                        Transform(sr._iteCond, builderT, predicateTransformer),
-                        Transform(sr._left, builderT, predicateTransformer),
-                        Transform(sr._right, builderT, predicateTransformer));
+                    Debug.Assert(sr._kind == SymbolicRegexKind.Not);
+                    Debug.Assert(sr._left is not null);
+                    return builderT.MkNot(Transform(sr._left, builderT, predicateTransformer));
             }
         }
 
@@ -607,15 +601,13 @@ namespace System.Text.RegularExpressions.Symbolic
                         return disj;
                         #endregion
                     }
-                case 'I': //if then else I(x,y,z)
+                case 'N': //Negation Nx
                     {
-                        #region ITE
-                        SymbolicRegexNode<TElement> cond = Parse(s, i + 2, out int n);
-                        SymbolicRegexNode<TElement> first = Parse(s, n + 1, out int m);
-                        SymbolicRegexNode<TElement> second = Parse(s, m + 1, out int k);
-                        var ite = SymbolicRegexNode<TElement>.MkIfThenElse(this, cond, first, second);
-                        i_next = k + 1;
-                        return ite;
+                        #region negation
+                        SymbolicRegexNode<TElement> cond = Parse(s, i + 1, out int n);
+                        var compl = SymbolicRegexNode<TElement>.MkNot(this, cond);
+                        i_next = n;
+                        return compl;
                         #endregion
                     }
                 case 'A':

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexInfo.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexInfo.cs
@@ -181,9 +181,14 @@ namespace System.Text.RegularExpressions.Symbolic
 
         public static SymbolicRegexInfo Not(SymbolicRegexInfo info) =>
             // Nullability is complemented, all other properties remain the same
-            // Observe that Not(Not(info)) == info
-            Mk(isAlwaysNullable: !info.IsNullable,
-                canBeNullable: !info.CanBeNullable,
+            // The following rules are used to determine nullability of Not(node):
+            // Observe that this is used as an over-approximation, actual nullability is checked dynamically based on given context.
+            // - If node is never nullable (for any context, info.CanBeNullable=false) then Not(node) is always nullable
+            // - If node is always nullable (info.IsNullable=true) then Not(node) can never be nullable
+            // For example \B.CanBeNullable=true and \B.IsNullable=false
+            // and ~(\B).CanBeNullable=true and ~(\B).IsNullable=false
+            Mk(isAlwaysNullable: !info.CanBeNullable,
+                canBeNullable: !info.IsNullable,
                 startsWithLineAnchor: info.StartsWithLineAnchor,
                 startsWithBoundaryAnchor: info.StartsWithBoundaryAnchor,
                 containsSomeAnchor: info.ContainsSomeAnchor,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexInfo.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexInfo.cs
@@ -179,19 +179,17 @@ namespace System.Text.RegularExpressions.Symbolic
             return Mk(i);
         }
 
-        public static SymbolicRegexInfo IfThenElse(SymbolicRegexInfo cond_info, SymbolicRegexInfo then_info, SymbolicRegexInfo else_info)
-        {
-            uint i = (cond_info._info | then_info._info | else_info._info) & ~IsAlwaysNullableMask;
-
-            // It is unclear exactly what the correct behavior should be of anchors in ITE and for lazy loops
-            bool isAlwaysNullable = cond_info.IsNullable ? then_info.IsNullable : else_info.IsNullable;
-            if (isAlwaysNullable)
-            {
-                i |= IsAlwaysNullableMask | CanBeNullableMask;
-            }
-
-            return Mk(i);
-        }
+        public static SymbolicRegexInfo Not(SymbolicRegexInfo info) =>
+            // Nullability is complemented, all other properties remain the same
+            // Observe that Not(Not(info)) == info
+            Mk(isAlwaysNullable: !info.IsNullable,
+                canBeNullable: !info.CanBeNullable,
+                startsWithLineAnchor: info.StartsWithLineAnchor,
+                startsWithBoundaryAnchor: info.StartsWithBoundaryAnchor,
+                containsSomeAnchor: info.ContainsSomeAnchor,
+                containsLineAnchor: info.ContainsLineAnchor,
+                containsSomeCharacter: info.ContainsSomeCharacter,
+                isLazy: info.IsLazy);
 
         public override bool Equals(object? obj) => obj is SymbolicRegexInfo i && i._info == _info;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexKind.cs
@@ -13,7 +13,7 @@ namespace System.Text.RegularExpressions.Symbolic
         Or = 0x10,
         Concat = 0x20,
         Loop = 0x40,
-        IfThenElse = 0x80,
+        Not = 0x80,
         And = 0x100,
         WatchDog = 0x200,
         BOLAnchor = 0x400,

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -53,8 +53,7 @@ namespace System.Text.RegularExpressions.Symbolic
             _upper = upper;
             _set = set;
             _alts = alts;
-            // Ensure Hashcode is precomputed at construction time
-            EnsureHashCode();
+            _hashcode = ComputeHashCode();
         }
         /// <summary>True if this node only involves lazy loops</summary>
         internal bool IsLazy => _info.IsLazy;
@@ -74,7 +73,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal SymbolicRegexInfo _info;
 
-        private int _hashcode = -1;
+        private readonly int _hashcode;
 
         #region Serialization
 
@@ -843,50 +842,40 @@ namespace System.Text.RegularExpressions.Symbolic
             return _hashcode;
         }
 
-        private void EnsureHashCode()
+        private int ComputeHashCode()
         {
-            if (_hashcode == -1)
+            switch (_kind)
             {
-                switch (_kind)
-                {
-                    case SymbolicRegexKind.EndAnchor:
-                    case SymbolicRegexKind.StartAnchor:
-                    case SymbolicRegexKind.BOLAnchor:
-                    case SymbolicRegexKind.EOLAnchor:
-                    case SymbolicRegexKind.Epsilon:
-                    case SymbolicRegexKind.WBAnchor:
-                    case SymbolicRegexKind.NWBAnchor:
-                    case SymbolicRegexKind.EndAnchorZ:
-                    case SymbolicRegexKind.EndAnchorZRev:
-                        _hashcode = HashCode.Combine(_kind, _info);
-                        break;
+                case SymbolicRegexKind.EndAnchor:
+                case SymbolicRegexKind.StartAnchor:
+                case SymbolicRegexKind.BOLAnchor:
+                case SymbolicRegexKind.EOLAnchor:
+                case SymbolicRegexKind.Epsilon:
+                case SymbolicRegexKind.WBAnchor:
+                case SymbolicRegexKind.NWBAnchor:
+                case SymbolicRegexKind.EndAnchorZ:
+                case SymbolicRegexKind.EndAnchorZRev:
+                    return HashCode.Combine(_kind, _info);
 
-                    case SymbolicRegexKind.WatchDog:
-                        _hashcode = HashCode.Combine(_kind, _lower);
-                        break;
+                case SymbolicRegexKind.WatchDog:
+                    return HashCode.Combine(_kind, _lower);
 
-                    case SymbolicRegexKind.Loop:
-                        _hashcode = HashCode.Combine(_kind, _left, _lower, _upper, _info);
-                        break;
+                case SymbolicRegexKind.Loop:
+                    return HashCode.Combine(_kind, _left, _lower, _upper, _info);
 
-                    case SymbolicRegexKind.Or or SymbolicRegexKind.And:
-                        _hashcode = HashCode.Combine(_kind, _alts, _info);
-                        break;
+                case SymbolicRegexKind.Or or SymbolicRegexKind.And:
+                    return HashCode.Combine(_kind, _alts, _info);
 
-                    case SymbolicRegexKind.Concat:
-                        _hashcode = HashCode.Combine(_left, _right, _info);
-                        break;
+                case SymbolicRegexKind.Concat:
+                    return HashCode.Combine(_left, _right, _info);
 
-                    case SymbolicRegexKind.Singleton:
-                        _hashcode = HashCode.Combine(_kind, _set);
-                        break;
+                case SymbolicRegexKind.Singleton:
+                    return HashCode.Combine(_kind, _set);
 
-                    default:
-                        Debug.Assert(_kind == SymbolicRegexKind.Not);
-                        _hashcode = HashCode.Combine(_kind, _left);
-                        break;
-                };
-            }
+                default:
+                    Debug.Assert(_kind == SymbolicRegexKind.Not);
+                    return HashCode.Combine(_kind, _left);
+            };
         }
 
         public override bool Equals([NotNullWhen(true)] object? obj)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -330,8 +330,7 @@ namespace System.Text.RegularExpressions.Symbolic
             {
                 Enumerator enumerator = GetEnumerator();
                 bool nonempty = enumerator.MoveNext();
-                // Collection must be nonempty because IsNothing is false and IsEverything is false
-                Debug.Assert(nonempty);
+                Debug.Assert(nonempty, "Collection must be nonempty because IsNothing is false and IsEverything is false");
                 SymbolicRegexNode<S> node = enumerator.Current;
                 if (!enumerator.MoveNext())
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -318,11 +318,9 @@ namespace System.Text.RegularExpressions.Symbolic
 
         public void ToString(StringBuilder sb)
         {
-            const string EmptyCharClass = "[]";
-
             if (IsNothing)
             {
-                sb.Append(EmptyCharClass);
+                sb.Append(SymbolicRegexNode<S>.EmptyCharClass);
             }
             else if (IsEverything)
             {
@@ -380,7 +378,7 @@ namespace System.Text.RegularExpressions.Symbolic
                         }
                         node.ToString(sb);
                         while (count-- > 0)
-                            sb.Append($"|{EmptyCharClass})");
+                            sb.Append($"|{SymbolicRegexNode<S>.EmptyCharClass})");
                     }
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -377,8 +377,11 @@ namespace System.Text.RegularExpressions.Symbolic
                             count++;
                         }
                         node.ToString(sb);
+
                         while (count-- > 0)
+                        {
                             sb.Append($"|{SymbolicRegexNode<S>.EmptyCharClass})");
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1316,8 +1316,9 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(RegexHelpers.RegexOptions_TestData), MemberType = typeof(RegexHelpers))]
         public void StressTestDeepNestingOfConcat(RegexOptions options)
         {
-            string pattern = string.Concat(Enumerable.Repeat("([a-z]", RegexHelpers.StressTestNestingDepth).Concat(Enumerable.Repeat(")", RegexHelpers.StressTestNestingDepth)));
-            string input = string.Concat(Enumerable.Repeat("abcde", RegexHelpers.StressTestNestingDepth / 5));
+            int k = RegexHelpers.StressTestNestingDepth;
+            string pattern = string.Concat(Enumerable.Repeat("([a-z]",k).Concat(Enumerable.Repeat(")", k)));
+            string input = string.Concat(Enumerable.Repeat("abcde", k / 5));
             var re = new Regex(pattern, options);
             Assert.True(re.IsMatch(input));
         }


### PR DESCRIPTION
- Updated `ToString` of `SymbolicRegexNode` to use `StringBuilder` internally.

- Eliminated `IfThenElse` node from the AST of `SymbolicRegexNode`. 
Replaced it by more restricted `Not` node.
Now the general case is not supported. 
It will now also be very easy to only allow And and Not in DEBUG build. 
with a small localized change to make this 
part conditional in DEBUG mode:

```
                    if (node.Type == RegexNode.Testgroup)
                    {
                        // Try to extract the special case representing complement or intersection
                        if (IsComplementedNode(node))
                        {
                            return _builder.MkNot(Convert(node.Child(0), false));
                        }
                        List<RegexNode> conjuncts = new();
                        if (TryGetIntersection(node, conjuncts))
                        {
                            return _builder.MkAnd(Array.ConvertAll(conjuncts.ToArray(), x => Convert(x, false)));
                        }
                    }
```

I also added the lines
```
        /// <summary>test conditional (?( test-pattern ) yes-pattern | no-pattern )</summary>
        internal static string @ExpressionDescription_IfThenElse => GetResourceString("@ExpressionDescription_IfThenElse", @"test conditional (?( test-pattern ) yes-pattern | no-pattern )");
```
into `System.SR.cs` but then noticed this file is autogenerated, not sure where/waht to edit so this gets added. So I'lll comment out the following line (or I guess else the build will fail)
        `//RegexNode.Testgroup => SR.ExpressionDescription_IfThenElse,`
in `RegexNodeToSymbolicConverter`