### PR TITLE
[NativeAOT-LLVM] Add field to LclVarDsc to represent LLVM arg index

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -377,7 +377,12 @@ public:
     // Initialize the ArgRegs to REG_STK.
     // Morph will update if this local is passed in a register.
     LclVarDsc()
-        : _lvArgReg(REG_STK)
+        :
+#if defined(TARGET_WASM)
+        lvLlvmArgNum(BAD_LLVM_ARG_NUM)
+        ,
+#endif // TARGET_WASM
+        _lvArgReg(REG_STK)
         ,
 #if FEATURE_MULTIREG_ARGS
         _lvOtherArgReg(REG_STK)
@@ -390,7 +395,6 @@ public:
         ,
 #endif // ASSERTION_PROP
         lvPerSsaData()
-
     {
     }
 
@@ -566,6 +570,10 @@ public:
     unsigned char lvFieldCnt; //  Number of fields in the promoted VarDsc.
     unsigned char lvFldOffset;
     unsigned char lvFldOrdinal;
+
+#if defined(TARGET_WASM)
+    unsigned int lvLlvmArgNum;
+#endif
 
 #ifdef DEBUG
     unsigned char lvSingleDefDisqualifyReason = 'H';

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -395,6 +395,7 @@ public:
         ,
 #endif // ASSERTION_PROP
         lvPerSsaData()
+
     {
     }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -379,7 +379,8 @@ public:
     LclVarDsc()
         :
 #if defined(TARGET_WASM)
-        lvLlvmArgNum(BAD_LLVM_ARG_NUM)
+        lvLlvmArgNum(BAD_LLVM_ARG_NUM),
+        lvCorInfoType(CORINFO_TYPE_UNDEF)
         ,
 #endif // TARGET_WASM
         _lvArgReg(REG_STK)
@@ -574,6 +575,7 @@ public:
 
 #if defined(TARGET_WASM)
     unsigned int lvLlvmArgNum;
+    CorInfoType  lvCorInfoType;
 #endif
 
 #ifdef DEBUG

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -331,6 +331,10 @@ bool jitIsCallInstruction(IL_OFFSETX offsx);
 
 const unsigned BAD_VAR_NUM = UINT_MAX;
 
+#if defined(TARGET_WASM)
+const unsigned BAD_LLVM_ARG_NUM = UINT_MAX;
+#endif
+
 // Code can't be more than 2^31 in any direction.  This is signed, so it should be used for anything that is
 // relative to something else.
 typedef int NATIVE_OFFSET;

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -459,6 +459,7 @@ bool canStoreLocalOnLlvmStack(LclVarDsc* varDsc)
     return !varDsc->HasGCPtr();
 }
 
