### PR TITLE
Set RegexOptions.ExplicitCapture when RegexOptions.NonBacktracking is set

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -71,7 +71,7 @@ namespace System.Text.RegularExpressions
             if ((options & RegexOptions.NonBacktracking) != 0)
             {
                 // If we're in non-backtracking mode, create the appropriate factory.
-                factory = SymbolicRegexRunner.CreateFactory(_code, options & ~RegexOptions.NonBacktracking, matchTimeout, culture);
+                factory = SymbolicRegexRunner.CreateFactory(_code, options, matchTimeout, culture);
                 _code = null;
             }
             else if (RuntimeFeature.IsDynamicCodeCompiled && UseOptionC())

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -54,6 +54,13 @@ namespace System.Text.RegularExpressions
             Debug.Assert(pattern != null, "Pattern must be set");
             Debug.Assert(culture != null, "Culture must be set");
 
+            if ((options & RegexOptions.NonBacktracking) != 0)
+            {
+                // The NonBacktracking engine ignores non-named capture groups.
+                // As such, we needn't pay to represent them.
+                options |= RegexOptions.ExplicitCapture;
+            }
+
             _pattern = pattern;
             _options = options;
             _culture = culture;


### PR DESCRIPTION
There's also no need to remove the NonBacktracking flag.  Might as well keep for debugging purposes.