### PR TITLE
Make BDDAlgebra lock reads too

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDD.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDD.cs
@@ -343,51 +343,43 @@ namespace System.Text.RegularExpressions.Symbolic
                 return arcs[0] == 0 ? False : True;
             }
 
-            algebra.Lock.EnterWriteLock();
-            try
+            // the number of bits used for ordinals and node identifiers are stored in the first two values
+            int k = arcs.Length;
+            int ordinal_bits = (int)arcs[0];
+            int node_bits = (int)arcs[1];
+
+            // create bit masks for the sizes of ordinals and node identifiers
+            long ordinal_mask = (1 << ordinal_bits) - 1;
+            long node_mask = (1 << node_bits) - 1;
+            BitLayout(ordinal_bits, node_bits, out int zero_node_shift, out int one_node_shift, out int ordinal_shift);
+
+            // store BDD nodes by their id when they are created
+            BDD[] nodes = new BDD[k];
+            nodes[0] = False;
+            nodes[1] = True;
+
+            for (int i = 2; i < k; i++)
             {
-                // the number of bits used for ordinals and node identifiers are stored in the first two values
-                int k = arcs.Length;
-                int ordinal_bits = (int)arcs[0];
-                int node_bits = (int)arcs[1];
-
-                // create bit masks for the sizes of ordinals and node identifiers
-                long ordinal_mask = (1 << ordinal_bits) - 1;
-                long node_mask = (1 << node_bits) - 1;
-                BitLayout(ordinal_bits, node_bits, out int zero_node_shift, out int one_node_shift, out int ordinal_shift);
-
-                // store BDD nodes by their id when they are created
-                BDD[] nodes = new BDD[k];
-                nodes[0] = False;
-                nodes[1] = True;
-
-                for (int i = 2; i < k; i++)
+                long arc = arcs[i];
+                if (arc <= 0)
                 {
-                    long arc = arcs[i];
-                    if (arc <= 0)
-                    {
-                        // this is an MTBDD leaf. Its ordinal was serialized negated
-                        nodes[i] = algebra.GetOrCreateBDD((int)-arc, null, null);
-                    }
-                    else
-                    {
-                        // reconstruct the ordinal and child identifiers for a non-terminal
-                        int ord = (int)((arc >> ordinal_shift) & ordinal_mask);
-                        int oneId = (int)((arc >> one_node_shift) & node_mask);
-                        int zeroId = (int)((arc >> zero_node_shift) & node_mask);
-
-                        // the BDD nodes for the children are guaranteed to exist already due to the topological order
-                        nodes[i] = algebra.GetOrCreateBDD(ord, nodes[oneId], nodes[zeroId]);
-                    }
+                    // this is an MTBDD leaf. Its ordinal was serialized negated
+                    nodes[i] = algebra.GetOrCreateBDD((int)-arc, null, null);
                 }
+                else
+                {
+                    // reconstruct the ordinal and child identifiers for a non-terminal
+                    int ord = (int)((arc >> ordinal_shift) & ordinal_mask);
+                    int oneId = (int)((arc >> one_node_shift) & node_mask);
+                    int zeroId = (int)((arc >> zero_node_shift) & node_mask);
 
-                //the result is the final BDD in the nodes array
-                return nodes[k - 1];
+                    // the BDD nodes for the children are guaranteed to exist already due to the topological order
+                    nodes[i] = algebra.GetOrCreateBDD(ord, nodes[oneId], nodes[zeroId]);
+                }
             }
-            finally
-            {
-                algebra.Lock.ExitWriteLock();
-            }
+
+            //the result is the final BDD in the nodes array
+            return nodes[k - 1];
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -342,19 +342,6 @@ namespace System.Text.RegularExpressions.Symbolic
         /// Intersect all sets in the enumeration
         /// </summary>
         public BDD And(IEnumerable<BDD> sets)
