### PR TITLE
Switch to R&D 1ES pools

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -111,12 +111,12 @@ jobs:
       pool:
         # Public Linux Build Pool
         ${{ if and(or(in(parameters.osGroup, 'Linux', 'FreeBSD', 'Android'), eq(parameters.hostedOs, 'Linux')), eq(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore1ESPool-Svc-Public
+          name: NetCore1ESPool-Public
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
         # Official Build Linux Pool
         ${{ if and(or(in(parameters.osGroup, 'Linux', 'FreeBSD', 'Browser', 'Android'), eq(parameters.hostedOs, 'Linux')), ne(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore1ESPool-Svc-Internal
+          name: NetCore1ESPool-Internal
           demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
         # OSX Build Pool (we don't have on-prem OSX BuildPool
@@ -125,12 +125,12 @@ jobs:
 
         # Official Build Windows Pool
         ${{ if and(eq(parameters.osGroup, 'windows'), ne(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore1ESPool-Svc-Internal
+          name: NetCore1ESPool-Internal
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
         # Public Windows Build Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')), eq(variables['System.TeamProject'], 'public')) }}:
-          name: NetCore1ESPool-Svc-Public
+          name: NetCore1ESPool-Public
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
 
 

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -28,7 +28,7 @@ jobs:
   displayName: Docker Linux
   timeoutInMinutes: 180
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
   steps:
@@ -76,7 +76,7 @@ jobs:
   displayName: Docker NanoServer
   timeoutInMinutes: 150
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
 
   steps:

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -66,12 +66,12 @@ jobs:
   - powershell: |
       $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
     displayName: Build CLR and Libraries
-
+  
   - powershell: |
       $(sslStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
     displayName: Build SslStress
-
+  
   - powershell: |
       cd '$(sslStressProject)'
       docker-compose up --abort-on-container-exit --no-color
-    displayName: Run SslStress
+    displayName: Run SslStress 

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -29,7 +29,7 @@ jobs:
   displayName: Docker Linux
   timeoutInMinutes: 120
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
 
   steps:
@@ -54,7 +54,7 @@ jobs:
   displayName: Docker NanoServer
   timeoutInMinutes: 120
   pool:
-    name: NetCore1ESPool-Svc-Public
+    name: NetCore1ESPool-Public
     demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
 
   steps:
@@ -66,12 +66,12 @@ jobs:
   - powershell: |
       $(dockerfilesFolder)/build-docker-sdk.ps1 -w -t $(sdkBaseImage) -c $(BUILD_CONFIGURATION)
     displayName: Build CLR and Libraries
-  
+
   - powershell: |
       $(sslStressProject)/run-docker-compose.ps1 -w -o -c $(BUILD_CONFIGURATION) -t $(sdkBaseImage)
     displayName: Build SslStress
-  
+
   - powershell: |
       cd '$(sslStressProject)'
       docker-compose up --abort-on-container-exit --no-color
-    displayName: Run SslStress 
+    displayName: Run SslStress

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -9,7 +9,7 @@ jobs:
   displayName: Prepare Signed Artifacts
   dependsOn: ${{ parameters.dependsOn }}
   pool:
-    name: NetCore1ESPool-Svc-Internal
+    name: NetCore1ESPool-Internal
     demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
   # Double the default timeout.
   timeoutInMinutes: 180


### PR DESCRIPTION
Switch from servicing pools to R&D ones to match runtime main. We use servicing pools for release branches.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276