### PR TITLE
NativeAOT-LLVM: add some support for floats/doubles/uint/long/byte/ubyte/short/ushort and GT_LE/LT/GE/GT

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -73,6 +73,8 @@ function(create_standalone_jit)
     target_compile_definitions(${TARGETDETAILS_TARGET} PRIVATE USE_STL)
     target_compile_definitions(${TARGETDETAILS_TARGET} PRIVATE PAL_STDCPP_COMPAT)
 
+    message("LLVM_CMAKE_CONFIG:")
+    message($ENV{LLVM_CMAKE_CONFIG})
     find_package(LLVM REQUIRED CONFIG PATHS $ENV{LLVM_CMAKE_CONFIG})
     include_directories(${LLVM_INCLUDE_DIRS})
     add_definitions(${LLVM_DEFINITIONS})

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -903,7 +903,7 @@ void buildCast(llvm::IRBuilder<>& builder, GenTreeCast* cast)
 
 void buildCnsDouble(llvm::IRBuilder<>& builder, GenTree* node)
 {
-    if (node->gtType == var_types::TYP_DOUBLE)
+    if (node->TypeIs(TYP_DOUBLE))
     {
         mapGenTreeToValue(node, llvm::ConstantFP::get(Type::getDoubleTy(_llvmContext), node->AsDblCon()->gtDconVal));
         return;

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -906,14 +906,12 @@ void buildCnsDouble(llvm::IRBuilder<>& builder, GenTreeDblCon* node)
     if (node->TypeIs(TYP_DOUBLE))
     {
         mapGenTreeToValue(node, llvm::ConstantFP::get(Type::getDoubleTy(_llvmContext), node->gtDconVal));
-        return;
     }
-    if (node->TypeIs(TYP_FLOAT))
+    else
     {
+        assert(node->TypeIs(TYP_FLOAT));
         mapGenTreeToValue(node, llvm::ConstantFP::get(Type::getFloatTy(_llvmContext), node->gtDconVal));
-        return;
     }
-    failFunctionCompilation();
 }
 
 void buildCnsInt(llvm::IRBuilder<>& builder, GenTree* node)

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -901,14 +901,19 @@ void buildCast(llvm::IRBuilder<>& builder, GenTreeCast* cast)
     }
 }
 
-void buildCnsDouble(llvm::IRBuilder<>& builder, GenTree* node)
+void buildCnsDouble(llvm::IRBuilder<>& builder, GenTreeDblCon* node)
 {
     if (node->TypeIs(TYP_DOUBLE))
     {
-        mapGenTreeToValue(node, llvm::ConstantFP::get(Type::getDoubleTy(_llvmContext), node->AsDblCon()->gtDconVal));
+        mapGenTreeToValue(node, llvm::ConstantFP::get(Type::getDoubleTy(_llvmContext), node->gtDconVal));
         return;
     }
-    failFunctionCompilation(); // TODO-LLVM: how are floats and decimals done?
+    if (node->TypeIs(TYP_FLOAT))
+    {
+        mapGenTreeToValue(node, llvm::ConstantFP::get(Type::getFloatTy(_llvmContext), node->gtDconVal));
+        return;
+    }
+    failFunctionCompilation();
 }
 
 void buildCnsInt(llvm::IRBuilder<>& builder, GenTree* node)
@@ -1305,7 +1310,7 @@ void visitNode(llvm::IRBuilder<>& builder, GenTree* node)
             buildCast(builder, node->AsCast());
             break;
         case GT_CNS_DBL:
-            buildCnsDouble(builder, node);
+            buildCnsDouble(builder, node->AsDblCon());
             break;
         case GT_CNS_INT:
             buildCnsInt(builder, node);


### PR DESCRIPTION
This PR adds some support in the RyuJIT backend for more types and some binary arithmetic comparisons.  

Increases coverage by about 1%.