### PR TITLE
Hide constructed/necessary type duality from RyuJIT

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9414,14 +9414,14 @@ GenTree* Compiler::fgExpandVirtualVtableCallTarget(GenTreeCall* call)
 
             // [tmp + vtabOffsOfIndirection]
             GenTree* tmpTree1 = gtNewOperNode(GT_ADD, TYP_I_IMPL, gtNewLclvNode(varNum1, TYP_I_IMPL),
-                                              gtNewIconNode(vtabOffsOfIndirection, TYP_INT));
+                                              gtNewIconNode(vtabOffsOfIndirection, TYP_I_IMPL));
             tmpTree1 = gtNewOperNode(GT_IND, TYP_I_IMPL, tmpTree1, false);
             tmpTree1->gtFlags |= GTF_IND_NONFAULTING;
             tmpTree1->gtFlags |= GTF_IND_INVARIANT;
 
             // var1 + vtabOffsOfIndirection + vtabOffsAfterIndirection
             GenTree* tmpTree2 = gtNewOperNode(GT_ADD, TYP_I_IMPL, gtNewLclvNode(varNum1, TYP_I_IMPL),
-                                              gtNewIconNode(vtabOffsOfIndirection + vtabOffsAfterIndirection, TYP_INT));
+                                              gtNewIconNode(vtabOffsOfIndirection + vtabOffsAfterIndirection, TYP_I_IMPL));
 
             // var1 + vtabOffsOfIndirection + vtabOffsAfterIndirection + [var1 + vtabOffsOfIndirection]
             tmpTree2         = gtNewOperNode(GT_ADD, TYP_I_IMPL, tmpTree2, tmpTree1);
