### PR TITLE
Update version of ILC

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ILCompilerVersion>7.0.0-alpha.1.21455.2</ILCompilerVersion>
+    <ILCompilerVersion>7.0.0-alpha.1.21560.2</ILCompilerVersion>
 
     <ObjWriterBuildType>$(Configuration)</ObjWriterBuildType>
     <ObjWriterBuildType Condition="'$(ObjWriterBuildType)' == 'Checked'">Debug</ObjWriterBuildType>


### PR DESCRIPTION
This bump to prevent errors during local compilation which happens after https://github.com/dotnet/runtime/pull/61333