### PR TITLE
Updated semantics of \b and \B anchors in NonBacktracking

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/DfaMatchingState.cs
@@ -62,7 +62,7 @@ namespace System.Text.RegularExpressions.Symbolic
         internal DfaMatchingState<T> Next(T atom)
         {
             ICharAlgebra<T> alg = Node._builder._solver;
-            T wordLetterPredicate = Node._builder._wordLetterPredicate;
+            T wordLetterPredicate = Node._builder._wordLetterPredicateForAnchors;
             T newLinePredicate = Node._builder._newLinePredicate;
 
             // atom == solver.False is used to represent the very last \n

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -341,9 +341,10 @@ namespace System.Text.RegularExpressions.Symbolic
             void EnsureWordLetterPredicateInitialized()
             {
                 // Update the word letter predicate based on the Unicode definition of it if it was not updated already
-                if (_builder._wordLetterPredicate.Equals(_builder._solver.False))
+                if (_builder._wordLetterPredicateForAnchors.Equals(_builder._solver.False))
                 {
-                    _builder._wordLetterPredicate = _categorizer.WordLetterCondition;
+                    // Use the predicate including joiner and non joiner
+                    _builder._wordLetterPredicateForAnchors = _categorizer.WordLetterConditionForAnchors;
                 }
             }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -31,7 +31,7 @@ namespace System.Text.RegularExpressions.Symbolic
         internal readonly SymbolicRegexSet<TElement> _emptySet;
         internal readonly SymbolicRegexNode<TElement> _eagerEmptyLoop;
 
-        internal TElement _wordLetterPredicate;
+        internal TElement _wordLetterPredicateForAnchors;
         internal TElement _newLinePredicate;
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace System.Text.RegularExpressions.Symbolic
             // initialized to False but updated later to the actual condition ony if \b or \B occurs anywhere in the regex
             // this implies that if a regex never uses \b or \B then the character context will never
             // update the previous character context to distinguish word and nonword letters
-            _wordLetterPredicate = solver.False;
+            _wordLetterPredicateForAnchors = solver.False;
 
             // initialized to False but updated later to the actual condition of \n ony if a line anchor occurs anywhere in the regex
             // this implies that if a regex never uses a line anchor then the character context will never
@@ -365,7 +365,7 @@ namespace System.Text.RegularExpressions.Symbolic
         public DfaMatchingState<TElement> MkState(SymbolicRegexNode<TElement> node, uint prevCharKind, bool antimirov = false)
         {
             //first prune the anchors in the node
-            TElement WLpred = _wordLetterPredicate;
+            TElement WLpred = _wordLetterPredicateForAnchors;
             TElement startSet = node.GetStartSet();
 
             //true if the startset of the node overlaps with some wordletter or the node can be nullable

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -832,7 +832,7 @@ namespace System.Text.RegularExpressions.Symbolic
             uint[] asciiCharKinds = _asciiCharKinds;
             return
                 nextChar < asciiCharKinds.Length ? asciiCharKinds[nextChar] :
-                _builder._solver.And(GetAtom(nextChar), _builder._wordLetterPredicate).Equals(_builder._solver.False) ? 0 : //apply the wordletter predicate to compute the kind of the next character
+                _builder._solver.And(GetAtom(nextChar), _builder._wordLetterPredicateForAnchors).Equals(_builder._solver.False) ? 0 : //apply the wordletter predicate to compute the kind of the next character
                 CharKind.WordLetter;
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -226,7 +226,7 @@ namespace System.Text.RegularExpressions.Symbolic
                     }
                     else
                     {
-                        predicate2 = _builder._wordLetterPredicate;
+                        predicate2 = _builder._wordLetterPredicateForAnchors;
                         charKind = CharKind.WordLetter;
                     }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -1297,7 +1297,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
                 case SymbolicRegexKind.NWBAnchor:
                 case SymbolicRegexKind.WBAnchor:
-                    predicates.Add(_builder._wordLetterPredicate);
+                    predicates.Add(_builder._wordLetterPredicateForAnchors);
                     return;
 
                 default:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunner.cs
@@ -33,7 +33,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
                 // The default constructor sets the following predicates to False; this update happens after the fact.
                 // It depends on whether anchors where used in the regex whether the predicates are actually different from False.
-                builderBV._wordLetterPredicate = algBV.ConvertFromCharSet(solver, converter._builder._wordLetterPredicate);
+                builderBV._wordLetterPredicateForAnchors = algBV.ConvertFromCharSet(solver, converter._builder._wordLetterPredicateForAnchors);
                 builderBV._newLinePredicate = algBV.ConvertFromCharSet(solver, converter._builder._newLinePredicate);
 
                 //Convert the BDD based AST to BV based AST
@@ -48,7 +48,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 {
                     // The default constructor sets the following predicates to False, this update happens after the fact
                     // It depends on whether anchors where used in the regex whether the predicates are actually different from False
-                    _wordLetterPredicate = alg64.ConvertFromCharSet(solver, converter._builder._wordLetterPredicate),
+                    _wordLetterPredicateForAnchors = alg64.ConvertFromCharSet(solver, converter._builder._wordLetterPredicateForAnchors),
                     _newLinePredicate = alg64.ConvertFromCharSet(solver, converter._builder._newLinePredicate)
                 };
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.KnownPattern.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.KnownPattern.Tests.cs
@@ -75,26 +75,34 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal("http:8080", m.Result("${proto}${port}"));
         }
 
