### PR TITLE
Generate better warnings for generic recursion

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -175,6 +175,11 @@ namespace ILCompiler
         {
             _genericCycleDetector.DetectCycle(owner, referent);
         }
+
+        public void LogWarnings(Logger logger)
+        {
+            _genericCycleDetector.LogWarnings(logger);
+        }
     }
 
     public class SharedGenericsConfiguration

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -3131,6 +3131,7 @@ namespace ILCompiler.Dataflow
                 public const string IL9700 = "Calling '{0}' which has `RequiresDynamicCodeAttribute` can break functionality when compiled fully ahead of time.";
                 // IL9701 - COM
                 // IL9702 - AOT analysis warnings
+                // IL9703 - Generic cycle
             }
         }
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
@@ -236,9 +236,10 @@ namespace ILCompiler
                         continue;
 
                     string message = $"Generic expansion to '{actualProblem.Key.Referent.GetDisplayName()}' was aborted " +
-                        "due to generic recursion. Generic recursion negatively affects compilation speed and the size " +
-                        "of the compilation output. It is advisable to remove the source of the generic recursion by restructuring " +
-                        "the program around the source of recursion. The source of generic recursion might include: ";
+                        "due to generic recursion. An exception will be thrown at runtime if this codepath is ever reached. " +
+                        "Generic recursion also negatively affects compilation speed and the size of the compilation output. " +
+                        "It is advisable to remove the source of the generic recursion by restructuring the program around " +
+                        "the source of recursion. The source of generic recursion might include: ";
 
                     ModuleCycleInfo cycleInfo = actualProblem.Value;
                     bool first = true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LazyGenerics/ModuleCycleInfo.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
