### PR TITLE
Remove FixedArgument from metadata schema

### DIFF
--- a/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Core/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -54,14 +54,13 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
                 if (cah.IsCustomAttributeOfType(_reader, "System.Runtime.InteropServices", "GuidAttribute"))
                 {
                     CustomAttribute ca = cah.GetCustomAttribute(_reader);
-                    FixedArgumentHandleCollection.Enumerator fahEnumerator = ca.FixedArguments.GetEnumerator();
+                    HandleCollection.Enumerator fahEnumerator = ca.FixedArguments.GetEnumerator();
                     if (!fahEnumerator.MoveNext())
                         continue;
-                    FixedArgumentHandle guidStringArgumentHandle = fahEnumerator.Current;
+                    Handle guidStringArgumentHandle = fahEnumerator.Current;
                     if (fahEnumerator.MoveNext())
                         continue;
-                    FixedArgument guidStringArgument = guidStringArgumentHandle.GetFixedArgument(_reader);
-                    if (!(guidStringArgument.Value.ParseConstantValue(_reader) is string guidString))
+                    if (!(guidStringArgumentHandle.ParseConstantValue(_reader) is string guidString))
                         continue;
                     return new Guid(guidString);
                 }

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryReaderGen.cs
@@ -33,7 +33,7 @@ class MdBinaryReaderGen : CsWriter
 
         foreach (var primitiveType in SchemaDef.PrimitiveTypes)
         {
-            EmitReadPrimitiveCollection(primitiveType.TypeName);
+            EmitReadPrimitiveCollection(primitiveType.TypeName, primitiveType.Name);
         }
 
         foreach (var enumType in SchemaDef.EnumTypes)
@@ -73,7 +73,7 @@ class MdBinaryReaderGen : CsWriter
         CloseScope("Read");
     }
 
-    private void EmitReadPrimitiveCollection(string typeName)
+    private void EmitReadPrimitiveCollection(string typeName, string shortName)
     {
         string collectionTypeName = $"{typeName}Collection";
 
@@ -81,7 +81,7 @@ class MdBinaryReaderGen : CsWriter
         WriteLine($"values = new {collectionTypeName}(reader, offset);");
         WriteLine("uint count;");
         WriteLine("offset = reader.DecodeUnsigned(offset, out count);");
-        WriteLine($"offset = checked(offset + count * sizeof({typeName}));");
+        WriteLine($"offset = checked(offset + count * sizeof({shortName}));");
         WriteLine("return offset;");
         CloseScope("Read");
     }

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/Program.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/Program.cs
@@ -15,7 +15,7 @@ class Program
             writer.EmitSource();
         }
 
-        using (var writer = new WriterGen(@"..\..\..\..\..\ILCompiler.MetadataTransform\src\Internal\Metadata\NativeFormat\Writer\NativeFormatWriterGen.cs"))
+        using (var writer = new WriterGen(@"..\..\..\..\aot\ILCompiler.MetadataTransform\Internal\Metadata\NativeFormat\Writer\NativeFormatWriterGen.cs"))
         {
             writer.EmitSource();
         }
@@ -25,7 +25,7 @@ class Program
             writer.EmitSource();
         }
 
-        using (var writer = new MdBinaryWriterGen(@"..\..\..\..\..\ILCompiler.MetadataTransform\src\Internal\Metadata\NativeFormat\Writer\MdBinaryWriterGen.cs"))
+        using (var writer = new MdBinaryWriterGen(@"..\..\..\..\aot\ILCompiler.MetadataTransform\Internal\Metadata\NativeFormat\Writer\MdBinaryWriterGen.cs"))
         {
             writer.EmitSource();
         }

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/ReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/ReaderGen.cs
@@ -164,8 +164,8 @@ class ReaderGen : CsWriter
         WriteLine("    throw new ArgumentException();");
         CloseScope("_Validate");
 
-        OpenScope("public override String ToString()");
-        WriteLine("return String.Format(\"{0:X8}\", _value);");
+        OpenScope("public override string ToString()");
+        WriteLine("return string.Format(\"{0:X8}\", _value);");
         CloseScope("ToString");
 
         CloseScope(handleName);

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -179,7 +179,6 @@ class SchemaDef
         new EnumType("CallingConventions", "ushort"),
         new EnumType("EventAttributes", "ushort"),
         new EnumType("FieldAttributes", "ushort"),
-        new EnumType("FixedArgumentAttributes", "byte"),
         new EnumType("GenericParameterAttributes", "ushort"),
         new EnumType("GenericParameterKind", "byte"),
         new EnumType("MethodAttributes", "ushort"),
@@ -232,17 +231,6 @@ class SchemaDef
                 new MemberDef(name: "None", value: "0x0"),
                 new MemberDef(name: "Reserved", value: "0x8003"),
                 new MemberDef(name: "SHA1", value: "0x8004"),
-            }
-        ),
-        // FixedArgumentAttributes - used to indicate if an argument for a custom attribute instantiation
-        // should be boxed.
-        new RecordDef(
-            name: "FixedArgumentAttributes",
-            baseTypeName: "byte",
-            flags: RecordDefFlags.Enum | RecordDefFlags.Flags,
-            members: new MemberDef[] {
-                new MemberDef(name: "None", value: "0x0"),
-                new MemberDef(name: "Boxed", value: "0x1", comment: "Values should be boxed as Object"),
             }
         ),
         // NamedArgumentMemberKind - used to disambiguate the referenced members of the named
