### PR TITLE
Exploration support of symbolic regex into symbolic NFA

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicNFA.cs" />
     <Compile Include="System\Text\SegmentStringBuilder.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />
     <Compile Include="System\Text\RegularExpressions\CaptureCollection.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
@@ -17,13 +17,12 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
         private readonly HashSet<int> _stateSet = new();
         private readonly List<Move<(SymbolicRegexNode<T>?, T)>> _moves = new();
         private readonly SymbolicRegexBuilder<T> _builder;
-        private readonly List<SymbolicRegexNode<T>> _nfaStates = new();
-        private readonly Dictionary<SymbolicRegexNode<T>, int> _nfaStateId = new();
-        private readonly bool _asNFA;
+        //private readonly List<SymbolicRegexNode<T>> _nfaStates = new();
+        //private readonly Dictionary<SymbolicRegexNode<T>, int> _nfaStateId = new();
+        private SymbolicNFA<T>? _nfa;
 
         internal RegexAutomaton(SymbolicRegexMatcher<T> srm, int bound, bool addDotStar, bool inReverse, bool asNFA)
         {
-            _asNFA = asNFA;
             _builder = srm._builder;
             uint startId = inReverse ?
                 (srm._reversePattern._info.StartsWithLineAnchor ? CharKind.StartStop : 0) :
@@ -34,32 +33,39 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
 
             if (asNFA)
             {
-                Stack<SymbolicRegexNode<T>> stack = new();
-                stack.Push(_q0.Node);
-                _nfaStates.Add(_q0.Node);
-                _nfaStateId[_q0.Node] = 0;
-                _states.Add(0);
-                _stateSet.Add(0);
-                while (stack.Count > 0 && (bound <= 0 || _nfaStates.Count < bound))
+                _nfa = _q0.Node.Explore(bound);
+                for (int q = 0; q < _nfa.StateCount; q++)
                 {
-                    SymbolicRegexNode<T> q = stack.Pop();
-                    int qId = _nfaStateId[q];
-                    foreach ((T, SymbolicRegexNode<T>?, SymbolicRegexNode<T>) branch in q.MkDerivative())
-                    {
-                        SymbolicRegexNode<T> p = branch.Item3;
-                        int pId;
-                        if (!_nfaStateId.TryGetValue(p, out pId))
-                        {
-                            pId = _nfaStates.Count;
-                            _nfaStateId[p] = pId;
-                            _nfaStates.Add(p);
-                            _stateSet.Add(pId);
-                            _states.Add(pId);
-                            stack.Push(p);
-                        }
-                        _moves.Add(Move<(SymbolicRegexNode<T>?, T)>.Create(qId, pId, (branch.Item2, branch.Item1)));
-                    }
+                    _states.Add(q);
+                    foreach ((T, SymbolicRegexNode<T>?, int) branch in _nfa.EnumeratePaths(q))
+                        _moves.Add(Move<(SymbolicRegexNode<T>?, T)>.Create(q, branch.Item3, (branch.Item2, branch.Item1)));
                 }
+                //Stack<SymbolicRegexNode<T>> stack = new();
+                //stack.Push(_q0.Node);
+                //_nfaStates.Add(_q0.Node);
+                //_nfaStateId[_q0.Node] = 0;
+                //_states.Add(0);
+                //_stateSet.Add(0);
+                //while (stack.Count > 0 && (bound <= 0 || _nfaStates.Count < bound))
+                //{
+                //    SymbolicRegexNode<T> q = stack.Pop();
+                //    int qId = _nfaStateId[q];
+                //    foreach ((T, SymbolicRegexNode<T>?, SymbolicRegexNode<T>) branch in q.MkDerivative())
+                //    {
+                //        SymbolicRegexNode<T> p = branch.Item3;
+                //        int pId;
+                //        if (!_nfaStateId.TryGetValue(p, out pId))
+                //        {
+                //            pId = _nfaStates.Count;
+                //            _nfaStateId[p] = pId;
+                //            _nfaStates.Add(p);
+                //            _stateSet.Add(pId);
+                //            _states.Add(pId);
+                //            stack.Push(p);
+                //        }
+                //        _moves.Add(Move<(SymbolicRegexNode<T>?, T)>.Create(qId, pId, (branch.Item2, branch.Item1)));
+                //    }
+                //}
             }
             else
             {
@@ -116,7 +122,7 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
             }
         }
 
