### PR TITLE
[NativeAOT-LLVM] Support for more unary and binary ops

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1213,7 +1213,6 @@ void Llvm::fillPhis()
                 localPhiArg = iter->second;
             }
 
-
             Value* phiRealArgValue;
             llvm::Instruction* castRequired = getCast(localPhiArg, llvmPhiNode->getType());
             if (castRequired != nullptr)

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -828,6 +828,27 @@ llvm::Value* Llvm::getShadowStackForCallee()
     return offset == 0 ? _function->getArg(0) : _builder.CreateGEP(_function->getArg(0), _builder.getInt32(offset));
 }
 
+//------------------------------------------------------------------------
+// consumeValue: Get the Value* "node" produces when consumed as "targetLlvmType".
+//
+// During codegen, we follow the "normalize on demand" convention, i. e.
+// the IR nodes produce "raw" values that have exactly the types of nodes,
+// preserving small types, pointers, etc. However, the user in the IR
+// consumes "actual" types, and this is the method where we normalize
+// to those types. We could have followed the reverse convention and
+// normalized on production of "Value*"s, but we presume the "on demand"
+// convention is more efficient LLVM-IR-size-wise. It allows us to avoid
+// situations where we'd be upcasting only to immediately truncate, which
+// would be the case for small typed arguments and relops feeding jumps,
+// to name a few examples.
+//
+// Arguments:
+//    node           - the node for which to obtain the normalized value of
+//    targetLlvmType - the LLVM type through which the user uses "node"
+//
+// Return Value:
+//    The normalized value, of "targetLlvmType" type.
+//
 Value* Llvm::consumeValue(GenTree* node, Type* targetLlvmType)
 {
     Value* nodeValue = getGenTreeValue(node);

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1371,7 +1371,8 @@ void Llvm::buildShift(GenTreeOp* node)
     Type*  llvmTargetType = getLlvmTypeForVarType(node->TypeGet());
     Value* numBitsToShift = consumeValue(node->gtOp2, getLlvmTypeForVarType(node->gtOp2->TypeGet()));
 
-    // the LLVM docs say that both operands must be the same type and a compilation failure results if this is not the case.
+    // LLVM requires the operands be the same type as the shift itself.
+    // Shift counts are assumed to never be negative, so we zero extend.
     if (numBitsToShift->getType()->getPrimitiveSizeInBits() < llvmTargetType->getPrimitiveSizeInBits())
     {
         numBitsToShift = _builder.CreateZExt(numBitsToShift, llvmTargetType);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -124,7 +124,7 @@ private:
     void buildAdd(GenTree* node, Value* op1, Value* op2);
     void buildCall(GenTree* node);
     void buildCast(GenTreeCast* cast);
-    void buildCmp(genTreeOps op, GenTree* node, Value* op1, Value* op2);
+    void buildCmp(GenTree* node, Value* op1, Value* op2);
     void buildCnsDouble(GenTreeDblCon* node);
     void buildCnsInt(GenTree* node);
     void buildHelperFuncCall(GenTreeCall* call);
@@ -132,9 +132,9 @@ private:
     void buildInd(GenTree* node, Value* ptr);
     Value* buildJTrue(GenTree* node, Value* opValue);
     void buildEmptyPhi(GenTreePhi* phi);
-    void buildUnaryOperation(genTreeOps oper, GenTree* node, Value* op1);
-    void buildBinaryOperation(genTreeOps oper, GenTree* node, Value* op1, Value* op2);
-    void buildShift(genTreeOps oper, GenTree* node, Value* op1, Value* op2);
+    void buildUnaryOperation(GenTree* node, Value* op1);
+    void buildBinaryOperation(GenTree* node);
+    void buildShift(GenTreeOp* node);
     void buildReturn(GenTree* node);
     void buildReturnRef(GenTreeOp* node);
     Value* buildUserFuncCall(GenTreeCall* call);
@@ -143,6 +143,7 @@ private:
     void castingStore(Value* toStore, Value* address, llvm::Type* llvmType);
     void castingStore(Value* toStore, Value* address, var_types type);
     Value* castToPointerToLlvmType(Value* address, llvm::Type* llvmType);
+    Value* consumeValue(GenTree* node, llvm::Type* targetLlvmType);
     llvm::DILocation* createDebugFunctionAndDiLocation(struct DebugMetadata debugMetadata, unsigned int lineNo);
     void ConvertShadowStackLocalNode(GenTreeLclVarCommon* node);
     void emitDoNothingCall();

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -132,7 +132,7 @@ private:
     void buildInd(GenTree* node, Value* ptr);
     Value* buildJTrue(GenTree* node, Value* opValue);
     void buildEmptyPhi(GenTreePhi* phi);
-    void buildUnaryOperation(GenTree* node, Value* op1);
+    void buildUnaryOperation(GenTree* node);
     void buildBinaryOperation(GenTree* node);
     void buildShift(GenTreeOp* node);
     void buildReturn(GenTree* node);
@@ -169,7 +169,6 @@ private:
     Value* getSsaLocalForPhi(unsigned lclNum, unsigned ssaNum);
     Value* getShadowStackOffest(Value* shadowStack, unsigned int offset);
     unsigned int getTotalRealLocalOffset();
-    Value* genTreeAsLlvmType(GenTree* tree, Type* type);
     unsigned getElementSize(CORINFO_CLASS_HANDLE fieldClassHandle, CorInfoType corInfoType);
     unsigned int getTotalLocalOffset();
     bool helperRequiresShadowStack(CORINFO_METHOD_HANDLE corinfoMethodHnd);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -132,6 +132,9 @@ private:
     void buildInd(GenTree* node, Value* ptr);
     Value* buildJTrue(GenTree* node, Value* opValue);
     void buildEmptyPhi(GenTreePhi* phi);
+    void buildUnaryOperation(genTreeOps oper, GenTree* node, Value* op1);
+    void buildBinaryOperation(genTreeOps oper, GenTree* node, Value* op1, Value* op2);
+    void buildShift(genTreeOps oper, GenTree* node, Value* op1, Value* op2);
     void buildReturn(GenTree* node);
     void buildReturnRef(GenTreeOp* node);
     Value* buildUserFuncCall(GenTreeCall* call);

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -619,13 +619,21 @@ void SsaBuilder::InsertPhiToRationalIRForm(BasicBlock* block, unsigned lclNum)
 void SsaBuilder::AddPhiArg(
     BasicBlock* block, Statement* stmt, GenTreePhi* phi, unsigned lclNum, unsigned ssaNum, BasicBlock* pred)
 {
-#if defined(DEBUG) && !defined(TARGET_WASM)
-    // Make sure it isn't already present: we should only add each definition once.
-    // Except for Wasm/LLVM where every predecessor must have its own phi arg
-    for (GenTreePhi::Use& use : phi->Uses())
+#if DEBUG
+#if defined(TARGET_WASM)
+    // For LLVM backed, every predecessor must have its own phi arg
+    if (!block->IsLIR())
     {
-        assert(use.GetNode()->AsPhiArg()->GetSsaNum() != ssaNum);
+#endif // TARGET_WASM
+        // Make sure it isn't already present: we should only add each definition once.
+        for (GenTreePhi::Use& use : phi->Uses())
+        {
+            assert(use.GetNode()->AsPhiArg()->GetSsaNum() != ssaNum);
+        }
+#if defined(TARGET_WASM)
     }
+#endif // TARGET_WASM
+
 #endif // DEBUG
 
     var_types type = m_pCompiler->lvaGetDesc(lclNum)->TypeGet();

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -619,8 +619,9 @@ void SsaBuilder::InsertPhiToRationalIRForm(BasicBlock* block, unsigned lclNum)
 void SsaBuilder::AddPhiArg(
     BasicBlock* block, Statement* stmt, GenTreePhi* phi, unsigned lclNum, unsigned ssaNum, BasicBlock* pred)
 {
-#ifdef DEBUG
+#if defined(DEBUG) && !defined(TARGET_WASM)
     // Make sure it isn't already present: we should only add each definition once.
+    // Except for Wasm/LLVM where every predecessor must have its own phi arg
     for (GenTreePhi::Use& use : phi->Uses())
     {
         assert(use.GetNode()->AsPhiArg()->GetSsaNum() != ssaNum);
@@ -1290,19 +1291,7 @@ void SsaBuilder::AddPhiArgsToSuccessors(BasicBlock* block)
                 GenTreePhi* phi    = tree->gtGetOp1()->AsPhi();
                 unsigned    ssaNum = m_renameStack.Top(lclNum);
 
-                bool found = false;
-                for (GenTreePhi::Use& use : phi->Uses())
-                {
-                    if (use.GetNode()->AsPhiArg()->GetSsaNum() == ssaNum)
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found)
-                {
-                    AddPhiArg(succ, nullptr /* no statements in LIR form */, phi, lclNum, ssaNum, block);
-                }
+                AddPhiArg(succ, nullptr /* no statements in LIR form */, phi, lclNum, ssaNum, block);
             }
         }
         else

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1494,7 +1494,7 @@ namespace Internal.IL
                     return true;
                 }
             }
-            else if (type is PointerType)
+            else if (type is PointerType || type is FunctionPointerType)
             {
                 return true;
             }

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -383,14 +383,18 @@ internal static class Program
         return Success ? 100 : -1;
     }
 