@@ -609,16 +597,8 @@ class SchemaDef
             flags: RecordDefFlags.ReentrantEquals,
             members: new MemberDef[] {
                 new MemberDef("Constructor", MethodDefOrRef, MemberDefFlags.RecordRef),
-                new MemberDef("FixedArguments", "FixedArgument", MemberDefFlags.List | MemberDefFlags.RecordRef | MemberDefFlags.Child | MemberDefFlags.EnumerateForHashCode),
+                new MemberDef("FixedArguments", TypeDefOrRefOrSpecOrConstant, MemberDefFlags.List | MemberDefFlags.RecordRef | MemberDefFlags.EnumerateForHashCode),
                 new MemberDef("NamedArguments", "NamedArgument", MemberDefFlags.List | MemberDefFlags.RecordRef | MemberDefFlags.Child | MemberDefFlags.EnumerateForHashCode),
-            }
-        ),
-        new RecordDef(
-            name: "FixedArgument",
-            members: new MemberDef[] {
-                new MemberDef("Flags", "FixedArgumentAttributes"),
-                new MemberDef("Type", TypeDefOrRefOrSpec, MemberDefFlags.RecordRef),
-                new MemberDef("Value", TypeDefOrRefOrSpecOrConstant, MemberDefFlags.RecordRef),
             }
         ),
         new RecordDef(
@@ -626,7 +606,8 @@ class SchemaDef
             members: new MemberDef[] {
                 new MemberDef("Flags", "NamedArgumentMemberKind"),
                 new MemberDef("Name", "ConstantStringValue", MemberDefFlags.RecordRef | MemberDefFlags.Child),
-                new MemberDef("Value", "FixedArgument", MemberDefFlags.RecordRef | MemberDefFlags.Child),
+                new MemberDef("Type", TypeDefOrRefOrSpec, MemberDefFlags.RecordRef),
+                new MemberDef("Value", TypeDefOrRefOrSpecOrConstant, MemberDefFlags.RecordRef),
             }
         ),
         new RecordDef(

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/MdBinaryReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/MdBinaryReaderGen.cs
@@ -164,14 +164,6 @@ namespace Internal.Metadata.NativeFormat
             return offset;
         } // Read
 
-        public static uint Read(this NativeReader reader, uint offset, out FixedArgumentAttributes value)
-        {
-            uint ivalue;
-            offset = reader.DecodeUnsigned(offset, out ivalue);
-            value = (FixedArgumentAttributes)ivalue;
-            return offset;
-        } // Read
-
         public static uint Read(this NativeReader reader, uint offset, out GenericParameterAttributes value)
         {
             uint ivalue;
@@ -588,15 +580,6 @@ namespace Internal.Metadata.NativeFormat
             return offset;
         } // Read
 
-        public static uint Read(this NativeReader reader, uint offset, out FixedArgumentHandle handle)
-        {
-            uint value;
-            offset = reader.DecodeUnsigned(offset, out value);
-            handle = new FixedArgumentHandle((int)value);
-            handle._Validate();
-            return offset;
-        } // Read
-
         public static uint Read(this NativeReader reader, uint offset, out FunctionPointerSignatureHandle handle)
         {
             uint value;
@@ -846,18 +829,6 @@ namespace Internal.Metadata.NativeFormat
             offset = reader.DecodeUnsigned(offset, out value);
             handle = new TypeVariableSignatureHandle((int)value);
             handle._Validate();
-            return offset;
-        } // Read
-
-        public static uint Read(this NativeReader reader, uint offset, out FixedArgumentHandleCollection values)
-        {
-            values = new FixedArgumentHandleCollection(reader, offset);
-            uint count;
-            offset = reader.DecodeUnsigned(offset, out count);
-            for (uint i = 0; i < count; ++i)
-            {
-                offset = reader.SkipInteger(offset);
-            }
             return offset;
         } // Read
 

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderCommonGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderCommonGen.cs
@@ -36,15 +36,6 @@ namespace Internal.Metadata.NativeFormat
         SHA1 = 0x8004,
     } // AssemblyHashAlgorithm
 