-        {
-            BDD res = True;
-            foreach (BDD bdd in sets)
-            {
-                res = And(res, bdd);
-            }
-            return res;
-        }
-
-        /// <summary>
-        /// Intersect all sets in the array
-        /// </summary>
-        public BDD And(params BDD[] sets)
         {
             BDD res = True;
             foreach (BDD bdd in sets)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
@@ -79,9 +79,10 @@ namespace System.Text.RegularExpressions.Symbolic
         public BDD Not(BDD a) =>
             a == False ? True :
             a == True ? False :
-            _opCache.GetOrAdd(new(BoolOp.Not, a, null), key => a.IsLeaf ?
+            _opCache.GetOrAdd(new(BoolOp.Not, a, null), (key, a) => a.IsLeaf ?
                 GetOrCreateBDD(CombineTerminals(BoolOp.Not, a.Ordinal, 0), null, null) : // multi-terminal case
-                GetOrCreateBDD(a.Ordinal, Not(a.One), Not(a.Zero)));
+                GetOrCreateBDD(a.Ordinal, Not(a.One), Not(a.Zero)),
+                a);
 
         /// <summary>
         /// Applies the binary Boolean operation op and constructs the BDD recursively from a and b.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
@@ -59,7 +59,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// Returns the BDD from the cache if it already exists.
         /// </summary>
         public BDD GetOrCreateBDD(int ordinal, BDD? one, BDD? zero) =>
-            _bddCache.GetOrAdd(new BDDKey(ordinal, one, zero), key => new BDD(ordinal, one, zero));
+            _bddCache.GetOrAdd(new BDDKey(ordinal, one, zero), (key, state) => new BDD(state.ordinal, state.one, state.zero), (ordinal, one, zero));
 
         #region IBooleanAlgebra members
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
@@ -141,7 +141,7 @@ namespace System.Text.RegularExpressions.Symbolic
             // Order operands by hash code to increase cache hits
             if (a.GetHashCode() > b.GetHashCode())
             {
-                var tmp = a;
+                BDD tmp = a;
                 a = b;
                 b = tmp;
             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BV64Algebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BV64Algebra.cs
@@ -60,23 +60,6 @@ namespace System.Text.RegularExpressions.Symbolic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsSatisfiable(ulong predicate) => predicate != _false;
 
-        public ulong And(params ulong[] predicates)
-        {
-            ulong and = _true;
-            for (int i = 0; i < predicates.Length; i++)
-            {
-                and &= predicates[i];
-
-                // short circuit the evaluation on false, since 0&x=0
-                if (and == _false)
-                {
-                    return _false;
-                }
-            }
-
-            return and;
-        }
-
         public ulong And(IEnumerable<ulong> predicates) => throw new NotSupportedException();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BVAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BVAlgebra.cs
@@ -83,17 +83,6 @@ namespace System.Text.RegularExpressions.Symbolic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsSatisfiable(BV predicate) => !predicate.Equals(False);
 
-        public BV And(params BV[] predicates)
-        {
-            BV and = True;
-            for (int i = 0; i < predicates.Length; i++)
-            {
-                and &= predicates[i];
-            }
-
-            return and;
-        }
-
         public BV And(IEnumerable<BV> predicates) => throw new NotSupportedException();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/IBooleanAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/IBooleanAlgebra.cs
@@ -35,12 +35,6 @@ namespace System.Text.RegularExpressions.Symbolic
         T And(IEnumerable<T> predicates);
 
         /// <summary>
-        /// Make a conjunction of all the predicates.
-        /// Returns True if the enumeration is empty.
-        /// </summary>
-        T And(params T[] predicates);
-
-        /// <summary>
         /// Make a disjunction of predicate1 and predicate2.
         /// </summary>
         T Or(T predicate1, T predicate2);


### PR DESCRIPTION
Switches the locking in BDDAlgebra to use `ReaderWriterLockSlim`. The operation caches were also unified into a single `_opCache`, which made the locking code slightly cleaner and I don't think should affect performance much in either direction.

Also removed an overload of And in IBooleanAlgebra that wasn't used anywhere.