### PR TITLE
Fix GC polls around Thread.Spinwait

### DIFF
--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -46,7 +46,7 @@ COOP_PINVOKE_HELPER(void, RhDebugBreak, ())
 }
 
 // Busy spin for the given number of iterations.
-COOP_PINVOKE_HELPER(void, RhSpinWait, (int32_t iterations))
+EXTERN_C REDHAWK_API void __cdecl RhSpinWait(int32_t iterations)
 {
     YieldProcessorNormalizationInfo normalizationInfo;
     YieldProcessorNormalizedForPreSkylakeCount(normalizationInfo, iterations);

--- a/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
+++ b/src/coreclr/nativeaot/Runtime/RuntimeInstance.cpp
@@ -313,11 +313,6 @@ COOP_PINVOKE_HELPER(TypeManagerHandle, RhpCreateTypeManager, (HANDLE osModule, v
     return TypeManagerHandle::Create(typeManager);
 }
 
-COOP_PINVOKE_HELPER(HANDLE, RhGetOSModuleForMrt, ())
-{
-    return GetRuntimeInstance()->GetPalInstance();
-}
-
 COOP_PINVOKE_HELPER(void*, RhpRegisterOsModule, (HANDLE hOsModule))
 {
     RuntimeInstance::OsModuleEntry * pEntry = new (nothrow) RuntimeInstance::OsModuleEntry();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -1061,11 +1061,6 @@ namespace Internal.Runtime.Augments
             RuntimeImports.RhHandleFree(handle);
         }
 
-        public static IntPtr RhGetOSModuleForMrt()
-        {
-            return RuntimeImports.RhGetOSModuleForMrt();
-        }
-
         public static IntPtr RhpGetCurrentThread()
         {
             return RuntimeImports.RhpGetCurrentThread();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -364,8 +364,8 @@ namespace System.Runtime
         internal static extern object RhMemberwiseClone(object obj);
 
         // Busy spin for the given number of iterations.
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhSpinWait")]
+        [DllImport(RuntimeLibrary, EntryPoint = "RhSpinWait", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [SuppressGCTransition]
         internal static extern void RhSpinWait(int iterations);
 
         // Yield the cpu to another thread ready to process, if one is available.
@@ -521,10 +521,6 @@ namespace System.Runtime
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetOSModuleFromEEType")]
         internal static extern IntPtr RhGetOSModuleFromEEType(IntPtr pEEType);
-
-        [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhGetOSModuleForMrt")]
-        internal static extern IntPtr RhGetOSModuleForMrt();
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhGetThreadStaticStorageForModule")]


### PR DESCRIPTION
Avoid GC starvation when Thread.Spinwait is called in a tight loop