### PR TITLE
Document configuration for keep ILC intermediate files during test run

### DIFF
--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -55,6 +55,10 @@ To run an individual test (after it was built), navigate to the `artifacts\tests
 
 `$repo_root` is the root of your clone of the repo.
 
+By default test suite running, cleanup built Native AOT images and response files if ILC does not crashed. If you want to keep these files after test run, set the following environment variables:
+
+* CLRTestNoCleanup=1
+
 For more advanced scenarios, look for at [Building Test Subsets](../../testing/coreclr/windows-test-instructions.md#building-test-subsets) and [Generating Core_Root](../../testing/coreclr/windows-test-instructions.md#generating-core_root)
 
 ## Design Documentation

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -55,7 +55,7 @@ To run an individual test (after it was built), navigate to the `artifacts\tests
 
 `$repo_root` is the root of your clone of the repo.
 
-By default test suite running, cleanup built Native AOT images and response files if ILC does not crashed. If you want to keep these files after test run, set the following environment variables:
+By default the test suite will delete the build artifacts (Native AOT images and response files) if the test compiled successfully. If you want to keep these files instead of deleting them after test run, set the following environment variables and make sure you'll have enough disk space (tens of MB per test):
 
 * CLRTestNoCleanup=1
 


### PR DESCRIPTION
That single variable saves me a lot of time during all my marshalling work. To discover it require guessing how things works, which not always intuitive.