### PR TITLE
[NativeAOT-LLVM] Add implementation for GetName to prevent EventSource throwing

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMBlockRefNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMBlockRefNode.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory context)
         {
-            throw new NotImplementedException();
+            return mangledName;
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)


### PR DESCRIPTION
This PR fixes an exception when the event source is enabled:

```
EXEC : error : The method or operation is not implemented. [E:\GitHub\wskia\wskia.csproj]
  System.NotImplementedException: The method or operation is not implemented.
     at ILCompiler.DependencyAnalysis.LLVMBlockRefNode.GetName(NodeFactory context)
     at ILCompiler.DependencyAnalysisFramework.EventSourceLogStrategy`1.ILCompiler.DependencyAnalysisFramework.IDependencyAnalysisMarkStrategy<DependencyContextType>.MarkNode(DependencyNodeCore`1 node, DependencyNodeCore`1 reasonNode, DependencyNodeCore`1 reasonNode2, String reason)
     at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.GetStaticDependenciesImpl(DependencyNodeCore`1 node)
     at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.GetStaticDependencies(DependencyNodeCore`1 node)
     at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.ProcessMarkStack()
     at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.ComputeMarkedNodes()
     at ILCompiler.LLVMCodegenCompilation.CompileInternal(String outputFile, ObjectDumper dumper)
     at ILCompiler.Compilation.ILCompiler.ICompilation.Compile(String outputFile, ObjectDumper dumper)
     at ILCompiler.Program.Run(String[] args)
     at ILCompiler.Program.Main(String[] args)
```
It returns the mangled name for `GetName`.  

cc @SingleAccretion