### PR TITLE
[NativeAOT-LLVM] Fix packaging

### DIFF
--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -37,6 +37,15 @@ With the above binaries built, the ILC can be run and debugged as normal. The ru
 Working on the Jit itself, one possible workflow is taking advantage of the generated VS project:
 - Open the Ilc solution and add the aforementioned Jit project, `clrjit_browser_wasm32_x64.vcxproj`. Then in the project properties, General section, change the output folder to the full path for `artifacts\bin\coreclr\windows.x64.Debug\ilc` e.g. `E:\GitHub\runtimelab\artifacts\bin\coreclr\windows.x64.Debug\ilc`. Build `clrjit_browser_wasm32_x64` project and you should now be able to change and put breakpoints in the C++ code.
 
+It is also possible to publish an ordinary console project for Wasm using packages produced by the build: `build nativeaot.packages && build nativeaot.packages -a wasm -os Browser`, assuming all the binaries mentioned above have been built (note that the order is important - the build always produces an architecture-independent package that has a dependency on an architecture-dependent one, and we want that architecture-dependent package to be built for Wasm). Add the `path-to-repo/artifacts/packages/[Debug|Release]/Shipping` directory to your project's `NuGet.Config`, and the following two references to the project file itself:
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="7.0.0-dev" />
+  <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="7.0.0-dev" />
+</ItemGroup>
+```
+You should now be able to publish the project for Wasm: `dotnet publish --self-contained -r browser-wasm /p:MSBuildEnableWorkloadResolver=false`. This produces `YourApp.html` and `YourApp.js` files under `bin\<Config>\<TFM>\browser-wasm\native`. The former can be opened in the browser, the latter - run via NodeJS.
+
 ## Visual Studio Solutions
 
 The repository has a number of Visual Studio Solutions files (`*.sln`) that are useful for editing parts of the repository. Build the repo from command line first before building using the solution files. Remember to select the appropriate configuration that you built. By default, `build.cmd` builds Debug x64 and so `Debug` and `x64` must be selected in the solution build configuration drop downs.

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.LLVM.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.LLVM.targets
@@ -1,41 +1,5 @@
-<Project
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
-    <!-- Define the name of the runtime specific compiler package to import -->
-    <PortableRuntimeIdentifier Condition="$(RuntimeIdentifier.StartsWith('win'))">win</PortableRuntimeIdentifier>
-    <PortableRuntimeIdentifier Condition="$(RuntimeIdentifier.StartsWith('osx'))">osx</PortableRuntimeIdentifier>
-    <PortableRuntimeIdentifier Condition="$(RuntimeIdentifier.StartsWith('linux-musl')) OR $(RuntimeIdentifier.StartsWith('alpine'))">linux-musl</PortableRuntimeIdentifier>
-    <PortableRuntimeIdentifier Condition="$(RuntimeIdentifier.StartsWith('browser-wasm'))">browser-wasm</PortableRuntimeIdentifier>
-    <PortableRuntimeIdentifier Condition="'$(PortableRuntimeIdentifier)' == ''">linux</PortableRuntimeIdentifier>
-    <PortableRuntimeIdentifier Condition="!($(RuntimeIdentifier.StartsWith('browser-wasm')))">$(PortableRuntimeIdentifier)-$(PlatformTarget)</PortableRuntimeIdentifier>
-    <RuntimeIlcPackageName>runtime.$(PortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM</RuntimeIlcPackageName>
-    <IlcCalledViaPackage>true</IlcCalledViaPackage>
+  <Import Project="$(MSBuildThisFileDirectory)\Microsoft.DotNet.ILCompiler.targets" />
 
-  </PropertyGroup>
-
-  <PropertyGroup>
-
-    <!-- If CoreRT is being consumed via its package, runtime-specific properties must be set before compilation can proceed -->
-    <ImportRuntimeIlcPackageTargetDependsOn>RunResolvePackageDependencies</ImportRuntimeIlcPackageTargetDependsOn>
-    <IlcSetupPropertiesDependsOn>ImportRuntimeIlcPackageTarget</IlcSetupPropertiesDependsOn>
-    <IlcDynamicBuildPropertyDependencies>SetupProperties</IlcDynamicBuildPropertyDependencies>
-
-  </PropertyGroup>
-
-  <!-- Part of workaround for lack of secondary build artifact import - https://github.com/Microsoft/msbuild/issues/2807 -->
-  <!-- Locate the runtime package according to the current target runtime -->
-  <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' AND $(IlcCalledViaPackage) == 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
-    <!-- CoreRT SDK and Framework Assemblies need to be defined to avoid CoreCLR implementations being set as compiler inputs -->
-    <Error Condition="'@(PackageDefinitions)' == ''" Text="The PackageDefinitions ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
-    <ItemGroup>
-      <RuntimePackage Include="@(PackageDefinitions)" Condition="'%(PackageDefinitions.Name)' == '$(RuntimeIlcPackageName)'" />
-    </ItemGroup>
-    <CreateProperty Value="%(RuntimePackage.ResolvedPath)">
-      <Output TaskParameter="Value" PropertyName="RuntimePackagePath"/>
-    </CreateProperty>
-  </Target>
-
-  <Import Project="$(MSBuildThisFileDirectory)\Microsoft.NETCore.Native.targets" />
 </Project>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.targets
@@ -5,6 +5,7 @@
     <!-- Define the name of the runtime specific compiler package to import -->
     <OSIdentifier Condition="$(RuntimeIdentifier.StartsWith('win'))">win</OSIdentifier>
     <OSIdentifier Condition="$(RuntimeIdentifier.StartsWith('osx'))">osx</OSIdentifier>
+    <OSIdentifier Condition="$(RuntimeIdentifier.StartsWith('browser'))">browser</OSIdentifier>
     <OSIdentifier Condition="$(RuntimeIdentifier.StartsWith('linux-musl')) OR $(RuntimeIdentifier.StartsWith('alpine'))">linux-musl</OSIdentifier>
     <OSIdentifier Condition="'$(OSIdentifier)' == ''">linux</OSIdentifier>
 
@@ -14,9 +15,15 @@
     <TargetArchitecture Condition="$(RidWithHyphen.Contains('-x64-'))">x64</TargetArchitecture>
     <TargetArchitecture Condition="$(RidWithHyphen.Contains('-arm-'))">arm</TargetArchitecture>
     <TargetArchitecture Condition="$(RidWithHyphen.Contains('-arm64-'))">arm64</TargetArchitecture>
+    <TargetArchitecture Condition="$(RidWithHyphen.Contains('-wasm-'))">wasm</TargetArchitecture>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">unknown</TargetArchitecture>
 
     <RuntimeIlcPackageName>runtime.$(OSIdentifier)-$(TargetArchitecture).Microsoft.DotNet.ILCompiler</RuntimeIlcPackageName>
+    <RuntimeIlcPackageName Condition="'$(TargetArchitecture)' == 'wasm'">$(RuntimeIlcPackageName).LLVM</RuntimeIlcPackageName>
+
+    <HostOSIdentifier Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx</HostOSIdentifier>
+    <HostOSIdentifier Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">win</HostOSIdentifier>
+    <HostOSIdentifier Condition="'$(HostOSIdentifier)' == ''">linux</HostOSIdentifier>
 
     <OSHostArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</OSHostArch>
     <!-- OSArchitecture does not report the true OS architecture for x86 and x64 processes running on Windows ARM64. -->
@@ -25,7 +32,8 @@
         $([System.Environment]::GetEnvironmentVariable('PROCESSOR_ARCHITECTURE', EnvironmentVariableTarget.Machine)) == 'ARM64'">arm64</OSHostArch>
 
     <IlcHostArch Condition="'$(IlcHostArch)' == ''">$(OSHostArch)</IlcHostArch>
-    <IlcHostPackageName>runtime.$(OSIdentifier)-$(IlcHostArch).Microsoft.DotNet.ILCompiler</IlcHostPackageName>
+    <IlcHostPackageName>runtime.$(HostOSIdentifier)-$(IlcHostArch).Microsoft.DotNet.ILCompiler</IlcHostPackageName>
+    <IlcHostPackageName Condition="'$(TargetArchitecture)' == 'wasm'">$(IlcHostPackageName).LLVM</IlcHostPackageName>
     <IlcCalledViaPackage>true</IlcCalledViaPackage>
 
   </PropertyGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -14,9 +14,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- how should these be done? -->
-  <PropertyGroup Condition="'$(Platform)' == 'wasm'">
-    <TargetOS>browser</TargetOS>
+  <PropertyGroup Condition="'$(TargetArchitecture)' == 'wasm'">
     <NativeCodeGen>llvm</NativeCodeGen>
   </PropertyGroup>
 
@@ -27,6 +25,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <NativeCompilationDuringPublish Condition="'$(NativeCompilationDuringPublish)' == ''">true</NativeCompilationDuringPublish>
     <IlcBuildTasksPath Condition="'$(IlcBuildTasksPath)' == ''">$(MSBuildThisFileDirectory)..\tools\netstandard\ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>
     <IlcHostPath Condition="'$(IlcPath)' != ''">$(IlcPath)</IlcHostPath>
+    <TargetOS Condition="'$(TargetOS)' == '' and '$(TargetArchitecture)' == 'wasm'">Browser</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == '' and '$([MSBuild]::IsOSPlatform(Windows))' == 'true'">windows</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == '' and '$([MSBuild]::IsOSPlatform(OSX))' == 'true'">OSX</TargetOS>
     <TargetOS Condition="'$(TargetOS)' == ''">$(OS)</TargetOS>
@@ -251,6 +250,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(MibcFile->'--mibc:%(Identity)')" />
       <IlcArg Condition="$(IlcGenerateMetadataLog) == 'true'" Include="--metadatalog:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).metadata.csv" />
       <IlcArg Condition="$(TargetArchitecture) != ''" Include="--targetarch:$(TargetArchitecture)" />
+      <IlcArg Condition="'$(TargetArchitecture)' == 'wasm'" Include="--targetos:wasm" />
       <IlcArg Condition="$(IlcMultiModule) == 'true'" Include="--multifile" />
       <IlcArg Condition="$(Optimize) == 'true'" Include="-O" />
       <IlcArg Condition="$(NativeDebugSymbols) == 'true'" Include="-g" />
@@ -260,8 +260,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(RdXmlFile->'--rdxml:%(Identity)')" />
       <IlcArg Condition="$(NativeLib) != ''" Include="--nativelib" />
       <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
-      <IlcArg Condition="'$(Platform)' == 'wasm'" Include="--targetarch:wasm" />
-      <IlcArg Condition="'$(Platform)' == 'wasm'" Include="--targetos:wasm" />
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(RuntimeHostConfigurationOption->'--appcontextswitch:%(Identity)=%(Value)')" />
       <IlcArg Include="@(DirectPInvoke->'--directpinvoke:%(Identity)')" />
@@ -422,7 +420,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <PropertyGroup>
       <EmccArgs>&quot;$(NativeObject)&quot; &quot;$(NativeClrjitObject)&quot; -o &quot;$(NativeBinary)&quot; -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s DISABLE_EXCEPTION_CATCHING=0 --emrun </EmccArgs>
-      <EmccArgs Condition="'$(Platform)'=='wasm'">$(EmccArgs) &quot;$(IlcPath)/sdk/libPortableRuntime.a&quot; &quot;$(IlcPath)/sdk/libbootstrapper.a&quot; &quot;$(IlcPath)/framework/libSystem.Native.a&quot; &quot;$(IlcPath)/framework/libSystem.Globalization.Native.a&quot; $(EmccExtraArgs)</EmccArgs>
+      <EmccArgs Condition="'$(TargetArchitecture)' == 'wasm'">$(EmccArgs) &quot;$(IlcPath)/sdk/libPortableRuntime.a&quot; &quot;$(IlcPath)/sdk/libbootstrapper.a&quot; &quot;$(IlcPath)/framework/libSystem.Native.a&quot; &quot;$(IlcPath)/framework/libSystem.Globalization.Native.a&quot; $(EmccExtraArgs)</EmccArgs>
       <EmccArgs Condition="'$(NativeDebugSymbols)' != 'true'">$(EmccArgs) -O2 -flto</EmccArgs>
       <EmccArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(EmccArgs) -g3</EmccArgs>
     </PropertyGroup>

--- a/src/tests/Common/CLRTest.NativeAot.targets
+++ b/src/tests/Common/CLRTest.NativeAot.targets
@@ -79,7 +79,6 @@ fi
 
   <Target Name="GetNativeAotBatchScript">
     <PropertyGroup>
-      <PlatformOverride Condition="'$(TargetArchitecture)' == 'wasm'">/p:Platform=wasm</PlatformOverride>
       <ExeRunner Condition="'$(TargetArchitecture)' == 'wasm'">%EMSDK_NODE% </ExeRunner>
       <ExeExtension Condition="'$(TargetArchitecture)' == 'wasm'">.js</ExeExtension>
       <NativeAotMultimoduleIncompatibleScript Condition="'$(NativeAotMultimoduleIncompatible)' == 'true'">
@@ -111,7 +110,7 @@ if defined RunNativeAot (
         set __Command=!__Command! "dotnet"
     )
 
-    set __Command=!__Command! msbuild /p:IlcPath=!CORE_ROOT!\nativeaot nativebuild.proj $(PlatformOverride)
+    set __Command=!__Command! msbuild /p:IlcPath=!CORE_ROOT!\nativeaot nativebuild.proj
 
     if defined NativeAotMultimodule (
         set __Command=!__Command! /p:IlcMultiModule=true /p:DisableFrameworkLibGeneration=true /p:FrameworkLibPath=!CORE_ROOT!\nativeaot\sdk


### PR DESCRIPTION
It appears that the packaging code has bit-rotted a little, so fix that, by deleting code duplication.