-    [Flags]
-    public enum FixedArgumentAttributes : byte
-    {
-        None = 0x0,
-
-        /// Values should be boxed as Object
-        Boxed = 0x1,
-    } // FixedArgumentAttributes
-
     public enum GenericParameterKind : byte
     {
         /// Represents a type parameter for a generic type.
@@ -102,34 +93,33 @@ namespace Internal.Metadata.NativeFormat
         Event = 0x22,
         Field = 0x23,
         FieldSignature = 0x24,
-        FixedArgument = 0x25,
-        FunctionPointerSignature = 0x26,
-        GenericParameter = 0x27,
-        MemberReference = 0x28,
-        Method = 0x29,
-        MethodImpl = 0x2a,
-        MethodInstantiation = 0x2b,
-        MethodSemantics = 0x2c,
-        MethodSignature = 0x2d,
-        MethodTypeVariableSignature = 0x2e,
-        ModifiedType = 0x2f,
-        NamedArgument = 0x30,
-        NamespaceDefinition = 0x31,
-        NamespaceReference = 0x32,
-        Parameter = 0x33,
-        PointerSignature = 0x34,
-        Property = 0x35,
-        PropertySignature = 0x36,
-        QualifiedField = 0x37,
-        QualifiedMethod = 0x38,
-        SZArraySignature = 0x39,
-        ScopeDefinition = 0x3a,
-        ScopeReference = 0x3b,
-        TypeDefinition = 0x3c,
-        TypeForwarder = 0x3d,
-        TypeInstantiationSignature = 0x3e,
-        TypeReference = 0x3f,
-        TypeSpecification = 0x40,
-        TypeVariableSignature = 0x41,
+        FunctionPointerSignature = 0x25,
+        GenericParameter = 0x26,
+        MemberReference = 0x27,
+        Method = 0x28,
+        MethodImpl = 0x29,
+        MethodInstantiation = 0x2a,
+        MethodSemantics = 0x2b,
+        MethodSignature = 0x2c,
+        MethodTypeVariableSignature = 0x2d,
+        ModifiedType = 0x2e,
+        NamedArgument = 0x2f,
+        NamespaceDefinition = 0x30,
+        NamespaceReference = 0x31,
+        Parameter = 0x32,
+        PointerSignature = 0x33,
+        Property = 0x34,
+        PropertySignature = 0x35,
+        QualifiedField = 0x36,
+        QualifiedMethod = 0x37,
+        SZArraySignature = 0x38,
+        ScopeDefinition = 0x39,
+        ScopeReference = 0x3a,
+        TypeDefinition = 0x3b,
+        TypeForwarder = 0x3c,
+        TypeInstantiationSignature = 0x3d,
+        TypeReference = 0x3e,
+        TypeSpecification = 0x3f,
+        TypeVariableSignature = 0x40,
     } // HandleType
 } // Internal.Metadata.NativeFormat

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -3506,8 +3506,9 @@ namespace Internal.Metadata.NativeFormat
         } // Constructor
 
         internal Handle _constructor;
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ConstantBooleanArray, ConstantBooleanValue, ConstantByteArray, ConstantByteValue, ConstantCharArray, ConstantCharValue, ConstantDoubleArray, ConstantDoubleValue, ConstantEnumArray, ConstantHandleArray, ConstantInt16Array, ConstantInt16Value, ConstantInt32Array, ConstantInt32Value, ConstantInt64Array, ConstantInt64Value, ConstantReferenceValue, ConstantSByteArray, ConstantSByteValue, ConstantSingleArray, ConstantSingleValue, ConstantStringArray, ConstantStringValue, ConstantUInt16Array, ConstantUInt16Value, ConstantUInt32Array, ConstantUInt32Value, ConstantUInt64Array, ConstantUInt64Value
 
-        public FixedArgumentHandleCollection FixedArguments
+        public HandleCollection FixedArguments
         {
             get
             {
@@ -3515,7 +3516,7 @@ namespace Internal.Metadata.NativeFormat
             }
         } // FixedArguments
 
-        internal FixedArgumentHandleCollection _fixedArguments;
+        internal HandleCollection _fixedArguments;
 
         public NamedArgumentHandleCollection NamedArguments
         {
@@ -4024,135 +4025,6 @@ namespace Internal.Metadata.NativeFormat
             return string.Format("{0:X8}", _value);
         } // ToString
     } // FieldSignatureHandle