@@ -9440,7 +9440,7 @@ GenTree* Compiler::fgExpandVirtualVtableCallTarget(GenTreeCall* call)
         else
         {
             // result = [vtab + vtabOffsOfIndirection]
-            result = gtNewOperNode(GT_ADD, TYP_I_IMPL, vtab, gtNewIconNode(vtabOffsOfIndirection, TYP_INT));
+            result = gtNewOperNode(GT_ADD, TYP_I_IMPL, vtab, gtNewIconNode(vtabOffsOfIndirection, TYP_I_IMPL));
             result = gtNewOperNode(GT_IND, TYP_I_IMPL, result, false);
             result->gtFlags |= GTF_IND_NONFAULTING;
             result->gtFlags |= GTF_IND_INVARIANT;
@@ -9456,7 +9456,7 @@ GenTree* Compiler::fgExpandVirtualVtableCallTarget(GenTreeCall* call)
     {
         // Load the function address
         // result = [result + vtabOffsAfterIndirection]
-        result = gtNewOperNode(GT_ADD, TYP_I_IMPL, result, gtNewIconNode(vtabOffsAfterIndirection, TYP_INT));
+        result = gtNewOperNode(GT_ADD, TYP_I_IMPL, result, gtNewIconNode(vtabOffsAfterIndirection, TYP_I_IMPL));
         // This last indirection is not invariant, but is non-faulting
         result = gtNewOperNode(GT_IND, TYP_I_IMPL, result, false);
         result->gtFlags |= GTF_IND_NONFAULTING;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8825,7 +8825,6 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 // Are we dereferencing the method table slot of some newly allocated object?
                 //
                 bool wasNewobj = false;
-#if 0 // TODO: https://github.com/dotnet/runtimelab/issues/1128
                 if ((oper == GT_IND) && (addr->TypeGet() == TYP_REF) && (tree->TypeGet() == TYP_I_IMPL))
                 {
                     VNFuncApp  funcApp;
@@ -8838,7 +8837,6 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         wasNewobj = true;
                     }
                 }
-#endif
 
                 if (!wasNewobj)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -26,7 +26,7 @@ namespace ILCompiler
         protected readonly NodeFactory _nodeFactory;
         protected readonly Logger _logger;
         protected readonly DebugInformationProvider _debugInformationProvider;
-        private readonly DevirtualizationManager _devirtualizationManager;
+        protected readonly DevirtualizationManager _devirtualizationManager;
         private readonly IInliningPolicy _inliningPolicy;
 
         public NameMangler NameMangler => _nodeFactory.NameMangler;
@@ -95,6 +95,11 @@ namespace ILCompiler
         public void DetectGenericCycles(MethodDesc caller, MethodDesc callee)
         {
             _nodeFactory.TypeSystemContext.DetectGenericCycles(caller, callee);
+        }
+
+        public virtual IEETypeNode NecessaryTypeSymbolIfPossible(TypeDesc type)
+        {
+            return _nodeFactory.NecessaryTypeSymbol(type);
         }
 
         public bool CanInline(MethodDesc caller, MethodDesc callee)
@@ -285,13 +290,13 @@ namespace ILCompiler
                 case ReadyToRunHelperId.TypeHandle:
                     return NodeFactory.ConstructedTypeSymbol((TypeDesc)targetOfLookup);
                 case ReadyToRunHelperId.NecessaryTypeHandle:
-                    return NodeFactory.NecessaryTypeSymbol((TypeDesc)targetOfLookup);
+                    return NecessaryTypeSymbolIfPossible((TypeDesc)targetOfLookup);
                 case ReadyToRunHelperId.TypeHandleForCasting:
                     {
                         var type = (TypeDesc)targetOfLookup;
                         if (type.IsNullable)
                             targetOfLookup = type.Instantiation[0];
-                        return NodeFactory.NecessaryTypeSymbol((TypeDesc)targetOfLookup);
+                        return NecessaryTypeSymbolIfPossible((TypeDesc)targetOfLookup);
                     }
                 case ReadyToRunHelperId.MethodDictionary:
                     return NodeFactory.MethodGenericDictionary((MethodDesc)targetOfLookup);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -405,14 +405,9 @@ namespace ILCompiler
                             //    didn't scan the virtual methods on them.
                             //
 
+                            _constructedTypes.Add(type);
+
                             TypeDesc canonType = type.ConvertToCanonForm(CanonicalFormKind.Specific);
-
-                            _constructedTypes.Add(canonType);
-
-                            // Since this is used for the purposes of devirtualization, it's really convenient
-                            // to also have Array<T> for each T[].
-                            if (canonType.IsArray)
-                                _constructedTypes.Add(canonType.GetClosestDefType());
 
                             bool hasNonAbstractTypeInHierarchy = canonType is not MetadataType mdType || !mdType.IsAbstract;
                             TypeDesc baseType = canonType.BaseType;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -72,9 +72,9 @@ namespace ILCompiler
             // information proving that it isn't, give RyuJIT the constructed symbol even
             // though we just need the unconstructed one.
             // https://github.com/dotnet/runtimelab/issues/1128
-            bool canConstructPerWholeProgramAnalysis = _devirtualizationManager == null
+            bool canPotentiallyConstruct = _devirtualizationManager == null
                 ? true : _devirtualizationManager.CanConstructType(type);
-            if (canConstructPerWholeProgramAnalysis)
+            if (canPotentiallyConstruct)
                 return _nodeFactory.MaximallyConstructableType(type);
 
             return _nodeFactory.NecessaryTypeSymbol(type);

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -79,7 +79,6 @@ namespace Internal.JitInterface
 
                 CompileMethodCleanup();
             }
-
         }
 
         private CORINFO_RUNTIME_LOOKUP_KIND GetLookupKindFromContextSource(GenericContextSource contextSource)

--- a/src/tests/nativeaot/SmokeTests/DeadCodeElimination/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/DeadCodeElimination/DeadCodeElimination.cs
@@ -44,14 +44,24 @@ class Program
             public Type DoSomething() => typeof(UnreferencedType);
         }
 
+#if DEBUG
+        static NeverAllocatedType s_instance = null;
+#else
         static object s_instance = new object[10];
+#endif
 
         public static void Run()
         {
             Console.WriteLine("Testing instance methods on unallocated types");
 
+#if DEBUG
+            if (s_instance != null)
+                s_instance.DoSomething();
+#else
+            // In release builds additionally test that the "is" check didn't introduce the constructed type
             if (s_instance is NeverAllocatedType never)
                 never.DoSomething();
+#endif
 
             ThrowIfPresent(typeof(TestInstanceMethodOptimization), nameof(UnreferencedType));
         }


### PR DESCRIPTION
If we have whole program view, use that to upgrade requests for "necessary" types to "constructed" types if we know a constructed was seen during scanning. This avoids RyuJIT seeing a constructed and necessary symbol for the same type.

If we don't have whole program view, forgo the optimization and use maximally loadable types instead of necessary types.

Fixes #1128.