### PR TITLE
password search unit test with conjunction and complement

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -438,7 +438,7 @@ namespace System.Text.RegularExpressions.Symbolic
             // TODO: recognizing strictly only [] (RegexNode.Nothing), for example [0-[0]] would not be recognized
             bool IsNothing(RegexNode node) => node.Type == RegexNode.Nothing || (node.Type == RegexNode.Set && ConvertSet(node).IsNothing);
 
-            bool IsDotStar(RegexNode node) => node.Type == RegexNode.Setloop && Convert(node, false).IsDotStar;
+            bool IsDotStar(RegexNode node) => node.Type == RegexNode.Setloop && Convert(node, false).IsAnyStar;
 
             bool IsIntersect(RegexNode node) => node.Type == RegexNode.Testgroup && IsNothing(node.Child(2));
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -119,7 +119,7 @@ namespace System.Text.RegularExpressions.Symbolic
             _newLinePredicate = solver.False;
             _nothing = SymbolicRegexNode<TElement>.MkFalse(this);
             _dot = SymbolicRegexNode<TElement>.MkTrue(this);
-            _dotStar = SymbolicRegexNode<TElement>.MkDotStar(this, _dot);
+            _dotStar = SymbolicRegexNode<TElement>.MkStar(this, _dot);
 
             // --- initialize singletonCache ---
             _singletonCache[_solver.False] = _nothing;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -23,8 +23,8 @@ namespace System.Text.RegularExpressions.Symbolic
         internal readonly SymbolicRegexNode<TElement> _endAnchorZRev;
         internal readonly SymbolicRegexNode<TElement> _bolAnchor;
         internal readonly SymbolicRegexNode<TElement> _eolAnchor;
-        internal readonly SymbolicRegexNode<TElement> _dot;
-        internal readonly SymbolicRegexNode<TElement> _dotStar;
+        internal readonly SymbolicRegexNode<TElement> _anyChar;
+        internal readonly SymbolicRegexNode<TElement> _anyStar;
         internal readonly SymbolicRegexNode<TElement> _wbAnchor;
         internal readonly SymbolicRegexNode<TElement> _nwbAnchor;
         internal readonly SymbolicRegexSet<TElement> _fullSet;
@@ -118,12 +118,12 @@ namespace System.Text.RegularExpressions.Symbolic
             // update the previous character context to mark that the previous caharcter was \n
             _newLinePredicate = solver.False;
             _nothing = SymbolicRegexNode<TElement>.MkFalse(this);
-            _dot = SymbolicRegexNode<TElement>.MkTrue(this);
-            _dotStar = SymbolicRegexNode<TElement>.MkStar(this, _dot);
+            _anyChar = SymbolicRegexNode<TElement>.MkTrue(this);
+            _anyStar = SymbolicRegexNode<TElement>.MkStar(this, _anyChar);
 
             // --- initialize singletonCache ---
             _singletonCache[_solver.False] = _nothing;
-            _singletonCache[_solver.True] = _dot;
+            _singletonCache[_solver.True] = _anyChar;
         }
 
         /// <summary>
@@ -143,12 +143,12 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         internal SymbolicRegexNode<TElement> MkOr(SymbolicRegexSet<TElement> alts) =>
             alts.IsNothing ? _nothing :
-            alts.IsEverything ? _dotStar :
+            alts.IsEverything ? _anyStar :
             alts.IsSingleton ? alts.GetSingletonElement() :
             SymbolicRegexNode<TElement>.MkOr(this, alts);
 
         internal SymbolicRegexNode<TElement> MkOr2(SymbolicRegexNode<TElement> x, SymbolicRegexNode<TElement> y) =>
-            x == _dotStar || y == _dotStar ? _dotStar :
+            x == _anyStar || y == _anyStar ? _anyStar :
             x == _nothing ? y :
             y == _nothing ? x :
             SymbolicRegexNode<TElement>.MkOr(this, x, y);
