### PR TITLE
Disable fat calls in delegate invoke methods

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -20874,6 +20874,14 @@ void Compiler::impMarkInlineCandidateHelper(GenTreeCall*           call,
         return;
     }
 
+    // Delegate Invoke method doesn't have a body and gets special cased instead.
+    // Don't even bother trying to inline it.
+    if (call->IsDelegateInvoke())
+    {
+        inlineResult.NoteFatal(InlineObservation::CALLEE_HAS_NO_BODY);
+        return;
+    }
+
     // Tail recursion elimination takes precedence over inlining.
     // TODO: We may want to do some of the additional checks from fgMorphCall
     // here to reduce the chance we don't inline a call that won't be optimized

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -412,9 +412,18 @@ namespace ILCompiler
             if ((signature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) != 0)
                 return false;
 
-            // Everything else except RawCalliHelpers could be a fat pointer
-            var owningType = containingMethod.OwningType as MetadataType;
-            return owningType?.Name != "RawCalliHelper";
+            if (containingMethod.OwningType is MetadataType owningType)
+            {
+                // RawCalliHelper is a way for the class library to opt out of fat calls
+                if (owningType.Name == "RawCalliHelper")
+                    return false;
+
+                // Delegate invocation never needs fat calls
+                if (owningType.IsDelegate && containingMethod.Name == "Invoke")
+                    return false;
+            }
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
The calli in delegate invoke is never a fat call. We generate a method body for delegate `Invoke` because reflection and some other corner cases (like creating a delegate to a delegate invoke method) might end up using it.

It's not supposed to be used by RyuJIT since RyuJIT special cases delegate invoke, but in NativeAOT this special casing stopped kicking in and I'm seeing delegate invoke methods getting inlined instead. Disabling fat calls limits the damage (and helps the situations where Invoke body is legit needed). The generated code is still not ideal:

What RyuJIT generates for delegate invoke after this change:

```
00007FF7D2CE2BE7  mov         rcx,qword ptr [rbp+0A8h]
00007FF7D2CE2BEE  mov         r8,qword ptr [rbx]
00007FF7D2CE2BF1  mov         rdx,qword ptr [rcx+8]
00007FF7D2CE2BF5  mov         rax,qword ptr [rcx+20h]
00007FF7D2CE2BF9  mov         rcx,rdx
00007FF7D2CE2BFC  mov         rdx,rdi
00007FF7D2CE2BFF  call        rax
```

What RyuJIT would generate if we returned a null MethodIL for delegate like CoreCLR does:

```
00007FF6170A2857  mov         rax,qword ptr [rbp+0A8h]
00007FF6170A285E  mov         rcx,qword ptr [rax+8]
00007FF6170A2862  mov         r8,qword ptr [rbx]
00007FF6170A2865  mov         rdx,rdi
00007FF6170A2868  call        qword ptr [rax+20h]
```