### PR TITLE
Undo MUSL changes

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -100,7 +100,6 @@ stages:
       - Linux_musl_x64
       - Linux_arm
       - Linux_arm64
-      - Linux_musl_arm64
       - windows_x64
       - windows_arm64
       - OSX_x64

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <SelfContained>true</SelfContained>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(__DistroRid)</RuntimeIdentifier>
 
     <!-- DistroRid is injected through environment variables in build scripts. Provide reasonable default
          when the build is invoked directly, e.g. building inside Visual Studio -->
@@ -53,7 +53,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="!Exists('$(ObjWriterArtifactPath)') and '$(__DistroRid)' != 'linux-musl-arm64'">
+  <ItemGroup Condition="!Exists('$(ObjWriterArtifactPath)')">
     <PackageReference Include="Microsoft.DotNet.ILCompiler">
       <Version>$(ILCompilerVersion)</Version>
     </PackageReference>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
@@ -4,7 +4,6 @@
     <OfficialBuildRID Include="linux-arm" Platform="arm" />
     <OfficialBuildRID Include="linux-arm64" Platform="arm64" />
     <OfficialBuildRID Include="linux-musl-x64" Platform="x64" />
-    <OfficialBuildRID Include="linux-musl-arm64" Platform="arm64" />
     <OfficialBuildRID Include="linux-x64" Platform="x64" />
     <OfficialBuildRID Include="osx-x64" Platform="x64" />
     <OfficialBuildRID Include="win-arm64" Platform="arm64" />


### PR DESCRIPTION
It still insists on generating a linux-arm64 package instead of the MUSL one. I decided to just block MUSL-ARM64 in the runtime repo.