### PR TITLE
Move new System.Native shim methods out of pal_environment

### DIFF
--- a/src/native/libs/System.Native/CMakeLists.txt
+++ b/src/native/libs/System.Native/CMakeLists.txt
@@ -15,7 +15,6 @@ if (CLR_CMAKE_TARGET_OSX)
 endif ()
 
 set(NATIVE_SOURCES
-    pal_environment.c
     pal_dynamicload.c
     pal_errno.c
     pal_interfaceaddresses.c

--- a/src/native/libs/System.Native/pal_environment.c
+++ b/src/native/libs/System.Native/pal_environment.c
@@ -9,9 +9,6 @@
 #if HAVE_NSGETENVIRON
 #include <crt_externs.h>
 #endif
-#if HAVE_SCHED_GETCPU
-#include <sched.h>
-#endif
 
 char* SystemNative_GetEnv(const char* variable)
 {
@@ -32,25 +29,4 @@ void SystemNative_FreeEnviron(char** environ)
 {
     // no op
     (void)environ;
-}
-
-int32_t SystemNative_SchedGetCpu()
-{
-#if HAVE_SCHED_GETCPU
-    return sched_getcpu();
-#else
-    return -1;
-#endif
-}
-
-__attribute__((noreturn))
-void SystemNative_Exit(int32_t exitCode)
-{
-    exit(exitCode);
-}
-
-__attribute__((noreturn))
-void SystemNative_Abort()
-{
-    abort();
 }

--- a/src/native/libs/System.Native/pal_environment.h
+++ b/src/native/libs/System.Native/pal_environment.h
@@ -12,9 +12,3 @@ PALEXPORT char** SystemNative_GetEnviron(void);
 
 PALEXPORT void SystemNative_FreeEnviron(char** environ);
 
-PALEXPORT int32_t SystemNative_SchedGetCpu(void);
-
-PALEXPORT __attribute__((noreturn)) void SystemNative_Exit(int32_t exitCode);
-
-PALEXPORT __attribute__((noreturn)) void SystemNative_Abort(void);
-

--- a/src/native/libs/System.Native/pal_threading.c
+++ b/src/native/libs/System.Native/pal_threading.c
@@ -12,6 +12,9 @@
 #include <errno.h>
 #include <time.h>
 #include <sys/time.h>
+#if HAVE_SCHED_GETCPU
+#include <sched.h>
+#endif
 
 #if defined(TARGET_OSX)
 // So we can use the declaration of pthread_cond_timedwait_relative_np
@@ -260,4 +263,25 @@ CreateThreadExit:
     assert(error == 0);
 
     return result;
+}
+
+int32_t SystemNative_SchedGetCpu()
+{
+#if HAVE_SCHED_GETCPU
+    return sched_getcpu();
+#else
+    return -1;
+#endif
+}
+
+__attribute__((noreturn))
+void SystemNative_Exit(int32_t exitCode)
+{
+    exit(exitCode);
+}
+
+__attribute__((noreturn))
+void SystemNative_Abort()
+{
+    abort();
 }

--- a/src/native/libs/System.Native/pal_threading.h
+++ b/src/native/libs/System.Native/pal_threading.h
@@ -23,3 +23,9 @@ PALEXPORT int32_t SystemNative_LowLevelMonitor_TimedWait(LowLevelMonitor *monito
 PALEXPORT void SystemNative_LowLevelMonitor_Signal_Release(LowLevelMonitor* monitor);
 
 PALEXPORT int32_t SystemNative_RuntimeThread_CreateThread(uintptr_t stackSize, void *(*startAddress)(void*), void *parameter);
+
+PALEXPORT int32_t SystemNative_SchedGetCpu(void);
+
+PALEXPORT __attribute__((noreturn)) void SystemNative_Exit(int32_t exitCode);
+
+PALEXPORT __attribute__((noreturn)) void SystemNative_Abort(void);


### PR DESCRIPTION
pal_environment should only contain methods related to env variables to make the iOS specific variant work well.