### PR TITLE
Use newly added rooting mechanism in CoreCLR tests

### DIFF
--- a/src/tests/Common/CLRTest.NativeAot.targets
+++ b/src/tests/Common/CLRTest.NativeAot.targets
@@ -140,7 +140,7 @@ if defined RunNativeAot (
     Outputs="$(OutputPath)\nativebuild.proj"
     BeforeTargets="Build">
     <PropertyGroup>
-      <_RootEntryAssemblyLine Condition="$(CLRTestFullTrimming) != 'true'">&lt;TrimmerRootAssembly Include=&quot;$(MSBuildProjectName)&quot; /&gt;</_RootEntryAssemblyLine>
+      <_RootEntryAssemblyLine Condition="$(CLRTestFullTrimming) != 'true'">&lt;TrimmerDefaultAction&gt;copyused&lt;/TrimmerDefaultAction&gt;</_RootEntryAssemblyLine>
 
       <_NativeAotBuildProjectFile>
         <![CDATA[
@@ -156,6 +156,7 @@ if defined RunNativeAot (
     <Optimize>$(Optimize)</Optimize>
     <DebugSymbols>true</DebugSymbols>
     <NETCoreSdkVersion>$(NETCoreSdkVersion)</NETCoreSdkVersion>
+    $(_RootEntryAssemblyLine)
   </PropertyGroup>
 
   $(NativeAotProjectLines)
@@ -166,8 +167,6 @@ if defined RunNativeAot (
 
     <!-- Copy RuntimeHostConfigurationOptions -->
 @(RuntimeHostConfigurationOption->'    <RuntimeHostConfigurationOption Include="%(Identity)" Value="%(Value)" />', '%0A')
-
-    $(_RootEntryAssemblyLine)
   </ItemGroup>
 
   <!-- We don't do anything in the Compile step since the test is already compiled to IL - the AOT compiler hooks up after this -->


### PR DESCRIPTION
This is better because it will also root any supporting libraries.