### PR TITLE
[NativeAOT-LLVM] Add support for *struct args

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -302,6 +302,11 @@ llvm::Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
     return _llvmStructs->at(structHandle);
 }
 
+//------------------------------------------------------------------------
+// Returns the VM defined TypeDesc.GetParameterType() for the given type
+// Intended for pointers to generate the appropriate LLVM pointer type
+// E.g. "[S.P.CoreLib]Internal.Runtime.MethodTable"*
+// 
 llvm::Type* Llvm::getLlvmTypeForParameterType(CORINFO_CLASS_HANDLE classHnd)
 {
     CORINFO_CLASS_HANDLE innerParameterHandle;
@@ -1055,9 +1060,8 @@ void Llvm::fillPhis()
             auto iter = _localsMap->find({ lclNum, ssaNum });
             if (iter == _localsMap->end())
             {
-                //// Function args can be used as phi args without having seen them, and added them to _localsMap via a local.
-                //// But only for non shadow stack args with u:1
-                assert(_compiler->lvaIsParameter(lclNum) && ssaNum == 1);
+                // Arguments are implicitly defined on entry to the method.
+                assert(_compiler->lvaIsParameter(lclNum) && ssaNum == SsaConfig::FIRST_SSA_NUM);
                 LlvmArgInfo  llvmArgInfo = getLlvmArgInfoForArgIx(_sigInfo, lclNum);
                 localPhiArg = _function->getArg(llvmArgInfo.m_argIx);
             }

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -35,7 +35,9 @@ static const char* (*_getDocumentFileName)(void*);
 static const uint32_t (*_firstSequencePointLineNumber)(void*);
 static const uint32_t (*_getOffsetLineNumber)(void*, unsigned int ilOffset);
 static const uint32_t(*_structIsWrappedPrimitive)(void*, CORINFO_CLASS_STRUCT_*, CorInfoType);
-static const uint32_t(*_padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned atOffset);
+static const uint32_t(*_padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned);
+static const CorInfoTypeWithMod(*_getArgTypeIncludingParameterized)(void*, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_HANDLE, CORINFO_CLASS_HANDLE*);
+static const CorInfoTypeWithMod(*_getParameterType)(void*, CORINFO_CLASS_HANDLE, CORINFO_CLASS_HANDLE*);
 
 static char*                              _outputFileName;
 static Function*                          _doNothingFunction;
@@ -55,7 +57,9 @@ extern "C" DLLEXPORT void registerLlvmCallbacks(void*       thisPtr,
                                                 const uint32_t (*firstSequencePointLineNumber)(void*),
                                                 const uint32_t (*getOffsetLineNumber)(void*, unsigned int),
                                                 const uint32_t(*structIsWrappedPrimitive)(void*, CORINFO_CLASS_STRUCT_*, CorInfoType),
-                                                const uint32_t(*padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned atOffset))
+                                                const uint32_t(*padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned),
+                                                const CorInfoTypeWithMod(*getArgTypeIncludingParameterized)(void*, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_HANDLE, CORINFO_CLASS_HANDLE*),
+                                                const CorInfoTypeWithMod(*getParameterType)(void*, CORINFO_CLASS_HANDLE, CORINFO_CLASS_HANDLE*))
 {
     _thisPtr = thisPtr;
     _getMangledMethodName         = getMangledMethodNamePtr;
@@ -66,7 +70,9 @@ extern "C" DLLEXPORT void registerLlvmCallbacks(void*       thisPtr,
     _firstSequencePointLineNumber = firstSequencePointLineNumber;
     _getOffsetLineNumber          = getOffsetLineNumber;
     _structIsWrappedPrimitive     = structIsWrappedPrimitive;
-    _padOffset                    = padOffset;
+    _padOffset = padOffset;
+    _getArgTypeIncludingParameterized = getArgTypeIncludingParameterized;
+    _getParameterType = getParameterType;
 
     if (_module == nullptr) // registerLlvmCallbacks is called for each method to compile, but must only created the module once.  Better perhaps to split this into 2 calls.
     {
@@ -296,8 +302,20 @@ llvm::Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
     return _llvmStructs->at(structHandle);
 }
 
+llvm::Type* Llvm::getLlvmTypeForParameterType(CORINFO_CLASS_HANDLE classHnd)
+{
+    CORINFO_CLASS_HANDLE innerParameterHandle;
+    CorInfoType parameterCorInfoType = strip(_getParameterType(_thisPtr, classHnd, &innerParameterHandle));
+    if (parameterCorInfoType == CorInfoType::CORINFO_TYPE_VOID)
+    {
+        return Type::getInt8Ty(_llvmContext); // LLVM doesn't allow void*
+    }
+    return getLlvmTypeForCorInfoType(parameterCorInfoType, innerParameterHandle);
+}
+
 // Copy of logic from ILImporter.GetLLVMTypeForTypeDesc
-llvm::Type* Llvm::getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd) {
+llvm::Type* Llvm::getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd)
+{
     switch (corInfoType)
     {
         case CorInfoType::CORINFO_TYPE_VOID:
@@ -322,6 +340,16 @@ llvm::Type* Llvm::getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLA
 
         case CorInfoType::CORINFO_TYPE_DOUBLE:
             return Type::getDoubleTy(_llvmContext);
+
+        case CorInfoType::CORINFO_TYPE_PTR:
+        {
+            if (classHnd == NO_CLASS_HANDLE)
+            {
+                return Type::getInt8Ty(_llvmContext)->getPointerTo();
+            }
+
+            return getLlvmTypeForParameterType(classHnd)->getPointerTo();
+        }
 
         case CorInfoType::CORINFO_TYPE_BYREF:
         case CorInfoType::CORINFO_TYPE_CLASS:
@@ -456,7 +484,7 @@ bool Llvm::needsReturnStackSlot(CorInfoType corInfoType, CORINFO_CLASS_HANDLE cl
 
 CorInfoType Llvm::getCorInfoTypeForArg(CORINFO_SIG_INFO& sigInfo, CORINFO_ARG_LIST_HANDLE& arg, CORINFO_CLASS_HANDLE* clsHnd)
 {
-    CorInfoTypeWithMod   corTypeWithMod = _info.compCompHnd->getArgType(&sigInfo, arg, clsHnd);
+    CorInfoTypeWithMod corTypeWithMod = _getArgTypeIncludingParameterized(_thisPtr, &sigInfo, arg, clsHnd);
     return strip(corTypeWithMod);
 }
 
@@ -476,7 +504,7 @@ FunctionType* Llvm::getFunctionTypeForSigInfo(CORINFO_SIG_INFO& sigInfo)
     }
     else
     {
-        retLlvmType   = getLlvmTypeForCorInfoType(sigInfo.retType, sigInfo.retTypeClass);
+        retLlvmType = getLlvmTypeForCorInfoType(sigInfo.retType, sigInfo.retTypeClass);
     }
 
     CORINFO_ARG_LIST_HANDLE  sigArgs = sigInfo.args;
@@ -1023,7 +1051,21 @@ void Llvm::fillPhis()
             unsigned       lclNum = phiArg->GetLclNum();
             unsigned       ssaNum = phiArg->GetSsaNum();
 
-            Value* localPhiArg = _localsMap->at({ lclNum, ssaNum });
+            Value* localPhiArg = nullptr;
+            auto iter = _localsMap->find({ lclNum, ssaNum });
+            if (iter == _localsMap->end())
+            {
+                //// Function args can be used as phi args without having seen them, and added them to _localsMap via a local.
+                //// But only for non shadow stack args with u:1
+                assert(_compiler->lvaIsParameter(lclNum) && ssaNum == 1);
+                LlvmArgInfo  llvmArgInfo = getLlvmArgInfoForArgIx(_sigInfo, lclNum);
+                localPhiArg = _function->getArg(llvmArgInfo.m_argIx);
+            }
+            else
+            {
+                localPhiArg = iter->second;
+            }
+
             Value* phiRealArgValue;
             llvm::Instruction* castRequired = getCast(localPhiArg, llvmPhiNode->getType());
             if (castRequired != nullptr)
@@ -1669,6 +1711,17 @@ void Llvm::Compile()
     {
         _function = Function::Create(getFunctionTypeForSigInfo(_sigInfo), Function::ExternalLinkage, 0U, mangledName,
             _module); // TODO: ExternalLinkage forced as linked from old module
+    }
+
+    // mono does this via Javascript (pal_random.js), but prefer not to introduce that dependency as it limits the ability to run out of the browser.
+    // Copy the temporary workaround from the IL->LLVM generator for now.
+    if (!strcmp(mangledName, "S_P_CoreLib_Interop__GetRandomBytes"))
+    {
+        // this would normally fill the buffer parameter, but we'll just leave the buffer as is and that will be our "random" data for now
+        llvm::BasicBlock* llvmBlock = llvm::BasicBlock::Create(_llvmContext, "", _function);
+        _builder.SetInsertPoint(llvmBlock);
+        _builder.CreateRetVoid();
+        return;
     }
 
     if (_compiler->opts.compDbgInfo)

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -76,7 +76,9 @@ extern "C" void registerLlvmCallbacks(void*       thisPtr,
                                       const uint32_t (*firstSequencePointLineNumber)(void*),
                                       const uint32_t (*getOffsetLineNumber)(void*, unsigned int),
                                       const uint32_t(*structIsWrappedPrimitive)(void*, CORINFO_CLASS_STRUCT_*, CorInfoType),
-                                      const uint32_t(*padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned atOffset));
+                                      const uint32_t(*padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned),
+                                      const CorInfoTypeWithMod(*_getArgTypeIncludingParameterized)(void*, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_HANDLE, CORINFO_CLASS_HANDLE*),
+                                      const CorInfoTypeWithMod(*_getParameterType)(void*, CORINFO_CLASS_HANDLE, CORINFO_CLASS_HANDLE*));
 
 struct PhiPair
 {
@@ -150,6 +152,7 @@ private:
     LlvmArgInfo getLlvmArgInfoForArgIx(CORINFO_SIG_INFO& sigInfo, unsigned int lclNum);
     llvm::BasicBlock* getLLVMBasicBlockForBlock(BasicBlock* block);
     Type* getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
+    Type* getLlvmTypeForParameterType(CORINFO_CLASS_HANDLE classHnd);
     Type* getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle);
     Type* getLLVMTypeForVarType(var_types type);
     int getLocalOffsetAtIndex(GenTreeLclVar* lclVar);


### PR DESCRIPTION
This PR adds support for LLVM signatures where an argument is a pointer to a struct (or any level of **..struct)

I've copied the algorithm at https://github.com/dotnet/runtimelab/blob/d623b2be57be73364ecf853a0fa31e7e9582b4ee/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs#L1242-L1269 where it recurses to get the type so I added 2 callbacks in order to do that.  The existing `getArgType` in `CorInfoImpl` does not return the class handle for parameterized types so rather than modify it I created another method.  I did that because up till now we've not modified
`CorInfoImpl` and adding callbacks is one way to see the changes required for LLVM.

This also highlighted a deficiency in the phi args, when the arg is an argument passed on the LLVM stack (and there is no `d:1` local for it), so there's a fix for that.

Also copied the workaround for `GetRandomBytes`  .  I don't really want to bake into the build a dependency on javascript libraries (which is how mono does this) as it would stop the compiler being able to generate pure Wasm builds, for other hosts, wasmer/wasmtime etc.  Long term this problem could perhaps be solved with an interface using the WebAssembly component ABI which could be fulfilled by either javascript, or a Wasm module.