-
-    public partial struct FixedArgument
-    {
-        internal MetadataReader _reader;
-        internal FixedArgumentHandle _handle;
-
-        public FixedArgumentHandle Handle
-        {
-            get
-            {
-                return _handle;
-            }
-        } // Handle
-
-        public FixedArgumentAttributes Flags
-        {
-            get
-            {
-                return _flags;
-            }
-        } // Flags
-
-        internal FixedArgumentAttributes _flags;
-        /// One of: TypeDefinition, TypeReference, TypeSpecification
-
-        public Handle Type
-        {
-            get
-            {
-                return _type;
-            }
-        } // Type
-
-        internal Handle _type;
-        /// One of: TypeDefinition, TypeReference, TypeSpecification, ConstantBooleanArray, ConstantBooleanValue, ConstantByteArray, ConstantByteValue, ConstantCharArray, ConstantCharValue, ConstantDoubleArray, ConstantDoubleValue, ConstantEnumArray, ConstantHandleArray, ConstantInt16Array, ConstantInt16Value, ConstantInt32Array, ConstantInt32Value, ConstantInt64Array, ConstantInt64Value, ConstantReferenceValue, ConstantSByteArray, ConstantSByteValue, ConstantSingleArray, ConstantSingleValue, ConstantStringArray, ConstantStringValue, ConstantUInt16Array, ConstantUInt16Value, ConstantUInt32Array, ConstantUInt32Value, ConstantUInt64Array, ConstantUInt64Value
-
-        public Handle Value
-        {
-            get
-            {
-                return _value;
-            }
-        } // Value
-
-        internal Handle _value;
-    } // FixedArgument
-
-    public partial struct FixedArgumentHandle
-    {
-        public override bool Equals(object obj)
-        {
-            if (obj is FixedArgumentHandle)
-                return _value == ((FixedArgumentHandle)obj)._value;
-            else if (obj is Handle)
-                return _value == ((Handle)obj)._value;
-            else
-                return false;
-        } // Equals
-
-        public bool Equals(FixedArgumentHandle handle)
-        {
-            return _value == handle._value;
-        } // Equals
-
-        public bool Equals(Handle handle)
-        {
-            return _value == handle._value;
-        } // Equals
-
-        public override int GetHashCode()
-        {
-            return (int)_value;
-        } // GetHashCode
-
-        internal int _value;
-
-        internal FixedArgumentHandle(Handle handle) : this(handle._value)
-        {
-        }
-
-        internal FixedArgumentHandle(int value)
-        {
-            HandleType hType = (HandleType)(value >> 24);
-            if (!(hType == 0 || hType == HandleType.FixedArgument || hType == HandleType.Null))
-                throw new ArgumentException();
-            _value = (value & 0x00FFFFFF) | (((int)HandleType.FixedArgument) << 24);
-            _Validate();
-        }
-
-        public static implicit operator  Handle(FixedArgumentHandle handle)
-        {
-            return new Handle(handle._value);
-        } // Handle
-
-        internal int Offset
-        {
-            get
-            {
-                return (this._value & 0x00FFFFFF);
-            }
-        } // Offset
-
-        public FixedArgument GetFixedArgument(MetadataReader reader)
-        {
-            return reader.GetFixedArgument(this);
-        } // GetFixedArgument
-
-        public bool IsNull(MetadataReader reader)
-        {
-            return reader.IsNull(this);
-        } // IsNull
-
-        public Handle ToHandle(MetadataReader reader)
-        {
-            return reader.ToHandle(this);
-        } // ToHandle
-
-        [System.Diagnostics.Conditional("DEBUG")]
-        internal void _Validate()
-        {
-            if ((HandleType)((_value & 0xFF000000) >> 24) != HandleType.FixedArgument)
-                throw new ArgumentException();
-        } // _Validate
-
-        public override string ToString()
-        {
-            return string.Format("{0:X8}", _value);
-        } // ToString
-    } // FixedArgumentHandle
 
     public partial struct FunctionPointerSignature
     {
@@ -5508,8 +5380,20 @@ namespace Internal.Metadata.NativeFormat
         } // Name
 
         internal ConstantStringValueHandle _name;
+        /// One of: TypeDefinition, TypeReference, TypeSpecification
 
-        public FixedArgumentHandle Value
+        public Handle Type
+        {
+            get
+            {
+                return _type;
+            }
+        } // Type
+
+        internal Handle _type;
+        /// One of: TypeDefinition, TypeReference, TypeSpecification, ConstantBooleanArray, ConstantBooleanValue, ConstantByteArray, ConstantByteValue, ConstantCharArray, ConstantCharValue, ConstantDoubleArray, ConstantDoubleValue, ConstantEnumArray, ConstantHandleArray, ConstantInt16Array, ConstantInt16Value, ConstantInt32Array, ConstantInt32Value, ConstantInt64Array, ConstantInt64Value, ConstantReferenceValue, ConstantSByteArray, ConstantSByteValue, ConstantSingleArray, ConstantSingleValue, ConstantStringArray, ConstantStringValue, ConstantUInt16Array, ConstantUInt16Value, ConstantUInt32Array, ConstantUInt32Value, ConstantUInt64Array, ConstantUInt64Value
+
+        public Handle Value
         {
             get
             {
@@ -5517,7 +5401,7 @@ namespace Internal.Metadata.NativeFormat
             }
         } // Value
 
-        internal FixedArgumentHandle _value;
+        internal Handle _value;
     } // NamedArgument
 
     public partial struct NamedArgumentHandle
@@ -8066,69 +7950,6 @@ namespace Internal.Metadata.NativeFormat
         } // ToString
     } // TypeVariableSignatureHandle
 
-    public partial struct FixedArgumentHandleCollection
-    {
-        private NativeReader _reader;
-        private uint _offset;
-
-        internal FixedArgumentHandleCollection(NativeReader reader, uint offset)
-        {
-            _offset = offset;
-            _reader = reader;
-        }
-
-        public int Count
-        {
-            get
-            {
-                uint count;
-                _reader.DecodeUnsigned(_offset, out count);
-                return (int)count;
-            }
-        } // Count
-
-        public Enumerator GetEnumerator()
-        {
-            return new Enumerator(_reader, _offset);
-        } // GetEnumerator
-
-        public struct Enumerator
-        {
-            private NativeReader _reader;
-            private uint _offset;
-            private uint _remaining;
-            private FixedArgumentHandle _current;
-
-            internal Enumerator(NativeReader reader, uint offset)
-            {
-                _reader = reader;
-                _offset = reader.DecodeUnsigned(offset, out _remaining);
-                _current = default(FixedArgumentHandle);
-            }
-
-            public FixedArgumentHandle Current
-            {
-                get
-                {
-                    return _current;
-                }
-            } // Current
-
-            public bool MoveNext()
-            {
-                if (_remaining == 0)
-                    return false;
-                _remaining--;
-                _offset = _reader.Read(_offset, out _current);
-                return true;
-            } // MoveNext
-
-            public void Dispose()
-            {
-            } // Dispose
-        } // Enumerator
-    } // FixedArgumentHandleCollection
-
     public partial struct NamedArgumentHandleCollection
     {
         private NativeReader _reader;
@@ -9949,11 +9770,6 @@ namespace Internal.Metadata.NativeFormat
             return new FieldSignatureHandle(this);
         } // ToFieldSignatureHandle
 