@@ -159,7 +159,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         internal SymbolicRegexNode<TElement> MkAnd(SymbolicRegexSet<TElement> alts) =>
             alts.IsNothing ? _nothing :
-            alts.IsEverything ? _dotStar :
+            alts.IsEverything ? _anyStar :
             alts.IsSingleton ? alts.GetSingletonElement() :
             SymbolicRegexNode<TElement>.MkAnd(this, alts);
 
@@ -229,7 +229,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 Debug.Assert(regex._set is not null);
                 if (_solver.AreEquivalent(_solver.True, regex._set))
                 {
-                    return _dotStar;
+                    return _anyStar;
                 }
             }
 
@@ -360,7 +360,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     {
                         #region .
                         i_next = i + 1;
-                        return _dot;
+                        return _anyChar;
                         #endregion
                     }
                 case '[':

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -284,7 +284,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
             }
 
-            _dotstarredPattern = _builder.MkConcat(_builder._dotStar, _pattern);
+            _dotstarredPattern = _builder.MkConcat(_builder._anyStar, _pattern);
             _reversePattern = _pattern.Reverse();
             ConfigureeRegexes();
             _prefixBoyerMoore = InitializePrefixBoyerMoore();
@@ -311,7 +311,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 _ => PartitionClassifier.Create((CharSetSolver)(object)_builder._solver, minterms),
             };
 
-            _dotstarredPattern = _builder.MkConcat(_builder._dotStar, _pattern);
+            _dotstarredPattern = _builder.MkConcat(_builder._anyStar, _pattern);
             _reversePattern = _pattern.Reverse();
             ConfigureeRegexes();
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -82,7 +82,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
 
                 #region start foreach
