### PR TITLE
Change how we deal with scanning failures

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -19,6 +19,7 @@ namespace ILCompiler
         protected DictionaryLayoutProvider _dictionaryLayoutProvider = new LazyDictionaryLayoutProvider();
         protected DebugInformationProvider _debugInformationProvider = new DebugInformationProvider();
         protected DevirtualizationManager _devirtualizationManager = new DevirtualizationManager();
+        protected MethodImportationErrorProvider _methodImportationErrorProvider = new MethodImportationErrorProvider();
         protected IInliningPolicy _inliningPolicy;
         protected bool _methodBodyFolding;
         protected bool _singleThreaded;
@@ -100,6 +101,12 @@ namespace ILCompiler
         public CompilationBuilder UsePreinitializationManager(PreinitializationManager manager)
         {
             _preinitializationManager = manager;
+            return this;
+        }
+
+        public CompilationBuilder UseMethodImportationErrorProvider(MethodImportationErrorProvider errorProvider)
+        {
+            _methodImportationErrorProvider = errorProvider;
             return this;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MethodImportationErrorProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MethodImportationErrorProvider.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Class that provides cached information about method body importation errors that occured in previous phases.
+    /// </summary>
+    public class MethodImportationErrorProvider
+    {
+        /// <summary>
+        /// Returns the error discovered while processing the method body for the given method in the past.
+        /// </summary>
+        /// <returns>Relevant <see cref="TypeSystemException"/> or null if no error was seen.</returns>
+        public virtual TypeSystemException GetCompilationError(MethodDesc method) => null;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -204,7 +204,7 @@ namespace Internal.IL
                     {
                         TypeDesc catchType = (TypeDesc)_methodIL.GetObject(region.ClassToken);
                         if (catchType.IsRuntimeDeterminedSubtype)
-                            _dependencies.Add(_factory.MethodEntrypoint(_factory.TypeSystemContext.GetHelperEntryPoint("ThrowHelpers", "ThrowInvalidProgramException")), "Unsupported EH");
+                            ThrowHelper.ThrowInvalidProgramException();
                     }
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Compiler\HardwareIntrinsicHelpers.Aot.cs" />
     <Compile Include="Compiler\IInliningPolicy.cs" />
     <Compile Include="Compiler\ManifestResourceBlockingPolicy.cs" />
+    <Compile Include="Compiler\MethodImportationErrorProvider.cs" />
     <Compile Include="Compiler\NoMetadataBlockingPolicy.cs" />
     <Compile Include="Compiler\DependencyAnalysis\FrozenObjectNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsPreInitDataNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilationBuilder.cs
@@ -117,7 +117,7 @@ namespace ILCompiler
 
             JitConfigProvider.Initialize(_context.Target, jitFlagBuilder.ToArray(), _ryujitOptions);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
-            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, _inliningPolicy ?? _compilationGroup, _instructionSetSupport, _profileDataManager, options);
+            return new RyuJitCompilation(graph, factory, _compilationRoots, _ilProvider, _debugInformationProvider, _logger, _devirtualizationManager, _inliningPolicy ?? _compilationGroup, _instructionSetSupport, _profileDataManager, _methodImportationErrorProvider, options);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -788,6 +788,12 @@ namespace ILCompiler
                 // This prevents e.g. devirtualizing and inlining methods on types that were
                 // never actually allocated.
                 builder.UseInliningPolicy(scanResults.GetInliningPolicy());
+
+                // Use an error provider that prevents us from re-importing methods that failed
+                // to import with an exception during scanning phase. We would see the same failure during
+                // compilation, but before RyuJIT gets there, it might ask questions that we don't
+                // have answers for because we didn't scan the entire method.
+                builder.UseMethodImportationErrorProvider(scanResults.GetMethodImportationErrorProvider());
             }
 
             ICompilation compilation = builder.ToCompilation();

--- a/src/tests/nativeaot/SmokeTests/Generics/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/Generics/Generics.cs
@@ -2522,14 +2522,19 @@ class Program
 
         public static void Run()
         {
+            bool failed = false;
+
             try
             {
                 DoGenericLookup<object>();
             }
-            catch (Exception ex)
+            catch (TypeLoadException)
             {
-                Console.WriteLine(ex.ToString());
+                failed = true;
             }
+
+            if (!failed)
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
When we import a method that has a problem in it (e.g. read a non-existent field because the user provided mismatched assemblies), we generate IL body for a throwing method that throws the appropriate exception matching JIT-based behavior. We then import that IL body instead of the original method.

We do this in both scanner and codegen. This worked for us so far, but I just hit a case where this doesn't work.

Before RyuJIT hits the problematic part of the method that makes us discard it, it might attempt to import stuff we didn't scan (e.g. try to do dictionary lookups, ask about virtual slots, etc.). This makes us take the "there's a compiler bug" codepaths before we find out it doesn't actually matter. We don't keep the partial dependencies from the scanning phase and even if we did, there's no guarantees RyuJIT imports in the same order as scanner - all we have is the dependencies of the throwing stub.

So instead, remember that a method had a problem during scanning and don't even attempt to give such method body to RyuJIT - just pass the throwing body right away.