@@ -15,6 +17,8 @@ namespace ILCompiler
         private class ModuleCycleInfo
         {
             private readonly HashSet<TypeSystemEntity> _entitiesInCycles;
+
+            public IEnumerable<TypeSystemEntity> EntitiesInCycles => _entitiesInCycles;
 
             public EcmaModule Module { get; }
 
@@ -146,6 +150,23 @@ namespace ILCompiler
         {
             private readonly CycleInfoHashtable _hashtable = new CycleInfoHashtable();
 
+            private readonly struct EntityPair : IEquatable<EntityPair>
+            {
+                public readonly TypeSystemEntity Owner;
+                public readonly TypeSystemEntity Referent;
+                public EntityPair(TypeSystemEntity owner, TypeSystemEntity referent)
+                    => (Owner, Referent) = (owner, referent);
+                public bool Equals(EntityPair other) => Owner == other.Owner && Referent == other.Referent;
+                public override bool Equals(object obj) => obj is EntityPair p && Equals(p);
+                public override int GetHashCode() => HashCode.Combine(Owner.GetHashCode(), Referent.GetHashCode());
+            }
+
+            // This is a set of entities that had actual problems that caused us to abort compilation
+            // somewhere.
+            // Would prefer this to be a ConcurrentHashSet but there isn't any. ModuleCycleInfo can be looked up
+            // from the key, but since this is a key/value pair, might as well use the value too...
+            private readonly ConcurrentDictionary<EntityPair, ModuleCycleInfo> _actualProblems = new ConcurrentDictionary<EntityPair, ModuleCycleInfo>();
+
             public void DetectCycle(TypeSystemEntity owner, TypeSystemEntity referent)
             {
                 // Not clear if generic recursion through fields is a thing
@@ -177,6 +198,8 @@ namespace ILCompiler
                     // we need to cut our losses.
                     if (cycleInfo.IsDeepPossiblyCyclicInstantiation(referent))
                     {
+                        _actualProblems.TryAdd(new EntityPair(owner, referent), cycleInfo);
+
                         if (referentType != null)
                         {
                             // TODO: better exception string ID?
@@ -188,6 +211,48 @@ namespace ILCompiler
                             ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadGeneral, referentMethod);
                         }
                     }
+                }
+            }
+
+            public void LogWarnings(Logger logger)
+            {
+                var problems = new List<KeyValuePair<EntityPair, ModuleCycleInfo>>(_actualProblems);
+
+                // Might need to sort these if we care about warning determinism, but we probably don't.
+
+                var reportedProblems = new HashSet<EntityPair>();
+
+                foreach (var actualProblem in _actualProblems)
+                {
+                    TypeSystemEntity referent = actualProblem.Key.Referent;
+                    TypeSystemEntity owner = actualProblem.Key.Owner;
+
+                    TypeSystemEntity referentDefinition = referent is TypeDesc referentType ? referentType.GetTypeDefinition()
+                        : ((MethodDesc)referent).GetTypicalMethodDefinition();
+                    TypeSystemEntity ownerDefinition = owner is TypeDesc ownerType ? ownerType.GetTypeDefinition()
+                        : ((MethodDesc)owner).GetTypicalMethodDefinition();
+
+                    if (!reportedProblems.Add(new EntityPair(ownerDefinition, referentDefinition)))
+                        continue;
+
+                    string message = $"Generic expansion to '{actualProblem.Key.Referent.GetDisplayName()}' was aborted " +
+                        "due to generic recursion. Generic recursion negatively affects compilation speed and the size " +
+                        "of the compilation output. It is advisable to remove the source of the generic recursion by restructuring " +
+                        "the program around the source of recursion. The source of generic recursion might include: ";
+
+                    ModuleCycleInfo cycleInfo = actualProblem.Value;
+                    bool first = true;
+                    foreach (TypeSystemEntity cycleEntity in cycleInfo.EntitiesInCycles)
+                    {
+                        if (!first)
+                            message += ", ";
+
+                        first = false;
+
+                        message += $"'{cycleEntity.GetDisplayName()}'";
+                    }
+
+                    logger.LogWarning(message, 9703, actualProblem.Key.Owner, MessageSubCategory.AotAnalysis);
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -813,6 +813,8 @@ namespace ILCompiler
                 defFileWriter.EmitExportedMethods();
             }
 
+            typeSystemContext.LogWarnings(logger);
+
             if (_dgmlLogFileName != null)
                 compilationResults.WriteDependencyLog(_dgmlLogFileName);
 


### PR DESCRIPTION
This generates more warnings than I would want to, but I couldn't come up with a scheme that would be more succinct. E.g. for NPGSQL:

```
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<System.ValueTuple`2<System.Net.IPAddress,int32>>>>>[]>[]>: Generic expansion to 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>>>>[]>[]>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlTsVector>>[]>>[]>: Generic expansion to 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTsVector>>[]>>[]>[]>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>>>[]>.ReadMultirangeArray<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>>>[]>(NpgsqlReadBuffer,Int32,Boolean,FieldDescription): Generic expansion to 'System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>>>[]>[]>.Start<<ReadMultirangeArray>d__5`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>>>[],NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>>>[]>>(<ReadMultirangeArray>d__5`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>>>[],NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>>>[]>&)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlBox>[]>>>>: Generic expansion to 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler.WriteWithLength<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlBox>[]>>>>>(NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlBox>[]>>>>,NpgsqlWriteBuffer,NpgsqlLengthCache,NpgsqlParameter,Boolean,CancellationToken)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<string>>[]>>>[]>: Generic expansion to 'Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<String>>[]>>>[]>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlLine>[]>>[]>>.ValidateAndGetLengthRange<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlLine>[]>>[]>>(NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlLine>[]>>[]>>,NpgsqlLengthCache&,NpgsqlParameter): Generic expansion to 'NpgsqlTypes.NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlLine>[]>>[]>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlPath>[]>[]>[]>[]>: Generic expansion to 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler.WriteWithLength<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlPath>[]>[]>[]>[]>[]>(NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlPath>[]>[]>[]>[]>[],NpgsqlWriteBuffer,NpgsqlLengthCache,NpgsqlParameter,Boolean,CancellationToken)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTid>>[]>[]>>.ReadRange<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTid>>[]>[]>>(NpgsqlReadBuffer,Int32,Boolean,FieldDescription): Generic expansion to 'System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTid>>[]>[]>>>.Start<<ReadRange>d__9`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTid>>[]>[]>,NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTid>>[]>[]>>>(<ReadRange>d__9`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTid>>[]>[]>,NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTid>>[]>[]>>&)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>[]>[]>>[]>.ReadMultirangeList<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>[]>[]>>[]>(NpgsqlReadBuffer,Int32,Boolean,FieldDescription): Generic expansion to 'System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<List`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>[]>[]>>[]>>>.Start<<ReadMultirangeList>d__7`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>[]>[]>>[],NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>[]>[]>>[]>>(<ReadMultirangeList>d__7`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>[]>[]>>[],NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>[]>[]>>[]>&)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlBox>>[]>[]>>: Generic expansion to 'System.Collections.Generic.List`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlBox>>[]>[]>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.RangeHandler`1+<WriteRange>d__13`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<System.DateTimeOffset>[]>[]>>[],NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<System.DateTimeOffset>[]>[]>>[]>: Generic expansion to 'NpgsqlTypes.NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DateTimeOffset>[]>[]>>[]>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<IPAddress>[]>>>>.ReadMultirangeList<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<IPAddress>[]>>>>(NpgsqlReadBuffer,Int32,Boolean,FieldDescription): Generic expansion to 'System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<List`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<IPAddress>[]>>>>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlPath>>[]>[]>>.ReadMultirangeArray<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlPath>>[]>[]>>(NpgsqlReadBuffer,Int32,Boolean,FieldDescription): Generic expansion to 'System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlPath>>[]>[]>>[]>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.MultirangeHandler`1+<WriteMultirange>d__13`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<System.DBNull>>[]>[]>[],NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<System.DBNull>>[]>[]>[]>: Generic expansion to 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler.WriteWithLength<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>[]>[]>[]>>(NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<DBNull>>[]>[]>[]>,NpgsqlWriteBuffer,NpgsqlLengthCache,NpgsqlParameter,Boolean,CancellationToken)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlTsQuery>>[]>>>[]>: Generic expansion to 'Npgsql.Internal.TypeHandlers.ArrayHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTsQuery>>[]>>>[]>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>>[]>[]>>.ReadRange<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>>[]>[]>>(NpgsqlReadBuffer,Int32,Boolean,FieldDescription): Generic expansion to 'System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<IPAddress,Int32>>>[]>[]>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<System.Collections.Generic.Dictionary`2<string,string>>>[]>[]>[]>[]>: Generic expansion to 'System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<Object>.Start<<ReadAsObject>d__2<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<Dictionary`2<String,String>>>[]>[]>[]>[]>>(<ReadAsObject>d__2<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<Dictionary`2<String,String>>>[]>[]>[]>[]>&)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTsQuery>[]>[]>[]>>.ValidateAndGetLengthMultirange<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTsQuery>[]>[]>[]>>(IList`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTsQuery>[]>[]>[]>>>,NpgsqlLengthCache&,NpgsqlParameter): Generic expansion to 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler.ValidateAndGetLength<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTsQuery>[]>[]>[]>>>(NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlTsQuery>[]>[]>[]>>,NpgsqlLengthCache&,NpgsqlParameter)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<char>>[]>[]>>: Generic expansion to 'NpgsqlTypes.NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<Char>>[]>[]>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<System.TimeSpan>>[]>[]>[]>: Generic expansion to 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<TimeSpan>>[]>[]>[]>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: [Npgsql]Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<NpgsqlTypes.NpgsqlRange`1<object[]>[]>>[]>>: Generic expansion to 'Npgsql.Internal.TypeHandlers.ArrayHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<Object[]>[]>>[]>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>.ValidateAndGetLengthMultirange<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>(IList`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>>,NpgsqlLengthCache&,NpgsqlParameter): Generic expansion to 'System.Collections.Generic.ICollection`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>>.get_Count()' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>>.ReadAsObject(NpgsqlReadBuffer,Int32,Boolean,FieldDescription): Generic expansion to 'System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1<Object>.Start<<ReadAsObject>d__2<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>>>(<ReadAsObject>d__2<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>>&)' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>(PostgresMultirangeType,RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>): Generic expansion to 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>[]>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>>>.CreateMultirangeHandler(PostgresMultirangeType): Generic expansion to 'Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>,NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>>.MoveNext(): Generic expansion to 'System.Collections.Generic.ICollection`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>>>.get_Count()' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>.ValidateObjectAndGetLength(Object,NpgsqlLengthCache&,NpgsqlParameter): Generic expansion to 'NpgsqlTypes.NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>.WriteObjectWithLength(Object,NpgsqlWriteBuffer,NpgsqlLengthCache,NpgsqlParameter,Boolean,CancellationToken): Generic expansion to 'NpgsqlTypes.NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>>.GetFieldType(FieldDescription): Generic expansion to 'NpgsqlTypes.NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>.ValidateObjectAndGetLength(Object,NpgsqlLengthCache&,NpgsqlParameter): Generic expansion to 'System.Collections.Generic.List`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.MultirangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>>.WriteObjectWithLength(Object,NpgsqlWriteBuffer,NpgsqlLengthCache,NpgsqlParameter,Boolean,CancellationToken): Generic expansion to 'System.Collections.Generic.List`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<ValueTuple`2<__Canon,Int32>>>>>>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
ILC: AOT analysis warning IL1234: Npgsql.Internal.TypeHandlers.RangeHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>.CreateArrayHandler(PostgresArrayType,ArrayNullabilityMode): Generic expansion to 'Npgsql.Internal.TypeHandlers.ArrayHandler`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<NpgsqlRange`1<__Canon>>>>>>>' was aborted due to generic recursion. Generic recursion negatively affects compilation speed and the size of the compilation output. It is advisable to remove the source of the generic recursion by restructuring the program around the source of recursion. The source of generic recursion might include: 'Npgsql.Internal.TypeHandling.NpgsqlTypeHandler`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeArray>d__5`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<ReadMultirangeList>d__7`1', 'Npgsql.Internal.TypeHandlers.MultirangeHandler`1.<WriteMultirange>d__13`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<ReadRange>d__9`1', 'Npgsql.Internal.TypeHandlers.RangeHandler`1.<WriteRange>d__13`1'
```