### PR TITLE
Transition regex support

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -83,7 +83,7 @@
     <Compile Include="System\Text\RegularExpressions\Symbolic\Dgml\DgmlWriter.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\Dgml\IAutomaton.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\Dgml\Move.cs" />
-    <Compile Include="System\Text\RegularExpressions\Symbolic\Dgml\RegexDFA.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\Dgml\RegexAutomaton.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\Unicode\GeneratorHelper.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\Unicode\IgnoreCaseRelation.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\Unicode\IgnoreCaseRelationGenerator.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -8,6 +8,8 @@
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexCharClass.MappingTable.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\TransitionRegex.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\TransitionRegexKind.cs" />
     <Compile Include="System\Text\SegmentStringBuilder.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />
     <Compile Include="System\Text\RegularExpressions\CaptureCollection.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.Symbolic.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.Symbolic.cs
@@ -19,15 +19,16 @@ namespace System.Text.RegularExpressions
         /// <param name="onlyDFAinfo">if true then compute and save only general DFA info</param>
         /// <param name="writer">dgml output is written here</param>
         /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
+        /// <param name="asNFA">if true creates NFA instead of DFA</param>
         [ExcludeFromCodeCoverage(Justification = "Debug only")]
-        internal void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength)
+        internal void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA)
         {
             if (factory is not SymbolicRegexRunnerFactory srmFactory)
             {
                 throw new NotSupportedException();
             }
 
-            srmFactory._runner._matcher.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, onlyDFAinfo, maxLabelLength);
+            srmFactory._runner._matcher.SaveDGML(writer, bound, hideStateInfo, addDotStar, inReverse, onlyDFAinfo, maxLabelLength, asNFA);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
@@ -10,7 +10,7 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
     /// <summary>
     /// Used by DgmlWriter to unwind a regex into a DFA up to a bound that limits the number of states
     /// </summary>
-    internal sealed class RegexDFA<T> : IAutomaton<(SymbolicRegexNode<T>?, T)> where T : notnull
+    internal sealed class RegexAutomaton<T> : IAutomaton<(SymbolicRegexNode<T>?, T)> where T : notnull
     {
         private readonly DfaMatchingState<T> _q0;
         private readonly List<int> _states = new();
@@ -21,7 +21,7 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
         private readonly Dictionary<SymbolicRegexNode<T>, int> _nfaStateId = new();
         private readonly bool _asNFA;
 
-        internal RegexDFA(SymbolicRegexMatcher<T> srm, int bound, bool addDotStar, bool inReverse, bool asNFA)
+        internal RegexAutomaton(SymbolicRegexMatcher<T> srm, int bound, bool addDotStar, bool inReverse, bool asNFA)
         {
             _asNFA = asNFA;
             _builder = srm._builder;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexDFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexDFA.cs
@@ -10,16 +10,20 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
     /// <summary>
     /// Used by DgmlWriter to unwind a regex into a DFA up to a bound that limits the number of states
     /// </summary>
-    internal sealed class RegexDFA<T> : IAutomaton<T> where T : notnull
+    internal sealed class RegexDFA<T> : IAutomaton<(SymbolicRegexNode<T>?, T)> where T : notnull
     {
         private readonly DfaMatchingState<T> _q0;
         private readonly List<int> _states = new();
         private readonly HashSet<int> _stateSet = new();
-        private readonly List<Move<T>> _moves = new();
+        private readonly List<Move<(SymbolicRegexNode<T>?, T)>> _moves = new();
         private readonly SymbolicRegexBuilder<T> _builder;
+        private readonly List<SymbolicRegexNode<T>> _nfaStates = new();
+        private readonly Dictionary<SymbolicRegexNode<T>, int> _nfaStateId = new();
+        private readonly bool _asNFA;
 
-        internal RegexDFA(SymbolicRegexMatcher<T> srm, int bound, bool addDotStar, bool inReverse)
+        internal RegexDFA(SymbolicRegexMatcher<T> srm, int bound, bool addDotStar, bool inReverse, bool asNFA)
         {
+            _asNFA = asNFA;
             _builder = srm._builder;
             uint startId = inReverse ?
                 (srm._reversePattern._info.StartsWithLineAnchor ? CharKind.StartStop : 0) :
@@ -27,67 +31,107 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
 
             //inReverse only matters if Ar contains some line anchor
             _q0 = _builder.MkState(inReverse ? srm._reversePattern : (addDotStar ? srm._dotstarredPattern : srm._pattern), startId);
-            var stack = new Stack<DfaMatchingState<T>>();
-            stack.Push(_q0);
-            _states.Add(_q0.Id);
-            _stateSet.Add(_q0.Id);
 
-            T[]? partition = _builder._solver.GetPartition();
-            Debug.Assert(partition is not null);
-
-            Dictionary<(int, int), T> normalizedmoves = new();
-
-            //unwind until the stack is empty or the bound has been reached
-            while (stack.Count > 0 && (bound <= 0 || _states.Count < bound))
+            if (asNFA)
             {
-                DfaMatchingState<T> q = stack.Pop();
-                foreach (T c in partition)
+                Stack<SymbolicRegexNode<T>> stack = new();
+                stack.Push(_q0.Node);
+                _nfaStates.Add(_q0.Node);
+                _nfaStateId[_q0.Node] = 0;
+                _states.Add(0);
+                _stateSet.Add(0);
+                while (stack.Count > 0 && (bound <= 0 || _nfaStates.Count < bound))
                 {
-                    DfaMatchingState<T> p = q.Next(c);
-
-                    // check that p is not a dead-end
-                    if (!p.IsNothing)
+                    SymbolicRegexNode<T> q = stack.Pop();
+                    int qId = _nfaStateId[q];
+                    foreach ((T, SymbolicRegexNode<T>?, SymbolicRegexNode<T>) branch in q.MkDerivative())
                     {
-                        if (_stateSet.Add(p.Id))
+                        SymbolicRegexNode<T> p = branch.Item3;
+                        int pId;
+                        if (!_nfaStateId.TryGetValue(p, out pId))
                         {
+                            pId = _nfaStates.Count;
+                            _nfaStateId[p] = pId;
+                            _nfaStates.Add(p);
+                            _stateSet.Add(pId);
+                            _states.Add(pId);
                             stack.Push(p);
-                            _states.Add(p.Id);
                         }
-
-                        var qp = (q.Id, p.Id);
-                        normalizedmoves[qp] = normalizedmoves.ContainsKey(qp) ?
-                            _builder._solver.Or(normalizedmoves[qp], c) :
-                            c;
+                        _moves.Add(Move<(SymbolicRegexNode<T>?, T)>.Create(qId, pId, (branch.Item2, branch.Item1)));
                     }
                 }
             }
+            else
+            {
+                Dictionary<(int, int), T> normalizedmoves = new();
+                Stack<DfaMatchingState<T>> stack = new();
+                stack.Push(_q0);
+                _states.Add(_q0.Id);
+                _stateSet.Add(_q0.Id);
 
-            foreach (KeyValuePair<(int, int), T> entry in normalizedmoves)
-                _moves.Add(Move<T>.Create(entry.Key.Item1, entry.Key.Item2, entry.Value));
+                T[]? partition = _builder._solver.GetPartition();
+                Debug.Assert(partition is not null);
+                //unwind until the stack is empty or the bound has been reached
+                while (stack.Count > 0 && (bound <= 0 || _states.Count < bound))
+                {
+                    DfaMatchingState<T> q = stack.Pop();
+                    foreach (T c in partition)
+                    {
+                        DfaMatchingState<T> p = q.Next(c);
+
+                        // check that p is not a dead-end
+                        if (!p.IsNothing)
+                        {
+                            if (_stateSet.Add(p.Id))
+                            {
+                                stack.Push(p);
+                                _states.Add(p.Id);
+                            }
+
+                            var qp = (q.Id, p.Id);
+                            normalizedmoves[qp] = normalizedmoves.ContainsKey(qp) ?
+                                _builder._solver.Or(normalizedmoves[qp], c) :
+                                c;
+                        }
+                    }
+                }
+
+                foreach (KeyValuePair<(int, int), T> entry in normalizedmoves)
+                    _moves.Add(Move<(SymbolicRegexNode<T>?, T)>.Create(entry.Key.Item1, entry.Key.Item2, (null, entry.Value)));
+            }
         }
 
-        public T[] Alphabet
+        public (SymbolicRegexNode<T>?, T)[] Alphabet
         {
             get
             {
                 T[]? alphabet = _builder._solver.GetPartition();
                 Debug.Assert(alphabet is not null);
-                return alphabet;
+                return Array.ConvertAll<T, (SymbolicRegexNode<T>?, T)>(alphabet, a => (null, a));
             }
         }
 
-        public int InitialState => _q0.Id;
+        public int InitialState => _asNFA ? 0 : _q0.Id;
 
         public int StateCount => _states.Count;
 
         public int TransitionCount => _moves.Count;
 
-        public string DescribeLabel(T lab) => HTMLEncodeChars(_builder._solver.PrettyPrint(lab));
+        public string DescribeLabel((SymbolicRegexNode<T>?, T) lab) =>
+            lab.Item1 is null ? Net.WebUtility.HtmlEncode(_builder._solver.PrettyPrint(lab.Item2)) :
+            // Conditional nullability based on anchors
+            Net.WebUtility.HtmlEncode($"{lab.Item1}/{_builder._solver.PrettyPrint(lab.Item2)}");
 
         public string DescribeStartLabel() => "";
 
         public string DescribeState(int state)
         {
+            if (_asNFA)
+            {
+                Debug.Assert(state < _nfaStates.Count);
+                return Net.WebUtility.HtmlEncode(_nfaStates[state].ToString());
+            }
+
             Debug.Assert(_builder._statearray is not null);
             return _builder._statearray[state].DgmlView;
         }
@@ -96,13 +140,17 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
 
         public bool IsFinalState(int state)
         {
-            Debug.Assert(_builder._statearray is not null);
+            if (_asNFA)
+            {
+                Debug.Assert(state < _nfaStates.Count);
+                return _nfaStates[state].CanBeNullable;
+            }
+
+            Debug.Assert(_builder._statearray is not null && state < _builder._statearray.Length);
             return _builder._statearray[state].IsNullable(CharKind.StartStop);
         }
 
-        public IEnumerable<Move<T>> GetMoves() => _moves;
-
-        private static string HTMLEncodeChars(string s) => s.Replace("&", "&amp;").Replace("\"", "&quot;").Replace("<", "&lt;").Replace(">", "&gt;");
+        public IEnumerable<Move<(SymbolicRegexNode<T>?, T)>> GetMoves() => _moves;
     }
 }
 #endif

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -278,6 +278,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 case RegexNode.Nothing:
                     return _builder._nothing;
 
+#if DEBUG
                 case RegexNode.Testgroup:
                     // Try to extract the special case representing complement or intersection
                     if (IsComplementedNode(node))
@@ -292,6 +293,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
 
                     goto default;
+#endif
 
                 default:
                     throw new NotSupportedException(SR.Format(SR.NotSupported_NonBacktrackingConflictingExpression, node.Type switch
@@ -435,6 +437,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 return _builder.MkLoop(body, isLazy, node.M, node.N);
             }
 
+#if DEBUG
             // TODO: recognizing strictly only [] (RegexNode.Nothing), for example [0-[0]] would not be recognized
             bool IsNothing(RegexNode node) => node.Type == RegexNode.Nothing || (node.Type == RegexNode.Set && ConvertSet(node).IsNothing);
 
@@ -464,6 +467,7 @@ namespace System.Text.RegularExpressions.Symbolic
             }
 
             bool IsComplementedNode(RegexNode node) => IsNothing(node.Child(1)) && IsDotStar(node.Child(2));
+#endif
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -51,6 +51,13 @@ namespace System.Text.RegularExpressions.Symbolic
             SymbolicRegexSet<TElement>?,
             SymbolicRegexInfo), SymbolicRegexNode<TElement>> _nodeCache = new();
 