+        public static IEnumerable<object[]> Docs_Examples_ValidateEmail_TestData()
+        {
+            // The email uses conditional test-patterns so NonBacktracking is not supported here
+            foreach (RegexOptions options in new RegexOptions[] { RegexOptions.None, RegexOptions.Compiled })
+            {
+                yield return new object[] { options, "david.jones@proseware.com", true };
+                yield return new object[] { options, "d.j@server1.proseware.com", true };
+                yield return new object[] { options, "jones@ms1.proseware.com", true };
+                yield return new object[] { options, "j.@server1.proseware.com", false };
+                yield return new object[] { options, "j@proseware.com9", true };
+                yield return new object[] { options, "js#internal@proseware.com", true };
+                yield return new object[] { options, "j_9@[129.126.118.1]", true };
+                yield return new object[] { options, "j..s@proseware.com", false };
+                yield return new object[] { options, "js*@proseware.com", false };
+                yield return new object[] { options, "js@proseware..com", false };
+                yield return new object[] { options, "js@proseware.com9", true };
+                yield return new object[] { options, "j.s@server1.proseware.com", true };
+                yield return new object[] { options, "\"j\\\"s\\\"\"@proseware.com", true };
+                yield return new object[] { options, "js@contoso.\u4E2D\u56FD", true };
+            }
+        }
+
         // https://docs.microsoft.com/en-us/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format
         [Theory]
