### PR TITLE
Move CompressARM64CFI to NativeAOT-specific CorInfoImpl

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -47,13 +47,6 @@ namespace Internal.JitInterface
             ARM = 0x01c4,
             ARM64 = 0xaa64,
         }
-        private enum CFI_OPCODE
-        {
-            CFI_ADJUST_CFA_OFFSET,    // Offset is adjusted relative to the current one.
-            CFI_DEF_CFA_REGISTER,     // New register is used to compute CFA
-            CFI_REL_OFFSET,           // Register is saved at offset from the current CFA
-            CFI_DEF_CFA               // Take address from register and add offset to it.
-        };
 
         internal const string JitLibrary = "clrjitilc";
 
@@ -3389,145 +3382,14 @@ namespace Internal.JitInterface
 
             var target = _compilation.TypeSystemContext.Target;
 
+#if !READYTORUN
             if (target.Architecture == TargetArchitecture.ARM64 && target.OperatingSystem == TargetOS.Linux)
             {
                 blobData = CompressARM64CFI(blobData);
             }
+#endif
 
             _frameInfos[_usedFrameInfos++] = new FrameInfo(flags, (int)startOffset, (int)endOffset, blobData);
-        }
-
-        // Get the CFI data in the same shape as clang/LLVM generated one. This improves the compatibility with libunwind and other unwind solutions
-        // - Combine in one single block for the whole prolog instead of one CFI block per assembler instruction
-        // - Store CFA definition first
-        // - Store all used registers in ascending order
-        private byte[] CompressARM64CFI(byte[] blobData)
-        {
-            if (blobData == null || blobData.Length == 0)
-            {
-                return blobData;
-            }
-
-            Debug.Assert(blobData.Length % 8 == 0);
-
-            short spReg = -1;
-
-            int codeOffset = 0;
-            short cfaRegister = spReg;
-            int cfaOffset = 0;
-            int spOffset = 0;
-
-            int[] registerOffset = new int[96]; 
-
-            for (int i = 0; i < registerOffset.Length; i++)
-            {
-                registerOffset[i] = int.MinValue;
-            }
-
-            int offset = 0;
-            while (offset < blobData.Length)
-            {
-                codeOffset = Math.Max(codeOffset, blobData[offset++]);
-                CFI_OPCODE opcode = (CFI_OPCODE)blobData[offset++];
-                short dwarfReg = BitConverter.ToInt16(blobData, offset);
-                offset += sizeof(short);
-                int cfiOffset = BitConverter.ToInt32(blobData, offset);
-                offset += sizeof(int);
-
-                switch (opcode)
-                {
-                    case CFI_OPCODE.CFI_DEF_CFA_REGISTER:
-                        cfaRegister = dwarfReg;
-
-                        if (spOffset != 0)
-                        {
-                            for (int i = 0; i < registerOffset.Length; i++)
-                            {
-                                if (registerOffset[i] != int.MinValue)
-                                {
-                                    registerOffset[i] -= spOffset;
-                                }
-                            }
-
-                            cfaOffset += spOffset;
-                            spOffset = 0;
-                        }
-
-                        break;
-
-                    case CFI_OPCODE.CFI_REL_OFFSET:
-                        Debug.Assert(cfaRegister == spReg);
-                        registerOffset[dwarfReg] = cfiOffset;
-                        break;
-
-                    case CFI_OPCODE.CFI_ADJUST_CFA_OFFSET:
-                        if (cfaRegister != spReg)
-                        {
-                            cfaOffset += cfiOffset;
-                        }
-                        else
-                        {
-                            spOffset += cfiOffset;
-
-                            for (int i = 0; i < registerOffset.Length; i++)
-                            {
-                                if (registerOffset[i] != int.MinValue)
-                                {
-                                    registerOffset[i] += cfiOffset;
-                                }
-                            }
-                        }
-                        break;
-                }
-            }
-
-            using (MemoryStream cfiStream = new MemoryStream())
-            {
-                int storeOffset = 0;
-
-                using (BinaryWriter cfiWriter = new BinaryWriter(cfiStream))
-                {
-                    if (cfaRegister != -1)
-                    {
-                        cfiWriter.Write((byte)codeOffset);
-                        cfiWriter.Write(cfaOffset != 0 ? (byte)CFI_OPCODE.CFI_DEF_CFA : (byte)CFI_OPCODE.CFI_DEF_CFA_REGISTER);
-                        cfiWriter.Write(cfaRegister);
-                        cfiWriter.Write(cfaOffset);
-                        storeOffset = cfaOffset;
-                    }
-                    else
-                    {
-                        if (cfaOffset != 0)
-                        {
-                            cfiWriter.Write((byte)codeOffset);
-                            cfiWriter.Write((byte)CFI_OPCODE.CFI_ADJUST_CFA_OFFSET);
-                            cfiWriter.Write((short)-1);
-                            cfiWriter.Write(cfaOffset);
-                        }
-
-                        if (spOffset != 0)
-                        {
-                            cfiWriter.Write((byte)codeOffset);
-                            cfiWriter.Write((byte)CFI_OPCODE.CFI_DEF_CFA);
-                            cfiWriter.Write((short)31); 
-                            cfiWriter.Write(spOffset);
-                        }
-                    }
-
-                    for (int i = registerOffset.Length - 1; i >= 0; i--)
-                    {
-                        if (registerOffset[i] != int.MinValue)
-                        {
-                            cfiWriter.Write((byte)codeOffset);
-                            cfiWriter.Write((byte)CFI_OPCODE.CFI_REL_OFFSET);
-                            cfiWriter.Write((short)i);
-                            cfiWriter.Write(registerOffset[i] + storeOffset);
-                        }
-                    }
-                }
-
-                return cfiStream.ToArray();
-            }
         }
 
         private void* allocGCInfo(UIntPtr size)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 
 using Internal.IL;
