### PR TITLE
[NativeAOT-LLVM] Upgrade emscripten and workaround cache lock problem

### DIFF
--- a/eng/native/gen-buildsys.cmd
+++ b/eng/native/gen-buildsys.cmd
@@ -84,6 +84,10 @@ if not "%__ConfigureOnly%" == "1" (
 )
 
 if /i "%__UseEmcmake%" == "1" (
+    REM workaround for https://github.com/emscripten-core/emscripten/issues/15440 - emscripten cache lock problems
+    REM build the ports for ICU and ZLIB upfront
+    embuilder build icu zlib
+
     REM Add call in front of emcmake as for some not understood reason, perhaps to do with scopes, by calling emcmake (or any batch script),
     REM delayed expansion is getting turned off. TODO: remove this and see if CI is ok and hence its just my machine.
     call emcmake "%CMakePath%" %__ExtraCmakeParams% --no-warn-unused-cli -G "%__CmakeGenerator%" -B %__IntermediatesDir% -S %__SourceDir% 

--- a/eng/pipelines/runtimelab/install-emscripten.cmd
+++ b/eng/pipelines/runtimelab/install-emscripten.cmd
@@ -5,8 +5,8 @@ git clone https://github.com/emscripten-core/emsdk.git
 
 cd emsdk
 rem Checkout a known good version to avoid a random break when emscripten changes the top of tree.
-
 git checkout 044d620
+
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 
 call python emsdk.py install 2.0.33

--- a/eng/pipelines/runtimelab/install-emscripten.cmd
+++ b/eng/pipelines/runtimelab/install-emscripten.cmd
@@ -5,13 +5,13 @@ git clone https://github.com/emscripten-core/emsdk.git
 
 cd emsdk
 rem Checkout a known good version to avoid a random break when emscripten changes the top of tree.
-git checkout 5ad9d72
 
+git checkout 044d620
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 
-call python emsdk.py install 2.0.12
+call python emsdk.py install 2.0.33
 if %errorlevel% NEQ 0 goto fail
-call emsdk activate 2.0.12
+call emsdk activate 2.0.33
 if %errorlevel% NEQ 0 goto fail
 
 rem We key off of this variable in the common/build.ps1 script.

--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -18,6 +18,8 @@ if(CLR_CMAKE_TARGET_UNIX)
         # add ICU support to emscripten and workaround https://github.com/emscripten-core/emscripten/issues/9302
         # ucol_setVariableTop is deprecated so disable warnings
         # emscripten ICU source has __xxxx variables so suppress reserved identifiers.
+        # TODO-LLVM: remove these suppresession when https://github.com/dotnet/runtime/commit/2265a61565e20fc26ca8ec0632eb14268b99158e is merged
+        # and when emscripten ICU is updated.
         add_compile_options(-s USE_ICU=1 -I$ENV{EMSDK}/upstream/emscripten/cache/ports/icu/icu/source/i18n -Wno-deprecated-declarations -Wno-reserved-identifier -Wno-unused-but-set-variable)
     elseif (NOT CLR_CMAKE_TARGET_ANDROID)
         if (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST)

--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CLR_CMAKE_TARGET_UNIX)
         # add ICU support to emscripten and workaround https://github.com/emscripten-core/emscripten/issues/9302
         # ucol_setVariableTop is deprecated so disable warnings
         # emscripten ICU source has __xxxx variables so suppress reserved identifiers.
