### PR TITLE
[NativeAOT-LLVM] Remove erroneous extra indirection loading field address from static base.

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -4618,7 +4618,7 @@ namespace Internal.IL
                             {
                                 node = _compilation.NodeFactory.TypeGCStaticsSymbol(owningType);
                                 LLVMValueRef basePtrPtr = LoadAddressOfSymbolNode(node);
-                                staticBase = _builder.BuildLoad(_builder.BuildPointerCast(basePtrPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), 0), "castBasePtr"), "base");
+                                staticBase = _builder.BuildPointerCast(basePtrPtr, LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "castBase");
                             }
                         }
                         else


### PR DESCRIPTION
This PR removes an indirection when loading the field address from the static base.  Nothing blew up before, but I noticed it playing with zerosharp and w4 (https://wasm4.org/).  The game crashed accessing invalid memory (it only has 64KB so things are more easily noticed)

cc @SingleAccretion