### PR TITLE
Scan field RVA data blobs

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -960,7 +960,10 @@ namespace Internal.IL
 
                 if (field.HasRva)
                 {
-                    // We could add a dependency to the data node, but we don't really need it.
+                    // We don't care about field RVA data for the usual cases, but if this is one of the
+                    // magic fields the compiler synthetized, the data blob might bring more dependencies
+                    // and we need to scan those.
+                    _dependencies.Add(_compilation.GetFieldRvaData(field), reason);
                     // TODO: lazy cctor dependency
                     return;
                 }


### PR DESCRIPTION
Fixes #1712.

Some RVA data blobs within the compiler are special and contain other dependencies the compiler needs to look at during scanning phase.

This fixes an issue where the `<Module>` type wasn't having its metadata generated in optimized builds because the scanning phase never saw the `<Module>` type being allocated and didn't predict it as needing metadata. The p/invoke fixup blob references the `<Module>` type as "a type from the assembly that contained the p/invoke". We need to scan the fixup blob during the scanning phase so that the type is seen.