### PR TITLE
Fix issue with empty character sets

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -1504,6 +1504,10 @@ namespace System.Text.RegularExpressions.Symbolic
                     // A path didn't have a next set as supported by this algorithm
                     yield break;
                 }
+                if (!_builder._solver.IsSatisfiable(next))
+                {
+                        yield break;
+                }
                 while (paths.Count > 0)
                 {
                     // For all other paths check that they produce the same set

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -1506,7 +1506,7 @@ namespace System.Text.RegularExpressions.Symbolic
                 }
                 if (!_builder._solver.IsSatisfiable(next))
                 {
-                        yield break;
+                    yield break;
                 }
                 while (paths.Count > 0)
                 {

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -432,12 +432,7 @@ namespace System.Text.RegularExpressions.Tests
                 yield return new object[] { engine, @"[ab\-\[cd-[-[]]]]", "e]]", RegexOptions.None, 0, 3, false, string.Empty };
                 yield return new object[] { engine, @"[ab\-\[cd-[[]]]]", "']]", RegexOptions.None, 0, 3, false, string.Empty };
                 yield return new object[] { engine, @"[ab\-\[cd-[[]]]]", "e]]", RegexOptions.None, 0, 3, false, string.Empty };
-
-                if (!RegexHelpers.IsNonBacktracking(engine))
-                {
-                    // TODO-NONBACKTRACKING: Triggering an assertion on NonBacktracking
-                    yield return new object[] { engine, @"[a-[a-f]]", "abcdefghijklmnopqrstuvwxyz", RegexOptions.None, 0, 26, false, string.Empty };
-                }
+                yield return new object[] { engine, @"[a-[a-f]]", "abcdefghijklmnopqrstuvwxyz", RegexOptions.None, 0, 26, false, string.Empty };
 
                 // \c
                 if (!PlatformDetection.IsNetFramework) // missing fix for https://github.com/dotnet/runtime/issues/24759


### PR DESCRIPTION
`GetFixedPrefix` was not working for empty predicates (probably since my iterative rewrite of it). This also enables a test with empty sets that was disabled for NonBackTracking.