### PR TITLE
[NativeAOT-LLVM] Make boxing on reference types a noop

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -4843,6 +4843,11 @@ namespace Internal.IL
             LLVMValueRef eeType;
             TypeDesc type = (TypeDesc)_methodIL.GetObject(token);
 
+            if (!type.IsValueType)
+            {
+                return; // Boxing reference types is a noop for the IL->LLVM compiler
+            }
+
             StackEntry eeTypeEntry;
             bool truncDouble = type.Equals(GetWellKnownType(WellKnownType.Single));
             if (type.IsRuntimeDeterminedSubtype)


### PR DESCRIPTION
This PR addresses the first point from https://github.com/dotnet/runtimelab/issues/1783#issuecomment-1011488581
To avoid adding depenencies for boxing reference types this becomes a NO-OP to bring the compilation in line with the scanner.