### PR TITLE
Reduce diffs with runtime repo in src/tests

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -115,6 +115,9 @@ namespace ILCompiler
             if (followVirtualDispatch && (target.IsFinal || target.OwningType.IsSealed()))
                 followVirtualDispatch = false;
 
+            if (followVirtualDispatch)
+                target = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(target);
+
             return DelegateCreationInfo.Create(delegateType, target, NodeFactory, followVirtualDispatch);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DelegateCreationInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DelegateCreationInfo.cs
@@ -147,6 +147,8 @@ namespace ILCompiler
 
         private DelegateCreationInfo(IMethodNode constructor, MethodDesc targetMethod, TargetKind targetKind, IMethodNode thunk = null)
         {
+            Debug.Assert(targetKind != TargetKind.VTableLookup
+                || MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(targetMethod) == targetMethod);
             Constructor = constructor;
             TargetMethod = targetMethod;
             _targetKind = targetKind;

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -19,20 +19,6 @@
       <DisabledProjects Include="$(TestRoot)TestWrappers*\**\*.csproj" />
     </ItemGroup>
 
-    <!-- These rely on implementation details of CoreCLR CoreLib -->
-    <ItemGroup Condition="'$(TestBuildMode)' == 'nativeaot'">
-      <DisabledProjects Include="$(TestRoot)Interop\COM\Activator\Activator.csproj" />
-      <DisabledProjects Include="$(TestRoot)Interop\COM\Activator\ActivatorBuiltInComDisabled.csproj" />
-      <DisabledProjects Include="$(TestRoot)Interop\ICastable\Castable.csproj" />
-      <DisabledProjects Include="$(TestRoot)Interop\IJW\LoadIjwFromModuleHandle\LoadIjwFromModuleHandle.csproj" />
-    </ItemGroup>
-
-    <!-- Temporarily don't build because we don't restore Microsoft.CodeAnalysis in external.csproj - DO NOT BRING THIS HACK OVER to dotnet/runtime -->
-    <ItemGroup>
-      <DisabledProjects Include="$(TestRoot)JIT\Performance\CodeQuality\Roslyn\CscBench.csproj" />
-      <DisabledProjects Include="$(TestRoot)managed\Compilation\Compilation.csproj" />
-    </ItemGroup>
-
     <ItemGroup>
       <BuildTestProjects Include="$(__BuildTestProject.Split(';'))" />
       <BuildTestDirs Include="$(__BuildTestDir.Split(';'))" />

--- a/src/tests/Common/external/external.csproj
+++ b/src/tests/Common/external/external.csproj
@@ -57,16 +57,11 @@
     <PackageToInclude Include="Microsoft.Diagnostics.Tracing.TraceEvent"/>
     <PackageToInclude Include="Newtonsoft.Json"/>
     <PackageToInclude Include="Newtonsoft.Json.Bson"/>
-
-    <!-- These are pretty big and slow down the CI considerably -->
-    <!-- PackageToInclude Include="Microsoft.CodeAnalysis.Analyzers"/>
+    <PackageToInclude Include="Microsoft.CodeAnalysis.Analyzers"/>
     <PackageToInclude Include="Microsoft.CodeAnalysis.Common"/>
     <PackageToInclude Include="Microsoft.CodeAnalysis.Compilers"/>
-    <PackageToInclude Include="Microsoft.CodeAnalysis.CSharp"/-->
-
-    <!-- This assembly has a generic recursion that ILC chokes on. It's not used by tests -->
-    <!--PackageToInclude Include="Microsoft.CodeAnalysis.VisualBasic"/-->
-
+    <PackageToInclude Include="Microsoft.CodeAnalysis.CSharp"/>
+    <PackageToInclude Include="Microsoft.CodeAnalysis.VisualBasic"/>
     <PackageToInclude Include="CommandLineParser"/>
 
     <PackageReference Include="Microsoft.CodeAnalysis.Compilers" Version="1.1.1" />

--- a/src/tests/Common/override.targets
+++ b/src/tests/Common/override.targets
@@ -15,7 +15,6 @@
 
     <ItemGroup>
       <ReferencePath Include="$(RepoRoot)\artifacts\bin\$(RuntimeFlavor)\$(TargetOS).$(TargetArchitecture).$(Configuration)\IL\System.Private.CoreLib.dll"/>
-      <ReferencePath Include="$(RepoRoot)\artifacts\bin\$(RuntimeFlavor)\$(TargetOS).$(TargetArchitecture).$(Configuration)\aotsdk\System.Private.CoreLib.dll" Condition="Exists('$(RepoRoot)\artifacts\bin\coreclr\$(TargetOS).$(TargetArchitecture).$(Configuration)\aotsdk\System.Private.CoreLib.dll')" />
     </ItemGroup>
   </Target>
 

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -81,6 +81,7 @@
     <_WillCLRTestProjectBuild Condition="'$(BuildAllProjects)' == 'true' And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)'">true</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(CLRTestBuildAllTargets)' != 'allTargets' And '$(CLRTestTargetUnsupported)' == 'true'">false</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(ReferenceSystemPrivateCoreLib)' == 'true' and '$(RuntimeFlavor)' == 'mono'">false</_WillCLRTestProjectBuild>
+    <_WillCLRTestProjectBuild Condition="'$(ReferenceSystemPrivateCoreLib)' == 'true' and '$(TestBuildMode)' == 'nativeaot'">false</_WillCLRTestProjectBuild>
     <_WillCLRTestProjectBuild Condition="'$(DisableProjectBuild)' == 'true'">false</_WillCLRTestProjectBuild>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -190,7 +190,7 @@ if %__Ninja% == 0 (
     set __CommonMSBuildArgs=%__CommonMSBuildArgs% /p:UseVisualStudioNativeBinariesLayout=true
 )
 
-set __msbuildArgs=%__CommonMSBuildArgs% /nologo /verbosity:minimal /clp:Summary /maxcpucount %__UnprocessedBuildArgs% /p:TestBuildMode=%__TestBuildMode%
+set __msbuildArgs=%__CommonMSBuildArgs% /nologo /verbosity:minimal /clp:Summary /maxcpucount %__UnprocessedBuildArgs%
 
 echo Common MSBuild args: %__msbuildArgs%
 

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -200,7 +200,7 @@ handle_arguments_local() {
             ;;
 
         nativeaot|-nativeaot)
-            __UnprocessedBuildArgs+=("/p:TestBuildMode=nativeaot")
+            __TestBuildMode=nativeaot
             ;;
 
         perfmap|-perfmap)


### PR DESCRIPTION
* Use `TestBuildMode` passed as an env variable, same as everyone else.
* Skip CoreCLR-JIT specific tests by using the same mechanism as Mono
* Compile Microsoft.CodeAnalysis junk. We no longer choke on recursion. This part I'm not too happy about. We should ideally have a scheme where we can test high-value external things outside the CoreCLR test infra.