### PR TITLE
Simplify integration of NonBacktracking into Regex

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -213,9 +213,6 @@
   <data name="NotSupported_ReadOnlyCollection" xml:space="preserve">
     <value>Collection is read-only.</value>
   </data>
-  <data name="OnlyAllowedOnce" xml:space="preserve">
-    <value>This operation is only allowed once per object.</value>
-  </data>
   <data name="PlatformNotSupported_CompileToAssembly" xml:space="preserve">
     <value>This platform does not support writing compiled regular expressions to an assembly.</value>
   </data>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -119,7 +119,7 @@ namespace System.Text.RegularExpressions
             }
 
             // Gets the weakly cached replacement helper or creates one if there isn't one already.
-            RegexReplacement repl = RegexReplacement.GetOrCreate(regex._replref!, replacement, regex.caps!, regex.capsize, regex.capnames!, regex.roptions);
+            RegexReplacement repl = RegexReplacement.GetOrCreate(regex.RegexReplacementWeakReference, replacement, regex.caps!, regex._capsizeForReplacements, regex.capnames!, regex.roptions);
             SegmentStringBuilder segments = SegmentStringBuilder.Create();
             repl.ReplacementImpl(ref segments, this);
             return segments.ToString();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -77,7 +77,7 @@ namespace System.Text.RegularExpressions
             // Gets the weakly cached replacement helper or creates one if there isn't one already,
             // then uses it to perform the replace.
             return
-                RegexReplacement.GetOrCreate(_replref!, replacement, caps!, capsize, capnames!, roptions).
+                RegexReplacement.GetOrCreate(RegexReplacementWeakReference, replacement, caps!, _capsizeForReplacements, capnames!, roptions).
                 Replace(this, input, count, startat);
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -62,17 +62,17 @@ namespace System.Text.RegularExpressions
             _capnames = capnames;
 
             _optionsStack = new ValueListBuilder<int>(optionSpan);
-            _stack = default;
-            _group = default;
-            _alternation = default;
-            _concatenation = default;
-            _unit = default;
+            _stack = null;
+            _group = null;
+            _alternation = null;
+            _concatenation = null;
+            _unit = null;
             _currentPos = 0;
-            _autocap = default;
-            _capcount = default;
-            _captop = default;
-            _capnumlist = default;
-            _capnamelist = default;
+            _autocap = 0;
+            _capcount = 0;
+            _captop = 0;
+            _capnumlist = null;
+            _capnamelist = null;
             _ignoreNextParen = false;
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexReplacement.cs
@@ -111,7 +111,7 @@ namespace System.Text.RegularExpressions
         /// Either returns a weakly cached RegexReplacement helper or creates one and caches it.
         /// </summary>
         /// <returns></returns>
-        public static RegexReplacement GetOrCreate(WeakReference<RegexReplacement> replRef, string replacement, Hashtable caps,
+        public static RegexReplacement GetOrCreate(WeakReference<RegexReplacement?> replRef, string replacement, Hashtable caps,
             int capsize, Hashtable capnames, RegexOptions roptions)
         {
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -83,12 +83,9 @@ namespace System.Text.RegularExpressions
         /// any characters that we know can't match.
         /// </summary>
         protected Match? Scan(Regex regex, string text, int textbeg, int textend, int textstart, int prevlen, bool quick) =>
-            ScanInternal(regex, text, textbeg, textend, textstart, prevlen, quick, regex.MatchTimeout);
+            Scan(regex, text, textbeg, textend, textstart, prevlen, quick, regex.MatchTimeout);
 
-        protected Match? Scan(Regex regex, string text, int textbeg, int textend, int textstart, int prevlen, bool quick, TimeSpan timeout) =>
-            ScanInternal(regex, text, textbeg, textend, textstart, prevlen, quick, timeout);
-
-        internal virtual Match? ScanInternal(Regex regex, string text, int textbeg, int textend, int textstart, int prevlen, bool quick, TimeSpan timeout)
+        protected internal Match? Scan(Regex regex, string text, int textbeg, int textend, int textstart, int prevlen, bool quick, TimeSpan timeout)
         {
             // Handle timeout argument
             _timeout = -1; // (int)Regex.InfiniteMatchTimeout.TotalMilliseconds
@@ -221,7 +218,7 @@ namespace System.Text.RegularExpressions
         /// This optionally repeatedly hands out the same Match instance, updated with new information.
         /// <paramref name="reuseMatchObject"/> should be set to false if the Match object is handed out to user code.
         /// </remarks>
-        internal virtual void ScanInternal<TState>(Regex regex, string text, int textstart, ref TState state, MatchCallback<TState> callback, bool reuseMatchObject, TimeSpan timeout)
+        internal void ScanInternal<TState>(Regex regex, string text, int textstart, ref TState state, MatchCallback<TState> callback, bool reuseMatchObject, TimeSpan timeout)
         {
             // Handle timeout argument
             _timeout = -1; // (int)Regex.InfiniteMatchTimeout.TotalMilliseconds

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ThrowHelper.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ThrowHelper.cs
@@ -57,7 +57,6 @@ namespace System.Text.RegularExpressions
                 ExceptionResource.BeginIndexNotNegative => SR.BeginIndexNotNegative,
                 ExceptionResource.CountTooSmall => SR.CountTooSmall,
                 ExceptionResource.LengthNotNegative => SR.LengthNotNegative,
-                ExceptionResource.OnlyAllowedOnce => SR.OnlyAllowedOnce,
                 ExceptionResource.ReplacementError => SR.ReplacementError,
                 _ => null
             };
@@ -90,7 +89,6 @@ namespace System.Text.RegularExpressions
         BeginIndexNotNegative,
         CountTooSmall,
         LengthNotNegative,
-        OnlyAllowedOnce,
         ReplacementError,
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -200,7 +200,15 @@ namespace System.Text.RegularExpressions.Tests
         {
             var r = new DerivedRegex();
             r.InitializeReferences();
-            Assert.Throws<NotSupportedException>(() => r.InitializeReferences());
+            if (PlatformDetection.IsNetFramework)
+            {
+                Assert.Throws<NotSupportedException>(() => r.InitializeReferences());
+            }
+            else
+            {
+                // As of .NET 7, this method is a nop.
+                r.InitializeReferences();
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Initially NonBacktracking was tacked on with its own processing loop and special-cased directly from Regex with code that detected the option and called into special functions.  I previously changed that to instead derive from RegexRunner, and added new virtual methods for it to override.  But such integration doesn't go far enough in terms of being able to plug into the currently public entry points, which will be required when we implement source generator support for NonBacktracking.

This PR fixes that up by:
- Undoing the previously added internal virtuals
- Changing SymbolicRegexRunner to instead override FindFirstChar and Go
- Deleting the custom Scan overrides
- Creating matches using the exposed Capture method rather than doing so manually

Doing this, and in particular changing it to use Capture, meant that the caps information in the Regex had to be correct, so it also:
- Fixes the Init method to properly populate these members based on the expected NonBacktracking semantics (i.e. no subcaptures)

That then required being able to pass the originally computed capture size from the pattern to Regex.Replace operations, as it uses that number to interpret whether constructs are backreferences or just text, which meant I had to store that value separately on the Regex.  And as I never like increasing the size of the object, I looked for things I could offset it with:
- Deleted the _refsInitialized member.  It was only used to record whether _replref had been initialized, which is obvious based on whether the field is non-null
- Made _replref itself initialized lazily, so that regex instances don't pay for that WeakReference object allocation unless Replace is actually being used
- That then made the old InitializeReferences protected method useless, so I made it a nop and removed the associated references