-        public int InitialState => _asNFA ? 0 : _q0.Id;
+        public int InitialState => _nfa is not null ? 0 : _q0.Id;
 
         public int StateCount => _states.Count;
 
@@ -131,10 +137,11 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
 
         public string DescribeState(int state)
         {
-            if (_asNFA)
+            if (_nfa is not null)
             {
-                Debug.Assert(state < _nfaStates.Count);
-                return Net.WebUtility.HtmlEncode(_nfaStates[state].ToString());
+                Debug.Assert(state < _nfa.StateCount);
+                var str = Net.WebUtility.HtmlEncode(_nfa.GetNode(state).ToString());
+                return _nfa.IsUnexplored(state) ? $"Unexplored:{str}" : str;
             }
 
             Debug.Assert(_builder._statearray is not null);
@@ -145,14 +152,14 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
 
         public bool IsFinalState(int state)
         {
-            if (_asNFA)
+            if (_nfa is not null)
             {
-                Debug.Assert(state < _nfaStates.Count);
-                return _nfaStates[state].CanBeNullable;
+                Debug.Assert(state < _nfa.StateCount);
+                return _nfa.CanBeNullable(state);
             }
 
             Debug.Assert(_builder._statearray is not null && state < _builder._statearray.Length);
-            return _builder._statearray[state].IsNullable(CharKind.StartStop);
+            return _builder._statearray[state].Node.CanBeNullable;
         }
 
         public IEnumerable<Move<(SymbolicRegexNode<T>?, T)>> GetMoves() => _moves;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
@@ -17,8 +17,6 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
         private readonly HashSet<int> _stateSet = new();
         private readonly List<Move<(SymbolicRegexNode<T>?, T)>> _moves = new();
         private readonly SymbolicRegexBuilder<T> _builder;
-        //private readonly List<SymbolicRegexNode<T>> _nfaStates = new();
-        //private readonly Dictionary<SymbolicRegexNode<T>, int> _nfaStateId = new();
         private SymbolicNFA<T>? _nfa;
 
         internal RegexAutomaton(SymbolicRegexMatcher<T> srm, int bound, bool addDotStar, bool inReverse, bool asNFA)
@@ -40,32 +38,6 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
                     foreach ((T, SymbolicRegexNode<T>?, int) branch in _nfa.EnumeratePaths(q))
                         _moves.Add(Move<(SymbolicRegexNode<T>?, T)>.Create(q, branch.Item3, (branch.Item2, branch.Item1)));
                 }
