### PR TITLE
update-feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,12 +5,11 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,10 +24,10 @@
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3-beta1.21268.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <!-- Package dependencies -->
     <SystemCommandLineVersion>2.0.0-beta1.21118.1</SystemCommandLineVersion>
-    <IcedVersion>1.8.0</IcedVersion>
+    <IcedVersion>1.11.3</IcedVersion>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
-    <CoverletVersion>1.3.0</CoverletVersion>
-    <DNNEVersion>1.0.22</DNNEVersion>
+    <CoverletVersion>3.1.0</CoverletVersion>
+    <DNNEVersion>1.0.23</DNNEVersion>
     <!-- Set the custom NETCoreApp version based on the VS redist package version -->
     <MicrosoftNETCoreAppVersion>$(VSRedistCommonNetCoreSharedFrameworkx6460Version)</MicrosoftNETCoreAppVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,7 @@
     <XUnitRunnerVisualStudioVersion>2.4.3</XUnitRunnerVisualStudioVersion>
     <!-- Roslyn dependencies -->
     <CompilerPlatformVersion>4.0.0-2.21329.25</CompilerPlatformVersion>
-    <CompilerPlatformTestingVersion>1.1.0</CompilerPlatformTestingVersion>
+    <CompilerPlatformTestingVersion>1.1.1-beta1.21351.1</CompilerPlatformTestingVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3-beta1.21268.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <!-- Package dependencies -->
     <SystemCommandLineVersion>2.0.0-beta1.21216.1</SystemCommandLineVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <CompilerPlatformTestingVersion>1.1.0</CompilerPlatformTestingVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3-beta1.21268.3</MicrosoftCodeAnalysisAnalyzersVersion>
     <!-- Package dependencies -->
-    <SystemCommandLineVersion>2.0.0-beta1.21118.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.21216.1</SystemCommandLineVersion>
     <IcedVersion>1.11.3</IcedVersion>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <CoverletVersion>3.1.0</CoverletVersion>


### PR DESCRIPTION
Update NuGet.config to not reference nuget.org and update package versions to packages that are on the dotnet-public feed.