-        [InlineData("david.jones@proseware.com", true)]
-        [InlineData("d.j@server1.proseware.com", true)]
-        [InlineData("jones@ms1.proseware.com", true)]
-        [InlineData("j.@server1.proseware.com", false)]
-        [InlineData("j@proseware.com9", true)]
-        [InlineData("js#internal@proseware.com", true)]
-        [InlineData("j_9@[129.126.118.1]", true)]
-        [InlineData("j..s@proseware.com", false)]
-        [InlineData("js*@proseware.com", false)]
-        [InlineData("js@proseware..com", false)]
-        [InlineData("js@proseware.com9", true)]
-        [InlineData("j.s@server1.proseware.com", true)]
-        [InlineData("\"j\\\"s\\\"\"@proseware.com", true)]
-        [InlineData("js@contoso.\u4E2D\u56FD", true)]
-        public void Docs_Examples_ValidateEmail(string email, bool expectedIsValid)
+        [MemberData(nameof(Docs_Examples_ValidateEmail_TestData))]
+        public void Docs_Examples_ValidateEmail(RegexOptions options, string email, bool expectedIsValid)
         {
-            Assert.Equal(expectedIsValid, IsValidEmail(email, RegexOptions.None));
-            Assert.Equal(expectedIsValid, IsValidEmail(email, RegexOptions.Compiled));
+            Assert.Equal(expectedIsValid, IsValidEmail(email, options));
 
             bool IsValidEmail(string email, RegexOptions options)
             {

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -624,6 +624,28 @@ namespace System.Text.RegularExpressions.Tests
             RegexAssert.Equal("a", match);
         }
 
+        public static IEnumerable<object[]> Match_TestThatTimeoutHappens_TestData()
+        {
+            foreach (RegexOptions options in RegexHelpers.RegexOptionsExtended())
+            {
+                yield return new object[] { @"a.{20}$", options, 10 };
+            }
+        }
+        /// <summary>
+        /// Test that timeout exception is being thrown.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Match_TestThatTimeoutHappens_TestData))]
+        private void Match_TestThatTimeoutHappens(string pattern, RegexOptions options, int ms)
+        {
+            Regex re = new(pattern, options, new TimeSpan(0, 0, 0, 0, ms));
+            Random rnd = new Random(0);
+            byte[] buffer = new byte[1000000];
+            rnd.NextBytes(buffer);
+            string input = new String(Array.ConvertAll(buffer, b => b < 200 ? 'a' : (char)b));
+            Assert.Throws<RegexMatchTimeoutException>(() => { re.Match(input); });
+        }
+
         [Theory]
         [InlineData(RegexOptions.None)]
         [InlineData(RegexOptions.None | RegexHelpers.RegexOptionDebug)]
@@ -1435,6 +1457,19 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { @"\b", options, "hello--world", new (int, int, string)[] { (0, 0, ""), (5, 0, ""), (7, 0, ""), (12, 0, "") } };
                 yield return new object[] { @"\B", options, "hello--world",
                     new (int, int, string)[] { (1, 0, ""), (2, 0, ""), (3, 0, ""), (4, 0, ""), (6, 0, ""), (8, 0, ""), (9, 0, ""), (10, 0, ""), (11, 0, "") } };
+
+                // Involving many different characters in the same regex
+                yield return new object[] { @"(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>:;@)+", options,
+                    "=====abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>:;@abcdefg======",
+                    new (int, int, string)[] { (5, 67, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>:;@") } };
+
+                //this will need a total of 2x70 + 2 parts in the partition of NonBacktracking
+                string pattern_orig = @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789<>:;&@%!";
+                string pattern_WL = new String(Array.ConvertAll(pattern_orig.ToCharArray(), c => (char)((int)c + 0xFF00 - 32)));
+                string pattern = "(" + pattern_orig + "===" + pattern_WL + ")+";
+                string input = "=====" + pattern_orig + "===" + pattern_WL + pattern_orig + "===" + pattern_WL + "===" + pattern_orig + "===" + pattern_orig;
+                int length = 2 * (pattern_orig.Length + 3 + pattern_WL.Length);
+                yield return new object[] { pattern, options, input, new (int, int, string)[]{(5, length, input.Substring(5, length)) } };
             }
         }
 
@@ -1483,6 +1518,26 @@ namespace System.Text.RegularExpressions.Tests
                     Assert.Equal(baseline.IsMatch(c.ToString()), regex.IsMatch(c.ToString()));
                 }
             }
+        }
+
+        public static IEnumerable<object[]> Match_DisjunctionOverCounting_TestData()
+        {
+            foreach (var options in RegexHelpers.RegexOptionsExtended())
+            {
+                yield return new object[] { options, "a[abc]{0,10}", "a[abc]{0,3}", "xxxabbbbbbbyyy", true, "abbbbbbb" };
+                yield return new object[] { options, "a[abc]{0,10}?", "a[abc]{0,3}?", "xxxabbbbbbbyyy", true, "a" };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Match_DisjunctionOverCounting_TestData))]
+        public void Match_DisjunctionOverCounting(RegexOptions options, string disjunct1, string disjunct2, string input, bool success, string match)
+        {
+            string pattern = disjunct1 + "|" + disjunct2;
+            Regex re = new Regex(pattern, options);
+            Match m = re.Match(input);
+            Assert.Equal(success, m.Success);
+            Assert.Equal(match, m.Value);
         }
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -302,5 +302,161 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(re[0].Match(input).Value, re[1].Match(input).Value); 
             Assert.Equal("II", re[0].Match(input).Value);
         }