+//TODO-LLVM: delete this function when we lower the args, its confusing with canStoreLocalOnLlvmStack regards: is the logic exactly the same?
 bool Llvm::canStoreArgOnLlvmStack(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd)
 {
     // structs with no GC pointers can go on LLVM stack.
@@ -467,7 +468,7 @@ bool Llvm::canStoreArgOnLlvmStack(CorInfoType corInfoType, CORINFO_CLASS_HANDLE 
         // Use getClassAtribs over typGetObjLayout because EETypePtr has CORINFO_FLG_GENERIC_TYPE_VARIABLE? which fails with typGetObjLayout
         uint32_t classAttribs = _info.compCompHnd->getClassAttribs(classHnd);
 
-        return (classAttribs & CORINFO_FLG_CONTAINS_GC_PTR) == 0;
+        return (classAttribs & (CORINFO_FLG_CONTAINS_GC_PTR | CORINFO_FLG_CONTAINS_STACK_PTR)) == 0;
     }
 
     if (corInfoType == CorInfoType::CORINFO_TYPE_BYREF || corInfoType == CorInfoType::CORINFO_TYPE_CLASS ||

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -492,7 +492,7 @@ FunctionType* Llvm::getFunctionType()
 
     for (unsigned i = 0; i < _compiler->lvaTableCnt; i++)
     {
-        LclVarDsc varDsc = _compiler->lvaTable[i];
+        LclVarDsc* varDsc = _compiler->lvaGetDesc(i);
         if (varDsc.lvIsParam)
         {
             assert(varDsc.lvLlvmArgNum != BAD_LLVM_ARG_NUM);

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -490,7 +490,7 @@ FunctionType* Llvm::getFunctionType()
     std::vector<llvm::Type*> argVec(_llvmArgCount);
     llvm::Type*              retLlvmType;
 
-    for (unsigned i = 0; i < _compiler->lvaTableCnt; i++)
+    for (unsigned i = 0; i < _compiler->lvaCount; i++)
     {
         LclVarDsc* varDsc = _compiler->lvaGetDesc(i);
         if (varDsc.lvIsParam)

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -95,7 +95,6 @@ private:
     Compiler::Info _info;
     llvm::Function* _function;
     CORINFO_SIG_INFO _sigInfo; // sigInfo of function being compiled
-    bool _functionSigHasReturnAddress;
     LIR::Range* _currentRange;
     BasicBlock* _currentBlock;
     IL_OFFSETX _currentOffset;
@@ -115,12 +114,14 @@ private:
     unsigned _shadowStackLocalsSize;
     unsigned _shadowStackLclNum;
     unsigned _retAddressLclNum;
+    unsigned _llvmArgCount;
 
     inline LIR::Range& CurrentRange()
     {
         return *_currentRange;
     }
 
+    void populateLlvmArgNums();
     void buildAdd(GenTree* node, Value* op1, Value* op2);
     void buildCall(GenTree* node);
     void buildCast(GenTreeCast* cast);
@@ -148,11 +149,12 @@ private:
     void ConvertShadowStackLocalNode(GenTreeLclVarCommon* node);
     void emitDoNothingCall();
     void endImportingBasicBlock(BasicBlock* block);
-    void failFunctionCompilation();
+    [[noreturn]] void   failFunctionCompilation();
     void fillPhis();
     llvm::Instruction* getCast(llvm::Value* source, Type* targetType);
     void generateProlog();
     CorInfoType getCorInfoTypeForArg(CORINFO_SIG_INFO& sigInfo, CORINFO_ARG_LIST_HANDLE& arg, CORINFO_CLASS_HANDLE* clsHnd);
+    llvm::FunctionType* Llvm::getFunctionType();
     llvm::FunctionType* getFunctionTypeForSigInfo(CORINFO_SIG_INFO& sigInfo);
     Value* getGenTreeValue(GenTree* node);
     LlvmArgInfo getLlvmArgInfoForArgIx(CORINFO_SIG_INFO& sigInfo, unsigned int lclNum);

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1481,36 +1481,6 @@ namespace Internal.IL
             return false;
         }
 
-        // TODO-LLVM: this is a copy of some of the logic in GatherClassGCLayout so we get the same logic as clrjit for
-        // determining if a struct should be passed on the shadow stack.  Span<char/T> is an example.
-        private static bool ContainsIsByReferenceOfT(TypeDesc type)
-        {
-            if (type.IsByReferenceOfT)
-            {
-                return true;
-            }
-
-            foreach (var field in type.GetFields())
-            {
-                if (field.IsStatic)
-                    continue;
-
-                var fieldType = field.FieldType;
-                if (fieldType.IsValueType)
-                {
-                    var fieldDefType = (DefType)fieldType;
-                    if (!fieldDefType.ContainsGCPointers && !fieldDefType.IsByRefLike)
-                        continue;
-
-                    if (ContainsIsByReferenceOfT(fieldType))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
         /// <summary>
         /// Returns true if the type can be stored on the local stack
         /// instead of the shadow stack in this method.
@@ -1519,7 +1489,7 @@ namespace Internal.IL
         {
             if (type is DefType defType)
             {
-                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !ContainsIsByReferenceOfT(type))
+                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !type.IsByRefLike)
                 {
                     return true;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1481,6 +1481,36 @@ namespace Internal.IL
             return false;
         }
 
+        // TODO-LLVM: this is a copy of some of the logic in GatherClassGCLayout so we get the same logic as clrjit for
+        // determining if a struct should be passed on the shadow stack.  Span<char/T> is an example.
+        private static bool ContainsIsByReferenceOfT(TypeDesc type)
+        {
+            if (type.IsByReferenceOfT)
+            {
+                return true;
+            }
+
+            foreach (var field in type.GetFields())
+            {
+                if (field.IsStatic)
+                    continue;
+
+                var fieldType = field.FieldType;
+                if (fieldType.IsValueType)
+                {
+                    var fieldDefType = (DefType)fieldType;
+                    if (!fieldDefType.ContainsGCPointers && !fieldDefType.IsByRefLike)
+                        continue;
+
+                    if (ContainsIsByReferenceOfT(fieldType))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         /// <summary>
         /// Returns true if the type can be stored on the local stack
         /// instead of the shadow stack in this method.
@@ -1489,7 +1519,7 @@ namespace Internal.IL
         {
             if (type is DefType defType)
             {
-                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !type.IsByRefLike)
+                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !ContainsIsByReferenceOfT(type))
                 {
                     return true;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1481,6 +1481,36 @@ namespace Internal.IL
             return false;
         }
 
+        // TODO-LLVM: this is a copy of some of the logic in GatherClassGCLayout so we get the same logic as clrjit for
+        // determining if a struct should be passed on the shadow stack.  Span<char/T> is an example.
+        private static bool ContainsIsByReferenceOfT(TypeDesc type)
+        {
+            if (type.IsByReferenceOfT)
+            {
+                return true;
+            }
+
+            foreach (var field in type.GetFields())
+            {
+                if (field.IsStatic)
+                    continue;
+
+                var fieldType = field.FieldType;
+                if (fieldType.IsValueType)
+                {
+                    var fieldDefType = (DefType)fieldType;
+                    if (!fieldDefType.ContainsGCPointers && !fieldDefType.IsByRefLike)
+                        continue;
+
+                    if (ContainsIsByReferenceOfT(fieldType))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         /// <summary>
         /// Returns true if the type can be stored on the local stack
         /// instead of the shadow stack in this method.
@@ -1489,7 +1519,7 @@ namespace Internal.IL
         {
             if (type is DefType defType)
             {
-                if (!defType.IsGCPointer && !defType.ContainsGCPointers)
+                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !ContainsIsByReferenceOfT(type))
                 {
                     return true;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -128,6 +128,8 @@ namespace ILCompiler
                 if (GetMethodIL(method).GetExceptionRegions().Length == 0)
                 {
                     var sig = method.Signature;
+                    // this could be inlined, by the local makes debugging easier
+                    var mangledName = NodeFactory.NameMangler.GetMangledMethodName(method).ToString();
                     corInfo.RegisterLlvmCallbacks((IntPtr)Unsafe.AsPointer(ref corInfo), _outputFile,
                         Module.Target,
                         Module.DataLayout);
@@ -135,8 +137,7 @@ namespace ILCompiler
                     corInfo.CompileMethod(methodCodeNodeNeedingCode);
                     methodCodeNodeNeedingCode.CompilationCompleted = true;
                     // TODO: delete this external function when old module is gone
-                    LLVMValueRef externFunc = Module.AddFunction(
-                        NodeFactory.NameMangler.GetMangledMethodName(method).ToString(),
+                    LLVMValueRef externFunc = Module.AddFunction(mangledName,
                         GetLLVMSignatureForMethod(sig, method.RequiresInstArg()));
                     externFunc.Linkage = LLVMLinkage.LLVMExternalLinkage;
 


### PR DESCRIPTION
WIP

This PR adds a node to represent LLVM args.  All arguments that are passed on the LLVM stack: e.g the shadowstack, non gc tracked IL args, will be have an `ARGLLVM` node that will be created and replaced into the IR as part of lowering to LLVM.  This will simplify the codegen phase.

For https://github.com/dotnet/runtimelab/blob/a87e9dd7a2d7f50cf9f55bbb346cc52613c0cf0e/src/coreclr/nativeaot/Runtime.Base/src/System/AttributeUsageAttribute.cs#L36 it produces
```
------------ BB01 [???..???), preds={} succs={BB02}
               [000012] ------------        t12 =    ARGLLVM   int    index: 0
                                                  /--*  t12    int
               [000013] DA----------              *  STORE_LCL_VAR int    V03 tmp1         d:2

------------ BB02 [000..008) (return), preds={BB01} succs={}
               [000009] ------------                 IL_OFFSET void   IL offset: 0x0
               [000014] ------------        t14 =    CNS_INT   int    0
               [000015] ------------        t15 =    LCL_VAR   int    V03 tmp1         u:2 (last use)
                                                  /--*  t15    int
                                                  +--*  t14    int
               [000016] ------------        t16 = *  ADD       int
                                                  /--*  t16    int
N001 (  3,  2) [000001] ------------         t1 = *  IND       ref
N002 (  1,  1) [000006] ------------         t6 =    CNS_INT   int    8 field offset Fseq[_allowMultiple]
                                                  /--*  t1     ref
                                                  +--*  t6     int
N003 (  4,  3) [000007] -------N----         t7 = *  ADD       byref
N005 (  3,  2) [000002] ------------         t2 =    LCL_VAR   int    V01 arg1         u:1 (last use)
                                                  /--*  t7     byref
                                                  +--*  t2     int
               [000010] -A-XG-------              *  STOREIND  bool
               [000011] ------------                 IL_OFFSET void   IL offset: 0x7
N001 (  0,  0) [000005] ------------                 RETURN    void
```

In `BB01` the arg node is created and stored into a local, `V03`.  Then for the `ADD` node at `t16` the local is used to generate the shadow stack offset for the `this`  arg.

WIP as lots to do, but @SingleAccretion, does this look like the IR you anticipated?