### PR TITLE
NativeAOT-LLVM: add support for returning ref types (in ShadowStack spill slot)

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -247,9 +247,9 @@ namespace ILCompiler
             return TypeSystemContext.GetWellKnownType(wellKnownType);
         }
 
-        public override void AddOrReturnGlobalSymbol(ISortableSymbolNode gcStaticSymbol, NameMangler nameMangler)
+        public override void AddOrReturnGlobalSymbol(ISymbolNode symbolNode, NameMangler nameMangler)
         {
-            LLVMObjectWriter.AddOrReturnGlobalSymbol(Module, gcStaticSymbol, nameMangler);
+            LLVMObjectWriter.AddOrReturnGlobalSymbol(Module, symbolNode, nameMangler);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -208,7 +208,7 @@ namespace ILCompiler
             return base.GetMethodIL(method);
         }
 
-        public virtual void AddOrReturnGlobalSymbol(ISortableSymbolNode gcStaticSymbol, NameMangler nameMangler)
+        public virtual void AddOrReturnGlobalSymbol(ISymbolNode symbolNode, NameMangler nameMangler)
         {
             throw new NotImplementedException("only called from clrjit for LLVM, what is a better way to do this?");
         }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -46,13 +46,23 @@ namespace Internal.JitInterface
                         break;
                     case ReadyToRunHelperId.GetThreadStaticBase:
                         _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0,
-                            _this._compilation.NodeFactory.TypeThreadStaticsSymbol(target)));
+                            _this._compilation.NodeFactory.TypeThreadStaticIndex(target)));
+                        _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0,
+                            _this._compilation.NodeFactory.TypeNonGCStaticsSymbol(target)));
                         var nonGcStaticSymbolForGCStaticBase2 = _this._compilation.NodeFactory.TypeNonGCStaticsSymbol(target);
                         _this.AddOrReturnGlobalSymbol(nonGcStaticSymbolForGCStaticBase2, _this._compilation.NameMangler);
                         break;
                     default:
                         throw new NotImplementedException();
                 }
+
+                return;
+            }
+
+            var frozenStringNode = node as FrozenStringNode;
+            if (frozenStringNode != null)
+            {
+                _this.AddOrReturnGlobalSymbol(frozenStringNode, _this._compilation.NameMangler);
             }
         }
 
@@ -183,9 +193,9 @@ namespace Internal.JitInterface
             _debugInformation = _compilation.GetDebugInfo(methodIL);
         }
 
-        void AddOrReturnGlobalSymbol(ISortableSymbolNode gcStaticSymbol, NameMangler nameMangler)
+        void AddOrReturnGlobalSymbol(ISymbolNode symbolNode, NameMangler nameMangler)
         {
-            _compilation.AddOrReturnGlobalSymbol(gcStaticSymbol, nameMangler);
+            _compilation.AddOrReturnGlobalSymbol(symbolNode, nameMangler);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -59,8 +59,7 @@ namespace Internal.JitInterface
                 return;
             }
 
-            var frozenStringNode = node as FrozenStringNode;
-            if (frozenStringNode != null)
+            if (node is FrozenStringNode frozenStringNode)
             {
                 _this.AddOrReturnGlobalSymbol(frozenStringNode, _this._compilation.NameMangler);
             }


### PR DESCRIPTION
This PR add support for functions that return `REF` types, using the same convention as the IL compiler, i.e return value in a shadow stack slot addressed by the second argument.

Also add string constant symbols (`FrozenStringNode`) as if they were not getting filled if not referenced from the IL->LLVM generation.