-        public FixedArgumentHandle ToFixedArgumentHandle(MetadataReader reader)
-        {
-            return new FixedArgumentHandle(this);
-        } // ToFixedArgumentHandle
-
         public FunctionPointerSignatureHandle ToFunctionPointerSignatureHandle(MetadataReader reader)
         {
             return new FunctionPointerSignatureHandle(this);
@@ -10417,7 +10233,7 @@ namespace Internal.Metadata.NativeFormat
         public ConstantStringValue GetConstantStringValue(ConstantStringValueHandle handle)
         {
             if (IsNull(handle))
-                return default;
+                return new ConstantStringValue();
             ConstantStringValue record;
             record._reader = this;
             record._handle = handle;
@@ -10536,18 +10352,6 @@ namespace Internal.Metadata.NativeFormat
             offset = _streamReader.Read(offset, out record._type);
             return record;
         } // GetFieldSignature
-
-        public FixedArgument GetFixedArgument(FixedArgumentHandle handle)
-        {
-            FixedArgument record;
-            record._reader = this;
-            record._handle = handle;
-            var offset = (uint)handle.Offset;
-            offset = _streamReader.Read(offset, out record._flags);
-            offset = _streamReader.Read(offset, out record._type);
-            offset = _streamReader.Read(offset, out record._value);
-            return record;
-        } // GetFixedArgument
 
         public FunctionPointerSignature GetFunctionPointerSignature(FunctionPointerSignatureHandle handle)
         {
@@ -10681,6 +10485,7 @@ namespace Internal.Metadata.NativeFormat
             var offset = (uint)handle.Offset;
             offset = _streamReader.Read(offset, out record._flags);
             offset = _streamReader.Read(offset, out record._name);
+            offset = _streamReader.Read(offset, out record._type);
             offset = _streamReader.Read(offset, out record._value);
             return record;
         } // GetNamedArgument
@@ -11098,11 +10903,6 @@ namespace Internal.Metadata.NativeFormat
             return new Handle(handle._value);
         } // ToHandle
 
-        internal Handle ToHandle(FixedArgumentHandle handle)
-        {
-            return new Handle(handle._value);
-        } // ToHandle
-
         internal Handle ToHandle(FunctionPointerSignatureHandle handle)
         {
             return new Handle(handle._value);
@@ -11423,11 +11223,6 @@ namespace Internal.Metadata.NativeFormat
             return new FieldSignatureHandle(handle._value);
         } // ToFieldSignatureHandle
 
-        internal FixedArgumentHandle ToFixedArgumentHandle(Handle handle)
-        {
-            return new FixedArgumentHandle(handle._value);
-        } // ToFixedArgumentHandle
-
         internal FunctionPointerSignatureHandle ToFunctionPointerSignatureHandle(Handle handle)
         {
             return new FunctionPointerSignatureHandle(handle._value);
@@ -11744,11 +11539,6 @@ namespace Internal.Metadata.NativeFormat
         } // IsNull
 
         internal bool IsNull(FieldSignatureHandle handle)
-        {
-            return (handle._value & 0x00FFFFFF) == 0;
-        } // IsNull
-
-        internal bool IsNull(FixedArgumentHandle handle)
         {
             return (handle._value & 0x00FFFFFF) == 0;
         } // IsNull

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.CustomAttribute.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.CustomAttribute.cs
@@ -52,11 +52,7 @@ namespace ILCompiler.Metadata
             result.FixedArguments.Capacity = decodedValue.FixedArguments.Length;
             foreach (var decodedArgument in decodedValue.FixedArguments)
             {
-                var fixedArgument = new FixedArgument
-                {
-                    Type = HandleType(decodedArgument.Type),
-                    Value = HandleCustomAttributeConstantValue(decodedArgument.Type, decodedArgument.Value),
-                };
+                var fixedArgument = HandleCustomAttributeConstantValue(decodedArgument.Type, decodedArgument.Value);
                 result.FixedArguments.Add(fixedArgument);
             }
 
@@ -68,11 +64,8 @@ namespace ILCompiler.Metadata
                     Flags = decodedArgument.Kind == Ecma.CustomAttributeNamedArgumentKind.Field ?
                         NamedArgumentMemberKind.Field : NamedArgumentMemberKind.Property,
                     Name = HandleString(decodedArgument.Name),
