### PR TITLE
regex sampler (utility for regex input generation)

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -8,6 +8,7 @@
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
     <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicNFA.cs" />
+    <Compile Include="System\Text\RegularExpressions\Symbolic\SymbolicRegexSampler.cs" />
     <Compile Include="System\Text\SegmentStringBuilder.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />
     <Compile Include="System\Text\RegularExpressions\CaptureCollection.cs" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.Symbolic.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.Symbolic.cs
@@ -41,6 +41,24 @@ namespace System.Text.RegularExpressions
             IgnoreCaseRelationGenerator.Generate("System.Text.RegularExpressions.Symbolic.Unicode", "IgnoreCaseRelation", path);
             UnicodeCategoryRangesGenerator.Generate("System.Text.RegularExpressions.Symbolic.Unicode", "UnicodeCategoryRanges", path);
         }
+
+        /// <summary>
+        /// Generates up to k random strings matched by the regex
+        /// </summary>
+        /// <param name="k">upper bound on the number of generated strings</param>
+        /// <param name="randomseed">random seed for the generator, 0 means no random seed</param>
+        /// <param name="negative">if true then generate inputs that do not match</param>
+        /// <returns></returns>
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
+        internal Collections.Generic.IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative)
+        {
+            if (factory is not SymbolicRegexRunnerFactory srmFactory)
+            {
+                throw new NotSupportedException();
+            }
+
+            return srmFactory._runner._matcher.GenerateRandomMembers(k, randomseed, negative);
+        }
     }
 }
 #endif

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.cs
@@ -31,6 +31,16 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <param name="maxLabelLength">maximum length of labels in nodes anything over that length is indicated with .. </param>
         /// <param name="asNFA">if true creates NFA instead of DFA</param>
         public abstract void SaveDGML(TextWriter writer, int bound, bool hideStateInfo, bool addDotStar, bool inReverse, bool onlyDFAinfo, int maxLabelLength, bool asNFA);
+
+
+        /// <summary>
+        /// Generates up to k random strings matched by the regex
+        /// </summary>
+        /// <param name="k">upper bound on the number of generated strings</param>
+        /// <param name="randomseed">random seed for the generator, 0 means no random seed</param>
+        /// <param name="negative">if true then generate inputs that do not match</param>
+        /// <returns></returns>
+        public abstract IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative);
 #endif
     }
 
@@ -869,6 +879,9 @@ namespace System.Text.RegularExpressions.Symbolic
             var dgml = new DGML.DgmlWriter(writer, hideStateInfo, maxLabelLength, onlyDFAinfo);
             dgml.Write(graph);
         }
