### PR TITLE
[NativeAOT-LLVM]: Move structs with ByRefs to the shadow stack

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -459,6 +459,7 @@ bool canStoreLocalOnLlvmStack(LclVarDsc* varDsc)
     return !varDsc->HasGCPtr();
 }
 
+//TODO-LLVM: delete this function when we lower the args, its confusing with canStoreLocalOnLlvmStack regards: is the logic exactly the same?
 bool Llvm::canStoreArgOnLlvmStack(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd)
 {
     // structs with no GC pointers can go on LLVM stack.
@@ -467,7 +468,7 @@ bool Llvm::canStoreArgOnLlvmStack(CorInfoType corInfoType, CORINFO_CLASS_HANDLE 
         // Use getClassAtribs over typGetObjLayout because EETypePtr has CORINFO_FLG_GENERIC_TYPE_VARIABLE? which fails with typGetObjLayout
         uint32_t classAttribs = _info.compCompHnd->getClassAttribs(classHnd);
 
-        return (classAttribs & CORINFO_FLG_CONTAINS_GC_PTR) == 0;
+        return (classAttribs & (CORINFO_FLG_CONTAINS_GC_PTR | CORINFO_FLG_CONTAINS_STACK_PTR)) == 0;
     }
 
     if (corInfoType == CorInfoType::CORINFO_TYPE_BYREF || corInfoType == CorInfoType::CORINFO_TYPE_CLASS ||

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1481,36 +1481,6 @@ namespace Internal.IL
             return false;
         }
 
-        // TODO-LLVM: this is a copy of some of the logic in GatherClassGCLayout so we get the same logic as clrjit for
-        // determining if a struct should be passed on the shadow stack.  Span<char/T> is an example.
-        private static bool ContainsIsByReferenceOfT(TypeDesc type)
-        {
-            if (type.IsByReferenceOfT)
-            {
-                return true;
-            }
-
-            foreach (var field in type.GetFields())
-            {
-                if (field.IsStatic)
-                    continue;
-
-                var fieldType = field.FieldType;
-                if (fieldType.IsValueType)
-                {
-                    var fieldDefType = (DefType)fieldType;
-                    if (!fieldDefType.ContainsGCPointers && !fieldDefType.IsByRefLike)
-                        continue;
-
-                    if (ContainsIsByReferenceOfT(fieldType))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
         /// <summary>
         /// Returns true if the type can be stored on the local stack
         /// instead of the shadow stack in this method.
@@ -1519,7 +1489,7 @@ namespace Internal.IL
         {
             if (type is DefType defType)
             {
-                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !ContainsIsByReferenceOfT(type))
+                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !type.IsByRefLike)
                 {
                     return true;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1481,6 +1481,36 @@ namespace Internal.IL
             return false;
         }
 
+        // TODO-LLVM: this is a copy of some of the logic in GatherClassGCLayout so we get the same logic as clrjit for
+        // determining if a struct should be passed on the shadow stack.  Span<char/T> is an example.
+        private static bool ContainsIsByReferenceOfT(TypeDesc type)
+        {
+            if (type.IsByReferenceOfT)
+            {
+                return true;
+            }
+
+            foreach (var field in type.GetFields())
+            {
+                if (field.IsStatic)
+                    continue;
+
+                var fieldType = field.FieldType;
+                if (fieldType.IsValueType)
+                {
+                    var fieldDefType = (DefType)fieldType;
+                    if (!fieldDefType.ContainsGCPointers && !fieldDefType.IsByRefLike)
+                        continue;
+
+                    if (ContainsIsByReferenceOfT(fieldType))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         /// <summary>
         /// Returns true if the type can be stored on the local stack
         /// instead of the shadow stack in this method.
@@ -1489,7 +1519,7 @@ namespace Internal.IL
         {
             if (type is DefType defType)
             {
-                if (!defType.IsGCPointer && !defType.ContainsGCPointers)
+                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !ContainsIsByReferenceOfT(type))
                 {
                     return true;
                 }


### PR DESCRIPTION
This PR fixes a problem with the IL backend where it was passing `Span<char>` (and probably all `Span<T>`) on the LLVM stack, preventing them from being considered for GC.

Follows https://github.com/dotnet/runtimelab/issues/1740

It copies some of the logic from `GatherClassGCLayout` in  `CorInfoImpl.cs` as I didn't see it exposed.  Probably ok as eventually this will be deleted when all the LLVM is generated from clrjit.