+
+        private const char Turkish_I_withDot = '\u0130';
+        private const char Turkish_i_withoutDot = '\u0131';
+        private const char Kelvin_sign = '\u212A';
+
+        /// <summary>
+        /// This test is to make sure that the generated IgnoreCaseRelation table for DFA does not need to be updated.
+        /// It would need to be updated/regenerated if this test fails.
+        /// </summary>
+        [OuterLoop("May take several seconds due to large number of cultures tested")]
+        [Theory]
+        [MemberData(nameof(RegexHelpers.RegexOptions_TestData), MemberType = typeof(RegexHelpers))]
+        public void TestIgnoreCaseRelation(RegexOptions options)
+        {
+            // these 22 characters are considered case-insensitive by regex, while they are case-sensitive outside regex
+            // but they are only case-sensitive in an asymmmetrical way: tolower(c)=c, tolower(toupper(c)) != c
+            HashSet<char> treatedAsCaseInsensitive =
+                 new("\u00B5\u017F\u0345\u03C2\u03D0\u03D1\u03D5\u03D6\u03F0\u03F1\u03F5\u1C80\u1C81\u1C82\u1C83\u1C84\u1C85\u1C86\u1C87\u1C88\u1E9B\u1FBE");
+            foreach (char c in treatedAsCaseInsensitive)
+            {
+                char cU = char.ToUpper(c);
+                Assert.NotEqual(c, cU);
+                Assert.False(Regex.IsMatch(c.ToString(), cU.ToString(), options | RegexOptions.IgnoreCase));
+            }
+
+            Assert.False(Regex.IsMatch(Turkish_i_withoutDot.ToString(), "i", options | RegexOptions.IgnoreCase));
+
+            // as baseline it is assumed the the invariant culture does not change
+            var inv_table = ComputeIgnoreCaseTable(CultureInfo.InvariantCulture, treatedAsCaseInsensitive);
+            var cultures = System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes.AllCultures);
+            // expected difference between invariant and tr or az culture
+            string tr_diff = string.Format("I:Ii/I{0},i:Ii/i{1},{1}:{1}/i{1},{0}:{0}/I{0}", Turkish_i_withoutDot, Turkish_I_withDot);
+            // expected differnce between invariant and other cultures including the default en-US
+            string default_diff = string.Format("I:Ii/Ii{0},i:Ii/Ii{0},{0}:{0}/Ii{0}", Turkish_I_withDot);
+            // the expected difference between invariant culture and all other cultures is only for i,I,Turkish_I_withDot,Turkish_i_withoutDot
+            // differentiate based on the TwoLetterISOLanguageName only (232 cases instead of 812)
+            List<CultureInfo> testcultures = new();
+            HashSet<string> done = new();
+            for (int i = 0; i < cultures.Length; i++)
+                if (cultures[i] != CultureInfo.InvariantCulture && done.Add(cultures[i].TwoLetterISOLanguageName))
+                    testcultures.Add(cultures[i]);
+            foreach (var culture in testcultures)
+            {
+                var table = ComputeIgnoreCaseTable(culture, treatedAsCaseInsensitive);
+                string diff = GetDiff(inv_table, table);
+                if (culture.TwoLetterISOLanguageName == "tr" || culture.TwoLetterISOLanguageName == "az")
+                    // tr or az alphabet
+                    Assert.Equal(tr_diff, diff);
+                else
+                    // all other alphabets are treated the same as en-US
+                    Assert.Equal(default_diff, diff);
+            }
+        }
+
+        /// <summary>
+        /// This test currently only works correctly in NonBacktracking mode.
+        /// </summary>
+        [OuterLoop("May take tens of seconds")]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Doesn't support NonBacktracking")]
+        [Theory]
+        [InlineData(RegexHelpers.RegexOptionNonBacktracking)]
+        public void TestIgnoreCaseRelationBorderCasesInNonBacktracking(RegexOptions options)
+        {
+            // these 22 characters are considered case-insensitive by regex, while they are case-sensitive outside regex
+            // but they are only case-sensitive in an asymmmetrical way: tolower(c)=c, tolower(toupper(c)) != c
+            HashSet<char> treatedAsCaseInsensitive =
+                 new("\u00B5\u017F\u0345\u03C2\u03D0\u03D1\u03D5\u03D6\u03F0\u03F1\u03F5\u1C80\u1C81\u1C82\u1C83\u1C84\u1C85\u1C86\u1C87\u1C88\u1E9B\u1FBE");
+            foreach (char c in treatedAsCaseInsensitive)
+            {
+                char cU = char.ToUpper(c);
+                Assert.NotEqual(c, cU);
+                Assert.False(Regex.IsMatch(c.ToString(), cU.ToString(), RegexOptions.IgnoreCase | options));
+            }
+
+            Assert.False(Regex.IsMatch(Turkish_i_withoutDot.ToString(), "i", RegexOptions.IgnoreCase | options));
+            Assert.True(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | options));
+            Assert.True(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | options));
+            Assert.False(Regex.IsMatch(Turkish_I_withDot.ToString(), "i", RegexOptions.IgnoreCase | options | RegexOptions.CultureInvariant));
+
+            // Turkish i without dot is not considered case-sensitive in the default en-US culture
+            treatedAsCaseInsensitive.Add(Turkish_i_withoutDot);
+
+            List<char> caseSensitiveChars = new();
+            for (char c = '\0'; c < '\uFFFF'; c++)
+                if (!treatedAsCaseInsensitive.Contains(c) && char.ToUpper(c) != char.ToLower(c))
+                    caseSensitiveChars.Add(c);
+
+            // test all case-sensitive characters exhaustively in DFA mode
+            foreach (char c in caseSensitiveChars)
+                Assert.True(Regex.IsMatch(char.ToUpper(c).ToString() + char.ToLower(c).ToString(),
+                    c.ToString() + c.ToString(), RegexOptions.IgnoreCase | options));
+        }
+
+        /// <summary>
+        /// Maps each character c to the set of all of its equivalent characters if case is ignored or null if c in case-insensitive
+        /// </summary>
+        /// <param name="culture">ignoring case wrt this culture</param>
+        /// <param name="treatedAsCaseInsensitive">characters that are otherwise case-sensitive but not in a regex</param>
+        private static HashSet<char>[] ComputeIgnoreCaseTable(CultureInfo culture, HashSet<char> treatedAsCaseInsensitive)
+        {
+            CultureInfo ci = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = culture;
+            var ignoreCase = new HashSet<char>[0x10000];
+            for (uint i = 0; i <= 0xFFFF; i++)
+            {
+                char c = (char)i;
+                char cU = char.ToUpper(c);
+                char cL = char.ToLower(c);
+                // Turkish i without dot is only considered case-sensitive in tr and az languages
+                if (treatedAsCaseInsensitive.Contains(c) ||
+                    (c == Turkish_i_withoutDot && culture.TwoLetterISOLanguageName != "tr" && culture.TwoLetterISOLanguageName != "az"))
+                    continue;
+                if (cU != cL)
+                {
+                    var set = (ignoreCase[c] == null ? (ignoreCase[cU] == null ? (ignoreCase[cL] == null ? new HashSet<char>()
+                                                     : ignoreCase[cL]) : ignoreCase[cU]) : ignoreCase[c]);
+                    set.Add(c);
+                    set.Add(cU);
+                    set.Add(cL);
+                    ignoreCase[c] = set;
+                    ignoreCase[cL] = set;
+                    ignoreCase[cU] = set;
+                }
+            }
+            CultureInfo.CurrentCulture = ci;
+            return ignoreCase;
+        }
+
+        /// <summary>
+        /// represents the difference between the two tables as a special string
+        /// </summary>
+        private static string GetDiff(HashSet<char>[] table1, HashSet<char>[] table2)
+        {
+            List<string> diffs = new();
+            Func<HashSet<char>, int, string> F = (s, i) =>
+            {
+                if (s == null)
+                    return ((char)i).ToString();
+
+                var elems = new List<char>(s);
+                elems.Sort();
+                return new string(elems.ToArray());
+            };
+
+            for (int i = 0; i <= 0xFFFF; i++)
+            {
+                string s1 = F(table1[i], i);
+                string s2 = F(table2[i], i);
+                if (s1 != s2)
+                {
+                    diffs.Add($"{(char)i}:{s1}/{s2}");
+                }
+            }
+
+            return string.Join(",", diffs.ToArray());
+        }
     }
 }


### PR DESCRIPTION
Main changes:
- Created separate word character predicate to be used with the anchors `\b` and `\B`. Now the semantics is the same as with `None` and `Compiled`.
- Added `OuterLoop` attribute to some longrunning stress-tests
- Moved/generalized most remaining `NonBacktracking` specific test also to `None` and `Compiled`. 
- The remining tests (still currently in `RegexSRMTests` -- perhaps be renamed to `Regex.NonBacktracking.Tests`) either only work under `DEBUG` mode where they test intersection and complement or dgml generation, or differences in generated matches due to alternation-order, and are thus quite specific to `NonBacktracking`. 