-                    Value = new FixedArgument
-                    {
-                        Type = HandleType(decodedArgument.Type),
-                        Value = HandleCustomAttributeConstantValue(decodedArgument.Type, decodedArgument.Value)
-                    }
+                    Type = HandleType(decodedArgument.Type),
+                    Value = HandleCustomAttributeConstantValue(decodedArgument.Type, decodedArgument.Value)
                 };
                 result.NamedArguments.Add(namedArgument);
             }

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
@@ -210,11 +210,6 @@ namespace Internal.Metadata.NativeFormat.Writer
             writer.WriteUnsigned((uint)value);
         } // Write
 
-        public static void Write(this NativeWriter writer, FixedArgumentAttributes value)
-        {
-            writer.WriteUnsigned((uint)value);
-        } // Write
-
         public static void Write(this NativeWriter writer, GenericParameterAttributes value)
         {
             writer.WriteUnsigned((uint)value);
@@ -1066,28 +1061,6 @@ namespace Internal.Metadata.NativeFormat.Writer
             }
             writer.WriteUnsigned((uint)values.Count);
             foreach (FieldSignature value in values)
-            {
-                writer.Write(value);
-            }
-        } // Write
-
-        public static void Write(this NativeWriter writer, FixedArgument record)
-        {
-            if (record != null)
-                writer.WriteUnsigned((uint)record.Handle.Offset);
-            else
-                writer.WriteUnsigned(0);
-        } // Write
-
-        public static void Write(this NativeWriter writer, List<FixedArgument> values)
-        {
-            if (values == null)
-            {
-                writer.WriteUnsigned(0);
-                return;
-            }
-            writer.WriteUnsigned((uint)values.Count);
-            foreach (FixedArgument value in values)
             {
                 writer.Write(value);
             }

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeFormatWriterGen.cs
@@ -2247,6 +2247,39 @@ namespace Internal.Metadata.NativeFormat.Writer
                 Constructor.HandleType == HandleType.QualifiedMethod ||
                 Constructor.HandleType == HandleType.MemberReference);
             writer.Write(Constructor);
+            Debug.Assert(FixedArguments.TrueForAll(handle => handle == null ||
+                handle.HandleType == HandleType.TypeDefinition ||
+                handle.HandleType == HandleType.TypeReference ||
+                handle.HandleType == HandleType.TypeSpecification ||
+                handle.HandleType == HandleType.ConstantBooleanArray ||
+                handle.HandleType == HandleType.ConstantBooleanValue ||
+                handle.HandleType == HandleType.ConstantByteArray ||
+                handle.HandleType == HandleType.ConstantByteValue ||
+                handle.HandleType == HandleType.ConstantCharArray ||
+                handle.HandleType == HandleType.ConstantCharValue ||
+                handle.HandleType == HandleType.ConstantDoubleArray ||
+                handle.HandleType == HandleType.ConstantDoubleValue ||
+                handle.HandleType == HandleType.ConstantEnumArray ||
+                handle.HandleType == HandleType.ConstantHandleArray ||
+                handle.HandleType == HandleType.ConstantInt16Array ||
+                handle.HandleType == HandleType.ConstantInt16Value ||
+                handle.HandleType == HandleType.ConstantInt32Array ||
+                handle.HandleType == HandleType.ConstantInt32Value ||
+                handle.HandleType == HandleType.ConstantInt64Array ||
+                handle.HandleType == HandleType.ConstantInt64Value ||
+                handle.HandleType == HandleType.ConstantReferenceValue ||
+                handle.HandleType == HandleType.ConstantSByteArray ||
+                handle.HandleType == HandleType.ConstantSByteValue ||
+                handle.HandleType == HandleType.ConstantSingleArray ||
+                handle.HandleType == HandleType.ConstantSingleValue ||
+                handle.HandleType == HandleType.ConstantStringArray ||
+                handle.HandleType == HandleType.ConstantStringValue ||
+                handle.HandleType == HandleType.ConstantUInt16Array ||
+                handle.HandleType == HandleType.ConstantUInt16Value ||
+                handle.HandleType == HandleType.ConstantUInt32Array ||
+                handle.HandleType == HandleType.ConstantUInt32Value ||
+                handle.HandleType == HandleType.ConstantUInt64Array ||
+                handle.HandleType == HandleType.ConstantUInt64Value));
             writer.Write(FixedArguments);
             writer.Write(NamedArguments);
         } // Save
@@ -2272,7 +2305,7 @@ namespace Internal.Metadata.NativeFormat.Writer
         } // Handle
 
         public MetadataRecord Constructor;
-        public List<FixedArgument> FixedArguments = new List<FixedArgument>();
+        public List<MetadataRecord> FixedArguments = new List<MetadataRecord>();
         public List<NamedArgument> NamedArguments = new List<NamedArgument>();
     } // CustomAttribute
 
@@ -2569,116 +2602,6 @@ namespace Internal.Metadata.NativeFormat.Writer
 
         public MetadataRecord Type;
     } // FieldSignature
