### PR TITLE
Align trimming settings with IL Linker

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -27,16 +27,17 @@ The .NET Foundation licenses this file to you under the MIT license.
     <NativeDebugSymbols Condition="$(DebugSymbols) == 'true' or ($(DebugType) != 'none' and $(DebugType) != '')">true</NativeDebugSymbols>
     <!-- Workaround for https://github.com/dotnet/runtimelab/issues/771 -->
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <!-- Set up the defaults for the compatibility mode -->
   <PropertyGroup>
-    <_BuildingInCompatibleMode Condition="$(TrimMode) == '' and $(IlcGenerateStackTraceData) == '' and $(IlcDisableReflection) == ''">true</_BuildingInCompatibleMode>
+    <_BuildingInCompatibleMode Condition="$(TrimmerDefaultAction) == '' and $(IlcGenerateStackTraceData) == '' and $(IlcDisableReflection) == ''">true</_BuildingInCompatibleMode>
 
     <IlcGenerateStackTraceData Condition="$(IlcGenerateStackTraceData) == ''">true</IlcGenerateStackTraceData>
     <IlcScanReflection Condition="$(IlcScanReflection) == ''">true</IlcScanReflection>
     <SuppressTrimAnalysisWarnings Condition="$(SuppressTrimAnalysisWarnings) == ''">true</SuppressTrimAnalysisWarnings>
-    <TrimMode Condition="$(TrimMode) == ''">copyused</TrimMode>
+    <TrimmerDefaultAction Condition="$([MSBuild]::VersionLessThan('$(NETCoreSdkVersion)', '6.0.0'))">copyused</TrimmerDefaultAction>
   </PropertyGroup>
 
   <!-- Set up default feature switches -->
@@ -116,13 +117,14 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Target Name="_ComputeManagedAssemblyForILLink" AfterTargets="_ComputeManagedAssemblyToLink">
     <ItemGroup>
       <ManagedAssemblyToLink Remove="@(ManagedAssemblyToLink)" />
+      <ManagedAssemblyToLink Include="@(DefaultFrameworkAssemblies);@(_ManagedResolvedAssembliesToPublish);@(ManagedBinary)" />
+    </ItemGroup>
+    <ItemGroup Condition="$([MSBuild]::VersionLessThan('$(TargetFrameworkVersion)', '6.0'))">
+      <ManagedAssemblyToLink Remove="@(ManagedAssemblyToLink)" />
       <ManagedAssemblyToLink Include="@(DefaultFrameworkAssemblies)">
         <IsTrimmable>true</IsTrimmable>
-        <TrimMode>link</TrimMode>
       </ManagedAssemblyToLink>
-      <ManagedAssemblyToLink Include="@(_ManagedResolvedAssembliesToPublish);@(ManagedBinary)">
-        <IsTrimmable>true</IsTrimmable>
-      </ManagedAssemblyToLink>
+      <ManagedAssemblyToLink Include="@(_ManagedResolvedAssembliesToPublish);@(ManagedBinary)" />
     </ItemGroup>
   </Target>
 
@@ -212,16 +214,11 @@ The .NET Foundation licenses this file to you under the MIT license.
       </ManagedAssemblyToLink>
     </ItemGroup>
 
-    <!-- Propagate the global TrimMode to all the assembly that don't have it yet -->
-    <ItemGroup>
-      <ManagedAssemblyToLink Condition=" '%(ManagedAssemblyToLink.TrimMode)' == '' ">
-        <TrimMode>$(TrimMode)</TrimMode>
-      </ManagedAssemblyToLink>
-    </ItemGroup>
-
     <ItemGroup>
       <_IlcRootedAssemblies Include="@(TrimmerRootAssembly)" />
+      <_IlcRootedAssemblies Include="@(ManagedAssemblyToLink)" Condition="%(ManagedAssemblyToLink.TrimMode) == 'copy'" />
       <_IlcConditionallyRootedAssemblies Include="@(ManagedAssemblyToLink)" Condition="%(ManagedAssemblyToLink.TrimMode) == 'copyused'" />
+      <_IlcTrimmedAssemblies Include="@(ManagedAssemblyToLink)" Condition="%(ManagedAssemblyToLink.TrimMode) == 'link'" />
       <_IlcNoSingleWarnAssemblies Include="@(ManagedAssemblyToLink)" Condition="%(ManagedAssemblyToLink.TrimmerSingleWarn) == 'false'" />
     </ItemGroup>
 
@@ -264,7 +261,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="'$(ControlFlowGuard)' == 'Guard' and '$(TargetOS)' == 'windows'" Include="--guard:cf" />
       <IlcArg Include="@(_IlcRootedAssemblies->'--root:%(Identity)')" />
       <IlcArg Include="@(_IlcConditionallyRootedAssemblies->'--conditionalroot:%(Identity)')" />
