### PR TITLE
Add guards against stack overflows in various NonBackTracking algorithms

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -8,6 +8,7 @@
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.MappingTable.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\StackHelper.cs" />
     <Compile Include="System\Text\SegmentStringBuilder.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />
     <Compile Include="System\Text\RegularExpressions\CaptureCollection.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
@@ -200,8 +201,12 @@ namespace System.Text.RegularExpressions.Symbolic
         public SymbolicRegexNode<BDD> Convert(RegexNode node, bool topLevel)
         {
             // Guard against stack overflow due to deep recursion
-            if (StackHelper.CallOnEmptyStackIfNecessary(() => Convert(node, topLevel), out SymbolicRegexNode<BDD>? result))
-                return result!;
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                RegexNode localNode = node;
+                bool localTopLevel = topLevel;
+                return StackHelper.CallOnEmptyStack(() => Convert(localNode, localTopLevel));
+            }
 
             switch (node.Type)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -197,9 +197,12 @@ namespace System.Text.RegularExpressions.Symbolic
             }
         }
 
-        // TODO https://github.com/dotnet/runtimelab/issues/1537: Avoid deep recursion
         public SymbolicRegexNode<BDD> Convert(RegexNode node, bool topLevel)
         {
+            // Guard against stack overflow due to deep recursion
+            if (StackHelper.CallOnEmptyStackIfNecessary(() => Convert(node, topLevel), out SymbolicRegexNode<BDD>? result))
+                return result!;
+
             switch (node.Type)
             {
                 case RegexNode.Alternate:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/StackHelper.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/StackHelper.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Text.RegularExpressions.Symbolic
+{
+    /// <summary>
+    /// Provides tools for avoiding stack overflows. The approach follows that of System.Linq.Expressions.StackGuard.
+    /// </summary>
+    internal static class StackHelper
+    {
+        /// <summary>
+        /// Calls the provided function on the stack of a new thread if stack space is close to running out (as indicated
+        /// by RuntimeHelpers.TryEnsureSufficientExecutionStack). Does nothing otherwise.
+        /// </summary>
+        /// <typeparam name="T">the return type of the function</typeparam>
+        /// <param name="func">the function to possibly call</param>
+        /// <param name="result">the return value of the function if it was called</param>
+        /// <returns>whether the function was called</returns>
+        public static bool CallOnEmptyStackIfNecessary<T>(Func<T> func, out T? result)
+        {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                // Using default scheduler rather than picking up the current scheduler.
+                Task<T> task = Task.Factory.StartNew(func, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                // Task.Wait has the potential of inlining the task's execution on the current thread; avoid this.
+                ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
+                // Using awaiter here to propagate original exception
+                result = task.GetAwaiter().GetResult();
+                return true;
+            }
+            else
+            {
+                result = default(T);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Calls the provided action on the stack of a new thread if stack space is close to running out (as indicated
+        /// by RuntimeHelpers.TryEnsureSufficientExecutionStack). Does nothing otherwise.
+        /// </summary>
+        /// <param name="action">the action to possibly call</param>
+        /// <returns>whether the action was called</returns>
+        public static bool CallOnEmptyStackIfNecessary(Action action)
+        {
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                // Using default scheduler rather than picking up the current scheduler.
+                Task task = Task.Factory.StartNew(action, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                // Task.Wait has the potential of inlining the task's execution on the current thread; avoid this.
+                ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
+                // Using awaiter here to propagate original exception
+                task.GetAwaiter().GetResult();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -174,7 +174,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
             _dotstarredPattern = _builder.MkConcat(_builder._anyStar, _pattern);
             _reversePattern = _pattern.Reverse();
-            ConfigureeRegexes();
+            ConfigureRegexes();
 
             _startSet = _pattern.GetStartSet();
             if (!_builder._solver.IsSatisfiable(_startSet) || _pattern.CanBeNullable)
@@ -243,7 +243,7 @@ namespace System.Text.RegularExpressions.Symbolic
             return null;
         }
 
-        private void ConfigureeRegexes()
+        private void ConfigureRegexes()
         {
             void Configure(uint i)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
@@ -667,8 +668,12 @@ namespace System.Text.RegularExpressions.Symbolic
         internal SymbolicRegexNode<S> MkDerivative(S elem, uint context)
         {
             // Guard against stack overflow due to deep recursion
-            if (StackHelper.CallOnEmptyStackIfNecessary(() => MkDerivative(elem, context), out SymbolicRegexNode<S>? result))
-                return result!;
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                S localElem = elem;
+                uint localContext = context;
+                return StackHelper.CallOnEmptyStack(() => MkDerivative(localElem, localContext));
+            }
 
             if (this == _builder._anyStar || this == _builder._nothing)
             {
@@ -910,8 +915,12 @@ namespace System.Text.RegularExpressions.Symbolic
         internal void ToString(StringBuilder sb)
         {
             // Guard against stack overflow due to deep recursion
-            if (StackHelper.CallOnEmptyStackIfNecessary(() => ToString(sb)))
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                StringBuilder localSb = sb;
+                StackHelper.CallOnEmptyStack(() => ToString(localSb));
                 return;
+            }
 
             switch (_kind)
             {
@@ -1466,8 +1475,13 @@ namespace System.Text.RegularExpressions.Symbolic
         internal SymbolicRegexNode<S> PruneAnchors(uint prevKind, bool contWithWL, bool contWithNWL)
         {
             // Guard against stack overflow due to deep recursion
-            if (StackHelper.CallOnEmptyStackIfNecessary(() => PruneAnchors(prevKind, contWithWL, contWithNWL), out SymbolicRegexNode<S>? result))
-                return result!;
+            if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                uint localPrevKind = prevKind;
+                bool localContWithWL = contWithWL;
+                bool localContWithNWL = contWithNWL;
+                return StackHelper.CallOnEmptyStack(() => PruneAnchors(localPrevKind, localContWithWL, localContWithNWL));
+            }
 
             if (!_info.StartsWithSomeAnchor)
                 return this;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -666,6 +666,10 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <returns></returns>
         internal SymbolicRegexNode<S> MkDerivative(S elem, uint context)
         {
+            // Guard against stack overflow due to deep recursion
+            if (StackHelper.CallOnEmptyStackIfNecessary(() => MkDerivative(elem, context), out SymbolicRegexNode<S>? result))
+                return result!;
+
             if (this == _builder._anyStar || this == _builder._nothing)
             {
                 return this;
@@ -905,6 +909,10 @@ namespace System.Text.RegularExpressions.Symbolic
 
         internal void ToString(StringBuilder sb)
         {
+            // Guard against stack overflow due to deep recursion
+            if (StackHelper.CallOnEmptyStackIfNecessary(() => ToString(sb)))
+                return;
+
             switch (_kind)
             {
                 case SymbolicRegexKind.EndAnchor:
@@ -1457,6 +1465,10 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="contWithNWL">if true the continuation can start with nonwordletter or stop</param>
         internal SymbolicRegexNode<S> PruneAnchors(uint prevKind, bool contWithWL, bool contWithNWL)
         {
+            // Guard against stack overflow due to deep recursion
+            if (StackHelper.CallOnEmptyStackIfNecessary(() => PruneAnchors(prevKind, contWithWL, contWithNWL), out SymbolicRegexNode<S>? result))
+                return result!;
+
             if (!_info.StartsWithSomeAnchor)
                 return this;
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -1296,10 +1296,10 @@ namespace System.Text.RegularExpressions.Tests
         {
             foreach (var options in RegexHelpers.RegexOptionsExtended())
             {
-                yield return new object[] { "[a-z]", "", options, "abcde", 1000, 200 };
-                yield return new object[] { "[a-e]*", "$", options, "abcde", 100, 20 };
-                yield return new object[] { "[a-d]?[a-e]?[a-f]?[a-g]?[a-h]?", "$", options, "abcda", 20, 4 };
-                yield return new object[] { "(a|A)", "", options, "aAaAa", 1000, 200 };
+                yield return new object[] { "[a-z]", "", options, "abcde", 2000, 400 };
+                yield return new object[] { "[a-e]*", "$", options, "abcde", 2000, 20 };
+                yield return new object[] { "[a-d]?[a-e]?[a-f]?[a-g]?[a-h]?", "$", options, "abcda", 400, 4 };
+                yield return new object[] { "(a|A)", "", options, "aAaAa", 2000, 400 };
             }
         }
         [Theory]
@@ -1307,6 +1307,25 @@ namespace System.Text.RegularExpressions.Tests
         public void StressTestDeepNestingOfConcat(string pattern, string anchor, RegexOptions options, string input, int pattern_repetition, int input_repetition)
         {
             string fullpattern = string.Concat(string.Concat(Enumerable.Repeat($"({pattern}", pattern_repetition).Concat(Enumerable.Repeat(")", pattern_repetition))), anchor);
+            string fullinput = string.Concat(Enumerable.Repeat(input, input_repetition));
+            var re = new Regex(fullpattern, options);
+            Assert.True(re.Match(fullinput).Success);
+        }
+
+        public static IEnumerable<object[]> StressTestDeepNestingOfLoops_TestData()
+        {
+            foreach (var options in RegexHelpers.RegexOptionsExtended())
+            {
+                yield return new object[] { "(", "a", ")*", options, "a", 2000, 1000 };
+                yield return new object[] { "(", "[aA]", ")+", options, "aA", 2000, 3000 };
+                yield return new object[] { "(", "ab", "){0,1}", options, "ab", 2000, 1000 };
+            }
+        }
+        [Theory]
+        [MemberData(nameof(StressTestDeepNestingOfLoops_TestData))]
+        public void StressTestDeepNestingOfLoops(string begin, string inner, string end, RegexOptions options, string input, int pattern_repetition, int input_repetition)
+        {
+            string fullpattern = string.Concat(Enumerable.Repeat(begin, pattern_repetition)) + inner + string.Concat(Enumerable.Repeat(end, pattern_repetition));
             string fullinput = string.Concat(Enumerable.Repeat(input, input_repetition));
             var re = new Regex(fullpattern, options);
             Assert.True(re.Match(fullinput).Success);


### PR DESCRIPTION
I implemented the approach that was discussed that guards against stack overflows by calling the function on another thread when the stack is too deep. I found an implementation of it in System.Linq.Expressions which I adapted: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/StackGuard.cs

I also updated the stress tests we had for deep nestings of concatenations. The constants were not large enough to actually trigger the overflows. I also added an analogous test for nesting a couple kinds of loops. 

There were several algorithms that were encountering stack overflows after I updated the tests, which I added the guards to.