### PR TITLE
[NativeAOT-LLVM] Include clr.wasmjit subset when building on windows for x64

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -62,6 +62,9 @@
 
     <DefaultNativeAotSubsets>clr.alljits+nativeaot.ilc+nativeaot.build+nativeaot.libs</DefaultNativeAotSubsets>
 
+    <!-- The wasmjit can only be built for x64 on Windows -->
+    <DefaultNativeAotSubsets Condition="$([MSBuild]::IsOsPlatform(Windows)) and '$(TargetArchitecture)' == 'x64'">$(DefaultNativeAotSubsets)+clr.wasmjit</DefaultNativeAotSubsets>
+
     <!-- The only NativeAOT components meaningfully buildable for Wasm are the native runtime and build integration. -->
     <DefaultNativeAotSubsets Condition="'$(TargetArchitecture)' == 'wasm'">nativeaot.build+nativeaot.libs</DefaultNativeAotSubsets>
 

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -140,6 +140,12 @@ jobs:
       - script: call $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-llvm.cmd $(Build.SourcesDirectory)\wasm-tools $(Build.SourcesDirectory) ${{ parameters.buildConfig }}
         displayName: Install/build LLVM
 
+
+    - ${{ if and(eq(parameters.osGroup, 'windows'), eq(parameters.archType, 'x64')) }}:
+      # Install LLVM for the win-x64 build as it will build the clrjit for browser_wasm cross compilation
+      - script: call $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-llvm.cmd $(Build.SourcesDirectory)\wasm-tools $(Build.SourcesDirectory) ${{ parameters.buildConfig }}
+        displayName: Install/build LLVM
+
     - ${{ if eq(parameters.nameSuffix, 'Browser_wasm_Windows') }}:
       # Update machine certs
       - task: PowerShell@2

--- a/eng/pipelines/runtimelab/install-llvm.cmd
+++ b/eng/pipelines/runtimelab/install-llvm.cmd
@@ -13,8 +13,8 @@ echo Using CMake at "%CMakePath%"
 
 set
 
-REM There is no [C/c]hecked LLVM config, so change to Release
-if /I %buildConfig% EQU checked set buildConfig=Release
+REM There is no [C/c]hecked LLVM config, so change to Debug
+if /I %buildConfig% EQU checked set buildConfig=Debug
 
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -File "%~dp0install-llvm.ps1" -buildConfig %buildConfig%
 if %errorlevel% NEQ 0 goto fail

--- a/eng/pipelines/runtimelab/install-llvm.cmd
+++ b/eng/pipelines/runtimelab/install-llvm.cmd
@@ -13,6 +13,9 @@ echo Using CMake at "%CMakePath%"
 
 set
 
+REM There is no [C/c]hecked LLVM config, so change to Release
+if /I %buildConfig% EQU checked set buildConfig=Release
+
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -File "%~dp0install-llvm.ps1" -buildConfig %buildConfig%
 if %errorlevel% NEQ 0 goto fail
 


### PR DESCRIPTION
This PR as per the title changes the subset of `DefaultNativeAotSubsets` to include `clr.wasmjit` when building on windows for x64.  This will get the clrjit for wasm built when doing a `build nativeaot` and gets it in the runtime package.  Hopefully this will fix the official job packaging.

cc @SingleAccretion