### PR TITLE
Fix stack overflow in SymbolicRegexNode.GetFixedLength

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BV64Algebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BV64Algebra.cs
@@ -36,7 +36,7 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         public BV64Algebra(CharSetSolver solver, BDD[] minterms) :
-            base(PartitionClassifier.Create(solver, minterms), Array.ConvertAll(minterms, solver.ComputeDomainSize), minterms)
+            base(PartitionClassifier.Create(solver, minterms), solver.ComputeDomainSizes(minterms), minterms)
         {
             Debug.Assert(minterms.Length <= 64);
             _mintermGenerator = new MintermGenerator<ulong>(this);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BVAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BVAlgebra.cs
@@ -57,7 +57,7 @@ namespace System.Text.RegularExpressions.Symbolic
         }
 
         public BVAlgebra(CharSetSolver solver, BDD[] minterms) :
-            base(PartitionClassifier.Create(solver, minterms), Array.ConvertAll(minterms, solver.ComputeDomainSize), minterms)
+            base(PartitionClassifier.Create(solver, minterms), solver.ComputeDomainSizes(minterms), minterms)
         {
             _mintermGenerator = new MintermGenerator<BV>(this);
             False = BV.CreateFalse(_bits);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/CharSetSolver.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/CharSetSolver.cs
@@ -121,13 +121,23 @@ namespace System.Text.RegularExpressions.Symbolic
 
         public IEnumerable<char> GenerateAllCharacters(BDD set) => GenerateAllCharacters(set, false);
 
-
-        /// <summary>
-        /// Calculate the number of elements in the set.
-        /// </summary>
+        /// <summary>Calculate the number of elements in the set.</summary>
         /// <param name="set">the given set</param>
         /// <returns>the cardinality of the set</returns>
         public ulong ComputeDomainSize(BDD set) => ComputeDomainSize(set, 15);
+
+        /// <summary>Calculate the number of elements in multiple sets.</summary>
+        /// <param name="sets">The sets</param>
+        /// <returns>An array of the cardinality of the sets.</returns>
+        public ulong[] ComputeDomainSizes(BDD[] sets)
+        {
+            var results = new ulong[sets.Length];
+            for (int i = 0; i < sets.Length; i++)
+            {
+                results[i] = ComputeDomainSize(sets[i]);
+            }
+            return results;
+        }
 
         /// <summary>
         /// Returns true iff the set contains exactly one element.

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Dgml/RegexAutomaton.cs
@@ -107,7 +107,12 @@ namespace System.Text.RegularExpressions.Symbolic.DGML
             {
                 T[]? alphabet = _builder._solver.GetPartition();
                 Debug.Assert(alphabet is not null);
-                return Array.ConvertAll<T, (SymbolicRegexNode<T>?, T)>(alphabet, a => (null, a));
+                var results = new (SymbolicRegexNode<T>?, T)[alphabet.Length];
+                for (int i = 0; i < alphabet.Length; i++)
+                {
+                    results[i] = (null, alphabet[i]);
+                }
+                return results;
             }
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexBuilder.cs
@@ -279,7 +279,11 @@ namespace System.Text.RegularExpressions.Symbolic
             }
             else
             {
-                SymbolicRegexNode<TElement>[] singletons = Array.ConvertAll(seq, MkSingleton);
+                var singletons = new SymbolicRegexNode<TElement>[seq.Length];
+                for (int i =0; i < singletons.Length; i++)
+                {
+                    singletons[i] = MkSingleton(seq[i]);
+                }
                 return MkConcat(singletons, topLevel);
             }
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunner.cs
@@ -16,7 +16,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Minimum length computed</summary>
         private readonly int _minRequiredLength;
 
-        private SymbolicRegexRunner(RegexCode code, RegexOptions options, TimeSpan matchTimeout, CultureInfo culture)
+        private SymbolicRegexRunner(RegexCode code, TimeSpan matchTimeout, CultureInfo culture)
         {
             var converter = new RegexNodeToSymbolicConverter(s_unicode, culture);
             var solver = (CharSetSolver)s_unicode._solver;
@@ -68,7 +68,7 @@ namespace System.Text.RegularExpressions.Symbolic
                         (options & RegexOptions.RightToLeft) != 0 ? nameof(RegexOptions.RightToLeft) : nameof(RegexOptions.ECMAScript)));
             }
 
-            return new SymbolicRegexRunnerFactory(new SymbolicRegexRunner(code, options, matchTimeout, culture));
+            return new SymbolicRegexRunnerFactory(new SymbolicRegexRunner(code, matchTimeout, culture));
         }
         protected override void InitTrackCount() { } // nop, no backtracking
 

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -601,12 +601,6 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(Match_VaryingLengthStrings_MemberData))]
         public async Task Match_VaryingLengthStrings(RegexEngine engine, RegexOptions options)
         {
-            if (RegexHelpers.IsNonBacktracking(engine))
-            {
-                // TODO-NONBACKTRACKING: Stack overflowing
-                throw new SkipTestException("ActiveIssue: Stack overflows on RegexOptions.NonBacktracking");
-            }
-
             var lengths = new List<int>() { 2, 3, 4, 5, 6, 7, 8, 9, 31, 32, 33, 63, 64, 65 };
             if ((options & RegexOptions.IgnoreCase) == 0)
             {


### PR DESCRIPTION
Also removed remaining uses of Array.ConvertAll, which were resulting in unnecessary array allocations and closures.