### PR TITLE
Add asserts for maxBit in BDD range conversions

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
@@ -308,6 +308,8 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="maxBit">bits above maxBit are unspecified</param>
         public BDD CreateSetFromRange(uint lower, uint upper, int maxBit)
         {
+            Debug.Assert(0 <= maxBit && maxBit <= 32, "maxBit must be between 0 and 32");
+
             if (upper < lower)
                 return False;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDAlgebra.cs
@@ -308,7 +308,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="maxBit">bits above maxBit are unspecified</param>
         public BDD CreateSetFromRange(uint lower, uint upper, int maxBit)
         {
-            Debug.Assert(0 <= maxBit && maxBit <= 32, "maxBit must be between 0 and 32");
+            Debug.Assert(0 <= maxBit && maxBit <= 31, "maxBit must be between 0 and 31");
 
             if (upper < lower)
                 return False;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDRangeConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDRangeConverter.cs
@@ -24,6 +24,8 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         public static (uint, uint)[] ToRanges(BDD set, int maxBit)
         {
+            Debug.Assert(0 <= maxBit && maxBit <= 32, "maxBit must be between 0 and 32");
+
             if (set.IsEmpty)
                 return Array.Empty<(uint, uint)>();
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDRangeConverter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/Algebras/BDDRangeConverter.cs
@@ -24,7 +24,7 @@ namespace System.Text.RegularExpressions.Symbolic
         /// </summary>
         public static (uint, uint)[] ToRanges(BDD set, int maxBit)
         {
-            Debug.Assert(0 <= maxBit && maxBit <= 32, "maxBit must be between 0 and 32");
+            Debug.Assert(0 <= maxBit && maxBit <= 31, "maxBit must be between 0 and 31");
 
             if (set.IsEmpty)
                 return Array.Empty<(uint, uint)>();


### PR DESCRIPTION
The ranges are 32-bit uints and this PR adds Debug.Asserts to check that the given maxBit is in the range from 0 to 32 (inclusive).