-                //Stack<SymbolicRegexNode<T>> stack = new();
-                //stack.Push(_q0.Node);
-                //_nfaStates.Add(_q0.Node);
-                //_nfaStateId[_q0.Node] = 0;
-                //_states.Add(0);
-                //_stateSet.Add(0);
-                //while (stack.Count > 0 && (bound <= 0 || _nfaStates.Count < bound))
-                //{
-                //    SymbolicRegexNode<T> q = stack.Pop();
-                //    int qId = _nfaStateId[q];
-                //    foreach ((T, SymbolicRegexNode<T>?, SymbolicRegexNode<T>) branch in q.MkDerivative())
-                //    {
-                //        SymbolicRegexNode<T> p = branch.Item3;
-                //        int pId;
-                //        if (!_nfaStateId.TryGetValue(p, out pId))
-                //        {
-                //            pId = _nfaStates.Count;
-                //            _nfaStateId[p] = pId;
-                //            _nfaStates.Add(p);
-                //            _stateSet.Add(pId);
-                //            _states.Add(pId);
-                //            stack.Push(p);
-                //        }
-                //        _moves.Add(Move<(SymbolicRegexNode<T>?, T)>.Create(qId, pId, (branch.Item2, branch.Item1)));
-                //    }
-                //}
             }
             else
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicNFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicNFA.cs
@@ -253,7 +253,6 @@ namespace System.Text.RegularExpressions.Symbolic
                 {
                     Debug.Assert(tr._kind != TransitionRegexKind.Leaf && tr._first is not null && tr._second is not null);
                     transition = new Transition(kind: tr._kind,
-                        leaf: DeadendState,
                         test: tr._test,
                         look: tr._node,
                         first: args.cache[tr._first],

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicNFA.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicNFA.cs
@@ -1,0 +1,403 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Text.RegularExpressions.Symbolic
+{
+    /// <summary>Represents the exploration of a symbolic regex as a symbolic NFA</summary>
+    internal class SymbolicNFA<S> where S : notnull
+    {
+        private IBooleanAlgebra<S> _solver;
+        private Transition[] _transitionFunction;
+        private SymbolicRegexNode<S>[] _finalCondition;
+        private HashSet<int> _unexplored;
+        private SymbolicRegexNode<S>[] _nodes;
+
+        private const int s_deadend_state = -1;
+        private const int s_unexplored_state = -2;
+
+        /// <summary>If true then some states have not been explored</summary>
+        public bool IsIncomplete => _unexplored.Count > 0;
+
+        private SymbolicNFA(IBooleanAlgebra<S> solver,
+            Transition[] transitionFunction,
+            HashSet<int> unexplored,
+            SymbolicRegexNode<S>[] nodes)
+        {
+            Debug.Assert(transitionFunction.Length > 0 && nodes.Length == transitionFunction.Length);
+            _solver = solver;
+            _transitionFunction = transitionFunction;
+            _finalCondition = Array.ConvertAll(nodes, node => node.ExtractNullabilityTest());
+            _unexplored = unexplored;
+            _nodes = nodes;
+        }
+
+        /// <summary>Total number of states, 0 is the ininital state, states are numbered from 0 to StateCount-1</summary>
+        public int StateCount => _transitionFunction.Length;
+
+        /// <summary>If true then the state has not been explored</summary>
+        public bool IsUnexplored(int state) => _transitionFunction[state]._leaf == s_unexplored_state;
+
+        /// <summary>If true then the state has no outgoing transitions</summary>
+        public bool IsDeadend(int state) => _transitionFunction[state]._leaf == s_deadend_state;
+
+        /// <summary>If true then the state involves lazy loops or has no loops</summary>
+        public bool IsLazy(int state) => _nodes[state].IsLazy;
+
+        /// <summary>Returns true if the state is nullable in the given context</summary>
+        public bool IsFinal(int state, uint context) => _finalCondition[state].IsNullableFor(context);
+
+        /// <summary>Returns true if the state is nullable for some context</summary>
+        public bool CanBeNullable(int state) => _finalCondition[state].CanBeNullable;
+
+        /// <summary>Returns true if the state is nullable for all contexts</summary>
+        public bool IsNullable(int state) => _finalCondition[state].IsNullable;
+
+        /// <summary>Gets the underlying node of the state</summary>
+        public SymbolicRegexNode<S> GetNode(int state) => _nodes[state];
+
+        /// <summary>Enumerates all target states from the given source state</summary>
+        /// <param name="sourceState">must be a an integer between 0 and StateCount-1</param>
+        /// <param name="input">must be a value that acts as a minterm for the transitions eminating from the source state</param>
+        /// <param name="context">reflects the immediate surrounding of the input and is used to determine nullability of anchors</param>
+        public IEnumerable<int> EnumerateTargetStates(int sourceState, S input, uint context)
+        {
+            Debug.Assert(sourceState >= 0 && sourceState < _transitionFunction.Length);
+
+            // First operate in a mode assuming no Union happens by finding the target leaf state if one exists
+            Transition transition = _transitionFunction[sourceState];
+            while (transition._kind != TransitionRegexKind.Union)
+            {
+                switch (transition._kind)
+                {
+                    case TransitionRegexKind.Leaf:
+                        // deadend and unexplored are negative
+                        if (transition._leaf >= 0)
+                        {
+                            Debug.Assert(transition._leaf < _transitionFunction.Length);
+                            yield return transition._leaf;
+                        }
+                        // The single target (or no target) state was found, so exit the whole enumeration
+                        yield break;
+
+                    case TransitionRegexKind.Conditional:
+                        Debug.Assert(transition._test is not null && transition._first is not null && transition._second is not null);
+                        // Branch according to the input condition in relation to the test condition
+                        if (_solver.IsSatisfiable(_solver.And(input, transition._test)))
+                        {
+                            // in a conditional transition input must be exclusive
+                            Debug.Assert(!_solver.IsSatisfiable(_solver.And(input, _solver.Not(transition._test))));
+                            transition = transition._first;
+                        }
+                        else
+                        {
+                            transition = transition._second;
+                        }
+                        break;
+
+                    default:
+                        Debug.Assert(transition._kind == TransitionRegexKind.Lookaround && transition._look is not null && transition._first is not null && transition._second is not null);
+                        // Branch according to nullability of the lookaround condition in the given context
+                        if (transition._look.IsNullableFor(context))
+                        {
+                            transition = transition._first;
+                        }
+                        else
+                        {
+                            transition = transition._second;
+                        }
+                        break;
+                }
+            }
+
+            // Continue operating in a mode where several target states can be yielded
+            Debug.Assert(transition._first is not null && transition._second is not null);
+            Stack<Transition> todo = new();
+            todo.Push(transition._second);
+            todo.Push(transition._first);
+            while (todo.Count > 0)
+            {
+                Transition top = todo.Pop();
+                switch (transition._kind)
+                {
+                    case TransitionRegexKind.Leaf:
+                        // dead-end
+                        if (transition._leaf >= 0)
+                        {
+                            Debug.Assert(transition._leaf < _transitionFunction.Length);
+                            yield return transition._leaf;
+                        }
+                        break;
+
+                    case TransitionRegexKind.Conditional:
+                        Debug.Assert(transition._test is not null && transition._first is not null && transition._second is not null);
+                        // Branch according to the input condition in relation to the test condition
+                        if (_solver.IsSatisfiable(_solver.And(input, transition._test)))
+                        {
+                            // in a conditional transition input must be exclusive
+                            Debug.Assert(!_solver.IsSatisfiable(_solver.And(input, _solver.Not(transition._test))));
+                            todo.Push(transition._first);
+                        }
+                        else
+                        {
+                            todo.Push(transition._second);
+                        }
+                        break;
+
+                    case TransitionRegexKind.Lookaround:
+                        Debug.Assert(transition._look is not null && transition._first is not null && transition._second is not null);
+                        // Branch according to nullability of the lookaround condition in the given context
+                        if (transition._look.IsNullableFor(context))
+                        {
+                            todo.Push(transition._first);
+                        }
+                        else
+                        {
+                            todo.Push(transition._second);
+                        }
+                        break;
+                    default:
+                        Debug.Assert(transition._kind == TransitionRegexKind.Union && transition._first is not null && transition._second is not null);
+                        todo.Push(transition._second);
+                        todo.Push(transition._first);
+                        break;
+                }
+            }
+        }
+
+        public IEnumerable<(S, SymbolicRegexNode<S>?, int)> EnumeratePaths(int sourceState) =>
+            _transitionFunction[sourceState].EnumeratePaths(_solver, _solver.True);
+
+        /// <summary>
+        /// TODO: Explore an unexplored state on transition further.
+        /// </summary>
+        public void ExploreState(int state) => new NotImplementedException();
+
+        public static SymbolicNFA<S> Explore(SymbolicRegexNode<S> root, int bound)
+        {
+            (Dictionary<TransitionRegex<S>, Transition> cache,
+             Dictionary<SymbolicRegexNode<S>, int> statemap,
+             List<SymbolicRegexNode<S>> nodes,
+             Stack<int> front) workState = (new(), new(), new(), new());
+
+            workState.nodes.Add(root);
+            workState.statemap[root] = 0;
+            workState.front.Push(0);
+
+            Dictionary<int, Transition> transitions = new();
+            Stack<int> front = new();
+
+            while (workState.front.Count > 0)
+            {
+                Debug.Assert(front.Count == 0);
+
+                // Work Breath-First in layers, swap front with workState.front
+                Stack<int> tmp = front;
+                front = workState.front;
+                workState.front = tmp;
+
+                // Process all the states in front first
+                // Any new states detected in Convert are added to workState.front
+                while (front.Count > 0 && (bound <= 0 || workState.nodes.Count < bound))
+                {
+                    int q = front.Pop();
+
+                    // If q was on the front it must be associated with a node but not have a transition yet
+                    Debug.Assert(q >= 0 && q < workState.nodes.Count &&  !transitions.ContainsKey(q));
+                    transitions[q] = Convert(workState.nodes[q].MkDerivative(), workState);
+                }
+
+                if (front.Count > 0)
+                {
+                    // The state bound was reached without completing the exploration so exit the loop
+                    break;
+                }
+            }
+
+            SymbolicRegexNode<S>[] nodes_array = workState.nodes.ToArray();
+
+            // All states are numbered from 0 to nodes.Count-1
+            Transition[] transition_array = new Transition[nodes_array.Length];
+            foreach (var entry in transitions)
+            {
+                transition_array[entry.Key] = entry.Value;
+            }
+
+            HashSet<int> unexplored = new(front);
+            unexplored.UnionWith(workState.front);
+            foreach (int q in unexplored)
+            {
+                transition_array[q] = Transition.s_unexplored;
+            }
+
+            // At this point no entry can be null in the transition array
+            Debug.Assert(Array.TrueForAll(transition_array, tr => tr is not null));
+
+            var nfa = new SymbolicNFA<S>(root._builder._solver, transition_array, unexplored, workState.nodes.ToArray());
+            return nfa;
+        }
+
+        private static Transition Convert(TransitionRegex<S> tregex,
+            (Dictionary<TransitionRegex<S>, Transition> cache,
+             Dictionary<SymbolicRegexNode<S>, int> statemap,
+             List<SymbolicRegexNode<S>> nodes,
+             Stack<int> front) args)
+        {
+            Transition? transition;
+            if (args.cache.TryGetValue(tregex, out transition))
+            {
+                return transition;
+            }
+
+            Stack<(TransitionRegex<S>, bool)> work = new();
+            work.Push((tregex, false));
+
+            while (work.Count > 0)
+            {
+                (TransitionRegex<S>, bool) top = work.Pop();
+                TransitionRegex<S> tr = top.Item1;
+                bool wasPushedSecondTime = top.Item2;
+                if (wasPushedSecondTime)
+                {
+                    Debug.Assert(tr._kind != TransitionRegexKind.Leaf && tr._first is not null && tr._second is not null);
+                    transition = new Transition(kind: tr._kind,
+                        leaf: s_deadend_state,
+                        test: tr._test,
+                        look: tr._node,
+                        first: args.cache[tr._first],
+                        second: args.cache[tr._second]);
+                    args.cache[tr] = transition;
+                }
+                else
+                {
+                    switch (tr._kind)
+                    {
+                        case TransitionRegexKind.Leaf:
+                            Debug.Assert(tr._node is not null);
+
+                            if (tr._node.IsNothing)
+                            {
+                                args.cache[tr] = Transition.s_deadend;
+                            }
+                            else
+                            {
+                                int state;
+                                if (!args.statemap.TryGetValue(tr._node, out state))
+                                {
+                                    state = args.nodes.Count;
+                                    args.nodes.Add(tr._node);
+                                    args.statemap[tr._node] = state;
+                                    args.front.Push(state);
+                                }
+                                transition = new Transition(kind: TransitionRegexKind.Leaf, leaf: state);
+                                args.cache[tr] = transition;
+                            }
+                            break;
+
+                        default:
+                            Debug.Assert(tr._first is not null && tr._second is not null);
+
+                            // Push the tr for the second time
+                            work.Push((tr, true));
+
+                            // Push the branches also, unless they have been computed already
+                            if (!args.cache.ContainsKey(tr._second))
+                            {
+                                work.Push((tr._second, false));
+                            }
+
+                            if (!args.cache.ContainsKey(tr._first))
+                            {
+                                work.Push((tr._first, false));
+                            }
+
+                            break;
+                    }
+                }
+            }
+
+            return args.cache[tregex];
+        }
+
+        /// <summary>Representation of transitions inside the parent class</summary>
+        private class Transition
+        {
+            public readonly TransitionRegexKind _kind;
+            public readonly int _leaf;
+            public readonly S? _test;
+            public readonly SymbolicRegexNode<S>? _look;
+            public readonly Transition? _first;
+            public readonly Transition? _second;
+
+            public static readonly Transition s_deadend = new Transition(TransitionRegexKind.Leaf);
+            public static readonly Transition s_unexplored = new Transition(TransitionRegexKind.Leaf, leaf: s_unexplored_state);
+
+            internal Transition(TransitionRegexKind kind, int leaf = s_deadend_state, S? test = default(S), SymbolicRegexNode<S>? look = null, Transition? first = null, Transition? second = null)
+            {
+                _kind = kind;
+                _leaf = leaf;
+                _test = test;
+                _look = look;
+                _first = first;
+                _second = second;
+            }
+
+            /// <summary>Enumerates all the paths in this transition excluding paths to dead-ends (and unexplored states if any)</summary>
+            internal IEnumerable<(S, SymbolicRegexNode<S>?, int)> EnumeratePaths(IBooleanAlgebra<S> solver, S pathCondition)
+            {
+                switch (_kind)
+                {
+                    case TransitionRegexKind.Leaf:
+                        // Omit any path that leads to a deadend or is unexplored
+                        if (_leaf >= 0)
+                        {
+                            yield return (pathCondition, null, _leaf);
+                        }
+                        break;
+
+                    case TransitionRegexKind.Union:
+                        Debug.Assert(_first is not null && _second is not null);
+                        foreach (var path in _first.EnumeratePaths(solver, pathCondition))
+                        {
+                            yield return path;
+                        }
+                        foreach (var path in _second.EnumeratePaths(solver, pathCondition))
+                        {
+                            yield return path;
+                        }
+                        break;
+
+                    case TransitionRegexKind.Conditional:
+                        Debug.Assert(_test is not null && _first is not null && _second is not null);
+                        foreach (var path in _first.EnumeratePaths(solver, solver.And(pathCondition, _test)))
+                        {
+                            yield return path;
+                        }
+                        foreach (var path in _second.EnumeratePaths(solver, solver.And(pathCondition, solver.Not(_test))))
+                        {
+                            yield return path;
+                        }
+                        break;
+
+                    default:
+                        Debug.Assert(_kind is TransitionRegexKind.Lookaround && _look is not null && _first is not null && _second is not null);
+                        foreach (var path in _first.EnumeratePaths(solver, pathCondition))
+                        {
+                            SymbolicRegexNode<S> nullabilityTest = path.Item2 is null ? _look : _look._builder.MkAnd(path.Item2, _look);
+                            yield return (path.Item1, nullabilityTest, path.Item3);
+                        }
+                        foreach (var path in _second.EnumeratePaths(solver, pathCondition))
+                        {
+                            // Complement the nullability test
+                            SymbolicRegexNode<S> nullabilityTest = path.Item2 is null ? _look._builder.MkNot(_look) : _look._builder.MkAnd(path.Item2, _look._builder.MkNot(_look));
+                            yield return (path.Item1, nullabilityTest, path.Item3);
+                        }
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -940,8 +940,17 @@ namespace System.Text.RegularExpressions.Symbolic
             return _transitionRegex;
         }
 
+        /// <summary>
+        /// Computes the closure of MkDerivative, by exploring all the leaves
+        /// of the transition regex until no more new leaves are found.
+        /// Converts the resulting transition system into a symbolic NFA.
+        /// If the exploration remains incomplete due to the given state bound
+        /// being reached then the InComplete property of the constructed NFA is true.
+        /// </summary>
+        internal SymbolicNFA<S> Explore(int bound) => SymbolicNFA<S>.Explore(this, bound);
+
         /// <summary>Extracts the nullability test as a Boolean combination of anchors</summary>
-        private SymbolicRegexNode<S> ExtractNullabilityTest()
+        public SymbolicRegexNode<S> ExtractNullabilityTest()
         {
             if (IsNullable)
             {

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexExperiment.cs
@@ -184,16 +184,23 @@ namespace System.Text.RegularExpressions.Tests
         [ConditionalFact(nameof(Enabled))]
         public void ViewSampleRegexInDGML()
         {
-            //string rawregex = @"\bis\w*\b";
-            //string rawregex = And(".*[0-9].*", ".*[A-Z].*", Not(".*(01|12).*"));
-            string rawregex = "a.{4}$";
-            Regex re = new Regex($@"{rawregex}", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
-            ViewDGML(re);
-            ViewDGML(re, inReverse: true);
-            ViewDGML(re, addDotStar: true);
-            ViewDGML(re, asNFA: true);
-            ViewDGML(re, inReverse: true, asNFA: true);
-            ViewDGML(re, addDotStar: true, asNFA: true);
+            try
+            {
+                //string rawregex = @"\bis\w*\b";
+                string rawregex = And(".*[0-9].*[0-9].*", ".*[A-Z].*[A-Z].*", Not(".*(01|12).*"));
+                //string rawregex = "a.{4}$";
+                Regex re = new Regex($@"{rawregex}", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
+                ViewDGML(re);
+                ViewDGML(re, inReverse: true);
+                ViewDGML(re, addDotStar: true);
+                ViewDGML(re, asNFA: true, bound: 12);
+                ViewDGML(re, inReverse: true, asNFA: true, bound: 12);
+                ViewDGML(re, addDotStar: true, asNFA: true, bound: 12);
+            }
+            catch (NotSupportedException e)
+            {
+                Assert.Contains("conditional", e.Message);
+            }
         }
 
         private void TestRunRegex(string name, string rawregex, string input, bool viewDGML = false, bool dotStar = false)

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexSRMTests.cs
@@ -109,22 +109,6 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
-
-        /*
-         *         public void ViewSampleRegexInDGML()
-        {
-            //string rawregex = @"\bis\w*\b";
-            string rawregex = And(".*[0-9].*[0-9].*", ".*[A-Z].*[A-Z].*", Not(".*(01|12).*"));
-            //string rawregex = "a.{4}$";
-            Regex re = new Regex($@"{rawregex}", RegexHelpers.RegexOptionNonBacktracking | RegexOptions.Singleline);
-            ViewDGML(re);
-            ViewDGML(re, inReverse: true);
-            ViewDGML(re, addDotStar: true);
-            ViewDGML(re, asNFA: true, bound:10);
-            ViewDGML(re, inReverse: true, asNFA: true, bound: 10);
-            ViewDGML(re, addDotStar: true, asNFA: true, bound: 10);
-        }
-         * */
         [Theory]
         [InlineData(".*a+", -1, new string[] { ".*a+" }, false, false)]
         [InlineData("ann", -1, new string[] { "nna" }, true, false)]


### PR DESCRIPTION
Added the missing piece intended later for code generation that calls into `MkDerivative()` to create an NFA under `Compiled` flag. 
- Added `SymbolicNFA` that encapsulates the closure of running `MkDerivative()` and `SymbolicRegexeNode.Explore(k)` that creates a `SymbolicNFA` with roughly up to `k` states.
- This creates an NFA whose number of states roughly equals the number of nodes of an AST 
of the regex whose counters have been unwound.  It can be used to validate that 
the underlying NFA is secure (e.g. stays within a `k =1000` state bound). 
-Updated DGML generator to use the new method for exploration and visual inspection.
- Updates some related unit tests.