+      <IlcArg Include="@(_IlcTrimmedAssemblies->'--trim:%(Identity)')" />
       <IlcArg Include="@(_IlcNoSingleWarnAssemblies->'--nosinglewarnassembly:%(Filename)')" />
+      <IlcArg Condition="'$(TrimmerDefaultAction)' == 'copyused' or '$(TrimmerDefaultAction)' == 'copy'" Include="--defaultrooting" />
 
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--feature:System.Reflection.IsReflectionExecutionAvailable=false" />
 
@@ -285,6 +284,10 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Message Text="Generating compatible native code. To optimize for size or speed, visit https://aka.ms/OptimizeCoreRT" Condition="$(_BuildingInCompatibleMode) == 'true'" Importance="high" />
 
     <Exec Command="&quot;$(IlcHostPath)\tools\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;" />
+
+    <!-- Trick ILLinker into not actually running -->
+    <MakeDir Directories="$(IntermediateLinkDir)" />
+    <Touch Files="$(_LinkSemaphore)" AlwaysCreate="true" />
   </Target>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.NETCore.Native.Windows.props" Condition="'$(TargetOS)' == 'windows'" />

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -85,6 +85,8 @@ namespace ILCompiler
 
         private IReadOnlyList<string> _rootedAssemblies = Array.Empty<string>();
         private IReadOnlyList<string> _conditionallyRootedAssemblies = Array.Empty<string>();
+        private IReadOnlyList<string> _trimmedAssemblies = Array.Empty<string>();
+        private bool _rootDefaultAssemblies;
 
         public IReadOnlyList<string> _mibcFilePaths = Array.Empty<string>();
 
@@ -215,6 +217,8 @@ namespace ILCompiler
 
                 syntax.DefineOptionList("root", ref _rootedAssemblies, "Fully generate given assembly");
                 syntax.DefineOptionList("conditionalroot", ref _conditionallyRootedAssemblies, "Fully generate given assembly if it's used");
+                syntax.DefineOptionList("trim", ref _trimmedAssemblies, "Trim the specified assembly");
+                syntax.DefineOption("defaultrooting", ref _rootDefaultAssemblies, "Root assemblies that are not marked [IsTrimmable]");
 
                 syntax.DefineOption("targetarch", ref _targetArchitectureStr, "Target architecture for cross compilation");
                 syntax.DefineOption("targetos", ref _targetOSStr, "Target OS for cross compilation");
@@ -582,6 +586,7 @@ namespace ILCompiler
 
             _rootedAssemblies = new List<string>(_rootedAssemblies.Select(a => ILLinkify(a)));
             _conditionallyRootedAssemblies = new List<string>(_conditionallyRootedAssemblies.Select(a => ILLinkify(a)));
+            _trimmedAssemblies = new List<string>(_trimmedAssemblies.Select(a => ILLinkify(a)));
 
             static string ILLinkify(string rootedAssembly)
             {
@@ -655,6 +660,8 @@ namespace ILCompiler
                     metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.ReflectionILScanning;
                 if (_reflectedOnly)
                     metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.ReflectedMembersOnly;
+                if (_rootDefaultAssemblies)
+                    metadataGenerationOptions |= UsageBasedMetadataGenerationOptions.RootDefaultAssemblies;
             }
             else
             {
@@ -678,7 +685,8 @@ namespace ILCompiler
                     metadataGenerationOptions,
                     logger,
                     featureSwitches,
-                    _conditionallyRootedAssemblies.Concat(_rootedAssemblies));
+                    _conditionallyRootedAssemblies.Concat(_rootedAssemblies),
+                    _trimmedAssemblies);
 
             InteropStateManager interopStateManager = new InteropStateManager(typeSystemContext.GeneratedAssembly);
             InteropStubManager interopStubManager = new UsageBasedInteropStubManager(interopStateManager, pinvokePolicy);


### PR DESCRIPTION
Aligns the ILCompiler targets with ILLink.

It's all rather complex because:

* One can specify that an assembly is trimmable using a custom attribute. This doesn't mean it will be trimmed in IL Link, it just marks it.
* One can specify a default trimming action (keep everything or trim) on the command line for assemblies not marked as trimmable
* One can specify a trimming action for listed assemblies on the command line
* In ILLink, one can also specify trimming action for assemblies marked IsTrimmable. For ILCompiler, I'm making this assume the action is trim. ILLink can also say to root. I don't see much point.

I tested this with both .NET 5 and .NET 6 SDKs.

There's a difference in behavior - in the past, setting `TrimMode=link` would trim the whole app, but that's not what illinker does. For .NET 5, one has to do the [custom target dance](https://github.com/davidfowl/LinkedAspNetCoreApplication/blob/fd7454f23e7e48a4302fb239f72a914ce4c9dc73/LinkedAspNetCoreApplication/LinkedAspNetCoreApplication.csproj#L14-L21). On .NET 6, one can just specify TrimmerDefaultAction=link.