-
-    public partial class FixedArgument : MetadataRecord
-    {
-        public override HandleType HandleType
-        {
-            get
-            {
-                return HandleType.FixedArgument;
-            }
-        } // HandleType
-
-        internal override void Visit(IRecordVisitor visitor)
-        {
-            Type = visitor.Visit(this, Type);
-            Value = visitor.Visit(this, Value);
-        } // Visit
-
-        public override sealed bool Equals(Object obj)
-        {
-            if (Object.ReferenceEquals(this, obj)) return true;
-            var other = obj as FixedArgument;
-            if (other == null) return false;
-            if (Flags != other.Flags) return false;
-            if (!Object.Equals(Type, other.Type)) return false;
-            if (!Object.Equals(Value, other.Value)) return false;
-            return true;
-        } // Equals
-
-        public override sealed int GetHashCode()
-        {
-            if (_hash != 0)
-                return _hash;
-            EnterGetHashCode();
-            int hash = -1598595313;
-            hash = ((hash << 13) - (hash >> 19)) ^ Flags.GetHashCode();
-            hash = ((hash << 13) - (hash >> 19)) ^ (Type == null ? 0 : Type.GetHashCode());
-            hash = ((hash << 13) - (hash >> 19)) ^ (Value == null ? 0 : Value.GetHashCode());
-            LeaveGetHashCode();
-            _hash = hash;
-            return _hash;
-        } // GetHashCode
-
-        internal override void Save(NativeWriter writer)
-        {
-            writer.Write(Flags);
-            Debug.Assert(Type == null ||
-                Type.HandleType == HandleType.TypeDefinition ||
-                Type.HandleType == HandleType.TypeReference ||
-                Type.HandleType == HandleType.TypeSpecification);
-            writer.Write(Type);
-            Debug.Assert(Value == null ||
-                Value.HandleType == HandleType.TypeDefinition ||
-                Value.HandleType == HandleType.TypeReference ||
-                Value.HandleType == HandleType.TypeSpecification ||
-                Value.HandleType == HandleType.ConstantBooleanArray ||
-                Value.HandleType == HandleType.ConstantBooleanValue ||
-                Value.HandleType == HandleType.ConstantByteArray ||
-                Value.HandleType == HandleType.ConstantByteValue ||
-                Value.HandleType == HandleType.ConstantCharArray ||
-                Value.HandleType == HandleType.ConstantCharValue ||
-                Value.HandleType == HandleType.ConstantDoubleArray ||
-                Value.HandleType == HandleType.ConstantDoubleValue ||
-                Value.HandleType == HandleType.ConstantEnumArray ||
-                Value.HandleType == HandleType.ConstantHandleArray ||
-                Value.HandleType == HandleType.ConstantInt16Array ||
-                Value.HandleType == HandleType.ConstantInt16Value ||
-                Value.HandleType == HandleType.ConstantInt32Array ||
-                Value.HandleType == HandleType.ConstantInt32Value ||
-                Value.HandleType == HandleType.ConstantInt64Array ||
-                Value.HandleType == HandleType.ConstantInt64Value ||
-                Value.HandleType == HandleType.ConstantReferenceValue ||
-                Value.HandleType == HandleType.ConstantSByteArray ||
-                Value.HandleType == HandleType.ConstantSByteValue ||
-                Value.HandleType == HandleType.ConstantSingleArray ||
-                Value.HandleType == HandleType.ConstantSingleValue ||
-                Value.HandleType == HandleType.ConstantStringArray ||
-                Value.HandleType == HandleType.ConstantStringValue ||
-                Value.HandleType == HandleType.ConstantUInt16Array ||
-                Value.HandleType == HandleType.ConstantUInt16Value ||
-                Value.HandleType == HandleType.ConstantUInt32Array ||
-                Value.HandleType == HandleType.ConstantUInt32Value ||
-                Value.HandleType == HandleType.ConstantUInt64Array ||
-                Value.HandleType == HandleType.ConstantUInt64Value);
-            writer.Write(Value);
-        } // Save
-
-        internal static FixedArgumentHandle AsHandle(FixedArgument record)
-        {
-            if (record == null)
-            {
-                return new FixedArgumentHandle(0);
-            }
-            else
-            {
-                return record.Handle;
-            }
-        } // AsHandle
-
-        internal new FixedArgumentHandle Handle
-        {
-            get
-            {
-                return new FixedArgumentHandle(HandleOffset);
-            }
-        } // Handle
-
-        public FixedArgumentAttributes Flags;
-        public MetadataRecord Type;
-        public MetadataRecord Value;
-    } // FixedArgument
 
     public partial class FunctionPointerSignature : MetadataRecord
     {
@@ -3517,6 +3440,7 @@ namespace Internal.Metadata.NativeFormat.Writer
         internal override void Visit(IRecordVisitor visitor)
         {
             Name = visitor.Visit(this, Name);
+            Type = visitor.Visit(this, Type);
             Value = visitor.Visit(this, Value);
         } // Visit
 
@@ -3527,6 +3451,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             if (other == null) return false;
             if (Flags != other.Flags) return false;
             if (!Object.Equals(Name, other.Name)) return false;
+            if (!Object.Equals(Type, other.Type)) return false;
             if (!Object.Equals(Value, other.Value)) return false;
             return true;
         } // Equals
@@ -3539,6 +3464,7 @@ namespace Internal.Metadata.NativeFormat.Writer
             int hash = -469180039;
             hash = ((hash << 13) - (hash >> 19)) ^ Flags.GetHashCode();
             hash = ((hash << 13) - (hash >> 19)) ^ (Name == null ? 0 : Name.GetHashCode());
