### PR TITLE
Delete XmlSerializer and DataContractSerializer feature switches

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -269,12 +269,6 @@ The .NET Foundation licenses this file to you under the MIT license.
 
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--feature:System.Reflection.IsReflectionExecutionAvailable=false" />
 
-      <!-- The Emit-based DataContractSerializer won't work -->
-      <IlcArg Include="--feature:System.Runtime.Serialization.DataContractSerializer.IsReflectionOnly=true" />
-
-      <!-- The Emit-based XmlSerializer won't work -->
-      <IlcArg Include="--feature:System.Xml.Serialization.XmlSerializer.IsReflectionOnly=true" />
-
       <!-- Configure LINQ expressions - disable Emit everywhere -->
       <IlcArg Include="--feature:System.Linq.Expressions.CanCompileToIL=false" />
       <IlcArg Include="--feature:System.Linq.Expressions.CanEmitObjectArrayDelegate=false" />

--- a/src/libraries/System.Private.DataContractSerialization/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Private.DataContractSerialization/src/ILLink/ILLink.Substitutions.xml
@@ -1,5 +1,0 @@
-<linker>
-  <type fullname="System.Runtime.Serialization.DataContractSerializer" featurevalue="true" feature="System.Runtime.Serialization.DataContractSerializer.IsReflectionOnly">
-    <method signature="System.Runtime.Serialization.SerializationOption get_Option()" body="stub" value="1" />
-  </type>
-</linker>

--- a/src/libraries/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/libraries/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -14,9 +14,6 @@
     <TextSources>System\Text</TextSources>
   </PropertyGroup>
   <ItemGroup>
-    <ILLinkSubstitutionsXmls Include="ILLink\ILLink.Substitutions.xml" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="$(CommonPath)System\NotImplemented.cs"
              Link="Common\System\NotImplemented.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs"

--- a/src/libraries/System.Private.Xml/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Private.Xml/src/ILLink/ILLink.Substitutions.xml
@@ -1,8 +1,0 @@
-<linker>
-  <type fullname="System.Xml.Serialization.XmlSerializer" featurevalue="true" feature="System.Xml.Serialization.XmlSerializer.IsReflectionOnly">
-    <method signature="System.Xml.Serialization.SerializationMode get_Mode()" body="stub" value="1" />
-  </type>
-  <type fullname="System.Xml.XmlDownloadManager" featurevalue="false" feature="System.Xml.XmlDownloadManager.IsNonFileStreamSupported">
-    <method signature="System.Threading.Tasks.Task`1&lt;System.IO.Stream&gt; GetNonFileStreamAsync(System.Uri,System.Net.ICredentials,System.Net.IWebProxy)" body="remove" />
-  </type>
-</linker>

--- a/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
+++ b/src/libraries/System.Private.Xml/src/System.Private.Xml.csproj
@@ -6,9 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ILLinkSubstitutionsXmls Include="ILLink\ILLink.Substitutions.xml" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="$(CommonPath)System\Text\StringBuilderCache.cs" Link="Common\System\StringBuilderCache.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs" Link="Common\System\HexConverter.cs" />
     <Compile Include="System\Xml\BinaryXml\XmlBinaryReader.cs" />


### PR DESCRIPTION
Should no longer be needed after https://github.com/dotnet/runtime/pull/56604 and https://github.com/dotnet/runtime/pull/55503.