+        internal readonly Dictionary<(TransitionRegexKind, // _kind
+            TElement?,                                     // _test
+            TransitionRegex<TElement>?,                    // _first
+            TransitionRegex<TElement>?,                    // _second
+            SymbolicRegexNode<TElement>?),                 // _leaf
+            TransitionRegex<TElement>> _trCache = new();
+
         /// <summary>
         /// Maps state ids to states, initial capacity is 1024 states.
         /// Each time more states are needed the length is increased by 1024.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -872,7 +872,7 @@ namespace System.Text.RegularExpressions.Symbolic
 #if DEBUG
         public override void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA)
         {
-            var graph = new DGML.RegexDFA<TSetType>(this, bound, addDotStar, inReverse, asNFA);
+            var graph = new DGML.RegexAutomaton<TSetType>(this, bound, addDotStar, inReverse, asNFA);
             var dgml = new DGML.DgmlWriter(writer, hideStateInfo, maxLabelLength, onlyDFAinfo);
             dgml.Write(graph);
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -28,7 +28,8 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="onlyDFAinfo">if true then compute and save only genral DFA info</param>
         /// <param name="writer">dgml output is written here</param>
         /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
-        public abstract void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength);
+        /// <param name="asNFA">if true creates NFA instead of DFA</param>
+        public abstract void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA);
 #endif
     }
 
@@ -869,9 +870,9 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
 #if DEBUG
