### PR TITLE
Delete unnecessary binplace of libraries .lib files

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -162,7 +162,6 @@
       <LibrariesRuntimeFiles Include="
         $(LibrariesNativeArtifactsPath)*.dll;
         $(LibrariesNativeArtifactsPath)*.dylib;
-        $(LibrariesNativeArtifactsPath)*.lib;
         $(LibrariesNativeArtifactsPath)*.a;
         $(LibrariesNativeArtifactsPath)*.so;
         $(LibrariesNativeArtifactsPath)*.dbg;


### PR DESCRIPTION
This was needed to make System.IO.Compression.lib work. It is not needed after the ControlFlowGuard changes