@@ -78,6 +79,147 @@ namespace Internal.JitInterface
 #endif
 
                 CompileMethodCleanup();
+            }
+        }
+
+        private enum CFI_OPCODE
+        {
+            CFI_ADJUST_CFA_OFFSET,    // Offset is adjusted relative to the current one.
+            CFI_DEF_CFA_REGISTER,     // New register is used to compute CFA
+            CFI_REL_OFFSET,           // Register is saved at offset from the current CFA
+            CFI_DEF_CFA               // Take address from register and add offset to it.
+        }
+
+        // Get the CFI data in the same shape as clang/LLVM generated one. This improves the compatibility with libunwind and other unwind solutions
+        // - Combine in one single block for the whole prolog instead of one CFI block per assembler instruction
+        // - Store CFA definition first
+        // - Store all used registers in ascending order
+        private byte[] CompressARM64CFI(byte[] blobData)
+        {
+            if (blobData == null || blobData.Length == 0)
+            {
+                return blobData;
+            }
+
+            Debug.Assert(blobData.Length % 8 == 0);
+
+            short spReg = -1;
+
+            int codeOffset = 0;
+            short cfaRegister = spReg;
+            int cfaOffset = 0;
+            int spOffset = 0;
+
+            int[] registerOffset = new int[96];
+
+            for (int i = 0; i < registerOffset.Length; i++)
+            {
+                registerOffset[i] = int.MinValue;
+            }
+
+            int offset = 0;
+            while (offset < blobData.Length)
+            {
+                codeOffset = Math.Max(codeOffset, blobData[offset++]);
+                CFI_OPCODE opcode = (CFI_OPCODE)blobData[offset++];
+                short dwarfReg = BitConverter.ToInt16(blobData, offset);
+                offset += sizeof(short);
+                int cfiOffset = BitConverter.ToInt32(blobData, offset);
+                offset += sizeof(int);
+
+                switch (opcode)
+                {
+                    case CFI_OPCODE.CFI_DEF_CFA_REGISTER:
+                        cfaRegister = dwarfReg;
+
+                        if (spOffset != 0)
+                        {
+                            for (int i = 0; i < registerOffset.Length; i++)
+                            {
+                                if (registerOffset[i] != int.MinValue)
+                                {
+                                    registerOffset[i] -= spOffset;
+                                }
+                            }
+
+                            cfaOffset += spOffset;
+                            spOffset = 0;
+                        }
+
+                        break;
+
+                    case CFI_OPCODE.CFI_REL_OFFSET:
+                        Debug.Assert(cfaRegister == spReg);
+                        registerOffset[dwarfReg] = cfiOffset;
+                        break;
+
+                    case CFI_OPCODE.CFI_ADJUST_CFA_OFFSET:
+                        if (cfaRegister != spReg)
+                        {
+                            cfaOffset += cfiOffset;
+                        }
+                        else
+                        {
+                            spOffset += cfiOffset;
+
+                            for (int i = 0; i < registerOffset.Length; i++)
+                            {
+                                if (registerOffset[i] != int.MinValue)
+                                {
+                                    registerOffset[i] += cfiOffset;
+                                }
+                            }
+                        }
+                        break;
+                }
+            }
+
+            using (MemoryStream cfiStream = new MemoryStream())
+            {
+                int storeOffset = 0;
+
+                using (BinaryWriter cfiWriter = new BinaryWriter(cfiStream))
+                {
+                    if (cfaRegister != -1)
+                    {
+                        cfiWriter.Write((byte)codeOffset);
+                        cfiWriter.Write(cfaOffset != 0 ? (byte)CFI_OPCODE.CFI_DEF_CFA : (byte)CFI_OPCODE.CFI_DEF_CFA_REGISTER);
+                        cfiWriter.Write(cfaRegister);
+                        cfiWriter.Write(cfaOffset);
+                        storeOffset = cfaOffset;
+                    }
+                    else
+                    {
+                        if (cfaOffset != 0)
+                        {
+                            cfiWriter.Write((byte)codeOffset);
+                            cfiWriter.Write((byte)CFI_OPCODE.CFI_ADJUST_CFA_OFFSET);
+                            cfiWriter.Write((short)-1);
+                            cfiWriter.Write(cfaOffset);
+                        }
+
+                        if (spOffset != 0)
+                        {
+                            cfiWriter.Write((byte)codeOffset);
+                            cfiWriter.Write((byte)CFI_OPCODE.CFI_DEF_CFA);
+                            cfiWriter.Write((short)31);
+                            cfiWriter.Write(spOffset);
+                        }
+                    }
+
+                    for (int i = registerOffset.Length - 1; i >= 0; i--)
+                    {
+                        if (registerOffset[i] != int.MinValue)
+                        {
+                            cfiWriter.Write((byte)codeOffset);
+                            cfiWriter.Write((byte)CFI_OPCODE.CFI_REL_OFFSET);
+                            cfiWriter.Write((short)i);
+                            cfiWriter.Write(registerOffset[i] + storeOffset);
+                        }
+                    }
+                }
+
+                return cfiStream.ToArray();
             }
         }
 


### PR DESCRIPTION
Unwind info is generated as CFI for NativeAOT only.