+            hash = ((hash << 13) - (hash >> 19)) ^ (Type == null ? 0 : Type.GetHashCode());
             hash = ((hash << 13) - (hash >> 19)) ^ (Value == null ? 0 : Value.GetHashCode());
             LeaveGetHashCode();
             _hash = hash;
@@ -3549,6 +3475,44 @@ namespace Internal.Metadata.NativeFormat.Writer
         {
             writer.Write(Flags);
             writer.Write(Name);
+            Debug.Assert(Type == null ||
+                Type.HandleType == HandleType.TypeDefinition ||
+                Type.HandleType == HandleType.TypeReference ||
+                Type.HandleType == HandleType.TypeSpecification);
+            writer.Write(Type);
+            Debug.Assert(Value == null ||
+                Value.HandleType == HandleType.TypeDefinition ||
+                Value.HandleType == HandleType.TypeReference ||
+                Value.HandleType == HandleType.TypeSpecification ||
+                Value.HandleType == HandleType.ConstantBooleanArray ||
+                Value.HandleType == HandleType.ConstantBooleanValue ||
+                Value.HandleType == HandleType.ConstantByteArray ||
+                Value.HandleType == HandleType.ConstantByteValue ||
+                Value.HandleType == HandleType.ConstantCharArray ||
+                Value.HandleType == HandleType.ConstantCharValue ||
+                Value.HandleType == HandleType.ConstantDoubleArray ||
+                Value.HandleType == HandleType.ConstantDoubleValue ||
+                Value.HandleType == HandleType.ConstantEnumArray ||
+                Value.HandleType == HandleType.ConstantHandleArray ||
+                Value.HandleType == HandleType.ConstantInt16Array ||
+                Value.HandleType == HandleType.ConstantInt16Value ||
+                Value.HandleType == HandleType.ConstantInt32Array ||
+                Value.HandleType == HandleType.ConstantInt32Value ||
+                Value.HandleType == HandleType.ConstantInt64Array ||
+                Value.HandleType == HandleType.ConstantInt64Value ||
+                Value.HandleType == HandleType.ConstantReferenceValue ||
+                Value.HandleType == HandleType.ConstantSByteArray ||
+                Value.HandleType == HandleType.ConstantSByteValue ||
+                Value.HandleType == HandleType.ConstantSingleArray ||
+                Value.HandleType == HandleType.ConstantSingleValue ||
+                Value.HandleType == HandleType.ConstantStringArray ||
+                Value.HandleType == HandleType.ConstantStringValue ||
+                Value.HandleType == HandleType.ConstantUInt16Array ||
+                Value.HandleType == HandleType.ConstantUInt16Value ||
+                Value.HandleType == HandleType.ConstantUInt32Array ||
+                Value.HandleType == HandleType.ConstantUInt32Value ||
+                Value.HandleType == HandleType.ConstantUInt64Array ||
+                Value.HandleType == HandleType.ConstantUInt64Value);
             writer.Write(Value);
         } // Save
 
@@ -3574,7 +3538,8 @@ namespace Internal.Metadata.NativeFormat.Writer
 
         public NamedArgumentMemberKind Flags;
         public ConstantStringValue Name;
-        public FixedArgument Value;
+        public MetadataRecord Type;
+        public MetadataRecord Value;
     } // NamedArgument
 
     public partial class NamespaceDefinition : MetadataRecord

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeMetadataWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/NativeMetadataWriter.cs
@@ -855,38 +855,6 @@ namespace Internal.Metadata.NativeFormat.Writer
         }
     }
 
-    public partial class FixedArgument
-    {
-        private static bool IsConstantArray(MetadataRecord rec)
-        {
-            switch (rec.HandleType)
-            {
-                case HandleType.ConstantBooleanArray:
-                case HandleType.ConstantCharArray:
-                case HandleType.ConstantStringArray:
-                case HandleType.ConstantByteArray:
-                case HandleType.ConstantSByteArray:
-                case HandleType.ConstantInt16Array:
-                case HandleType.ConstantUInt16Array:
-                case HandleType.ConstantInt32Array:
-                case HandleType.ConstantUInt32Array:
-                case HandleType.ConstantInt64Array:
-                case HandleType.ConstantUInt64Array:
-                case HandleType.ConstantSingleArray:
-                case HandleType.ConstantDoubleArray:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-        public override string ToString()
-        {
-            return Flags.FlagsToString()
-                + (Type != null ? " (" + Type.ToString() + ")" : "")
-                + (Value != null ? " " + Value.ToString() : "");
-        }
-    }
-
     public partial class NamedArgument
     {
         public override string ToString()


### PR DESCRIPTION
SchemaDef.cs is the meat of this change, most of the rest is just generated code and a small adjustment on the reader and writer side.

* `FixedArgumentAttributes` (`FixedArgument.Flags`) was unused
* The type of a fixed argument is redundant with the constructor signature (and is therefore not captured in the ECMA format). We shouldn't duplicate it.
* `NamedArgument` having a `FixedArgument` field was an odd shortcut.