### PR TITLE
Fix dotnet template name for nuget.config

### DIFF
--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -12,7 +12,7 @@ To use Native AOT with your project, you need to add a reference to the ILCompil
 
 If your project has no `nuget.config` file, it may be created by running
 ```bash
-> dotnet new nuget
+> dotnet new nugetconfig
 ```
 
 from the project's root directory. New package sources must be added after the `<clear />` element if you decide to keep it.

--- a/samples/HelloWorld/README.md
+++ b/samples/HelloWorld/README.md
@@ -20,7 +20,7 @@ For the compiler to work, it first needs to be added to your project.
 In your shell/command prompt navigate to the root directory of your project and run the command:
 
 ```bash
-> dotnet new nuget
+> dotnet new nugetconfig
 ```
 
 This will add a nuget.config file to your application. Open the file and in the ``<packageSources> `` element under ``<clear/>`` add the following:


### PR DESCRIPTION
Minor fix for the NativeAOT Hello World docs: the `dotnet` CLI template for a nuget.config file is named [`nugetconfig` not `nuget`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new).