### PR TITLE
Switch to 1ES R&D pools

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -111,13 +111,13 @@ jobs:
       pool:
         # Public Linux Build Pool
         ${{ if and(or(in(parameters.osGroup, 'Linux', 'FreeBSD', 'Android'), eq(parameters.hostedOs, 'Linux')), eq(variables['System.TeamProject'], 'public')) }}:
-          name:  NetCorePublic-Pool
-          queue: BuildPool.Ubuntu.1804.Amd64.Open
+          name:  NetCore1ESPool-Public
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         # Official Build Linux Pool
         ${{ if and(or(in(parameters.osGroup, 'Linux', 'FreeBSD', 'Browser', 'Android'), eq(parameters.hostedOs, 'Linux')), ne(variables['System.TeamProject'], 'public')) }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Ubuntu.1804.Amd64
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
         # OSX Build Pool (we don't have on-prem OSX BuildPool
         ${{ if in(parameters.osGroup, 'OSX', 'MacCatalyst', 'iOS', 'iOSSimulator', 'tvOS', 'tvOSSimulator') }}:
@@ -125,13 +125,13 @@ jobs:
 
         # Official Build Windows Pool
         ${{ if and(eq(parameters.osGroup, 'windows'), ne(variables['System.TeamProject'], 'public')) }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
         # Public Windows Build Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')), eq(variables['System.TeamProject'], 'public')) }}:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Open
+          name: NetCore1ESPool-Public
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
 
 
     ${{ if eq(parameters.helixQueuesTemplate, '') }}:

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -55,12 +55,7 @@ jobs:
         testDisplayName: ${{ parameters.runtimeFlavor }}_interpreter_${{ parameters.liveRuntimeBuildConfig }}
 
       # To run the tests we just send to helix and wait, use ubuntu hosted pools for faster providing and to not back up our build pools
-      ${{ if startsWith(parameters.pool.queue, 'BuildPool.Ubuntu') }}:
-        pool:
-          vmImage: 'ubuntu-latest'
-      
-      ${{ if not(startsWith(parameters.pool.queue, 'BuildPool.Ubuntu')) }}:
-        pool: ${{ parameters.pool }}
+      pool: ${{ parameters.pool }}
 
       dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
       dependsOn:

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -28,8 +28,8 @@ jobs:
   displayName: Docker Linux
   timeoutInMinutes: 180
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Ubuntu.1804.Amd64.Open
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
   steps:
   - checkout: self
@@ -76,8 +76,8 @@ jobs:
   displayName: Docker NanoServer
   timeoutInMinutes: 150
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Server.Amd64.VS2019.Open
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
 
   steps:
   - checkout: self

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -29,8 +29,8 @@ jobs:
   displayName: Docker Linux
   timeoutInMinutes: 120
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Ubuntu.1804.Amd64.Open
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
   steps:
   - checkout: self
@@ -54,8 +54,8 @@ jobs:
   displayName: Docker NanoServer
   timeoutInMinutes: 120
   pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Server.Amd64.VS2019.Open
+    name: NetCore1ESPool-Public
+    demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
 
   steps:
   - checkout: self

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -9,8 +9,8 @@ jobs:
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    name: NetCoreInternal-Pool
-    queue: buildpool.windows.10.amd64.vs2019
+    name: NetCore1ESPool-Internal
+    demands: ImageOverride -equals build.windows.10.amd64.vs2019
   # Double the default timeout.
   timeoutInMinutes: 180
   workspace:


### PR DESCRIPTION
We are migrating to 1ES hosted pools. This is a cherry pick from runtime PR: https://github.com/dotnet/runtime/pull/59767

Tracking issue: https://github.com/dotnet/core-eng/issues/14276