### PR TITLE
Use OutputRid instead of __DistroRid

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <SelfContained>true</SelfContained>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <RuntimeIdentifier>$(__DistroRid)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
 
     <!-- DistroRid is injected through environment variables in build scripts. Provide reasonable default
          when the build is invoked directly, e.g. building inside Visual Studio -->


### PR DESCRIPTION
Apparently __DistroRid in the musl-cross container is linux-arm64.