### PR TITLE
detect and throw NotSupported for balancing capture group

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.RegularExpressions/src/Resources/Strings.resx
@@ -312,4 +312,7 @@
   <data name="ExpressionDescription_IfThenElse" xml:space="preserve">
     <value>test conditional (?( test-pattern ) yes-pattern | no-pattern )</value>
   </data>
+  <data name="ExpressionDescription_BalancingGroup" xml:space="preserve">
+    <value>balancing group (?&lt;name1-name2&gt;subexpression) or (?'name1-name2' subexpression)</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/RegexNodeToSymbolicConverter.cs
@@ -227,15 +227,8 @@ namespace System.Text.RegularExpressions.Symbolic
                     EnsureNewlinePredicateInitialized();
                     return _builder._bolAnchor;
 
-                case RegexNode.Capture: // treat as non-capturing group (...)
-                    if (node.N == -1)
-                    {
-                        // This is a nonbalancing capture group
-                        return Convert(node.Child(0), topLevel);
-                    }
-
-                    // Balancing groups are not supported
-                    goto default;
+                case RegexNode.Capture when node.N == -1:
+                    return Convert(node.Child(0), topLevel); // treat as non-capturing group (...)
 
                 case RegexNode.Concatenate:
                     {

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Ctor.Tests.cs
@@ -145,6 +145,9 @@ namespace System.Text.RegularExpressions.Tests
         /// </summary>
         public static IEnumerable<object[]> Ctor_Invalid_NonBacktracking_Data()
         {
+            yield return new object[] { @"(?<cat-0>cat)", RegexOptions.None, "balancing group" };
+            yield return new object[] { @"(?<cat>cat)\w+(?<dog-0>dog)", RegexOptions.None, "balancing group"};
+            yield return new object[] { @"(?<cat>cat)\w+(?<dog-cat>dog)", RegexOptions.None, "balancing group" };
             yield return new object[] { @"abc", RegexOptions.RightToLeft, "RightToLeft" };
             yield return new object[] { @"abc", RegexOptions.ECMAScript, "ECMAScript" };
             yield return new object[] { @"^(a)?(?(1)a|b)+$", RegexOptions.None, "conditional" };

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -293,8 +293,7 @@ namespace System.Text.RegularExpressions.Tests
 
                 if (!RegexHelpers.IsNonBacktracking(engine))
                 {
-                    // TODO-NONBACKTRACKING: This test fails by successfully matching.
-                    // < in group
+                    // Throws NotSupported with NonBacktracking engine because of the balancing group dog-0
                     yield return new object[] { engine, @"(?<cat>cat)\w+(?<dog-0>dog)", "cat_Hello_World_dog", RegexOptions.None, 0, 19, false, string.Empty };
                 }
 


### PR DESCRIPTION
Fixed a TODO for `NonBacktracking`. 
- Detecting the case when a balancing group` (?<pat1-pat2>...)` is being used and throwing `NotSupportedException`.
- Updated unit tests (removed the related TODO comment and added extra unit test for constructor, to exercise the new code paths)
- Updated the resource file with corresponding error messages