### PR TITLE
Improve failure mode of recursive generic lookups

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -28,6 +28,11 @@ namespace Internal.Runtime.CompilerHelpers
             throw new NotSupportedException(SR.NotSupported_InstanceBodyRemoved);
         }
 
+        internal static void ThrowUnavailableType()
+        {
+            throw new TypeLoadException(SR.Arg_UnavailableTypeLoadException);
+        }
+
         public static void ThrowOverflowException()
         {
             throw new OverflowException();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
@@ -198,6 +198,9 @@
   <data name="Arg_DecBitCtor" xml:space="preserve">
     <value>Decimal byte array constructor requires an array of length four containing valid decimal bytes.</value>
   </data>
+  <data name="Arg_UnavailableTypeLoadException" xml:space="preserve">
+    <value>Attempted to load a type that couldn't be loaded during ahead of time compilation.</value>
+  </data>
   <data name="Arg_DivideByZero" xml:space="preserve">
     <value>Attempted to divide by zero.</value>
   </data>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Resources/Strings.resx
@@ -199,7 +199,7 @@
     <value>Decimal byte array constructor requires an array of length four containing valid decimal bytes.</value>
   </data>
   <data name="Arg_UnavailableTypeLoadException" xml:space="preserve">
-    <value>Attempted to load a type that couldn't be loaded during ahead of time compilation.</value>
+    <value>Attempted to load a type that was not created during ahead of time compilation.</value>
   </data>
   <data name="Arg_DivideByZero" xml:space="preserve">
     <value>Attempted to divide by zero.</value>

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X64/X64Emitter.cs
@@ -174,6 +174,12 @@ namespace ILCompiler.DependencyAnalysis.X64
             Builder.EmitByte(0xC3);
         }
 
+        public void EmitCompareToZero(Register reg)
+        {
+            AddrMode rexAddrMode = new AddrMode(Register.RegDirect | reg, null, 0, 0, AddrModeSize.Int64);
+            EmitIndirInstructionSize(0x84, reg, ref rexAddrMode);
+        }
+
         public void EmitZeroReg(Register reg)
         {
             // High 32 bits get cleared automatically when using 32bit registers

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Internal.IL;
 using Internal.Text;
 using Internal.TypeSystem;
 
@@ -14,15 +15,27 @@ namespace ILCompiler.DependencyAnalysis
 {
     public abstract partial class ReadyToRunGenericHelperNode : AssemblyStubNode, INodeWithRuntimeDeterminedDependencies
     {
-        private ReadyToRunHelperId _id;
-        private object _target;
-        protected TypeSystemEntity _dictionaryOwner;
-        protected GenericLookupResult _lookupSignature;
+        private readonly ReadyToRunHelperId _id;
+        private readonly object _target;
+        protected readonly TypeSystemEntity _dictionaryOwner;
+        protected readonly GenericLookupResult _lookupSignature;
+
+        // True if any of slots in dictionaries associated with this layout could not be filled
+        // at compile time due to a TypeSystemException. Only query through HandlesInvalidEntries
+        // below so that we can assert this is not queried at an inappropriate time before
+        // the whole program view has been established.
+        private bool _hasInvalidEntries;
 
         public ReadyToRunHelperId Id => _id;
         public Object Target => _target;
         public TypeSystemEntity DictionaryOwner => _dictionaryOwner;
         public GenericLookupResult LookupSignature => _lookupSignature;
+
+        public bool HandlesInvalidEntries(NodeFactory factory)
+        {
+            Debug.Assert(factory.MarkingComplete);
+            return _hasInvalidEntries;
+        }
 
         public ReadyToRunGenericHelperNode(NodeFactory factory, ReadyToRunHelperId helperId, object target, TypeSystemEntity dictionaryOwner)
         {
@@ -152,12 +165,19 @@ namespace ILCompiler.DependencyAnalysis
             }
             catch (TypeSystemException)
             {
-                // TODO: we need to mark this ReadyToRun helper as "injured". We're now in a situation
-                // when a runtime lookup could produce an error result. The helper should check for that
-                // situation and throw exception if result of the lookup produces an injured result.
+                // If there was an exception, we're going to generate a null slot in the associated
+                // dictionary. The helper needs to be able to handle a null slot and tailcall
+                // and exception throwing helper instead of returning a result.
+                _hasInvalidEntries = true;
+                result.Add(GetBadSlotHelper(factory), "Failure to build dictionary slot");
             }
 
             return result.ToArray();
+        }
+
+        private static IMethodNode GetBadSlotHelper(NodeFactory factory)
+        {
+            return factory.MethodEntrypoint(factory.TypeSystemContext.GetHelperEntryPoint("ThrowHelpers", "ThrowUnavailableType"));
         }
 
         protected void AppendLookupSignatureMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunGenericHelperNode.cs
@@ -38,6 +38,17 @@ namespace ILCompiler.DependencyAnalysis
                 context, null, dictionarySlot * factory.Target.PointerSize, 0, AddrModeSize.Int64);
             encoder.EmitMOV(result, ref loadEntry);
 
+            // If there's any invalid entries, we need to test for them
+            //
+            // Only do this in relocsOnly to make it easier to weed out bugs - the _hasInvalidEntries
+            // flag can change over the course of compilation and the bad slot helper dependency
+            // should be reported by someone else - the system should not rely on it coming from here.
+            if (!relocsOnly && _hasInvalidEntries)
+            {
+                encoder.EmitCompareToZero(result);
+                encoder.EmitJE(GetBadSlotHelper(factory));
+            }
+
             switch (lookup.LookupResultReferenceType(factory))
             {
                 case GenericLookupResultReferenceType.Indirect:

--- a/src/tests/nativeaot/SmokeTests/Generics/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/Generics/Generics.cs
@@ -3027,21 +3027,25 @@ class Program
             RecurseOverStruct<int>(2);
             RecurseOverClass<int>(2);
 
+            bool caughtException = false;
             try
             {
                 RecurseOverStruct<int>(100);
             }
-            catch (Exception) { }
+            catch (TypeLoadException) { caughtException = true; }
 
-            // Doesn't currently work in Debug builds because we end up hitting a NullRef
-            // during a dictionary lookup and the runtime cannot deal with that.
-#if false
+            if (!caughtException)
+                throw new Exception();
+
+            caughtException = false;
             try
             {
                 RecurseOverClass<int>(100);
             }
-            catch (Exception) { }
-#endif
+            catch (TypeLoadException) { caughtException = true; }
+
+            if (!caughtException)
+                throw new Exception();
         }
     }
 


### PR DESCRIPTION
Throw a `TypeLoadException` instead of a wild null dereference that may or may not translate to `NullReferenceException` when generic recursion cutoff gets hit at runtime.

* Remember there was a dictionary associated with a ReadyToRun generic lookup helper that has a null slot.
* Add an extra null check to affected helpers that tailcall a throw helper.
* Remember we had to do this during scanning and make sure the same thing happens in a compilation after scanning (i.e. RyuJIT doesn't need to be aware of this because we'll just keep piping these through the ReadyToRun helper even in optimized builds).

I didn't do ARM64 because I can't test this. We'll see a failing test once we enable ARM64 testing. This is a corner situation that I'm not too worried about.