### PR TITLE
Fix InvokeMember corner case

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeSupportDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeSupportDependencyAlgorithm.cs
@@ -46,7 +46,9 @@ namespace ILCompiler.DependencyAnalysis
                     if (!reader.GetCustomAttributeHandle(param.GetCustomAttributes(), "System", "ParamArrayAttribute").IsNil)
                     {
                         dependencies ??= new DependencyList();
-                        dependencies.Add(factory.ConstructedTypeSymbol(sig[sig.Length - 1]), "Reflection invoke");
+                        dependencies.Add(
+                            factory.ConstructedTypeSymbol(sig[sig.Length - 1].NormalizeInstantiation()),
+                            "Reflection invoke");
                     }
 
                     break;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeSupportDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionInvokeSupportDependencyAlgorithm.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection.Metadata;
+
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    internal static class ReflectionInvokeSupportDependencyAlgorithm
+    {
+        // Inserts dependencies to make the following corner case work (we need MethodTable for `MyStruct[]`):
+        //
+        // struct MyStruct
+        // {
+        //     public static int Count(params MyStruct[] myStructs)
+        //     {
+        //         return myStructs.Length;
+        //     }
+        //
+        //     public static void Main()
+        //     {
+        //         typeof(MyStruct).InvokeMember(nameof(Count), BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static, null, null, new object[] { default(MyStruct) });
+        //     }
+        // }
+        public static void GetDependenciesFromParamsArray(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
+        {
+            MethodSignature sig = method.Signature;
+            if (sig.Length < 1 || !sig[sig.Length - 1].IsArray)
+                return;
+
+            if (method.GetTypicalMethodDefinition() is not EcmaMethod ecmaMethod)
+                return;
+
+            MetadataReader reader = ecmaMethod.MetadataReader;
+            MethodDefinition methodDef = reader.GetMethodDefinition(ecmaMethod.Handle);
+
+            foreach (ParameterHandle paramHandle in methodDef.GetParameters())
+            {
+                Parameter param = reader.GetParameter(paramHandle);
+                if (param.SequenceNumber == sig.Length /* SequenceNumber is 1-based */)
+                {
+                    if (!reader.GetCustomAttributeHandle(param.GetCustomAttributes(), "System", "ParamArrayAttribute").IsNil)
+                    {
+                        dependencies ??= new DependencyList();
+                        dependencies.Add(factory.ConstructedTypeSymbol(sig[sig.Length - 1]), "Reflection invoke");
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -332,6 +332,8 @@ namespace ILCompiler
                 {
                     // We're going to generate a mapping table entry for this. Collect dependencies.
                     ReflectionInvokeMapNode.AddDependenciesDueToReflectability(ref dependencies, factory, method);
+
+                    ReflectionInvokeSupportDependencyAlgorithm.GetDependenciesFromParamsArray(ref dependencies, factory, method);
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -204,6 +204,7 @@
     <Compile Include="Compiler\DependencyAnalysis\MethodExceptionHandlingInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ModuleInitializerListNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectGetTypeFlowDependenciesNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReflectionInvokeSupportDependencyAlgorithm.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionMethodBodyScanner.cs" />
     <Compile Include="Compiler\DependencyAnalysis\StructMarshallingDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_ARM64\ARM64TentativeMethodNode.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
@@ -30,7 +30,7 @@ namespace System
         // The most specific match will be selected.
         //
         [UnconditionalSuppressMessage("AotAnalysis", "IL3050:RequiresDynamicCode",
-            Justification = "Known corner case bug https://github.com/dotnet/runtimelab/issues/1079.")]
+            Justification = "AOT compiler ensures params arrays are created for reflection-invokable methods")]
         public sealed override MethodBase BindToMethod(
             BindingFlags bindingAttr, MethodBase[] match, ref object?[] args,
             ParameterModifier[]? modifiers, CultureInfo? cultureInfo, string[]? names, out object? state)

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -59,6 +59,7 @@ internal class ReflectionTest
         TestGetUninitializedObject.Run();
         TestInstanceFields.Run();
         TestReflectionInvoke.Run();
+        TestInvokeMemberParamsCornerCase.Run();
         TestDefaultInterfaceInvoke.Run();
         TestCovariantReturnInvoke.Run();
 #if !CODEGEN_CPP
@@ -261,6 +262,26 @@ internal class ReflectionTest
                     throw new Exception();
             }
 #endif
+        }
+    }
+
+    class TestInvokeMemberParamsCornerCase
+    {
+        public struct MyStruct { }
+
+        public static int Count(params MyStruct[] myStructs)
+        {
+            return myStructs.Length;
+        }
+
+        public static void Run()
+        {
+            Console.WriteLine(nameof(TestInvokeMemberParamsCornerCase));
+
+            // Needs MethodTable for MyStruct[] and the compiler should have created it.
+            typeof(TestInvokeMemberParamsCornerCase).InvokeMember(nameof(Count),
+                BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static,
+                null, null, new object[] { default(MyStruct) });
         }
     }
 


### PR DESCRIPTION
The change in DefaultBinder is in a shared file and it didn't feel right to move it to dotnet/runtime with a known runtimelab bug.