### PR TITLE
Add back "quick" optimization to SymbolicRegexRunner

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -57,6 +57,9 @@ namespace System.Text.RegularExpressions
         protected internal Match? runmatch;        // result object
         protected internal Regex? runregex;        // regex object
 
+        // TODO: Expose something as protected internal: https://github.com/dotnet/runtime/issues/59629
+        private protected bool quick;              // false if match details matter, true if only the fact that match occurred matters
+
         private int _timeout;              // timeout in milliseconds (needed for actual)
         private bool _ignoreTimeout;
         private int _timeoutOccursAt;
@@ -87,6 +90,8 @@ namespace System.Text.RegularExpressions
 
         protected internal Match? Scan(Regex regex, string text, int textbeg, int textend, int textstart, int prevlen, bool quick, TimeSpan timeout)
         {
+            this.quick = quick;
+
             // Handle timeout argument
             _timeout = -1; // (int)Regex.InfiniteMatchTimeout.TotalMilliseconds
             bool ignoreTimeout = _ignoreTimeout = Regex.InfiniteMatchTimeout == timeout;
@@ -220,6 +225,8 @@ namespace System.Text.RegularExpressions
         /// </remarks>
         internal void ScanInternal<TState>(Regex regex, string text, int textstart, ref TState state, MatchCallback<TState> callback, bool reuseMatchObject, TimeSpan timeout)
         {
+            quick = false;
+
             // Handle timeout argument
             _timeout = -1; // (int)Regex.InfiniteMatchTimeout.TotalMilliseconds
             bool ignoreTimeout = _ignoreTimeout = Regex.InfiniteMatchTimeout == timeout;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexRunner.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.IO;
 using System.Text.RegularExpressions.Symbolic.Unicode;
 
 namespace System.Text.RegularExpressions.Symbolic
@@ -78,19 +77,8 @@ namespace System.Text.RegularExpressions.Symbolic
 
         protected override void Go()
         {
-            // TODO-NONBACKTRACKING: In order to produce a SymbolicMatch with a valid Index/Length, FindMatch needs to do additional
-            // work once it's found the end of a match to find the beginning of the match.  If this is an IsMatch
-            // call, however, the details of the match will be ignored, with the only important information being
-            // that there was a match.  We need a mechanism of supplying that information to this operation. At the
-            // moment the only obvious answer to that is new protected surface area, either additional protected
-            // field/property that could be consulted, or a new virtual Scan method that this implementation could
-            // override instead of using the base Scan method that invokes FindFirstChar/Go.  We could choose to bypass
-            // this public/protected surface area for the in-memory implementation, e.g. having it look at some
-            // new private protected field we add to RegexRunner, but for now we simply don't benefit from this optimization.
-            const bool calledFromIsMatch = false;
-
             // Perform the match.
-            SymbolicMatch pos = _matcher.FindMatch(calledFromIsMatch, runtext!, runtextpos, runtextend);
+            SymbolicMatch pos = _matcher.FindMatch(quick, runtext!, runtextpos, runtextend);
             if (pos.Success)
             {
                 // If we successfully matched, capture the match, and then jump the current position to the end of the match.


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/59629