-        public override void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength)
+        public override void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA)
         {
-            var graph = new DGML.RegexDFA<TSetType>(this, bound, addDotStar, inReverse);
+            var graph = new DGML.RegexDFA<TSetType>(this, bound, addDotStar, inReverse, asNFA);
             var dgml = new DGML.DgmlWriter(writer, hideStateInfo, maxLabelLength, onlyDFAinfo);
             dgml.Write(graph);
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -251,7 +251,26 @@ namespace System.Text.RegularExpressions.Symbolic
                     if (_left._kind == SymbolicRegexKind.Singleton)
                     {
                         Debug.Assert(_left._set is not null);
-                        return !IsLazy && _builder._solver.AreEquivalent(_builder._solver.True, _left._set);
+                        return !IsLazy && _builder._solver.True.Equals(_left._set);
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        /// <summary>Returns true if this is equivalent to .+ (the node must be eager also)</summary>
+        public bool IsAnyPlus
+        {
+            get
+            {
+                if (IsPlus)
+                {
+                    Debug.Assert(_left is not null);
+                    if (_left._kind == SymbolicRegexKind.Singleton)
+                    {
+                        Debug.Assert(_left._set is not null);
+                        return !IsLazy && _builder._solver.True.Equals(_left._set);
                     }
                 }
 
@@ -806,6 +825,161 @@ namespace System.Text.RegularExpressions.Symbolic
 
             _MkDerivative_Cache[key] = deriv;
             return deriv;
+        }
+
+        private TransitionRegex<S>? _transitionRegex;
+        /// <summary>Computes the symbolic derivative as a transition regex</summary>
+        internal TransitionRegex<S> MkDerivative()
+        {
+            if (_transitionRegex is not null)
+            {
+                return _transitionRegex;
+
+            }
+
+            if (IsNothing || IsEpsilon)
+            {
+                _transitionRegex = TransitionRegex<S>.Leaf(_builder._nothing);
+                return _transitionRegex;
+            }
+
+            if (IsAnyStar || IsAnyPlus)
+            {
+                _transitionRegex = TransitionRegex<S>.Leaf(_builder._anyStar);
+                return _transitionRegex;
+            }
+
+            switch (_kind)
+            {
+                case SymbolicRegexKind.Singleton:
+                    Debug.Assert(_set is not null);
+                    _transitionRegex = TransitionRegex<S>.Conditional(_set, TransitionRegex<S>.Leaf(_builder._epsilon), TransitionRegex<S>.Leaf(_builder._nothing));
+                    break;
+
+                case SymbolicRegexKind.Concat:
+                    Debug.Assert(_left is not null && _right is not null);
+                    TransitionRegex<S> mainTransition = _left.MkDerivative().Concat(_right);
+
+                    if (!_left.CanBeNullable)
+                    {
+                        // If _left is never nullable
+                        _transitionRegex = mainTransition;
+                    }
+                    else if (_left.IsNullable)
+                    {
+                        // If _left is unconditionally nullable
+                        _transitionRegex = mainTransition | _right.MkDerivative();
+                    }
+                    else
+                    {
+                        // The left side contains anchors and can be nullable in some context
+                        // Extract the nullability as the lookaround condition
+                        SymbolicRegexNode<S> leftNullabilityTest = _left.ExtractNullabilityTest();
+                        _transitionRegex = TransitionRegex<S>.Lookaround(leftNullabilityTest, mainTransition | _right.MkDerivative(), mainTransition);
+                    }
+                    break;
+
+                case SymbolicRegexKind.Loop:
+                    // d(R*) = d(R+) = d(R)R*
+                    Debug.Assert(_left is not null);
+                    Debug.Assert(_upper > 0);
+                    TransitionRegex<S> step = _left.MkDerivative();
+
+                    if (IsStar || IsPlus)
+                    {
+                        _transitionRegex = step.Concat(_builder.MkLoop(_left, IsLazy));
+                    }
+                    else
+                    {
+                        int newupper = _upper == int.MaxValue ? int.MaxValue : _upper - 1;
+                        int newlower = _lower == 0 ? 0 : _lower - 1;
+                        SymbolicRegexNode<S> rest = _builder.MkLoop(_left, IsLazy, newlower, newupper);
+                        _transitionRegex = step.Concat(rest);
+                    }
+                    break;
+
+                case SymbolicRegexKind.Or:
+                    Debug.Assert(_alts is not null);
+                    _transitionRegex = TransitionRegex<S>.Leaf(_builder._nothing);
+                    foreach (SymbolicRegexNode<S> elem in _alts)
+                    {
+                        _transitionRegex = _transitionRegex | elem.MkDerivative();
+                    }
+                    break;
+
+                case SymbolicRegexKind.And:
+                    Debug.Assert(_alts is not null);
+                    _transitionRegex = TransitionRegex<S>.Leaf(_builder._anyStar);
+                    foreach (SymbolicRegexNode<S> elem in _alts)
+                    {
+                        _transitionRegex = _transitionRegex & elem.MkDerivative();
+                    }
+                    break;
+
+                case SymbolicRegexKind.Not:
+                    Debug.Assert(_left is not null);
+                    _transitionRegex = ~_left.MkDerivative();
+                    break;
+
+                default:
+                    _transitionRegex = TransitionRegex<S>.Leaf(_builder._nothing);
+                    break;
+            }
+            return _transitionRegex;
+        }
+
+        /// <summary>Extracts the nullability test as a Boolean combination of anchors</summary>
+        private SymbolicRegexNode<S> ExtractNullabilityTest()
+        {
+            if (IsNullable)
+            {
+                return _builder._anyStar;
+            }
+
+            if (!CanBeNullable)
+            {
+                return _builder._nothing;
+            }
+
+            switch (_kind)
+            {
+                case SymbolicRegexKind.StartAnchor:
+                case SymbolicRegexKind.EndAnchor:
+                case SymbolicRegexKind.BOLAnchor:
+                case SymbolicRegexKind.EOLAnchor:
+                case SymbolicRegexKind.WBAnchor:
+                case SymbolicRegexKind.NWBAnchor:
+                case SymbolicRegexKind.EndAnchorZ:
+                case SymbolicRegexKind.EndAnchorZRev:
+                    return this;
+                case SymbolicRegexKind.Concat:
+                    Debug.Assert(_left is not null && _right is not null);
+                    return _builder.MkAnd(_left.ExtractNullabilityTest(), _right.ExtractNullabilityTest());
+                case SymbolicRegexKind.Or:
+                    Debug.Assert(_alts is not null);
+                    SymbolicRegexNode<S> disjunction = _builder._nothing;
+                    foreach (SymbolicRegexNode<S> elem in _alts)
+                    {
+                        disjunction = _builder.MkOr(disjunction, elem.ExtractNullabilityTest());
+                    }
+                    return disjunction;
+                case SymbolicRegexKind.And:
+                    Debug.Assert(_alts is not null);
+                    SymbolicRegexNode<S> conjunction = _builder._anyStar;
+                    foreach (SymbolicRegexNode<S> elem in _alts)
+                    {
+                        conjunction = _builder.MkAnd(conjunction, elem.ExtractNullabilityTest());
+                    }
+                    return conjunction;
+                case SymbolicRegexKind.Loop:
+                    Debug.Assert(_left is not null);
+                    return _left.ExtractNullabilityTest();
+                default:
+                    // All remaininng cases could not be nullable or were trivially nullable
+                    // Sigleton cannot be nullable and Epsilon and Watchdog are trivially nullable
+                    Debug.Assert(_kind == SymbolicRegexKind.Not && _left is not null);
+                    return _builder.MkNot(_left.ExtractNullabilityTest());
+            }
         }
 
         public override int GetHashCode()

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace System.Text.RegularExpressions.Symbolic
 {
@@ -975,7 +973,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     Debug.Assert(_left is not null);
                     return _left.ExtractNullabilityTest();
                 default:
-                    // All remaininng cases could not be nullable or were trivially nullable
+                    // All remaining cases could not be nullable or were trivially nullable
                     // Sigleton cannot be nullable and Epsilon and Watchdog are trivially nullable
                     Debug.Assert(_kind == SymbolicRegexKind.Not && _left is not null);
                     return _builder.MkNot(_left.ExtractNullabilityTest());
@@ -1199,11 +1197,12 @@ namespace System.Text.RegularExpressions.Symbolic
                     return;
 
                 default:
+                    // Using the operator ~ for complement
                     Debug.Assert(_kind == SymbolicRegexKind.Not);
                     Debug.Assert(_left is not null);
-                    sb.Append("(?(");
+                    sb.Append("~(");
                     _left.ToString(sb);
-                    sb.Append($"){EmptyCharClass}|.*)");
+                    sb.Append(')');
                     return;
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -832,7 +832,6 @@ namespace System.Text.RegularExpressions.Symbolic
             if (_transitionRegex is not null)
             {
                 return _transitionRegex;
-
             }
 
             if (IsNothing || IsEpsilon)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSet.cs
@@ -394,49 +394,21 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
                 else
                 {
-                    if (_kind == SymbolicRegexKind.Or)
+                    // Union of two or more elements
+                    sb.Append('(');
+                    // Append the first two elements
+                    node.ToString(sb);
+                    // Using the operator & for intersection
+                    char op = _kind == SymbolicRegexKind.Or ? '|' : '&';
+                    sb.Append(op);
+                    enumerator.Current.ToString(sb);
+                    while (enumerator.MoveNext())
                     {
-                        // Union of two or more elements
-                        sb.Append('(');
-                        // Append the first two elements
-                        node.ToString(sb);
-                        sb.Append('|');
+                        // Append all the remaining elements
+                        sb.Append(op);
                         enumerator.Current.ToString(sb);
-                        while (enumerator.MoveNext())
-                        {
-                            // Append all the remaining elements
-                            sb.Append('|');
-                            enumerator.Current.ToString(sb);
-                        }
-                        sb.Append(')');
                     }
-                    else
-                    {
-                        // Intersection A&B is displayed as (?(A)B|[])
-                        // Intersection A&B&C is displayed as (?(A)(?(B)C|[])|[])
-                        // Intersection A&B&C&D is displayed as (?(A)(?(B)(?(C)D|[])|[])|[]) ... etc
-
-                        // Intersection of two or more elements
-                        sb.Append("(?(");
-                        node.ToString(sb);
-                        sb.Append(')');
-                        node = enumerator.Current;
-                        int count = 1;
-                        while (enumerator.MoveNext())
-                        {
-                            sb.Append("(?(");
-                            node.ToString(sb);
-                            sb.Append(')');
-                            node = enumerator.Current;
-                            count++;
-                        }
-                        node.ToString(sb);
-
-                        while (count-- > 0)
-                        {
-                            sb.Append($"|{SymbolicRegexNode<S>.EmptyCharClass})");
-                        }
-                    }
+                    sb.Append(')');
                 }
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
@@ -1,0 +1,291 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.RegularExpressions.Symbolic
+{
+    /// <summary>Represents a symbolic derivative created from a symbolic regex without using minterms</summary>
+    internal class TransitionRegex<S> : IEnumerable<(S, SymbolicRegexNode<S>)> where S : notnull
+    {
+        public readonly SymbolicRegexBuilder<S> _builder;
+        public readonly TransitionRegexKind _kind;
+        public readonly S? _test;
+        public readonly TransitionRegex<S>? _first;
+        public readonly TransitionRegex<S>? _second;
+        public readonly SymbolicRegexNode<S>? _leaf;
+
+        private readonly int _hashCode;
+
+        public bool IsNothing
+        {
+            get
+            {
+                if (_kind == TransitionRegexKind.Leaf)
+                {
+                    Debug.Assert(_leaf != null);
+                    return _leaf.IsNothing;
+                }
+                return false;
+            }
+        }
+
+        public bool IsAnyStar
+        {
+            get
+            {
+                if (_kind == TransitionRegexKind.Leaf)
+                {
+                    Debug.Assert(_leaf != null);
+                    return _leaf.IsAnyStar;
+                }
+                return false;
+            }
+        }
+
+        private TransitionRegex(SymbolicRegexBuilder<S> builder, TransitionRegexKind kind, S? test, TransitionRegex<S>? first, TransitionRegex<S>? second, SymbolicRegexNode<S>? leaf)
+        {
+            Debug.Assert(builder is not null);
+            Debug.Assert(
+                kind is TransitionRegexKind.Leaf && leaf is not null && Equals(test, default(S)) && first is null && second is null ||
+                kind is TransitionRegexKind.Conditional && test is not null && first is not null && second is not null && leaf is null ||
+                kind is TransitionRegexKind.Union && Equals(test, default(S)) && first is not null && second is not null && leaf is null);
+            _builder = builder;
+            _kind = kind;
+            _test = test;
+            _first = first;
+            _second = second;
+            _leaf = leaf;
+            _hashCode = HashCode.Combine(kind, test, first, second, leaf);
+        }
+
+        private static TransitionRegex<S> Create(SymbolicRegexBuilder<S> builder, TransitionRegexKind kind, S? test, TransitionRegex<S>? one, TransitionRegex<S>? two, SymbolicRegexNode<S>? leaf)
+        {
+            // Keep transition regexes internalized
+            (TransitionRegexKind, S?, TransitionRegex<S>?, TransitionRegex<S>?, SymbolicRegexNode<S>?) key = (kind, test, one, two, leaf);
+            TransitionRegex<S>? tr;
+            if (!builder._trCache.TryGetValue(key, out tr))
+            {
+                tr = new TransitionRegex<S>(builder, kind, test, one, two, leaf);
+                builder._trCache[key] = tr;
+            }
+            return tr;
+        }
+
+        public TransitionRegex<S> Complement()
+        {
+            switch (_kind)
+            {
+                case TransitionRegexKind.Conditional:
+                    Debug.Assert(_test is not null && _first is not null && _second is not null);
+                    return new TransitionRegex<S>(_builder, TransitionRegexKind.Conditional, _test, _first.Complement(), _second.Complement(), null);
+                case TransitionRegexKind.Leaf:
+                    Debug.Assert(_leaf is not null);
+                    return new TransitionRegex<S>(_builder, TransitionRegexKind.Leaf, default(S), null, null, _leaf._builder.MkNot(_leaf));
+                default:
+                    Debug.Assert(_kind == TransitionRegexKind.Union && _first is not null && _second is not null);
+                    return Intersect(_first.Complement(), _second.Complement());
+            }
+        }
+
+        /// <summary>Concatenate a node at the end of this transition regex</summary>
+        public TransitionRegex<S> Concat(SymbolicRegexNode<S> node)
+        {
+            switch (_kind)
+            {
+                case TransitionRegexKind.Leaf:
+                    Debug.Assert(_leaf is not null);
+                    return new TransitionRegex<S>(_builder, TransitionRegexKind.Leaf, default(S), null, null, _leaf._builder.MkConcat(_leaf, node));
+                default:
+                    Debug.Assert(_first is not null && _second is not null);
+                    return new TransitionRegex<S>(_builder, _kind, _test, _first.Concat(node), _second.Concat(node), null);
+            }
+        }
+
+        private static TransitionRegex<S> Intersect(TransitionRegex<S> one, TransitionRegex<S> two)
+        {
+            // Apply standard simplifications
+            // [] & t = [], t & .* = t
+            if (one.IsNothing || two.IsAnyStar || one == two)
+            {
+                return one;
+            }
+
+            // t & [] = [], .* & t = t
+            if (two.IsNothing || one.IsAnyStar)
+            {
+                return two;
+            }
+
+            return one.IntersectWith(two, one._builder._solver.True);
+        }
+
+        private TransitionRegex<S> IntersectWith(TransitionRegex<S> that, S context)
+        {
+            Debug.Assert(!_builder._solver.IsSatisfiable(context));
+            // Intersect when this is a Conditional
+            if (_kind == TransitionRegexKind.Conditional)
+            {
+                Debug.Assert(_test is not null && _first is not null && _second is not null);
+                S thenPath = _builder._solver.And(context, _test);
+                S elsePath = _builder._solver.And(context, _builder._solver.Not(_test));
+                if (!_builder._solver.IsSatisfiable(thenPath))
+                {
+                    // then case being infeasible implies that elsePath must be satisfiable
+                    return _second.IntersectWith(that, elsePath);
+                }
+                if (!_builder._solver.IsSatisfiable(elsePath))
+                {
+                    // else case is infeasible
+                    return _first.IntersectWith(that, thenPath);
+                }
+                TransitionRegex<S> thencase = _first.IntersectWith(that, thenPath);
+                TransitionRegex<S> elsecase = _second.IntersectWith(that, elsePath);
+                if (thencase == elsecase)
+                {
+                    // Both branches result in the same thing, so the test can be omitted
+                    return thencase;
+                }
+                return new TransitionRegex<S>(_builder, TransitionRegexKind.Conditional, _test, thencase, elsecase, null);
+            }
+
+            // Swap the order of this and that if that is a Conditional
+            if (that._kind == TransitionRegexKind.Conditional)
+            {
+                return that.IntersectWith(this, context);
+            }
+
+            // Intersect when this is a Union
+            // Use the following law of distributivity: (A|B)&C = A&C|B&C
+            if (_kind == TransitionRegexKind.Union)
+            {
+                Debug.Assert(_first is not null && _second is not null);
+                return new TransitionRegex<S>(_builder, TransitionRegexKind.Union, default(S), _first.IntersectWith(that, context), _second.IntersectWith(that, context), null);
+            }
+
+            // Swap the order of this and that if that is a Union
+            if (that._kind == TransitionRegexKind.Union)
+            {
+                return that.IntersectWith(this, context);
+            }
+
+            // Propagate intersection to the leaves
+            Debug.Assert(_kind is TransitionRegexKind.Leaf && that._kind is TransitionRegexKind.Leaf && _leaf is not null && that._leaf is not null);
+            return new TransitionRegex<S>(_builder, TransitionRegexKind.Leaf, default(S), null, null, _builder.MkAnd(_leaf, that._leaf));
+        }
+
+        private static TransitionRegex<S> Union(TransitionRegex<S> one, TransitionRegex<S> two)
+        {
+            // Apply common simplifications, always trying to push the operations into the leaves or to eliminate redundant branches
+            if (one.IsNothing || two.IsAnyStar || one.Equals(two))
+            {
+                return two;
+            }
+
+            if (two.IsNothing || one.IsAnyStar)
+            {
+                return one;
+            }
+
+            if (one._kind == TransitionRegexKind.Conditional && two._kind == TransitionRegexKind.Conditional)
+            {
+                Debug.Assert(one._test is not null && one._first is not null && one._second is not null);
+                Debug.Assert(two._test is not null && two._first is not null && two._second is not null);
+
+                // if(psi, t1, t2) | if(psi, s1, s2) = if(psi, t1|s1, t2|s2)
+                if (one._test.Equals(two._test))
+                {
+                    return IfThenElse(one._test, Union(one._first, two._first), Union(one._second, two._second));
+                }
+
+                // if(psi, t, []) | if(phi, t, []) = if(psi or phi, t, [])
+                if (one._second.IsNothing && two._second.IsNothing && one._first.Equals(two._first))
+                {
+                    return IfThenElse(one._builder._solver.Or(one._test, two._test), one._first, one._second);
+                }
+            }
+            // TODO: keep the representation of Union in right-associative form ordered by hashcode "as a list"
+            // so that in a Union, _first is never a union and _first._hashcode is less than _second._hashcode (if _second is not a Union)
+            // and if _second is a union then _first._hashcode is less than _second._first._hashcode, etc.
+            // This will help to maintain a canonical representation of two equivalent unions and avoid equivalent unions being nonequal
+            return Create(one._builder, TransitionRegexKind.Union, default(S), one, two, null);
+        }
+
+        private static TransitionRegex<S> IfThenElse(S test, TransitionRegex<S> thencase, TransitionRegex<S> elsecase) =>
+            (thencase == elsecase || thencase._builder._solver.True.Equals(test)) ? thencase :
+            thencase._builder._solver.False.Equals(test) ? elsecase :
+            Create(thencase._builder, TransitionRegexKind.Conditional, test, thencase, elsecase, null);
+
+        /// <summary>Intersection of transition regexes</summary>
+        public static TransitionRegex<S> operator &(TransitionRegex<S> one, TransitionRegex<S> two) => Intersect(one, two);
+
+        /// <summary>Union of transition regexes</summary>
+        public static TransitionRegex<S> operator |(TransitionRegex<S> one, TransitionRegex<S> two) => Union(one, two);
+
+        /// <summary>Complement of transition regex</summary>
+        public static TransitionRegex<S> operator ~(TransitionRegex<S> tr) => tr.Complement();
+
+        public override int GetHashCode() => _hashCode;
+
+        /// <summary>Equality is object identity due to internalization</summary>
+        public override bool Equals(object? obj) => this == obj;
+
+        public override string ToString()
+        {
+            switch (_kind)
+            {
+                case TransitionRegexKind.Conditional:
+                    return $"if({_test},{_first},{_second})";
+                case TransitionRegexKind.Leaf:
+                    return $"{_leaf}";
+                default:
+                    return $"{_first}|{_second}";
+            }
+        }
+
+        public IEnumerator<(S, SymbolicRegexNode<S>)> GetEnumerator() => EnumeratePaths(_builder._solver.True).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => EnumeratePaths(_builder._solver.True).GetEnumerator();
+
+        /// <summary>Enumerates the paths as outgoing transitions in an NFA</summary>
+        private IEnumerable<(S, SymbolicRegexNode<S>)> EnumeratePaths(S pathCondition)
+        {
+            switch (_kind)
+            {
+                case TransitionRegexKind.Leaf:
+                    Debug.Assert(_leaf is not null);
+                    // Omit any path that leads to a deadend
+                    if (!_leaf.IsNothing)
+                    {
+                        yield return (pathCondition, _leaf);
+                    }
+                    yield break;
+                case TransitionRegexKind.Conditional:
+                    Debug.Assert(_test is not null && _first is not null && _second is not null);
+                    foreach ((S, SymbolicRegexNode<S>) path in _first.EnumeratePaths(_builder._solver.And(pathCondition, _test)))
+                    {
+                        yield return path;
+                    }
+                    foreach ((S, SymbolicRegexNode<S>) path in _second.EnumeratePaths(_builder._solver.And(pathCondition, _builder._solver.Not(_test))))
+                    {
+                        yield return path;
+                    }
+                    yield break;
+                default:
+                    Debug.Assert(_kind is TransitionRegexKind.Union && _first is not null && _second is not null);
+                    foreach ((S, SymbolicRegexNode<S>) path in _first.EnumeratePaths(pathCondition))
+                    {
+                        yield return path;
+                    }
+                    foreach ((S, SymbolicRegexNode<S>) path in _second.EnumeratePaths(pathCondition))
+                    {
+                        yield return path;
+                    }
+                    yield break;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegexKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegexKind.cs
@@ -3,11 +3,12 @@
 
 namespace System.Text.RegularExpressions.Symbolic
 {
-    /// <summary>Kinds of transition regexes</summary>
+    /// <summary>Kinds of transition regexes. Transition regexes maintain a DNF form that pushes all intersections and complements to the leaves.</summary>
     internal enum TransitionRegexKind
     {
         Leaf,
         Conditional,
-        Union
+        Union,
+        Lookaround
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegexKind.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegexKind.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.RegularExpressions.Symbolic
+{
+    /// <summary>Kinds of transition regexes</summary>
+    internal enum TransitionRegexKind
+    {
+        Leaf,
+        Conditional,
+        Union
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -19,7 +19,7 @@ namespace System.Text.RegularExpressions.Tests
         public static bool Enabled => false;
 
         /// <summary>Temporary local output directory for experiment results.</summary>
-        private static readonly string s_tmpWorkingDir = "c:\\tmp"; // Path.GetTempPath();
+        private static readonly string s_tmpWorkingDir = Path.GetTempPath();
 
         /// <summary>Works as a console.</summary>
         private static string OutputFilePath => Path.Combine(s_tmpWorkingDir, "vsoutput.txt");

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -238,11 +238,19 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("[abc]{0,10}?", "a[abc]{0,3}?", "xxxabbbbbbbyyy", true, "a")]
         public void TestConjunctionOverCounting(string conjunct1, string conjunct2, string input, bool success, string match)
         {
-            string pattern = And(conjunct1, conjunct2);
-            Regex re = new Regex(pattern, RegexOptions.NonBacktracking);
-            Match m = re.Match(input);
-            Assert.Equal(success, m.Success);
-            Assert.Equal(match, m.Value);
+            try
+            {
+                string pattern = And(conjunct1, conjunct2);
+                Regex re = new Regex(pattern, RegexOptions.NonBacktracking);
+                Match m = re.Match(input);
+                Assert.Equal(success, m.Success);
+                Assert.Equal(match, m.Value);
+            }
+            catch(NotSupportedException e)
+            {
+                // In Release build (?( test-pattern ) yes-pattern | no-pattern ) is not supported
+                Assert.Contains("conditional", e.Message);
+            }
         }
 
         [Theory]
@@ -390,187 +398,227 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void SRMTest_ConjuctionIsMatch()
         {
-            var re = new Regex(And(".*a.*",".*b.*"), RegexOptions.NonBacktracking | RegexOptions.Singleline | RegexOptions.IgnoreCase);
-            bool ok = re.IsMatch("xxaaxxBxaa");
-            Assert.True(ok);
-            bool fail = re.IsMatch("xxaaxxcxaa");
-            Assert.False(fail);
+            try
+            {
+                var re = new Regex(And(".*a.*", ".*b.*"), RegexOptions.NonBacktracking | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+                bool ok = re.IsMatch("xxaaxxBxaa");
+                Assert.True(ok);
+                bool fail = re.IsMatch("xxaaxxcxaa");
+                Assert.False(fail);
+            }
+            catch (NotSupportedException e)
+            {
+                // In Release build (?( test-pattern ) yes-pattern | no-pattern ) is not supported
+                Assert.Contains("conditional", e.Message);
+            }
         }
 
         [Fact]
         public void SRMTest_ConjuctionFindMatch()
         {
-            // contains lower, upper, and a digit, and is between 2 and 4 characters long
-            var re = new Regex(And(".*[a-z].*", ".*[A-Z].*", ".*[0-9].*", ".{2,4}"), RegexOptions.NonBacktracking | RegexOptions.Singleline);
-            var match = re.Match("xxaac\n5Bxaa");
-            Assert.True(match.Success);
-            Assert.Equal(4, match.Index);
-            Assert.Equal(4, match.Length);
+            try
+            {
+                // contains lower, upper, and a digit, and is between 2 and 4 characters long
+                var re = new Regex(And(".*[a-z].*", ".*[A-Z].*", ".*[0-9].*", ".{2,4}"), RegexOptions.NonBacktracking | RegexOptions.Singleline);
+                var match = re.Match("xxaac\n5Bxaa");
+                Assert.True(match.Success);
+                Assert.Equal(4, match.Index);
+                Assert.Equal(4, match.Length);
+            }
+            catch (NotSupportedException e)
+            {
+                // In Release build (?( test-pattern ) yes-pattern | no-pattern ) is not supported
+                Assert.Contains("conditional", e.Message);
+            }
         }
 
         [Fact]
         public void SRMTest_ComplementFindMatch()
         {
-            // contains lower, upper, and a digit, and is between 4 and 8 characters long, does not contain 2 consequtive digits
-            var re = new Regex(And(".*[a-z].*", ".*[A-Z].*", ".*[0-9].*", ".{4,8}",
-                Not(".*(01|12|23|34|45|56|67|78|89).*")), RegexOptions.NonBacktracking | RegexOptions.Singleline);
-            var match = re.Match("xxaac12Bxaas3455");
-            Assert.True(match.Success);
-            Assert.Equal(6, match.Index);
-            Assert.Equal(7, match.Length);
+            try
+            {
+                // contains lower, upper, and a digit, and is between 4 and 8 characters long, does not contain 2 consequtive digits
+                var re = new Regex(And(".*[a-z].*", ".*[A-Z].*", ".*[0-9].*", ".{4,8}",
+                    Not(".*(01|12|23|34|45|56|67|78|89).*")), RegexOptions.NonBacktracking | RegexOptions.Singleline);
+                var match = re.Match("xxaac12Bxaas3455");
+                Assert.True(match.Success);
+                Assert.Equal(6, match.Index);
+                Assert.Equal(7, match.Length);
+            }
+            catch (NotSupportedException e)
+            {
+                // In Release build (?( test-pattern ) yes-pattern | no-pattern ) is not supported
+                Assert.Contains("conditional", e.Message);
+            }
         }
 
         [Fact]
         public void PasswordSearch()
         {
-            string twoLower = ".*[a-z].*[a-z].*";
-            string twoUpper = ".*[A-Z].*[A-Z].*";
-            string threeDigits = ".*[0-9].*[0-9].*[0-9].*";
-            string oneSpecial = @".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*";
-            string Not_countUp = Not(".*(012|123|234|345|456|567|678|789).*");
-            string Not_countDown = Not(".*(987|876|765|654|543|432|321|210).*");
-            // Observe that the space character (immediately before '!' in ASCII) is excluded
-            string length = "[!-~]{8,12}";
- 
-           // Just to make the chance that the randomly generated part actually has a match
-           // be astronomically unlikely require 'P' and 'r' to be present also,
-           // although this constraint is really bogus from password constraints point of view
-            string contains_first_P_and_then_r = ".*P.*r.*";
-
-            // Conjunction of all the above constraints
-            string all = And(twoLower, twoUpper, threeDigits, oneSpecial, Not_countUp, Not_countDown, length, contains_first_P_and_then_r);
-
-            // search for the password in a context surrounded by word boundaries
-            Regex re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
-
-            // Does not qualify because of 123 and connot end between 2 and 3 because of \b
-            string almostPassw1 = "P@ssW0rd123";
-            // Does not have at least two uppercase
-            string almostPassw2 = "P@55w0rd";
-
-            // These two qualify
-            string password1 = "P@55W0rd";
-            string password2 = "Pa5$w00rD";
-
-            foreach (int k in new int[] {500, 1000, 5000, 10000, 50000, 100000})
+            try
             {
-                Random random = new(k);
-                byte[] buffer1 = new byte[k];
-                byte[] buffer2 = new byte[k];
-                byte[] buffer3 = new byte[k];
-                random.NextBytes(buffer1);
-                random.NextBytes(buffer2);
-                random.NextBytes(buffer3);
-                string part1 = new string(Array.ConvertAll(buffer1, b => (char)b));
-                string part2 = new string(Array.ConvertAll(buffer2, b => (char)b));
-                string part3 = new string(Array.ConvertAll(buffer3, b => (char)b));
+                string twoLower = ".*[a-z].*[a-z].*";
+                string twoUpper = ".*[A-Z].*[A-Z].*";
+                string threeDigits = ".*[0-9].*[0-9].*[0-9].*";
+                string oneSpecial = @".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*";
+                string Not_countUp = Not(".*(012|123|234|345|456|567|678|789).*");
+                string Not_countDown = Not(".*(987|876|765|654|543|432|321|210).*");
+                // Observe that the space character (immediately before '!' in ASCII) is excluded
+                string length = "[!-~]{8,12}";
 
-                string input = $"{part1} {almostPassw1} {part2} {password1} {part3} {password2}, finally this {almostPassw2} does not qualify either";
+                // Just to make the chance that the randomly generated part actually has a match
+                // be astronomically unlikely require 'P' and 'r' to be present also,
+                // although this constraint is really bogus from password constraints point of view
+                string contains_first_P_and_then_r = ".*P.*r.*";
 
-                int expextedMatch1Index = (2 * k) + almostPassw1.Length + 3;
-                int expextedMatch1Length = password1.Length;
+                // Conjunction of all the above constraints
+                string all = And(twoLower, twoUpper, threeDigits, oneSpecial, Not_countUp, Not_countDown, length, contains_first_P_and_then_r);
 
-                int expextedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
-                int expextedMatch2Length = password2.Length;
+                // search for the password in a context surrounded by word boundaries
+                Regex re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
 
-                // Random text hiding almostPassw and password
-                int t = System.Environment.TickCount;
-                Match match1 = re.Match(input);
-                Match match2 = match1.NextMatch();
-                Match match3 = match2.NextMatch();
-                t = System.Environment.TickCount - t;
+                // Does not qualify because of 123 and connot end between 2 and 3 because of \b
+                string almostPassw1 = "P@ssW0rd123";
+                // Does not have at least two uppercase
+                string almostPassw2 = "P@55w0rd";
 
-                _output.WriteLine($@"k={k}, t={t}ms");
+                // These two qualify
+                string password1 = "P@55W0rd";
+                string password2 = "Pa5$w00rD";
 
-                Assert.True(match1.Success);
-                Assert.Equal(expextedMatch1Index, match1.Index);
-                Assert.Equal(expextedMatch1Length, match1.Length);
-                Assert.Equal(password1, match1.Value);
+                foreach (int k in new int[] { 500, 1000, 5000, 10000, 50000, 100000 })
+                {
+                    Random random = new(k);
+                    byte[] buffer1 = new byte[k];
+                    byte[] buffer2 = new byte[k];
+                    byte[] buffer3 = new byte[k];
+                    random.NextBytes(buffer1);
+                    random.NextBytes(buffer2);
+                    random.NextBytes(buffer3);
+                    string part1 = new string(Array.ConvertAll(buffer1, b => (char)b));
+                    string part2 = new string(Array.ConvertAll(buffer2, b => (char)b));
+                    string part3 = new string(Array.ConvertAll(buffer3, b => (char)b));
 
-                Assert.True(match2.Success);
-                Assert.Equal(expextedMatch2Index, match2.Index);
-                Assert.Equal(expextedMatch2Length, match2.Length);
-                Assert.Equal(password2, match2.Value);
+                    string input = $"{part1} {almostPassw1} {part2} {password1} {part3} {password2}, finally this {almostPassw2} does not qualify either";
 
-                Assert.False(match3.Success);
+                    int expextedMatch1Index = (2 * k) + almostPassw1.Length + 3;
+                    int expextedMatch1Length = password1.Length;
+
+                    int expextedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
+                    int expextedMatch2Length = password2.Length;
+
+                    // Random text hiding almostPassw and password
+                    int t = System.Environment.TickCount;
+                    Match match1 = re.Match(input);
+                    Match match2 = match1.NextMatch();
+                    Match match3 = match2.NextMatch();
+                    t = System.Environment.TickCount - t;
+
+                    _output.WriteLine($@"k={k}, t={t}ms");
+
+                    Assert.True(match1.Success);
+                    Assert.Equal(expextedMatch1Index, match1.Index);
+                    Assert.Equal(expextedMatch1Length, match1.Length);
+                    Assert.Equal(password1, match1.Value);
+
+                    Assert.True(match2.Success);
+                    Assert.Equal(expextedMatch2Index, match2.Index);
+                    Assert.Equal(expextedMatch2Length, match2.Length);
+                    Assert.Equal(password2, match2.Value);
+
+                    Assert.False(match3.Success);
+                }
+            }
+            catch (NotSupportedException e)
+            {
+                // In Release build (?( test-pattern ) yes-pattern | no-pattern ) is not supported
+                Assert.Contains("conditional", e.Message);
             }
         }
 
         [Fact]
         public void PasswordSearchDual()
         {
-            string Not_twoLower = Not(".*[a-z].*[a-z].*");
-            string Not_twoUpper = Not(".*[A-Z].*[A-Z].*");
-            string Not_threeDigits = Not(".*[0-9].*[0-9].*[0-9].*");
-            string Not_oneSpecial = Not(@".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*");
-            string countUp = ".*(012|123|234|345|456|567|678|789).*";
-            string countDown = ".*(987|876|765|654|543|432|321|210).*";
-            // Observe that the space character (immediately before '!' in ASCII) is excluded
-            string Not_length = Not("[!-~]{8,12}");
-
-            // Just to make the chance that the randomly generated part actually has a match
-            // be astronomically unlikely require 'P' and 'r' to be present also,
-            // although this constraint is really bogus from password constraints point of view
-            string Not_contains_first_P_and_then_r = Not(".*P.*r.*");
-
-            // Negated disjunction of all the above constraints
-            // By deMorgan's laws we know that ~(A|B|...|C) = ~A&~B&...&~C and ~~A = A
-            // So Not(Not_twoLower|...) is equivalent to twoLower&~(...)
-            string all = Not($"{Not_twoLower}|{Not_twoUpper}|{Not_threeDigits}|{Not_oneSpecial}|{countUp}|{countDown}|{Not_length}|{Not_contains_first_P_and_then_r}");
-
-            // search for the password in a context surrounded by word boundaries
-            Regex re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
-
-            // Does not qualify because of 123 and connot end between 2 and 3 because of \b
-            string almostPassw1 = "P@ssW0rd123";
-            // Does not have at least two uppercase
-            string almostPassw2 = "P@55w0rd";
-
-            // These two qualify
-            string password1 = "P@55W0rd";
-            string password2 = "Pa5$w00rD";
-
-            foreach (int k in new int[] { 500, 1000, 5000, 10000, 50000, 100000})
+            try
             {
-                Random random = new(k);
-                byte[] buffer1 = new byte[k];
-                byte[] buffer2 = new byte[k];
-                byte[] buffer3 = new byte[k];
-                random.NextBytes(buffer1);
-                random.NextBytes(buffer2);
-                random.NextBytes(buffer3);
-                string part1 = new string(Array.ConvertAll(buffer1, b => (char)b));
-                string part2 = new string(Array.ConvertAll(buffer2, b => (char)b));
-                string part3 = new string(Array.ConvertAll(buffer3, b => (char)b));
+                string Not_twoLower = Not(".*[a-z].*[a-z].*");
+                string Not_twoUpper = Not(".*[A-Z].*[A-Z].*");
+                string Not_threeDigits = Not(".*[0-9].*[0-9].*[0-9].*");
+                string Not_oneSpecial = Not(@".*[\x21-\x2F\x3A-\x40\x5B-x60\x7B-\x7E].*");
+                string countUp = ".*(012|123|234|345|456|567|678|789).*";
+                string countDown = ".*(987|876|765|654|543|432|321|210).*";
+                // Observe that the space character (immediately before '!' in ASCII) is excluded
+                string Not_length = Not("[!-~]{8,12}");
 
-                string input = $"{part1} {almostPassw1} {part2} {password1} {part3} {password2}, finally this {almostPassw2} does not qualify either";
+                // Just to make the chance that the randomly generated part actually has a match
+                // be astronomically unlikely require 'P' and 'r' to be present also,
+                // although this constraint is really bogus from password constraints point of view
+                string Not_contains_first_P_and_then_r = Not(".*P.*r.*");
 
-                int expectedMatch1Index = (2 * k) + almostPassw1.Length + 3;
-                int expectedMatch1Length = password1.Length;
+                // Negated disjunction of all the above constraints
+                // By deMorgan's laws we know that ~(A|B|...|C) = ~A&~B&...&~C and ~~A = A
+                // So Not(Not_twoLower|...) is equivalent to twoLower&~(...)
+                string all = Not($"{Not_twoLower}|{Not_twoUpper}|{Not_threeDigits}|{Not_oneSpecial}|{countUp}|{countDown}|{Not_length}|{Not_contains_first_P_and_then_r}");
 
-                int expectedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
-                int expectedMatch2Length = password2.Length;
+                // search for the password in a context surrounded by word boundaries
+                Regex re = new Regex($@"\b{all}\b", RegexOptions.NonBacktracking | RegexOptions.Singleline);
 
-                // Random text hiding almostPassw and password
-                int t = System.Environment.TickCount;
-                Match match1 = re.Match(input);
-                Match match2 = match1.NextMatch();
-                Match match3 = match2.NextMatch();
-                t = System.Environment.TickCount - t;
+                // Does not qualify because of 123 and connot end between 2 and 3 because of \b
+                string almostPassw1 = "P@ssW0rd123";
+                // Does not have at least two uppercase
+                string almostPassw2 = "P@55w0rd";
 
-                _output.WriteLine($@"k={k}, t={t}ms");
+                // These two qualify
+                string password1 = "P@55W0rd";
+                string password2 = "Pa5$w00rD";
 
-                Assert.True(match1.Success);
-                Assert.Equal(expectedMatch1Index, match1.Index);
-                Assert.Equal(expectedMatch1Length, match1.Length);
-                Assert.Equal(password1, match1.Value);
+                foreach (int k in new int[] { 500, 1000, 5000, 10000, 50000, 100000 })
+                {
+                    Random random = new(k);
+                    byte[] buffer1 = new byte[k];
+                    byte[] buffer2 = new byte[k];
+                    byte[] buffer3 = new byte[k];
+                    random.NextBytes(buffer1);
+                    random.NextBytes(buffer2);
+                    random.NextBytes(buffer3);
+                    string part1 = new string(Array.ConvertAll(buffer1, b => (char)b));
+                    string part2 = new string(Array.ConvertAll(buffer2, b => (char)b));
+                    string part3 = new string(Array.ConvertAll(buffer3, b => (char)b));
 
-                Assert.True(match2.Success);
-                Assert.Equal(expectedMatch2Index, match2.Index);
-                Assert.Equal(expectedMatch2Length, match2.Length);
-                Assert.Equal(password2, match2.Value);
+                    string input = $"{part1} {almostPassw1} {part2} {password1} {part3} {password2}, finally this {almostPassw2} does not qualify either";
 
-                Assert.False(match3.Success);
+                    int expectedMatch1Index = (2 * k) + almostPassw1.Length + 3;
+                    int expectedMatch1Length = password1.Length;
+
+                    int expectedMatch2Index = (3 * k) + almostPassw1.Length + password1.Length + 5;
+                    int expectedMatch2Length = password2.Length;
+
+                    // Random text hiding almostPassw and password
+                    int t = System.Environment.TickCount;
+                    Match match1 = re.Match(input);
+                    Match match2 = match1.NextMatch();
+                    Match match3 = match2.NextMatch();
+                    t = System.Environment.TickCount - t;
+
+                    _output.WriteLine($@"k={k}, t={t}ms");
+
+                    Assert.True(match1.Success);
+                    Assert.Equal(expectedMatch1Index, match1.Index);
+                    Assert.Equal(expectedMatch1Length, match1.Length);
+                    Assert.Equal(password1, match1.Value);
+
+                    Assert.True(match2.Success);
+                    Assert.Equal(expectedMatch2Index, match2.Index);
+                    Assert.Equal(expectedMatch2Length, match2.Length);
+                    Assert.Equal(password2, match2.Value);
+
+                    Assert.False(match3.Success);
+                }
+            }
+            catch (NotSupportedException e)
+            {
+                // In Release build (?( test-pattern ) yes-pattern | no-pattern ) is not supported
+                Assert.Contains("conditional", e.Message);
             }
         }
     }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -326,12 +326,12 @@ namespace System.Text.RegularExpressions.Tests
                 Assert.Contains(".*a+", str);
             }
 
-            static bool TrySaveDGML(Regex regex, TextWriter writer, int bound = -1, bool hideStateInfo = false, bool addDotStar = false, bool inReverse = false, bool onlyDFAinfo = false, int maxLabelLength = -1)
+            static bool TrySaveDGML(Regex regex, TextWriter writer, int bound = -1, bool hideStateInfo = false, bool addDotStar = false, bool inReverse = false, bool onlyDFAinfo = false, int maxLabelLength = -1, bool asNFA = false)
             {
                 MethodInfo saveDgml = regex.GetType().GetMethod("SaveDGML", BindingFlags.NonPublic | BindingFlags.Instance);
                 if (saveDgml is not null)
                 {
-                    saveDgml.Invoke(regex, new object[] { writer, bound, hideStateInfo, addDotStar, inReverse, onlyDFAinfo, maxLabelLength });
+                    saveDgml.Invoke(regex, new object[] { writer, bound, hideStateInfo, addDotStar, inReverse, onlyDFAinfo, maxLabelLength, asNFA });
                     return true;
                 }
 


### PR DESCRIPTION
- Added `TransitionRegex `as a separate abstraction of a branching structure of symbolic derivatives.
- Added `MkDerivative()` that computes the `TransitionRegex` from a symbolic regex.
- Extended `DGML` support to debug the new additions, and updated some unit tests `ViewSampleRegexInDGML()` in particular good to look (change `RegexExperiment.s_tmpWorkingDir` locally to some local tmp folder and then open the dgml files created there to look at the output) -- it now calls repeatedly into `MkDerivative()` to explore the whole regex and creates an **NFA** from it (not **DFA**) i.e., possibly nondeterministic.

The size of the NFA can be used to determine if the regex is **secure** - say has less than 10k AST nodes. The size (nr of states) of the NFA is roughly proportional to the number of nodes of the AST of the regex when counters are unwound. Currently the full NFA creation is part of the dgml creation code, but this part is rather straightforward DFS search. 

Can also support **lookarounds** going forward. 
Using MkDerivative() to explore the whole regex is in a nutshell the core idea for the code-generator. As said, we have done this before with Olli in this style. The somewhat new thing here is the branching structure and actually that **minterms** are not needed, but also this we are familiar with from earlier works with Olli.

The new code is really only reachable right now via dgml creation, but as I said, its real purpose is to be used in code-gen and possibly as an alternative backend to the current `DfaMatchingState.Next()` method. The previous character kind is no longer stored or needed there so state becomes just the SymbolicrRegexNode and there is a special lookaround conditional that currently only involves anchors (but could be other stuff -- lookahed/lookbehind in the future). So this is pretty important stuff from that point of view.
