### PR TITLE
Fix building System.IO.Compression.Native

### DIFF
--- a/src/libraries/Native/Windows/CMakeLists.txt
+++ b/src/libraries/Native/Windows/CMakeLists.txt
@@ -62,6 +62,7 @@ if (${CLR_CMAKE_HOST_ARCH} STREQUAL "x86")
 endif ()
 
 # enable control-flow-guard support for native components
+add_compile_options(/guard:cf)
 list(APPEND __SharedLinkArgs /guard:cf)
 
 if (${CLR_CMAKE_HOST_ARCH} STREQUAL "x86_64" OR ${CLR_CMAKE_HOST_ARCH} STREQUAL "amd64" OR ${CLR_CMAKE_HOST_ARCH} STREQUAL "x64")
@@ -79,6 +80,8 @@ endif ()
 # production-time scenarios.
 
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+add_compile_options($<$<CONFIG:RELEASE>:/GL>)
 
 list(APPEND __LinkLibraries $<$<CONFIG:DEBUG>:libcmtd.lib>)
 list(APPEND __LinkLibraries $<$<CONFIG:RELEASE>:libcmt.lib>)

--- a/src/libraries/Native/Windows/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/libraries/Native/Windows/System.IO.Compression.Native/CMakeLists.txt
@@ -89,8 +89,6 @@ if (GEN_SHARED_LIB)
         # This will add versioning to the library
         ${CMAKE_REPO_ROOT}/artifacts/obj/NativeVersion.rc
     )
-    target_compile_options(System.IO.Compression.Native PRIVATE /guard:cf)
-    target_compile_options(System.IO.Compression.Native PRIVATE $<$<CONFIG:RELEASE>:/GL>)
 endif()
 
 if (NOT GEN_SHARED_LIB AND NOT CLR_CMAKE_TARGET_MACCATALYST AND NOT CLR_CMAKE_TARGET_IOS AND NOT CLR_CMAKE_TARGET_TVOS AND NOT CLR_CMAKE_TARGET_ANDROID AND NOT CLR_CMAKE_TARGET_BROWSER)
@@ -101,20 +99,20 @@ add_library(System.IO.Compression.Native-Static
     STATIC
     ${NATIVECOMPRESSION_SOURCES}
 )
-target_compile_options(System.IO.Compression.Native-Static PRIVATE /guard:cf)
-target_compile_options(System.IO.Compression.Native-Static PRIVATE $<$<CONFIG:RELEASE>:/GL>)
 
 if(STATIC_LIBS_ONLY)
     add_library(System.IO.Compression.Native.Aot
         STATIC
         ${NATIVECOMPRESSION_SOURCES}
     )
+    target_compile_options(System.IO.Compression.Native.Aot PRIVATE /guard:cf-)
+    target_compile_options(System.IO.Compression.Native.Aot PRIVATE /GL-)
 
     add_library(System.IO.Compression.Native.Aot.GuardCF
         STATIC
         ${NATIVECOMPRESSION_SOURCES}
     )
-    target_compile_options(System.IO.Compression.Native.Aot.GuardCF PRIVATE /guard:cf)
+    target_compile_options(System.IO.Compression.Native.Aot.GuardCF PRIVATE /GL-)
 endif()
 
 # Allow specification of arguments that should be passed to the linker


### PR DESCRIPTION
CMakeLists for S.I.Compression.Native assumes a clean room and fully configures the compiler. That's how it was written to produce clrcompression.dll.

For single file host, it was hacked to be includable from CLR build that already preconfigures the compiler in some way. Then a STATIC_LIBS_ONLY was carefully threaded through to make it sort of do what we need when included from the CLR build. But we're now in a situation where a partially configured compilation is being reconfigured and various settings are clashing. We were inheriting `/GL` from the CLR build for example.

The low impact fix is to just pass extra /guard:cf- and /GL- wherever we need.