### PR TITLE
Enable MUSL ARM64 builds

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -100,6 +100,7 @@ stages:
       - Linux_musl_x64
       - Linux_arm
       - Linux_arm64
+      - Linux_musl_arm64
       - windows_x64
       - windows_arm64
       - OSX_x64

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -53,7 +53,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="!Exists('$(ObjWriterArtifactPath)')">
+  <ItemGroup Condition="!Exists('$(ObjWriterArtifactPath)') and '$(__DistroRid)' != 'linux-musl-arm64'">
     <PackageReference Include="Microsoft.DotNet.ILCompiler">
       <Version>$(ILCompilerVersion)</Version>
     </PackageReference>


### PR DESCRIPTION
Want to get an ObjWriter package out for this so that I don't need yet another condition on the runtime side.