+    class ShortAndByte { internal short aShort; internal byte aByte; }
     private static void TestDifferentSizeIntOperator()
     {
         StartTest("Logical and short and int");
 
-        short s = 1;
-        int i = 4;
+        var o = new ShortAndByte
+        {
+            aShort = 3,
+            aByte = 2,
+        };
 
-        EndTest(s & i);
+        EndTest((o.aShort & o.aByte) == 2);
     }
 
     private static void TestGC()
@@ -1175,13 +1179,13 @@ internal static class Program
         EndTest(callbackResult);
     }
 
-//    [System.Runtime.InteropServices.UnmanagedCallersOnly(EntryPoint = "CallMe")]
+    [System.Runtime.InteropServices.UnmanagedCallersOnly(EntryPoint = "CallMe")]
     private static void _CallMe(int x)
     {
-        //if (x == 123)
-        //{
-        //    callbackResult = true;
-        //}
+        if (x == 123)
+        {
+            callbackResult = true;
+        }
     }
 
     [System.Runtime.InteropServices.DllImport("*")]

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -373,12 +373,24 @@ internal static class Program
 
         TestBoolCompare();
 
+        TestDifferentSizeIntOperator();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
 
         PrintLine("Done");
         return Success ? 100 : -1;
+    }
+
+    private static void TestDifferentSizeIntOperator()
+    {
+        StartTest("Logical and short and int");
+
+        short s = 1;
+        int i = 4;
+
+        EndTest(s & i);
     }
 
     private static void TestGC()
@@ -1163,13 +1175,13 @@ internal static class Program
         EndTest(callbackResult);
     }
 
-    [System.Runtime.InteropServices.UnmanagedCallersOnly(EntryPoint = "CallMe")]
+//    [System.Runtime.InteropServices.UnmanagedCallersOnly(EntryPoint = "CallMe")]
     private static void _CallMe(int x)
     {
-        if (x == 123)
-        {
-            callbackResult = true;
-        }
+        //if (x == 123)
+        //{
+        //    callbackResult = true;
+        //}
     }
 
     [System.Runtime.InteropServices.DllImport("*")]


### PR DESCRIPTION
This PR adds support in the RyuJIT ->LLVM backend for some more unary ops (NEG and NOT) and some binary ops, shifts and logical ops.

Closes #1731