### PR TITLE
Introduce detection of generic cycles

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -92,6 +92,11 @@ namespace ILCompiler
 
         protected abstract void CompileInternal(string outputFile, ObjectDumper dumper);
 
+        public void DetectGenericCycles(MethodDesc caller, MethodDesc callee)
+        {
+            _nodeFactory.TypeSystemContext.DetectGenericCycles(caller, callee);
+        }
+
         public bool CanInline(MethodDesc caller, MethodDesc callee)
         {
             return _inliningPolicy.CanInline(caller, callee);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -168,6 +168,13 @@ namespace ILCompiler
         {
             return new DelegateInfo(delegateType, _delegateFeatures);
         }
+
+        private readonly LazyGenericsSupport.GenericCycleDetector _genericCycleDetector = new LazyGenericsSupport.GenericCycleDetector();
+
+        public void DetectGenericCycles(TypeSystemEntity owner, TypeSystemEntity referent)
+        {
+            _genericCycleDetector.DetectCycle(owner, referent);
+        }
     }
 
     public class SharedGenericsConfiguration

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -143,10 +143,19 @@ namespace ILCompiler.DependencyAnalysis
                     break;
             }
 
-            // All generic lookups depend on the thing they point to
-            result.Add(new DependencyListEntry(
-                        _lookupSignature.GetTarget(factory, lookupContext),
-                        "Dictionary dependency"));
+            try
+            {
+                // All generic lookups depend on the thing they point to
+                result.Add(new DependencyListEntry(
+                            _lookupSignature.GetTarget(factory, lookupContext),
+                            "Dictionary dependency"));
+            }
+            catch (TypeSystemException)
+            {
+                // TODO: we need to mark this ReadyToRun helper as "injured". We're now in a situation
+                // when a runtime lookup could produce an error result. The helper should check for that
+                // situation and throw exception if result of the lookup produces an injured result.
+            }
 
             return result.ToArray();
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.Cycles.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.Cycles.cs
@@ -1,0 +1,390 @@
+namespace Microsoft.Build.ILTasks.Transforms
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Linq;
+    using System.Collections;
+    using System.Diagnostics;
+    using System.Collections.Generic;
+
+    internal static partial class LazyGenericsSupport
+    {
+        private const long s_previousAlgorithmTimeout = 10000;
+
+        private sealed partial class Graph<P>
+        {
+            class TarjanWorkerClass
+            {
+                Stack<Vertex> _inProgress = new Stack<Vertex>();
+                int _currentComponentIndex = 0;
+                Vertex[] _vertices;
+                List<List<Vertex>> _result = new List<List<Vertex>>();
+
+                public TarjanWorkerClass(Vertex[] vertices, bool iterative)
+                {
+                    this._vertices = vertices;
+
+                    foreach (Vertex vertex in vertices)
+                    {
+                        vertex.Index = -1;
+                        vertex.LowLink = -1;
+                        vertex.OnStack = false;
+                    }
+
+                    foreach (Vertex vertex in vertices)
+                    {
+                        if (vertex.Index == -1)
+                        {
+                            if (iterative)
+                            {
+                                StrongConnectIterative(vertex);
+                            }
+                            else
+                            {
+                                StrongConnectRecursive(vertex);
+                            }
+                        }
+                    }
+                }
+
+                void StrongConnectRecursive(Vertex vertex)
+                {
+                    vertex.Index = _currentComponentIndex;
+                    vertex.LowLink = _currentComponentIndex;
+
+                    _currentComponentIndex++;
+
+                    _inProgress.Push(vertex);
+                    vertex.OnStack = true;
+
+                    foreach (Edge edge in vertex.Edges)
+                    {
+                        if (edge.Destination.Index == -1)
+                        {
+                            // Recurse if the destination has not begun processing yet
+                            StrongConnectRecursive(edge.Destination);
+                            vertex.LowLink = Math.Min(vertex.LowLink, edge.Destination.LowLink);
+                        }
+                        else if (edge.Destination.OnStack)
+                        {
+                            vertex.LowLink = Math.Min(vertex.LowLink, edge.Destination.Index);
+                        }
+                    }
+
+                    // If v is a root node, pop the stack and generate an SCC
+                    if (vertex.LowLink == vertex.Index)
+                    {
+                        List<Vertex> newStronglyConnectedComponent = new List<Vertex>();
+                        Vertex poppedVertex = null;
+                        while (poppedVertex != vertex)
+                        {
+                            poppedVertex = _inProgress.Pop();
+                            poppedVertex.OnStack = false;
+
+                            newStronglyConnectedComponent.Add(poppedVertex);
+                        }
+
+                        _result.Add(newStronglyConnectedComponent);
+                    }
+                }
+
+                struct StrongConnectStackElement
+                {
+                    public Vertex Vertex;
+                    public IEnumerator<Edge> EdgeEnumeratorPosition;
+                }
+
+                private Stack<StrongConnectStackElement> IterativeStrongConnectStack = new Stack<StrongConnectStackElement>();
+
+                void StrongConnectIterative(Vertex vertex)
+                {
+                    IEnumerator<Edge> currentEdgeEnumerator = null;
+
+StartOfFunctionWithLogicalRecursion:
+                    vertex.Index = _currentComponentIndex;
+                    vertex.LowLink = _currentComponentIndex;
+
+                    _currentComponentIndex++;
+
+                    _inProgress.Push(vertex);
+                    vertex.OnStack = true;
+
+                    currentEdgeEnumerator = vertex.Edges.GetEnumerator();
+
+ReturnFromEndOfRecursiveFunction:
+                    if (currentEdgeEnumerator == null)
+                    {
+                        // Return from logically recursive call
+                        StrongConnectStackElement iterativeStackElementOnReturn = IterativeStrongConnectStack.Pop();
+                        vertex = iterativeStackElementOnReturn.Vertex;
+                        currentEdgeEnumerator = iterativeStackElementOnReturn.EdgeEnumeratorPosition;
+
+                        vertex.LowLink = Math.Min(vertex.LowLink, currentEdgeEnumerator.Current.Destination.LowLink);
+                    }
+
+                    while (currentEdgeEnumerator.MoveNext())
+                    {
+                        Edge edge = currentEdgeEnumerator.Current;
+
+                        if (edge.Destination.Index == -1)
+                        {
+                            // Recurse if the destination has not begun processing yet
+                            StrongConnectStackElement iterativeStackElement = new StrongConnectStackElement();
+                            iterativeStackElement.Vertex = vertex;
+                            iterativeStackElement.EdgeEnumeratorPosition = currentEdgeEnumerator;
+
+                            IterativeStrongConnectStack.Push(iterativeStackElement);
+
+                            currentEdgeEnumerator = null;
+                            vertex = edge.Destination;
+                            goto StartOfFunctionWithLogicalRecursion;
+                        }
+                        else if (edge.Destination.OnStack)
+                        {
+                            vertex.LowLink = Math.Min(vertex.LowLink, edge.Destination.Index);
+                        }
+                    }
+
+                    // If v is a root node, pop the stack and generate an SCC
+                    if (vertex.LowLink == vertex.Index)
+                    {
+                        List<Vertex> newStronglyConnectedComponent = new List<Vertex>();
+                        Vertex poppedVertex = null;
+                        while (poppedVertex != vertex)
+                        {
+                            poppedVertex = _inProgress.Pop();
+                            poppedVertex.OnStack = false;
+
+                            newStronglyConnectedComponent.Add(poppedVertex);
+                        }
+
+                        _result.Add(newStronglyConnectedComponent);
+                    }
+
+                    if (IterativeStrongConnectStack.Count > 0)
+                    {
+                        currentEdgeEnumerator = null;
+                        vertex = null;
+                        goto ReturnFromEndOfRecursiveFunction;
+                    }
+                }
+
+                public IEnumerable<List<Vertex>> Result
+                {
+                    get
+                    {
+                        return _result;
+                    }
+                }
+            }
+
+            private IEnumerable<List<Vertex>> TarjansAlgorithm()
+            {
+                Vertex[] vertices = _vertexMap.Values.ToArray();
+
+                TarjanWorkerClass tarjansResultsIterative = new TarjanWorkerClass(vertices, true);
+
+#if DEBUG
+                TarjanWorkerClass tarjansResultsRecursive = new TarjanWorkerClass(vertices, false);
+
+                // assert the result of the iterative and recursive versions of the algorithm are EXACTLY the same
+                Debug.Assert(tarjansResultsIterative.Result.SelectMany(x => x).SequenceEqual(tarjansResultsRecursive.Result.SelectMany(x => x)));
+#endif
+                return tarjansResultsIterative.Result;
+            }
+
+            /// <summary>
+            /// Returns the set of vertices that are part of at least one cycle where one of the edges are flagged.
+            /// </summary>
+            public IEnumerable<P> ComputeVerticesInvolvedInAFlaggedCycle()
+            {
+                // New Algorithm.
+                IEnumerable<List<Vertex>> stronglyConnectedComponents = this.TarjansAlgorithm();
+                foreach (List<Vertex> stronglyConnectedComponent in stronglyConnectedComponents)
+                {
+                    HashSet<Vertex> strongConnectedComponentVertexContainsChecker = new HashSet<Vertex>(stronglyConnectedComponent);
+                    // Detect flags between elements of cycle. 
+                    // Walk all edges of the strongly connected component.
+                    //  - If an edge is not flagged, it can't affect behavior
+                    //  - If an edge is flagged, if it refers to another Vertex in the strongly connected component, then the cycle should be flagged.
+                    bool flagDetected = false;
+                    foreach (Vertex vertex in stronglyConnectedComponent)
+                    {
+                        foreach (Edge edge in vertex.Edges)
+                        {
+                            if (edge.Flagged)
+                            {
+                                if (strongConnectedComponentVertexContainsChecker.Contains(edge.Destination))
+                                {
+                                    flagDetected = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (flagDetected)
+                        {
+                            break;
+                        }
+                    }
+
+                    // Flag was detected, therefore each vertex in the strongly connected component is part of a flagged cycle
+                    if (flagDetected)
+                    {
+                        foreach (Vertex vertex in stronglyConnectedComponent)
+                        {
+                            vertex.ProvedToBeInvolvedInAFlaggedCycle = true;
+                        }
+                    }
+                }
+
+                IEnumerable<Vertex> verticesInAFlaggedCycleTarjanStyle = _vertexMap.Values.Where(v => v.ProvedToBeInvolvedInAFlaggedCycle);
+
+#if DEBUG
+                Vertex[] vertices = _vertexMap.Values.ToArray();
+                foreach (Vertex vertex in vertices)
+                {
+                    vertex.ProvedToBeNotPartOfAnyCycle = false;
+                    vertex.ProvedToBeInvolvedInAFlaggedCycle = false;
+                }
+
+                Stopwatch previousAlgorithmTimeoutWatch = new Stopwatch();
+                previousAlgorithmTimeoutWatch.Start();
+                bool abortedDueToTimeout = false;
+                int operationCount = 0;
+
+                for (; ; )
+                {
+                    //
+                    // Each pass visits every vertex and attempts to detect whether it is part of a flagged cycle. The first pass only finds simple
+                    // cycles (i.e. it finds T==>U==>T but not T-->U==>V==>U-->T where "-->" denotes a non-flagged edge and "==>" denotes a flagged edge.). The second
+                    // pass detects the "T-->U==>V==>U-->T" cycle (as it now benefits from the knowledge that any cycle including "U" is itself a flagged cycle.)
+                    // More complex graphs require more than two passes, with the worst case being the number of vertices.
+                    //
+                    // Rather than count the passes, however, we will iterate the passes until we find no new cycles.
+                    //
+
+                    int count = vertices.Count(v => v.ProvedToBeInvolvedInAFlaggedCycle);
+                    foreach (Vertex vertex in vertices)
+                    {
+                        if (!vertex.ProvedToBeNotPartOfAnyCycle)
+                        {
+                            if (!vertex.ProvedToBeInvolvedInAFlaggedCycle)
+                            {
+                                // FindCyclesWorker recurses on edges rather than vertices, so we have to invent a fictitious edge leading to the root vertex
+                                // to kick it off.
+                                Edge startingEdge = new Edge(vertex, false);
+                                FindCyclesWorker(startingEdge, new List<Edge>(), ref operationCount, previousAlgorithmTimeoutWatch);
+                            }
+                        }
+                    }
+
+                    if (previousAlgorithmTimeoutWatch.ElapsedMilliseconds > s_previousAlgorithmTimeout)
+                    {
+                        abortedDueToTimeout = true;
+                        break;
+                    }
+
+                    int newCount = vertices.Count(v => v.ProvedToBeInvolvedInAFlaggedCycle);
+                    if (count == newCount)
+                        break;
+
+                }
+                previousAlgorithmTimeoutWatch.Stop();
+
+                if (!abortedDueToTimeout)
+                {
+                    Vertex[] verticesInAFlaggedCyclePreviousAlgorithmStyle = vertices.Where(v => v.ProvedToBeInvolvedInAFlaggedCycle).ToArray();
+
+                    // Generate hashset of preview algorithm style result
+                    Debug.Assert(verticesInAFlaggedCyclePreviousAlgorithmStyle.Length == verticesInAFlaggedCycleTarjanStyle.Count());
+                    HashSet<Vertex> verticesInFlaggedCyclePreviousAlgorithmStyleHashset = new HashSet<Vertex>(verticesInAFlaggedCyclePreviousAlgorithmStyle);
+                    foreach (Vertex v in verticesInAFlaggedCycleTarjanStyle)
+                    {
+                        Debug.Assert(verticesInFlaggedCyclePreviousAlgorithmStyleHashset.Contains(v));
+                    }
+                }
+#endif
+
+                return verticesInAFlaggedCycleTarjanStyle.Select(v => v.Payload).ToArray();
+            }
+
+            /// <summary>
+            /// Depth-first walk every path from edge.Destination to every other reachable vertex. If one of those vertices is edge.Destination itself
+            /// and the cycle includes a flagged edge or a vertex that itself is involved in a flagged cycle, then mark edge.Destination as belonging to a flagged cycle.
+            /// </summary>
+            /// <remarks>
+            /// "alreadySeen" is actually a stack but we use a List&lt;&gt; because Stack&lt;&gt; doesn't support indexing.
+            /// </remarks>
+            private void FindCyclesWorker(Edge edge, List<Edge> alreadySeen, ref int operationCount, Stopwatch previousAlgorithmTimeoutWatch)
+            {
+                Vertex vertex = edge.Destination;
+
+                if (vertex.ProvedToBeNotPartOfAnyCycle)
+                    return;
+
+                if ((operationCount % 10000) == 0)
+                {
+                    if (previousAlgorithmTimeoutWatch.ElapsedMilliseconds > s_previousAlgorithmTimeout)
+                    {
+                        return;
+                    }
+                }
+                operationCount++;
+
+                // If this a vertex we've visited already on this path?
+                bool flagged = edge.Flagged || vertex.ProvedToBeInvolvedInAFlaggedCycle;
+                
+                int idx = alreadySeen.Count - 1;
+                while (idx != -1 && !(alreadySeen[idx].Destination == vertex))
+                {
+                    if (alreadySeen[idx].Flagged || alreadySeen[idx].Destination.ProvedToBeInvolvedInAFlaggedCycle)
+                        flagged = true;
+                    idx--;
+                }
+
+                if (idx != -1)
+                {
+                    Debug.Assert(alreadySeen[idx].Destination == vertex);
+
+                    // We've seen this vertex already in our path. We now know that this vertex is involved in a simple cycle. 
+                    //
+                    // At minimum, we need to mark the root vertex (alreadySeen[0].Destination) if the cycle includes the root and 
+                    // includes a flagged edge or a vertex that is itself known to be part of a flagged cycle. 
+                    // That's the primary answer our caller seeks.
+                    //
+                    // At minimum, we also need to stop recursing so that our caller gets an answer at all.
+                    //
+                    // Having said that, we are in a position to do more than the minimum since we may have
+                    // discovered a flagged cycle involving vertices other than the root and are in a position to mark them.
+                    // So we'll be nice and do that too as this will save work overall.
+                    if (flagged)
+                    {
+                        while (idx < alreadySeen.Count)
+                        {
+                            alreadySeen[idx++].Destination.ProvedToBeInvolvedInAFlaggedCycle = true;
+                        }
+                    }
+
+                    return;
+                }
+
+                bool allChildrenProvenNotPartOfCycle = true;
+                alreadySeen.Add(edge);  // Push
+                foreach (Edge newEdge in vertex.Edges)
+                {
+                    FindCyclesWorker(newEdge, alreadySeen, ref operationCount, previousAlgorithmTimeoutWatch);
+                    allChildrenProvenNotPartOfCycle = allChildrenProvenNotPartOfCycle && newEdge.Destination.ProvedToBeNotPartOfAnyCycle;
+                }
+                alreadySeen.RemoveAt(alreadySeen.Count - 1); // Pop
+
+                if (allChildrenProvenNotPartOfCycle)
+                    vertex.ProvedToBeNotPartOfAnyCycle = true;
+
+                return;
+            }
+        }
+    }
+}
+

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.Cycles.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.Cycles.cs
@@ -1,13 +1,13 @@
-namespace Microsoft.Build.ILTasks.Transforms
-{
-    using System;
-    using System.IO;
-    using System.Text;
-    using System.Linq;
-    using System.Collections;
-    using System.Diagnostics;
-    using System.Collections.Generic;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace ILCompiler
+{
     internal static partial class LazyGenericsSupport
     {
         private const long s_previousAlgorithmTimeout = 10000;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.Vertex.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.Vertex.cs
@@ -1,0 +1,122 @@
+namespace Microsoft.Build.ILTasks.Transforms
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Linq;
+    using System.Collections;
+    using System.Diagnostics;
+    using System.Collections.Generic;
+
+    internal static partial class LazyGenericsSupport
+    {
+        private sealed partial class Graph<P>
+        {
+            /// <summary>
+            /// Gets or creates the canonical Vertex object for this payload value. Payload equality is defined by its Object.Equals() override. Vertex equality
+            /// is determined by reference equality.
+            /// </summary>
+            private Vertex GetVertex(P payload)
+            {
+                Vertex vertex;
+                if (_vertexMap.TryGetValue(payload, out vertex))
+                    return vertex;
+                vertex = new Vertex(payload);
+                _vertexMap.Add(payload, vertex);
+                return vertex;
+            }
+
+            private sealed class Vertex
+            {
+                public Vertex(P payload)
+                {
+                    this.Payload = payload;
+                    this._edges = new List<Edge>();
+                    return;
+                }
+
+                public P Payload { get; private set; }
+
+                public IEnumerable<Edge> Edges { get { return _edges; } }
+
+                public void AddEdge(Vertex toVertex, bool flagged)
+                {
+                    for (int i = 0; i < _edges.Count; i++)
+                    {
+                        if (_edges[i].Destination.Equals(toVertex))
+                        {
+                            if (flagged)
+                            {
+                                // Don't shorten to "_edge[i].Flagged = true" - that falls into the "update a compiler temp" gotcha.
+                                Edge e = _edges[i];
+                                e.Flagged = true;
+                                _edges[i] = e;
+                            }
+                            return;
+                        }
+                    }
+                    Edge newEdge = new Edge(toVertex, flagged);
+                    _edges.Add(newEdge);
+                    return;
+                }
+
+
+                /// <summary>
+                /// If true, we have established that this vertex is part of a cycle in which at least one edge is flagged (abbreviated as "flagged cycle"
+                ///   in the interests of brevity.)
+                /// If false, we have not yet established (but may yet establish) this fact.
+                /// </summary>
+                public bool ProvedToBeInvolvedInAFlaggedCycle;
+
+                /// <summary>
+                /// If true, we have established that this vertex is not part of any cycle.
+                /// If false, we have not yet established (but may yet establish) this fact.
+                /// </summary>
+                public bool ProvedToBeNotPartOfAnyCycle;
+
+                /// <summary>
+                /// Flag used during Tarjan's algorithm
+                /// </summary>
+                public bool OnStack = false;
+
+                /// <summary>
+                /// Index used in Tarjan's algorithm
+                /// </summary>
+                public int Index = -1;
+
+                /// <summary>
+                /// LowLink field for Tarjan's algorithm
+                /// </summary>
+                public int LowLink = -1;
+
+                public sealed override String ToString()
+                {
+                    return this.Payload.ToString();
+                }
+
+                private List<Edge> _edges = new List<Edge>();
+            }
+
+            private struct Edge
+            {
+                public Edge(Vertex destination, bool flagged)
+                {
+                    this.Destination = destination;
+                    this.Flagged = flagged;
+                    return;
+                }
+
+                public readonly Vertex Destination;
+                public bool Flagged;
+
+                public override String ToString()
+                {
+                    return "[" + (Flagged ? "==>" : "-->") + Destination + "]";
+                }
+            }
+        
+            private Dictionary<P, Vertex> _vertexMap = new Dictionary<P, Vertex>();
+        }
+    }
+}
+

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.Vertex.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.Vertex.cs
@@ -1,13 +1,11 @@
-namespace Microsoft.Build.ILTasks.Transforms
-{
-    using System;
-    using System.IO;
-    using System.Text;
-    using System.Linq;
-    using System.Collections;
-    using System.Diagnostics;
-    using System.Collections.Generic;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+
+namespace ILCompiler
+{
     internal static partial class LazyGenericsSupport
     {
         private sealed partial class Graph<P>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.cs
@@ -1,0 +1,43 @@
+namespace Microsoft.Build.ILTasks.Transforms
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Linq;
+    using System.Collections;
+    using System.Diagnostics;
+    using System.Collections.Generic;
+
+    internal static partial class LazyGenericsSupport
+    {
+        /// <summary>
+        /// A weighted directed graph abstraction. For our purposes, we only use two weights, so our "weight" is a boolean: "Flagged" or "Not Flagged".
+        /// 
+        /// The generic type "P" denotes the type that holds the payload data of graph vertices. Its overload of Object.Equals() is used
+        /// to determine whether two "P"'s represent the same vertex.
+        /// </summary>
+        private sealed partial class Graph<P>
+        {
+            /// <summary>
+            /// Adds an edge from "from" to "to". If an edge already exists, the "flagged" value is merged (using boolean OR) into
+            /// the existing edge.
+            /// </summary>
+            public void AddEdge(P from, P to, bool flagged)
+            {
+                Vertex fromVertex = GetVertex(from);
+                Vertex toVertex = GetVertex(to);
+                fromVertex.AddEdge(toVertex, flagged);
+                return;
+            }
+
+            public IEnumerable<P> Vertices
+            {
+                get
+                {
+                    return this._vertexMap.Keys.ToArray();
+                }
+            }
+        }
+    }
+}
+

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/Graph.cs
@@ -1,13 +1,11 @@
-namespace Microsoft.Build.ILTasks.Transforms
-{
-    using System;
-    using System.IO;
-    using System.Text;
-    using System.Linq;
-    using System.Collections;
-    using System.Diagnostics;
-    using System.Collections.Generic;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILCompiler
+{
     internal static partial class LazyGenericsSupport
     {
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/GraphBuilder.ForEach.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/GraphBuilder.ForEach.cs
@@ -1,0 +1,126 @@
+﻿namespace Microsoft.Build.ILTasks.Transforms
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Linq;
+    using System.Collections;
+    using System.Diagnostics;
+    using System.Collections.Generic;
+
+    using Microsoft.Cci;
+    using Microsoft.Cci.Extensions;
+
+    internal static partial class LazyGenericsSupport
+    {
+        private sealed partial class GraphBuilder
+        {
+            /// <summary>
+            /// Walk through the type expression and find any embedded generic parameter references. For each one found,
+            /// invoke the collector delegate with that generic parameter and a boolean indicate whether this is
+            /// a proper embedding (i.e. there is something actually nesting this.)
+            /// 
+            /// Typically, the type expression is something that a generic type formal is being bound to, and we're
+            /// looking to see if another other generic type formals are referenced within that type expression.
+            /// 
+            /// This method also records bindings for any generic instances it finds inside the tree expression.
+            /// Sometimes, this side-effect is all that's wanted - in such cases, invoke this method with a null collector.
+            /// </summary>
+            private void ForEachEmbeddedGenericFormal(ITypeReference typeExpression, System.Action<GenericFormal, bool> collector = null)
+            {
+                System.Action<GenericFormal, int> wrappedCollector =
+                    delegate(GenericFormal embedded, int depth)
+                    {
+                        bool isProperEmbedding = (depth > 0);
+                        if (collector != null)
+                            collector(embedded, isProperEmbedding);
+                        return;
+                    };
+                ForEachEmbeddedGenericFormalWorker(typeExpression, wrappedCollector, depth: 0);
+            }
+
+            private void ForEachEmbeddedGenericFormalWorker(ITypeReference type, System.Action<GenericFormal, int> collector, int depth)
+            {
+                if (type is IArrayTypeReference)
+                {
+                    ForEachEmbeddedGenericFormalWorker(((IArrayTypeReference)type).ElementType, collector, depth + 1);
+                    return;
+                }
+
+                if (type is IManagedPointerTypeReference)
+                {
+                    ForEachEmbeddedGenericFormalWorker(((IManagedPointerTypeReference)type).TargetType, collector, depth + 1);
+                    return;
+                }
+
+                if (type is IPointerTypeReference)
+                {
+                    ForEachEmbeddedGenericFormalWorker(((IPointerTypeReference)type).TargetType, collector, depth + 1);
+                    return;
+                }
+
+                if (type.IsConstructedGenericType())
+                {
+                    INamedTypeDefinition genericTypeDefinition = type.GetGenericTypeDefinition().ConfirmedResolvedType<INamedTypeDefinition>();
+                    IList<GenericFormal> genericTypeParameters = genericTypeDefinition.GenericTypeParameters().Select(igtp => igtp.AsGenericTypeFormal(genericTypeDefinition)).ToArray();
+                    IList<ITypeReference> genericTypeArguments = type.GenericTypeArguments().ToArray();
+                    for (int i = 0; i < genericTypeArguments.Count; i++)
+                    {
+                        GenericFormal genericTypeParameter = genericTypeParameters[i];
+                        ITypeReference genericTypeArgument = genericTypeArguments[i];
+
+                        int newDepth = depth + 1;
+                        ForEachEmbeddedGenericFormalWorker(
+                            genericTypeArgument,
+                            delegate(GenericFormal embedded, int depth2)
+                            {
+                                collector(embedded, depth2);
+                                bool isProperEmbedding = (depth2 > newDepth);
+                                RecordBinding(genericTypeParameter, embedded, isProperEmbedding);
+                            },
+                            newDepth
+                        );
+                    }
+                    return;
+                }
+
+                if (type is IGenericParameterReference)
+                {
+                    GenericFormal embedded = ((IGenericParameterReference)type).AsGenericFormal(_declaringType);
+                    collector(embedded, depth);
+                    return;
+                }
+
+                if (type is INamespaceTypeReference || type is INestedTypeReference)
+                {
+                    // Non-constructed type. End of recursion.
+                    return;
+                }
+
+                if (type is IFunctionPointerTypeReference)
+                {
+                    // Function pointer type.
+                    return;
+                }
+
+                // Custom modifiers wrap normal types
+                if (type is IModifiedTypeReference)
+                {
+                    IModifiedTypeReference modifiedType = (IModifiedTypeReference)type;
+                    foreach (ICustomModifier customMod in modifiedType.CustomModifiers)
+                    {
+                        ForEachEmbeddedGenericFormalWorker(customMod.Modifier, collector, depth + 1);
+                    }
+
+                    // Look for generic formals on the unmodified type
+                    ForEachEmbeddedGenericFormalWorker(modifiedType.UnmodifiedType, collector, depth + 1);
+                    return;
+                }
+
+                // Did CCI invent a new kind of Type that we're unaware of?
+                Debug.Fail("Unexpected failure to bucket CCI type: " + type);
+                throw new InvalidOperationException();
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/GraphBuilder.MethodCall.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/GraphBuilder.MethodCall.cs
@@ -1,0 +1,73 @@
+﻿namespace Microsoft.Build.ILTasks.Transforms
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Linq;
+    using System.Collections;
+    using System.Diagnostics;
+    using System.Collections.Generic;
+
+    using Microsoft.Cci;
+    using Microsoft.Cci.Extensions;
+
+    internal static partial class LazyGenericsSupport
+    {
+        private sealed partial class GraphBuilder
+        {
+            /// <summary>
+            /// Found a method call inside a method body. Method calls may bind generic parameters of the target method. If so,
+            /// we have to record that fact.
+            /// </summary>
+            private void ProcessMethodCall(IMethodReference target)
+            {
+                IGenericMethodInstance resolvedTargetAsGenericMethodInstance = target.ConfirmedResolvedMethod() as IGenericMethodInstance;
+                if (resolvedTargetAsGenericMethodInstance == null)
+                    return;
+
+                //
+                // Collect all the generic parameters that have to be bound. There are two (non-mutually-exclusive) cases to consider:
+                //
+                //    - The target method is declared on a generic type.
+                //    - The target method is itself generic.
+                //
+                // We already took care of any generic type parameters in ProcessTypeReference. So we only need to handle
+                // any generic method parameters here.
+                //
+
+
+                IMethodDefinition targetGenericMethod = resolvedTargetAsGenericMethodInstance.GenericMethod.ConfirmedResolvedMethod();
+                IList<GenericMethodFormal> genericTypeParameters = targetGenericMethod.GenericParameters.Select(igmp => igmp.AsGenericMethodFormal()).ToArray();
+                IList<ITypeReference> genericTypeArguments = resolvedTargetAsGenericMethodInstance.GenericArguments.ToArray();
+
+                Debug.Assert(genericTypeParameters.Count == genericTypeArguments.Count);
+
+                // We've now collected all the generic parameters for the target and the generic arguments that the caller is binding them to.
+                // Recursively walk each generic argument to see if we're passing along one of the caller's generic parameters, and if so,
+                // are we embedding it into a more complex type.
+                for (int i = 0; i < genericTypeParameters.Count; i++)
+                {
+                    ForEachEmbeddedGenericFormal(
+                        genericTypeArguments[i],
+                        delegate(GenericFormal embedded, bool isProperEmbedding)
+                        {
+                            // If we got here, we found a method with generic arity (either from itself or its declaring type or both)
+                            // that invokes a generic method. The caller is binding one of the target's generic formals to a type expression 
+                            // involving one of the caller's own formals.
+                            //
+                            // e.g.
+                            //
+                            //  void Caller<G>()
+                            //  {
+                            //      Target<IList<G>>();
+                            //      return;
+                            //  }
+                            //
+                            RecordBinding(genericTypeParameters[i], embedded, isProperEmbedding);
+                        }
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/GraphBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/GraphBuilder.cs
@@ -1,0 +1,154 @@
+﻿namespace Microsoft.Build.ILTasks.Transforms
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Linq;
+    using System.Collections;
+    using System.Diagnostics;
+    using System.Collections.Generic;
+
+    using Microsoft.Cci;
+    using Microsoft.Cci.Extensions;
+
+    internal static partial class LazyGenericsSupport
+    {
+        private sealed partial class GraphBuilder
+        {
+            public GraphBuilder(IAssembly assembly, ILTransformLogger logger)
+            {
+                _graph = new Graph<GenericFormal>();
+                foreach (INamedTypeDefinition declaringType in assembly.GetAllTypes())
+                {
+                    _logger = logger;
+                    _declaringType = declaringType;
+                    WalkAncestorTypes();
+                    WalkFields();
+                    WalkMethods();
+                }
+                return;
+            }
+
+            public Graph<GenericFormal> Graph { get { return _graph; } }
+
+            // Base types and interfaces.
+            private void WalkAncestorTypes()
+            {
+                if (!_declaringType.IsGenericTypeDefinition())
+                    return;
+
+                ITypeReference baseType = _declaringType.BaseClasses.Any() ? _declaringType.BaseClasses.First() : null;
+                if (baseType != null)
+                {
+                    ProcessAncestorType(baseType);
+                }
+                foreach (ITypeReference ifcType in _declaringType.Interfaces)
+                {
+                    ProcessAncestorType(ifcType);
+                }
+                return;
+
+            }
+
+            private void ProcessAncestorType(ITypeReference ancestorType)
+            {
+                ForEachEmbeddedGenericFormal(ancestorType);
+            }
+
+            private void WalkFields()
+            {
+                if (!_declaringType.IsGenericTypeDefinition())
+                    return;
+
+                foreach (IFieldDefinition field in _declaringType.Fields)
+                {
+                    ITypeReference fieldType = field.Type;
+                    ProcessTypeReference(fieldType);
+                }
+            }
+
+            private void WalkMethods()
+            {
+                // Do not bail out early just because _declaringType is not generic. There are still generic methods to consider.
+
+                foreach (IMethodDefinition method in _declaringType.Methods)
+                {
+                    ProcessTypeReference(method.Type);
+                    foreach (IParameterDefinition parameter in method.Parameters)
+                    {
+                        ProcessTypeReference(parameter.Type);
+                    }
+
+                    if (method.IsAbstract || method.Body == null || method.Body.Operations == null)
+                        continue;
+
+                    foreach (IOperation op in method.Body.Operations)
+                    {
+                        IMethodReference target = op.Value as IMethodReference;
+                        if (target != null)
+                        {
+                            ProcessTypeReference(target.ContainingType);
+                            ProcessMethodCall(target);
+                        }
+
+                        IFieldReference field = op.Value as IFieldReference;
+                        if (field != null)
+                        {
+                            ProcessTypeReference(field.ContainingType);
+                        }
+
+                        ITypeReference typeReference = op.Value as ITypeReference;
+                        if (typeReference != null)
+                        {
+                            ProcessTypeReference(typeReference);
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Inside a method body, we found a reference to another type (e.g. ldtoken, or a member access.)
+            /// If the type is a generic instance, record any bindings between its formals and the referencer's
+            /// formals.
+            /// </summary>
+            private void ProcessTypeReference(ITypeReference typeReference)
+            {
+                ForEachEmbeddedGenericFormal(typeReference);
+            }
+
+            /// <summary>
+            /// Records the fact that the type formal "receiver" is being bound to a type expression that references
+            /// "embedded."
+            /// </summary>
+            private void RecordBinding(GenericFormal receiver, GenericFormal embedded, bool isProperEmbedding)
+            {
+                bool flagged;
+                if (isProperEmbedding)
+                {
+                    // If we got here, we have a potential codepath that binds "receiver" to a type expression involving "embedded"
+                    // (and is not simply "embedded" itself.)
+                    flagged = true;
+                }
+                else
+                {
+                    // If we got here, we have a potential codepath that binds "receiver" to a type expression that is simply "embedded"
+                    flagged = false;
+                }
+
+                _graph.AddEdge(embedded, receiver, flagged);
+
+                return;
+            }
+
+            private Graph<GenericFormal> _graph;
+
+            //
+            // Stores the type being analyzed. Kinda sucks for it be an instance field but we have to pass it around in so many
+            // places (including the helper code to transform an IGenericTypeParameter to a GenericFormal), it's just less confusing this way.
+            //
+            private INamedTypeDefinition _declaringType;
+
+            private ILTransformLogger _logger;
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
@@ -1,0 +1,189 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler
+{
+    internal static partial class LazyGenericsSupport
+    {
+        private class ModuleCycleInfo
+        {
+            private readonly HashSet<TypeSystemEntity> _entitiesInCycles;
+
+            public EcmaModule Module { get; }
+
+            public ModuleCycleInfo(EcmaModule module, HashSet<TypeSystemEntity> entitiesInCycles)
+            {
+                Module = module;
+                _entitiesInCycles = entitiesInCycles;
+            }
+
+            public bool FormsCycle(TypeSystemEntity owner, TypeSystemEntity referent)
+            {
+                TypeDesc ownerType = (owner as EcmaMethod)?.OwningType;
+                TypeDesc referentType = (referent as EcmaMethod)?.OwningType;
+
+                return (_entitiesInCycles.Contains(owner) || (ownerType != null && _entitiesInCycles.Contains(ownerType)))
+                    && (_entitiesInCycles.Contains(referent) || (referentType != null && _entitiesInCycles.Contains(referentType)));
+            }
+
+            // Chosen rather arbitrarily. For the app that I was looking at, cutoff point of 7 compiled
+            // more than 10 minutes on a release build of the compiler, and I lost patience.
+            // Cutoff point of 5 produced an 1.7 GB object file.
+            // Cutoff point of 4 produced an 830 MB object file.
+            // Cutoff point of 3 produced an 470 MB object file.
+            // We want this to be high enough so that it doesn't cut off too early. But also not too
+            // high because things that are recursive often end up expanding laterally as well
+            // through various other generic code the deep code calls into.
+            private const int CutoffPoint = 4;
+
+            public bool IsDeepPossiblyCyclicInstantiation(TypeSystemEntity entity)
+            {
+                if (entity is TypeDesc type)
+                {
+                    return IsDeepPossiblyCyclicInstantiation(type);
+                }
+                else
+                {
+                    return IsDeepPossiblyCyclicInstantiation((MethodDesc)entity);
+                }
+            }
+
+            public bool IsDeepPossiblyCyclicInstantiation(TypeDesc type, List<TypeDesc> seenTypes = null)
+            {
+                switch (type.Category)
+                {
+                    case TypeFlags.Array:
+                    case TypeFlags.SzArray:
+                        return IsDeepPossiblyCyclicInstantiation(((ParameterizedType)type).ParameterType, seenTypes);
+                    default:
+                        TypeDesc typeDef = type.GetTypeDefinition();
+                        if (type != typeDef)
+                        {
+                            (seenTypes ??= new List<TypeDesc>()).Add(typeDef);
+                            for (int i = 0; i < seenTypes.Count; i++)
+                            {
+                                TypeDesc typeToFind = seenTypes[i];
+                                int count = 1;
+                                for (int j = i + 1; j < seenTypes.Count; j++)
+                                {
+                                    if (seenTypes[j] == typeToFind)
+                                    {
+                                        count++;
+                                    }
+
+                                    if (count > CutoffPoint)
+                                    {
+                                        return true;
+                                    }
+                                }
+                            }
+
+                            bool result = IsDeepPossiblyCyclicInstantiation(type.Instantiation, seenTypes);
+                            seenTypes.RemoveAt(seenTypes.Count - 1);
+                            return result;
+                        }
+                        return false;
+                }
+            }
+
+            private bool IsDeepPossiblyCyclicInstantiation(Instantiation instantiation, List<TypeDesc> seenTypes = null)
+            {
+                foreach (TypeDesc arg in instantiation)
+                {
+                    if (IsDeepPossiblyCyclicInstantiation(arg, seenTypes))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            public bool IsDeepPossiblyCyclicInstantiation(MethodDesc method)
+            {
+                return IsDeepPossiblyCyclicInstantiation(method.Instantiation) || IsDeepPossiblyCyclicInstantiation(method.OwningType);
+            }
+        }
+
+        private class CycleInfoHashtable : LockFreeReaderHashtable<EcmaModule, ModuleCycleInfo>
+        {
+            protected override bool CompareKeyToValue(EcmaModule key, ModuleCycleInfo value) => key == value.Module;
+            protected override bool CompareValueToValue(ModuleCycleInfo value1, ModuleCycleInfo value2) => value1.Module == value2.Module;
+            protected override int GetKeyHashCode(EcmaModule key) => key.GetHashCode();
+            protected override int GetValueHashCode(ModuleCycleInfo value) => value.Module.GetHashCode();
+
+            protected override ModuleCycleInfo CreateValueFromKey(EcmaModule key)
+            {
+                GraphBuilder gb = new GraphBuilder(key);
+                Graph<EcmaGenericParameter> graph = gb.Graph;
+
+                var formalsNeedingLazyGenerics = graph.ComputeVerticesInvolvedInAFlaggedCycle();
+                var entitiesNeedingLazyGenerics = new HashSet<TypeSystemEntity>();
+
+                foreach (EcmaGenericParameter formal in formalsNeedingLazyGenerics)
+                {
+                    var formalDefinition = key.MetadataReader.GetGenericParameter(formal.Handle);
+                    if (formal.Kind == GenericParameterKind.Type)
+                    {
+                        entitiesNeedingLazyGenerics.Add(key.GetType(formalDefinition.Parent));
+                    }
+                    else
+                    {
+                        entitiesNeedingLazyGenerics.Add(key.GetMethod(formalDefinition.Parent));
+                    }
+                }
+
+                return new ModuleCycleInfo(key, entitiesNeedingLazyGenerics);
+            }
+        }
+
+        internal class GenericCycleDetector
+        {
+            private readonly CycleInfoHashtable _hashtable = new CycleInfoHashtable();
+
+            public void DetectCycle(TypeSystemEntity owner, TypeSystemEntity referent)
+            {
+                var ownerType = owner as TypeDesc;
+                var ownerMethod = owner as MethodDesc;
+                var ownerDefinition = ownerType?.GetTypeDefinition() ?? (TypeSystemEntity)ownerMethod.GetTypicalMethodDefinition();
+                var referentType = referent as TypeDesc;
+                var referentMethod = referent as MethodDesc;
+                var referentDefinition = referentType?.GetTypeDefinition() ?? (TypeSystemEntity)referentMethod.GetTypicalMethodDefinition();
+
+                // We don't track cycles in non-ecma entities.
+                if ((referentDefinition is not EcmaMethod && referentDefinition is not EcmaType)
+                    || (ownerDefinition is not EcmaMethod && ownerDefinition is not EcmaType))
+                {
+                    return;
+                }
+
+                EcmaModule ownerModule = (ownerDefinition as EcmaType)?.EcmaModule ?? ((EcmaMethod)ownerDefinition).Module;
+
+                ModuleCycleInfo cycleInfo = _hashtable.GetOrCreateValue(ownerModule);
+                if (cycleInfo.FormsCycle(ownerDefinition, referentDefinition))
+                {
+                    // Just the presence of a cycle is not a problem, but once we start getting too deep,
+                    // we need to cut our losses.
+                    if (cycleInfo.IsDeepPossiblyCyclicInstantiation(referent))
+                    {
+                        if (referentType != null)
+                        {
+                            // TODO: better exception string ID?
+                            ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, referentType);
+                        }
+                        else
+                        {
+                            // TODO: better exception string ID?
+                            ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, referentMethod);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -245,7 +245,17 @@ namespace Internal.IL
                 _dependencies.Add(_compilation.ComputeConstantLookup(ReadyToRunHelperId.TypeHandleForCasting, type), "IsInst/CastClass");
             }
         }
-        
+
+        private IMethodNode GetMethodEntrypoint(MethodDesc method)
+        {
+            if (method.HasInstantiation || method.OwningType.HasInstantiation)
+            {
+                _compilation.DetectGenericCycles(_canonMethod, method);
+            }
+
+            return _factory.MethodEntrypoint(method);
+        }
+
         private void ImportCall(ILOpcode opcode, int token)
         {
             // We get both the canonical and runtime determined form - JitInterface mostly operates
@@ -620,7 +630,7 @@ namespace Internal.IL
                     else
                     {
                         Debug.Assert(!forceUseRuntimeLookup);
-                        _dependencies.Add(_factory.MethodEntrypoint(targetMethod), reason);
+                        _dependencies.Add(GetMethodEntrypoint(targetMethod), reason);
 
                         if (targetMethod.RequiresInstMethodTableArg() && resolvedConstraint)
                         {
@@ -682,7 +692,7 @@ namespace Internal.IL
                         _dependencies.Add(_compilation.NodeFactory.MaximallyConstructableType(concreteMethod.OwningType), reason + " - inlining protection");
                     }
 
-                    _dependencies.Add(_compilation.NodeFactory.MethodEntrypoint(targetMethod), reason);
+                    _dependencies.Add(GetMethodEntrypoint(targetMethod), reason);
                 }
             }
             else if (method.HasInstantiation)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -228,6 +228,12 @@
     <Compile Include="Compiler\FeatureSwitchManager.cs" />
     <Compile Include="Compiler\GeneratingMetadataManager.cs" />
     <Compile Include="Compiler\GenericRootProvider.cs" />
+    <Compile Include="Compiler\LazyGenerics\Graph.cs" />
+    <Compile Include="Compiler\LazyGenerics\Graph.Cycles.cs" />
+    <Compile Include="Compiler\LazyGenerics\Graph.Vertex.cs" />
+    <Compile Include="Compiler\LazyGenerics\GraphBuilder.cs" />
+    <Compile Include="Compiler\LazyGenerics\GraphBuilder.ForEach.cs" />
+    <Compile Include="Compiler\LazyGenerics\GraphBuilder.MethodCall.cs" />
     <Compile Include="Compiler\HardwareIntrinsicHelpers.Aot.cs" />
     <Compile Include="Compiler\IInliningPolicy.cs" />
     <Compile Include="Compiler\ManifestResourceBlockingPolicy.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Compiler\FeatureSwitchManager.cs" />
     <Compile Include="Compiler\GeneratingMetadataManager.cs" />
     <Compile Include="Compiler\GenericRootProvider.cs" />
+    <Compile Include="Compiler\LazyGenerics\ModuleCycleInfo.cs" />
     <Compile Include="Compiler\LazyGenerics\Graph.cs" />
     <Compile Include="Compiler\LazyGenerics\Graph.Cycles.cs" />
     <Compile Include="Compiler\LazyGenerics\Graph.Vertex.cs" />


### PR DESCRIPTION
Motivated by https://github.com/npgsql/npgsql/issues/4057. The generic recursion that was in Npgsql made its way back into Npgsql. We've seen these show up too often. Not because it's common to write recursions in C#, but because popular NuGets end up having these and then people hit it too often.

This brings over the generic cycle detection from .NET Native and hooks it up in a rudimentary way. The pull request is split into logical commits for better reviewability.

We detect generic recursion at two spots:
* In the code generation phase. This detects all the cases where shared generics are not involved.
* In generic dictionaries. This is the more typical case where recursion results in never-ending expansion in terms of types and generic dictionaries.

If we detect a recursion, we unceremoniously cut it off after a couple levels of nesting. The cutoff point is fairly low because in the cases I’ve seen, the recursion also causes an expansion in breadth, not just depth, and allowing that to go unchecked was resulting in sadness. If the code goes beyond the cutoff point at runtime, it will not work.

The recursion detector is essentially a prepass – it goes over everything in the assembly, trying to look for recursions and generating a list of types/generic method involved in a cycle. I’m fairly convinced it cannot be done in other ways than with a prepass.

Looking at the .NET Native code, we had quite a few limitations where generic recursion would not be detected. Given a failure to detect a cycle results in a compiler failure, and we’ve not heard of this failure over the years, the .NET Native approach is likely sufficient.

## What’s missing

If we cutoff the generic recursion within a generic dictionary, the failure mode at runtime is a NullRef shortly after a dictionary lookup (because the cut off slot will be null). It’s not great. I think we can update the lookup helpers to check for null while restricting the check to only the helpers where we’ve seen a damaged slot. We also need to make sure such lookups never get inlined by RyuJIT and always go through our helpers. I think it’s doable and not hard. I just don’t want to put more in this pull request than what’s strictly necessary.

Lazy generics. If the recursion happens over reference types, we could potentially generate fully working code by failing back to lazy generics. The cases I was looking at were not over reference types.

We might want to allow specifying the cutoff point at compile time (also allow disabling all of this).

## Perf

I've seen a 2% regression in compilation throughput for WebApi template. We can make this more efficient by e.g. not hydrating type system objects for everything when we're scanning for cycles and staying with S.R.Metadata for longer.
