### PR TITLE
Enable -pie and -z,relro,-z,now for NativeAOT binaries

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.props
@@ -89,6 +89,12 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-licucore" Condition="'$(TargetOS)' == 'OSX'" />
       <LinkerArg Include="-dynamiclib" Condition="'$(TargetOS)' == 'OSX' and '$(NativeLib)' == 'Shared'" />
       <LinkerArg Include="-shared" Condition="'$(TargetOS)' != 'OSX' and '$(NativeLib)' == 'Shared'" />
+      <!-- binskim warning BA3001 PIE disabled on executable -->
+      <LinkerArg Include="-pie" Condition="'$(TargetOS)' != 'OSX' and '$(NativeLib)' == ''" />
+      <!-- binskim warning BA3010 The GNU_RELRO segment is missing -->
+      <LinkerArg Include="-Wl,-z,relro" Condition="'$(TargetOS)' != 'OSX'" />
+      <!-- binskim warning BA3011 The BIND_NOW flag is missing -->
+      <LinkerArg Include="-Wl,-z,now" Condition="'$(TargetOS)' != 'OSX'" />
       <LinkerArg Include="-Wl,-u,_CoreRT_StaticInitialization" Condition="'$(TargetOS)' == 'OSX' and '$(NativeLib)' == 'Shared'" />
       <LinkerArg Include="-Wl,--require-defined,CoreRT_StaticInitialization" Condition="'$(TargetOS)' != 'OSX' and '$(NativeLib)' == 'Shared'" />
 


### PR DESCRIPTION
Fixes binskim warning BA3001 and BA3011

Contributes to dotnet/runtime#96848