-        add_compile_options(-s USE_ICU=1 -I$ENV{EMSDK}/upstream/emscripten/cache/ports/icu/icu/source/i18n -Wno-deprecated-declarations -Wno-reserved-identifier)
+        add_compile_options(-s USE_ICU=1 -I$ENV{EMSDK}/upstream/emscripten/cache/ports/icu/icu/source/i18n -Wno-deprecated-declarations -Wno-reserved-identifier -Wno-unused-but-set-variable)
     elseif (NOT CLR_CMAKE_TARGET_ANDROID)
         if (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST)
             execute_process(COMMAND  brew --prefix OUTPUT_VARIABLE brew_prefix OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -15,7 +15,6 @@ if(CLR_CMAKE_TARGET_UNIX)
 
     if (CLR_CMAKE_TARGET_UNIX_WASM)
         message("including ICU")
-
         # add ICU support to emscripten and workaround https://github.com/emscripten-core/emscripten/issues/9302
         # ucol_setVariableTop is deprecated so disable warnings
         # emscripten ICU source has __xxxx variables so suppress reserved identifiers.

--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -16,11 +16,10 @@ if(CLR_CMAKE_TARGET_UNIX)
     if (CLR_CMAKE_TARGET_UNIX_WASM)
         message("including ICU")
 
-        add_compile_options(-Wno-reserved-identifier)
-
         # add ICU support to emscripten and workaround https://github.com/emscripten-core/emscripten/issues/9302
         # ucol_setVariableTop is deprecated so disable warnings
-        add_compile_options(-s USE_ICU=1 -I$ENV{EMSDK}/upstream/emscripten/cache/ports/icu/icu/source/i18n -Wno-deprecated-declarations)
+        # emscripten ICU source has __xxxx variables so suppress reserved identifiers.
+        add_compile_options(-s USE_ICU=1 -I$ENV{EMSDK}/upstream/emscripten/cache/ports/icu/icu/source/i18n -Wno-deprecated-declarations -Wno-reserved-identifier)
     elseif (NOT CLR_CMAKE_TARGET_ANDROID)
         if (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_MACCATALYST)
             execute_process(COMMAND  brew --prefix OUTPUT_VARIABLE brew_prefix OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -15,6 +15,9 @@ if(CLR_CMAKE_TARGET_UNIX)
 
     if (CLR_CMAKE_TARGET_UNIX_WASM)
         message("including ICU")
+
+        add_compile_options(-Wno-reserved-identifier)
+
         # add ICU support to emscripten and workaround https://github.com/emscripten-core/emscripten/issues/9302
         # ucol_setVariableTop is deprecated so disable warnings
         add_compile_options(-s USE_ICU=1 -I$ENV{EMSDK}/upstream/emscripten/cache/ports/icu/icu/source/i18n -Wno-deprecated-declarations)

--- a/src/libraries/Native/Unix/System.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Native/CMakeLists.txt
@@ -14,6 +14,10 @@ if (CLR_CMAKE_TARGET_OSX)
     add_definitions(-D_DARWIN_C_SOURCE)
 endif ()
 
+if (CLR_CMAKE_TARGET_UNIX_WASM)
+    add_compile_options(-Wno-unused-but-set-variable)
+endif ()
+
 include_directories("${CLR_SRC_NATIVE_DIR}/common")
 
 set(NATIVE_SOURCES

--- a/src/libraries/Native/Unix/System.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Native/CMakeLists.txt
@@ -14,6 +14,7 @@ if (CLR_CMAKE_TARGET_OSX)
     add_definitions(-D_DARWIN_C_SOURCE)
 endif ()
 
+# TODO-LLVM: remove when https://github.com/dotnet/runtime/commit/2265a61565e20fc26ca8ec0632eb14268b99158e is merged
 if (CLR_CMAKE_TARGET_UNIX_WASM)
     add_compile_options(-Wno-unused-but-set-variable)
 endif ()


### PR DESCRIPTION
This PR upgrades the Emscripten version and puts a workaround for the cache lock problem we've been experiencing.  I've not got to the bottom of the underlying reason, but the workaround seems ok locally (and it was failing locally before).  

Workaround is to build the Emscripten ports for ICU and zlib upfront.  These builds are cached, so it does not incur extra build work.

https://github.com/emscripten-core/emscripten/issues/15440

Also suppress warning for __x variables as latest clang defines them as reserved identifiers.