-                if (elem == builder._dotStar)
+                if (elem == builder._anyStar)
                 {
                     // .* is the absorbing element for disjunction
                     if (kind == SymbolicRegexKind.Or)

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -476,34 +476,34 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void PasswordSearch()
         {
-            var twoLower = ".*[a-z].*[a-z].*";
-            var twoUpper = ".*[A-Z].*[A-Z].*";
-            var threeDigits = ".*[0-9].*[0-9].*[0-9].*";
-            var oneSpecial = @".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*";
-            var noCountUp = Not(".*(012|123|234|345|456|567|678|789).*");
-            var noCountDown = Not(".*(987|876|765|654|543|432|321|210).*");
+            string twoLower = ".*[a-z].*[a-z].*";
+            string twoUpper = ".*[A-Z].*[A-Z].*";
+            string threeDigits = ".*[0-9].*[0-9].*[0-9].*";
+            string oneSpecial = @".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*";
+            string Not_countUp = Not(".*(012|123|234|345|456|567|678|789).*");
+            string Not_countDown = Not(".*(987|876|765|654|543|432|321|210).*");
             // Observe that the space character (immediately before '!' in ASCII) is excluded
-            var length = "[!-~]{8,12}";
+            string length = "[!-~]{8,12}";
  
            // Just to make the chance that the randomly generated part actually has a match
            // be astronomically unlikely require 'P' and 'r' to be present also,
            // although this constraint is really bogus from password constraints point of view
-            var contains_first_P_and_then_r = ".*P.*r.*";
+            string contains_first_P_and_then_r = ".*P.*r.*";
 
             // Conjunction of all the above constraints
-            var all = And(twoLower, twoUpper, threeDigits, oneSpecial, noCountUp, noCountDown, length, contains_first_P_and_then_r);
+            string all = And(twoLower, twoUpper, threeDigits, oneSpecial, Not_countUp, Not_countDown, length, contains_first_P_and_then_r);
 
             // search for the password in a context surrounded by word boundaries
-            var re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
+            Regex re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
 
             // Does not qualify because of 123 and connot end between 2 and 3 because of \b
-            var almostPassw1 = "P@ssW0rd123";
+            string almostPassw1 = "P@ssW0rd123";
             // Does not have at least two uppercase
-            var almostPassw2 = "P@55w0rd";
+            string almostPassw2 = "P@55w0rd";
 
             // These two qualify
-            var password1 = "P@55W0rd";
-            var password2 = "Pa5$w00rD";
+            string password1 = "P@55W0rd";
+            string password2 = "Pa5$w00rD";
 
             foreach (int k in new int[] {500, 1000, 5000, 10000, 50000, 100000})
             {
@@ -552,36 +552,36 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void PasswordSearchDual()
         {
-            var Not_twoLower = Not(".*[a-z].*[a-z].*");
-            var Not_twoUpper = Not(".*[A-Z].*[A-Z].*");
-            var Not_threeDigits = Not(".*[0-9].*[0-9].*[0-9].*");
-            var Not_oneSpecial = Not(@".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*");
-            var countUp = ".*(012|123|234|345|456|567|678|789).*";
-            var countDown = ".*(987|876|765|654|543|432|321|210).*";
+            string Not_twoLower = Not(".*[a-z].*[a-z].*");
+            string Not_twoUpper = Not(".*[A-Z].*[A-Z].*");
+            string Not_threeDigits = Not(".*[0-9].*[0-9].*[0-9].*");
+            string Not_oneSpecial = Not(@".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*");
+            string countUp = ".*(012|123|234|345|456|567|678|789).*";
+            string countDown = ".*(987|876|765|654|543|432|321|210).*";
             // Observe that the space character (immediately before '!' in ASCII) is excluded
-            var Not_length = Not("[!-~]{8,12}");
+            string Not_length = Not("[!-~]{8,12}");
 
             // Just to make the chance that the randomly generated part actually has a match
             // be astronomically unlikely require 'P' and 'r' to be present also,
             // although this constraint is really bogus from password constraints point of view
-            var Not_contains_first_P_and_then_r = Not(".*P.*r.*");
+            string Not_contains_first_P_and_then_r = Not(".*P.*r.*");
 
             // Negated disjunction of all the above constraints
             // By deMorgan's laws we know that ~(A|B|...|C) = ~A&~B&...&~C and ~~A = A
             // So Not(Not_twoLower|...) is equivalent to twoLower&~(...)
-            var all = Not($"{Not_twoLower}|{Not_twoUpper}|{Not_threeDigits}|{Not_oneSpecial}|{countUp}|{countDown}|{Not_length}|{Not_contains_first_P_and_then_r}");
+            string all = Not($"{Not_twoLower}|{Not_twoUpper}|{Not_threeDigits}|{Not_oneSpecial}|{countUp}|{countDown}|{Not_length}|{Not_contains_first_P_and_then_r}");
 
             // search for the password in a context surrounded by word boundaries
-            var re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
+            Regex re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
 
             // Does not qualify because of 123 and connot end between 2 and 3 because of \b
-            var almostPassw1 = "P@ssW0rd123";
+            string almostPassw1 = "P@ssW0rd123";
             // Does not have at least two uppercase
-            var almostPassw2 = "P@55w0rd";
+            string almostPassw2 = "P@55w0rd";
 
             // These two qualify
-            var password1 = "P@55W0rd";
-            var password2 = "Pa5$w00rD";
+            string password1 = "P@55W0rd";
+            string password2 = "Pa5$w00rD";
 
             foreach (int k in new int[] { 500, 1000, 5000, 10000, 50000, 100000})
             {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -508,7 +508,7 @@ namespace System.Text.RegularExpressions.Tests
                 byte[] buffer3 = new byte[k];
                 random.NextBytes(buffer1);
                 random.NextBytes(buffer2);
-                random.NextBytes(buffer2);
+                random.NextBytes(buffer3);
                 string part1 = new string(Array.ConvertAll(buffer1, b => (char)b));
                 string part2 = new string(Array.ConvertAll(buffer2, b => (char)b));
                 string part3 = new string(Array.ConvertAll(buffer3, b => (char)b));

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -484,9 +484,14 @@ namespace System.Text.RegularExpressions.Tests
             var noCountDown = Not(".*(987|876|765|654|543|432|321|210).*");
             // Observe that the space character (immediately before '!' in ASCII) is excluded
             var length = "[!-~]{8,12}";
+ 
+           // Just to make the chance that the randomly generated part actually has a match
+           // be astronomically unlikely require 'P' and 'r' to be present also,
+           // although this constraint is really bogus from password constraints point of view
+            var contains_first_P_and_then_r = ".*P.*r.*";
 
             // Conjunction of all the above constraints
-            var all = And(twoLower, twoUpper, threeDigits, oneSpecial, noCountUp, noCountDown, length);
+            var all = And(twoLower, twoUpper, threeDigits, oneSpecial, noCountUp, noCountDown, length, contains_first_P_and_then_r);
 
             // search for the password in a context surrounded by word boundaries
             var re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
@@ -500,7 +505,7 @@ namespace System.Text.RegularExpressions.Tests
             var password1 = "P@55W0rd";
             var password2 = "Pa5$w00rD";
 
-            foreach (int k in new int[] {500, 1000, 5000, 10000, 50000, 100000, 200000 })
+            foreach (int k in new int[] {500, 1000, 5000, 10000, 50000, 100000, 200000, 500000})
             {
                 Random random = new(k);
                 byte[] buffer1 = new byte[k];

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -505,7 +505,85 @@ namespace System.Text.RegularExpressions.Tests
             var password1 = "P@55W0rd";
             var password2 = "Pa5$w00rD";
 
-            foreach (int k in new int[] {500, 1000, 5000, 10000, 50000, 100000, 200000, 500000})
+            foreach (int k in new int[] {500, 1000, 5000, 10000, 50000, 100000})
+            {
+                Random random = new(k);
+                byte[] buffer1 = new byte[k];
+                byte[] buffer2 = new byte[k];
+                byte[] buffer3 = new byte[k];
+                random.NextBytes(buffer1);
+                random.NextBytes(buffer2);
+                random.NextBytes(buffer3);
+                string part1 = new string(Array.ConvertAll(buffer1, b => (char)b));
+                string part2 = new string(Array.ConvertAll(buffer2, b => (char)b));
+                string part3 = new string(Array.ConvertAll(buffer3, b => (char)b));
+
+                string input = $"{part1} {almostPassw1} {part2} {password1} {part3} {password2}, finally this {almostPassw2} does not qualify either";
+
+                int expextedMatch1Index = (2 * k) + almostPassw1.Length + 3;
+                int expextedMatch1Length = password1.Length;
+
+                int expextedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
+                int expextedMatch2Length = password2.Length;
+
+                // Random text hiding almostPassw and password
+                int t = System.Environment.TickCount;
+                Match match1 = re.Match(input);
+                Match match2 = match1.NextMatch();
+                Match match3 = match2.NextMatch();
+                t = System.Environment.TickCount - t;
+
+                _output.WriteLine($@"k={k}, t={t}ms");
+
+                Assert.True(match1.Success);
+                Assert.Equal(expextedMatch1Index, match1.Index);
+                Assert.Equal(expextedMatch1Length, match1.Length);
+                Assert.Equal(password1, match1.Value);
+
+                Assert.True(match2.Success);
+                Assert.Equal(expextedMatch2Index, match2.Index);
+                Assert.Equal(expextedMatch2Length, match2.Length);
+                Assert.Equal(password2, match2.Value);
+
+                Assert.False(match3.Success);
+            }
+        }
+
+        [Fact]
+        public void PasswordSearchDual()
+        {
+            var Not_twoLower = Not(".*[a-z].*[a-z].*");
+            var Not_twoUpper = Not(".*[A-Z].*[A-Z].*");
+            var Not_threeDigits = Not(".*[0-9].*[0-9].*[0-9].*");
+            var Not_oneSpecial = Not(@".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*");
+            var countUp = ".*(012|123|234|345|456|567|678|789).*";
+            var countDown = ".*(987|876|765|654|543|432|321|210).*";
+            // Observe that the space character (immediately before '!' in ASCII) is excluded
+            var Not_length = Not("[!-~]{8,12}");
+
+            // Just to make the chance that the randomly generated part actually has a match
+            // be astronomically unlikely require 'P' and 'r' to be present also,
+            // although this constraint is really bogus from password constraints point of view
+            var Not_contains_first_P_and_then_r = Not(".*P.*r.*");
+
+            // Negated disjunction of all the above constraints
+            // By deMorgan's laws we know that ~(A|B|...|C) = ~A&~B&...&~C and ~~A = A
+            // So Not(Not_twoLower|...) is equivalent to twoLower&~(...)
+            var all = Not($"{Not_twoLower}|{Not_twoUpper}|{Not_threeDigits}|{Not_oneSpecial}|{countUp}|{countDown}|{Not_length}|{Not_contains_first_P_and_then_r}");
+
+            // search for the password in a context surrounded by word boundaries
+            var re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
+
+            // Does not qualify because of 123 and connot end between 2 and 3 because of \b
+            var almostPassw1 = "P@ssW0rd123";
+            // Does not have at least two uppercase
+            var almostPassw2 = "P@55w0rd";
+
+            // These two qualify
+            var password1 = "P@55W0rd";
+            var password2 = "Pa5$w00rD";
+
+            foreach (int k in new int[] { 500, 1000, 5000, 10000, 50000, 100000})
             {
                 Random random = new(k);
                 byte[] buffer1 = new byte[k];

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -520,11 +520,11 @@ namespace System.Text.RegularExpressions.Tests
 
                 string input = $"{part1} {almostPassw1} {part2} {password1} {part3} {password2}, finally this {almostPassw2} does not qualify either";
 
-                int expextedMatch1Index = (2 * k) + almostPassw1.Length + 3;
-                int expextedMatch1Length = password1.Length;
+                int expectedMatch1Index = (2 * k) + almostPassw1.Length + 3;
+                int expectedMatch1Length = password1.Length;
 
-                int expextedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
-                int expextedMatch2Length = password2.Length;
+                int expectedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
+                int expectedMatch2Length = password2.Length;
 
                 // Random text hiding almostPassw and password
                 int t = System.Environment.TickCount;
@@ -536,13 +536,13 @@ namespace System.Text.RegularExpressions.Tests
                 _output.WriteLine($@"k={k}, t={t}ms");
 
                 Assert.True(match1.Success);
-                Assert.Equal(expextedMatch1Index, match1.Index);
-                Assert.Equal(expextedMatch1Length, match1.Length);
+                Assert.Equal(expectedMatch1Index, match1.Index);
+                Assert.Equal(expectedMatch1Length, match1.Length);
                 Assert.Equal(password1, match1.Value);
 
                 Assert.True(match2.Success);
-                Assert.Equal(expextedMatch2Index, match2.Index);
-                Assert.Equal(expextedMatch2Length, match2.Length);
+                Assert.Equal(expectedMatch2Index, match2.Index);
+                Assert.Equal(expectedMatch2Length, match2.Length);
                 Assert.Equal(password2, match2.Value);
 
                 Assert.False(match3.Success);


### PR DESCRIPTION
A sophisticated unit test demonstrating the capability and the performance of handling intersection and complement by NonBacktracking. Arguably the same search is not possible by other means **and no other regex matcher**. **If I'm wrong I would really like to see how**. Pay attention to the printed timing output -- the search is very performant.
(I've added the constraint so that random text in between would have a match with **very low** likelihood so the test may fail very rarely -- something to fix with appropriate fixed input rather than randomly generated blobs.)

I really like this test. It somehow highlights a hidden gem with the engine. Something we should definitely revisit later. I added a `RegexOptions.Extended` note that I discussed with Olli in the board also.