### PR TITLE
[NativeAOT-LLVM] Fix build regressions

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -406,7 +406,7 @@ for /f "delims=" %%a in ("-%__RequestedBuildComponents%-") do (
 
         if not defined LLVM_CMAKE_CONFIG (
             echo %__ErrMsgPrefix%%__MsgPrefix%Error: The LLVM_CMAKE_CONFIG environment variable pointing to llvm-build-dir/lib/cmake/llvm must be set.
-            exit /B 1
+            goto ExitWithError
         )
     )
     if not "!string:-alljits-=!"=="!string!" (
@@ -427,7 +427,7 @@ for /f "delims=" %%a in ("-%__RequestedBuildComponents%-") do (
         if "%__BuildArch%"=="wasm" (
             if not defined EMSDK (
                 echo %__ErrMsgPrefix%%__MsgPrefix%Error: The EMSDK environment variable pointing to emsdk root must be set.
-                exit /B 1
+                goto ExitWithError
             )
         )
     )

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -68,6 +68,7 @@ function(create_standalone_jit)
 
     find_package(LLVM REQUIRED CONFIG PATHS $ENV{LLVM_CMAKE_CONFIG})
     target_include_directories(${TARGETDETAILS_TARGET} PRIVATE ${LLVM_INCLUDE_DIRS})
+    separate_arguments(LLVM_DEFINITIONS)
     target_compile_definitions(${TARGETDETAILS_TARGET} PRIVATE ${LLVM_DEFINITIONS})
     llvm_map_components_to_libnames(llvm_libs core bitwriter)
     target_link_libraries(${TARGETDETAILS_TARGET} ${llvm_libs})


### PR DESCRIPTION
Exit with error if `LLVM_CMAKE_CONFIG` is not set.

Make `LLVM_DEFINITIONS` into a comma-separated list, it is a whitespace-separated one by default, and `target_compile_definitions` does not like such lists.

Fixes #1684.