+
+        public override IEnumerable<string> GenerateRandomMembers(int k, int randomseed, bool negative) =>
+            new SymbolicRegexSampler<TSetType>(_pattern, randomseed, negative).GenerateRandomMembers(k);
 #endif
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSampler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexSampler.cs
@@ -1,0 +1,237 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if DEBUG
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Text.RegularExpressions.Symbolic
+{
+    internal class SymbolicRegexSampler<S> where S : notnull
+    {
+        private Random _random;
+        private SymbolicRegexNode<S> _root;
+        /// <summary>The used random seed</summary>
+        public int RandomSeed { get; private set; }
+        private BDD _asciiWordCharacters;
+        private BDD _asciiNonWordCharacters; // omits all characters before ' '
+        private BDD _ascii;                  // omits all characters before ' '
+        private ICharAlgebra<S> _solver;
+
+        public SymbolicRegexSampler(SymbolicRegexNode<S> root, int randomseed, bool negative)
+        {
+            _root = negative ? root._builder.MkNot(root) : root;
+            // Treat 0 as no seed and instead choose a random seed randomly
+            RandomSeed = randomseed == 0 ? new Random().Next() : randomseed;
+            _random = new Random(RandomSeed);
+            _solver = root._builder._solver;
+            ICharAlgebra<BDD> bddSolver = SymbolicRegexRunner.s_unicode._solver;
+            _asciiWordCharacters = bddSolver.Or(new BDD[] {
+                bddSolver.RangeConstraint('A', 'Z'),
+                bddSolver.RangeConstraint('a', 'z'),
+                bddSolver.CharConstraint('_'),
+                bddSolver.RangeConstraint('0', '9')});
+            // Visible ASCII range for input character generation
+            _ascii = bddSolver.RangeConstraint('\x20', '\x7E');
+            _asciiNonWordCharacters = bddSolver.And(_ascii, bddSolver.Not(_asciiWordCharacters));
+        }
+
+        /// <summary>Generates up to k random strings accepted by the regex</summary>
+        public IEnumerable<string> GenerateRandomMembers(int k)
+        {
+            ICharAlgebra<BDD> bddSolver = SymbolicRegexRunner.s_unicode._solver;
+            for (int i = 0; i < k; i++)
+            {
+                // Holds the generated input so far
+                StringBuilder input_so_far = new();
+
+                // Initially there is no previous character
+                // Here one could also consider previous characters for example for \b, \B, and ^ anchors
+                // and initialize input_so_far accordingly
+                uint prevCharKind = CharKind.StartStop;
+
+                // This flag is set to false in the unlikely situation that generation ends up in a dead-end
+                bool generationSucceeded = true;
+
+                // Current set of states reached initially contains just the root
+                List<SymbolicRegexNode<S>> states = new();
+                states.Add(_root);
+
+                // Used for end suffixes
+                List<string> possible_endings = new();
+
+                List<SymbolicRegexNode<S>> nextStates = new();
+
+                while (true)
+                {
+                    Debug.Assert(states.Count > 0);
+
+                    if (CanBeFinal(states))
+                    {
+                        // Unconditionally final state or end of the input due to \Z anchor for example
+                        if (IsFinal(states) || IsFinal(states, CharKind.Context(prevCharKind, CharKind.StartStop)))
+                        {
+                            possible_endings.Add("");
+                        }
+
+                        // End of line due to end-of-line anchor
+                        if (IsFinal(states, CharKind.Context(prevCharKind, CharKind.Newline)))
+                        {
+                            possible_endings.Add("\n");
+                        }
+
+                        // Related to wordborder due to \b or \B
+                        if (IsFinal(states, CharKind.Context(prevCharKind, CharKind.WordLetter)))
+                        {
+                            possible_endings.Add(ChooseChar(_asciiWordCharacters).ToString());
+                        }
+
+                        // Related to wordborder due to \b or \B
+                        if (IsFinal(states, CharKind.Context(prevCharKind, CharKind.General)))
+                        {
+                            possible_endings.Add(ChooseChar(_asciiNonWordCharacters).ToString());
+                        }
+                    }
+
+                    // Choose to stop here based on a coin-toss
+                    if (possible_endings.Count > 0 && ChooseRandomlyTrueOrFalse())
+                    {
+                        //Choose some suffix that allows some anchor (if any) to be nullable
+                        input_so_far.Append(Choose(possible_endings));
+                        break;
+                    }
+
+                    SymbolicRegexNode<S> state = Choose(states);
+                    char c = '\0';
+                    uint cKind = 0;
+                    // Observe that state.MkDerivative() can be a deadend
+                    List<(S, SymbolicRegexNode<S>?, SymbolicRegexNode<S>)> paths = new(state.MkDerivative().EnumeratePaths(_solver.True));
+                    if (paths.Count > 0)
+                    {
+                        (S, SymbolicRegexNode<S>?, SymbolicRegexNode<S>) path = Choose(paths);
+                        // Consider a random path from some random state in states and
+                        // select a random member of the predicate on that path
+                        c = ChooseChar(ToBDD(path.Item1));
+
+                        // Map the character back into the corresponding character constraint of the solver
+                        S c_pred = _solver.CharConstraint(c);
+
+                        // Determine the character kind of c
+                        cKind = IsNewline(c_pred) ? CharKind.Newline : (IsWordchar(c_pred) ? CharKind.WordLetter : CharKind.General);
+
+                        // Construct the combined context of previous and c kind
+                        uint context = CharKind.Context(prevCharKind, cKind);
+
+                        // Step into the next set of states
+                        nextStates.AddRange(Step(states, c_pred, context));
+                    }
+
+                    // In the case that there are no next states: stop here
+                    if (nextStates.Count == 0)
+                    {
+                        if (possible_endings.Count > 0)
+                        {
+                            input_so_far.Append(Choose(possible_endings));
+                        }
+                        else
+                        {
+                            // Ending up here is unlikely but possible for example for infeasible patterns such as @"no\bway"
+                            // or due to poor choice of c -- no anchor is enabled -- so this is a deadend
+                            generationSucceeded = false;
+                        }
+                        break;
+                    }
+
+                    input_so_far.Append(c);
+                    states.Clear();
+                    possible_endings.Clear();
+                    List<SymbolicRegexNode<S>> tmp = states;
+                    states = nextStates;
+                    nextStates = tmp;
+                    prevCharKind = cKind;
+                }
+
+                if (generationSucceeded)
+                {
+                    yield return input_so_far.ToString();
+                }
+            }
+        }
+
+        private IEnumerable<SymbolicRegexNode<S>> Step(List<SymbolicRegexNode<S>> states, S pred, uint context)
+        {
+            HashSet<SymbolicRegexNode<S>> seen = new();
+            foreach (SymbolicRegexNode<S> state in states)
+            {
+                foreach ((S, SymbolicRegexNode<S>?, SymbolicRegexNode<S>) path in state.MkDerivative().EnumeratePaths(pred))
+                {
+                    // Either there are no anchors or else check that the anchors are nullable in the given context
+                    if (path.Item2 is null || path.Item2.IsNullableFor(context))
+                    {
+                        // Omit repetitions from the enumeration
+                        if (seen.Add(path.Item3))
+                        {
+                            yield return path.Item3;
+                        }
+                    }
+                }
+            }
+        }
+
+        private BDD ToBDD(S pred) => _solver.ConvertToCharSet(SymbolicRegexRunner.s_unicode._solver, pred);
+        private T Choose<T>(IList<T> elems) => elems[_random.Next(elems.Count)];
+        private T Choose<T>(IEnumerable<T> elems)
+        {
+            List<T> list = new List<T>(elems);
+            return list[_random.Next(list.Count)];
+        }
+        private char ChooseChar((uint, uint) pair) => (char)_random.Next((int)pair.Item1, (int)pair.Item2 + 1);
+        private char ChooseChar(BDD bdd)
+        {
+            Debug.Assert(!bdd.IsEmpty);
+            // Select characters from the visible ASCII range whenever possible
+            BDD bdd1 = SymbolicRegexRunner.s_unicode._solver.And(bdd, _ascii);
+            return ChooseChar(Choose(((CharSetSolver)SymbolicRegexRunner.s_unicode._solver).ToRanges(bdd1.IsEmpty ? bdd : bdd1)));
+        }
+        private bool ChooseRandomlyTrueOrFalse() => _random.Next(100) < 50;
+        /// <summary>Returns true if some state is unconditionally final</summary>
+        private bool IsFinal(IEnumerable<SymbolicRegexNode<S>> states)
+        {
+            foreach (SymbolicRegexNode<S> state in states)
+            {
+                if (state.IsNullable)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        /// <summary>Returns true if some state can be final</summary>
+        private bool CanBeFinal(IEnumerable<SymbolicRegexNode<S>> states)
+        {
+            foreach (SymbolicRegexNode<S> state in states)
+            {
+                if (state.CanBeNullable)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        /// <summary>Returns true if some state is final in the given context</summary>
+        private bool IsFinal(IEnumerable<SymbolicRegexNode<S>> states, uint context)
+        {
+            foreach (SymbolicRegexNode<S> state in states)
+            {
+                if (state.IsNullableFor(context))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        private bool IsWordchar(S pred) => _solver.IsSatisfiable(_solver.And(pred, _root._builder._wordLetterPredicateForAnchors));
+        private bool IsNewline(S pred) => _solver.IsSatisfiable(_solver.And(pred, _root._builder._newLinePredicate));
+    }
+}
+#endif

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/TransitionRegex.cs
@@ -279,7 +279,7 @@ namespace System.Text.RegularExpressions.Symbolic
         IEnumerator IEnumerable.GetEnumerator() => EnumeratePaths(_builder._solver.True).GetEnumerator();
 
         /// <summary>Enumerates all the paths in this transition regex excluding dead-end paths</summary>
-        private IEnumerable<(S, SymbolicRegexNode<S>?, SymbolicRegexNode<S>)> EnumeratePaths(S pathCondition)
+        public IEnumerable<(S, SymbolicRegexNode<S>?, SymbolicRegexNode<S>)> EnumeratePaths(S pathCondition)
         {
             switch (_kind)
             {


### PR DESCRIPTION
Added a random input generator to symbolic regexes. 
Included only in DEBUG build through an internal method exposed from Regex.
Provides both positive and negative input generation.
Added some unit tests for some samples that checks correctness in all engines.

This is a very basic generator but it can be extended in many different ways and 
can serve as an aid for example for input generation for **regex fuzz testing** that covers 
different behaviors in a regex through random input generation.