### PR TITLE
[NativeAOT-LLVM]: Struct padding on the shadow stack

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7181,7 +7181,7 @@ struct GenTreeCC final : public GenTree
 
 inline bool GenTree::OperIsBlkOp()
 {
-    return ((gtOper == GT_ASG) && varTypeIsStruct(AsOp()->gtOp1)) || (OperIsBlk() && (AsBlk()->Data() != nullptr));
+    return ((gtOper == GT_ASG) && varTypeIsStruct(AsOp()->gtOp1)) || (OperIsBlk() && (OperIs(GT_STORE_DYN_BLK, GT_STORE_BLK, GT_STORE_OBJ)));
 }
 
 inline bool GenTree::OperIsDynBlkOp()

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7181,7 +7181,7 @@ struct GenTreeCC final : public GenTree
 
 inline bool GenTree::OperIsBlkOp()
 {
-    return ((gtOper == GT_ASG) && varTypeIsStruct(AsOp()->gtOp1)) || (OperIsBlk() && (OperIs(GT_STORE_DYN_BLK, GT_STORE_BLK, GT_STORE_OBJ)));
+    return ((gtOper == GT_ASG) && varTypeIsStruct(AsOp()->gtOp1)) || OperIs(GT_STORE_DYN_BLK, GT_STORE_BLK, GT_STORE_OBJ);
 }
 
 inline bool GenTree::OperIsDynBlkOp()

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -47,13 +47,6 @@ struct DebugMetadata
     llvm::DICompileUnit* diCompileUnit;
 };
 
-// TODO: might need the LLVM Value* in here for exception funclets.
-struct SpilledExpressionEntry
-{
-    CorInfoType corInfoType;
-    CORINFO_CLASS_HANDLE classHandle;
-};
-
 struct IncomingPhi
 {
     llvm::PHINode* phiNode;
@@ -117,7 +110,6 @@ private:
     DebugMetadata  _debugMetadata;
     std::unordered_map<std::string, struct DebugMetadata> _debugMetadataMap;
 
-    std::vector<SpilledExpressionEntry> _spilledExpressions;
     unsigned _shadowStackLocalsSize;
     unsigned _shadowStackLclNum;
     unsigned _retAddressLclNum;
@@ -183,6 +175,7 @@ private:
     void storeOnShadowStack(GenTree* operand, Value* shadowStackForCallee, unsigned int offset);
     void storeLocalVar(GenTreeLclVar* lclVar);
     CorInfoType toCorInfoType(var_types varType);
+    CORINFO_CLASS_HANDLE tryGetStructClassHandle(LclVarDsc* varDsc);
     void visitNode(GenTree* node);
     Value* Llvm::zextIntIfNecessary(Value* intValue);
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -50,7 +50,8 @@ struct DebugMetadata
 // TODO: might need the LLVM Value* in here for exception funclets.
 struct SpilledExpressionEntry
 {
-    CorInfoType m_CorInfoType;
+    CorInfoType corInfoType;
+    CORINFO_CLASS_HANDLE classHandle;
 };
 
 struct IncomingPhi
@@ -81,7 +82,8 @@ extern "C" void registerLlvmCallbacks(void*       thisPtr,
                                       const char* (*getDocumentFileName)(void*),
                                       const uint32_t (*firstSequencePointLineNumber)(void*),
                                       const uint32_t (*getOffsetLineNumber)(void*, unsigned int),
-                                      const uint32_t (*structIsWrappedPrimitive)(void*, CORINFO_CLASS_STRUCT_*, CorInfoType));
+                                      const uint32_t(*structIsWrappedPrimitive)(void*, CORINFO_CLASS_STRUCT_*, CorInfoType),
+                                      const uint32_t(*padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned atOffset));
 
 struct PhiPair
 {
@@ -174,8 +176,8 @@ private:
     Value* localVar(GenTreeLclVar* lclVar);
     Value* mapGenTreeToValue(GenTree* genTree, Value* valueRef);
     bool needsReturnStackSlot(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
-    unsigned int padNextOffset(CorInfoType corInfoType, unsigned int atOffset);
-    unsigned int padOffset(CorInfoType corInfoType, unsigned int atOffset);
+    unsigned int padNextOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned int atOffset);
+    unsigned int padOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned int atOffset);
     void startImportingBasicBlock(BasicBlock* block);
     void startImportingNode();
     void storeOnShadowStack(GenTree* operand, Value* shadowStackForCallee, unsigned int offset);

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -256,5 +256,10 @@ namespace ILCompiler
         {
             return ILImporter.StructIsWrappedPrimitive(method, primitiveTypeDesc);
         }
+
+        public override int PadOffset(TypeDesc type, uint atOffset)
+        {
+            return ILImporter.PadOffset(type, (int)atOffset);
+        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -220,6 +220,11 @@ namespace ILCompiler
         {
             throw new NotImplementedException();
         }
+
+        public virtual int PadOffset(TypeDesc type, uint atOffset)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     [Flags]

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -183,6 +183,15 @@ namespace Internal.JitInterface
             return _this._compilation.StructIsWrappedPrimitive(typeDesc, primitiveTypeDesc) ? 1u : 0u;
         }
 
+        [UnmanagedCallersOnly]
+        public static uint padOffset(IntPtr thisHandle, CORINFO_CLASS_STRUCT_* structHnd, uint ilOffset)
+        {
+            var _this = GetThis(thisHandle);
+            TypeDesc typeDesc = _this.HandleToObject(structHnd);
+
+            return (uint)_this._compilation.PadOffset(typeDesc, ilOffset);
+        }
+
         [DllImport(JitLibrary)]
         private extern static void registerLlvmCallbacks(IntPtr thisHandle, byte* outputFileName, byte* triple, byte* dataLayout,
             delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*> getMangedMethodNamePtr,
@@ -192,7 +201,8 @@ namespace Internal.JitInterface
             delegate* unmanaged<IntPtr, byte*> getDocumentFileName,
             delegate* unmanaged<IntPtr, uint> firstSequencePointLineNumber,
             delegate* unmanaged<IntPtr, uint, uint> getOffsetLineNumber,
-            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType, uint> structIsWrappedPrimitive
+            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType, uint> structIsWrappedPrimitive,
+            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint, uint> padOffset
             );
 
         public void RegisterLlvmCallbacks(IntPtr corInfoPtr, string outputFileName, string triple, string dataLayout)
@@ -207,7 +217,8 @@ namespace Internal.JitInterface
                 &getDocumentFileName,
                 &firstSequencePointLineNumber,
                 &getOffsetLineNumber,
-                &structIsWrappedPrimitive
+                &structIsWrappedPrimitive,
+                &padOffset
             );
         }
 


### PR DESCRIPTION
This PR adds a call back to calculate the padding required for structs on the shadowstack, and removes the forced failures for this scenario.  Also 

- Allows multiple returns
- Changes `OperIsBlkOp ` to explicitly check the operands instead of `Data()  != nullptr` <-  Shall I create a PR to push that upstream?
- For Blk operations sets the layout and `gtBlkOpKind`. I fixed it to  `BlkOpKindHelper`  which is just a guess.