### PR TITLE
[NativeAOT-LLVM] Enable IL scanner for LLVM to enable precomputed vtable slots

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/AssemblyStubNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/AssemblyStubNode.cs
@@ -70,7 +70,11 @@ namespace ILCompiler.DependencyAnalysis
 
                 case TargetArchitecture.Wasm32:
                 case TargetArchitecture.Wasm64:
-                    return new ObjectData(null, null, 0, null);
+                    Wasm.WasmEmitter wasmEmitter = new Wasm.WasmEmitter(factory, relocsOnly);
+
+                    EmitCode(factory, ref wasmEmitter, relocsOnly);
+
+                    return wasmEmitter.Builder.ToObjectData();
 
                 default:
                     throw new NotImplementedException();
@@ -81,5 +85,6 @@ namespace ILCompiler.DependencyAnalysis
         protected abstract void EmitCode(NodeFactory factory, ref X86.X86Emitter instructionEncoder, bool relocsOnly);
         protected abstract void EmitCode(NodeFactory factory, ref ARM.ARMEmitter instructionEncoder, bool relocsOnly);
         protected abstract void EmitCode(NodeFactory factory, ref ARM64.ARM64Emitter instructionEncoder, bool relocsOnly);
+        protected abstract void EmitCode(NodeFactory factory, ref Wasm.WasmEmitter instructionEncoder, bool relocsOnly);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -356,8 +356,9 @@ namespace ILCompiler
 
             // Can we do a fixed lookup? Start by checking if we can get to the dictionary.
             // Context source having a vtable with fixed slots is a prerequisite.
-            if (contextSource == GenericContextSource.MethodParameter
-                || HasFixedSlotVTable(contextMethod.OwningType))
+            // TODO-LLVM: Is this going to prevent CT_INDIRECT being implemented for LLVM clrjit?
+            if (!TargetArchIsWasm() && (contextSource == GenericContextSource.MethodParameter
+                || HasFixedSlotVTable(contextMethod.OwningType)))
             {
                 DictionaryLayoutNode dictionaryLayout;
                 if (contextSource == GenericContextSource.MethodParameter)
@@ -508,6 +509,13 @@ namespace ILCompiler
             }
 
             return new CompilationResults(_dependencyGraph, _nodeFactory);
+        }
+
+        // TODO-LLVM: delete when IL->LLVM module has gone
+        public bool TargetArchIsWasm()
+        {
+            return TypeSystemContext.Target.Architecture == TargetArchitecture.Wasm32 ||
+                   TypeSystemContext.Target.Architecture == TargetArchitecture.Wasm64;
         }
 
         private sealed class ILCache : LockFreeReaderHashtable<MethodDesc, ILCache.MethodILData>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMInitialInterfaceDispatchStubNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMInitialInterfaceDispatchStubNode.cs
@@ -8,6 +8,7 @@ using ILCompiler.DependencyAnalysis.ARM;
 using ILCompiler.DependencyAnalysis.X64;
 using ILCompiler.DependencyAnalysis.X86;
 using ILCompiler.DependencyAnalysis.ARM64;
+using ILCompiler.DependencyAnalysis.Wasm;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -47,6 +48,11 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         protected override void EmitCode(NodeFactory factory, ref ARM64Emitter instructionEncoder, bool relocsOnly)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void EmitCode(NodeFactory factory, ref WasmEmitter instructionEncoder, bool relocsOnly)
         {
             throw new NotImplementedException();
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ILCompiler.DependencyAnalysis.Wasm
+{
+    public struct WasmEmitter
+    {
+        public WasmEmitter(NodeFactory factory, bool relocsOnly)
+        {
+            Builder = new ObjectDataBuilder(factory, relocsOnly);
+        }
+
+        public ObjectDataBuilder Builder;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using ILCompiler.DependencyAnalysis.Wasm;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    partial class ReadyToRunGenericHelperNode
+    {
+        protected sealed override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
+        {
+            switch (_id)
+            {
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)_target;
+
+                        if (factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        {
+                            encoder.Builder.EmitReloc(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnNonGCStaticBase), RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                    }
+                    break;
+
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)_target;
+
+                        if (factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        {
+                            encoder.Builder.EmitReloc(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnGCStaticBase), RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                    }
+                    break;
+
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    {
+                        MetadataType target = (MetadataType)_target;
+
+                        ISymbolNode helperEntrypoint;
+                        if (factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        {
+                            helperEntrypoint = factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase);
+                        }
+                        else
+                        {
+                            helperEntrypoint = factory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType);
+                        }
+
+                        encoder.Builder.EmitReloc(helperEntrypoint, RelocType.IMAGE_REL_BASED_REL32);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.DelegateCtor:
+                    {
+                        var target = (DelegateCreationInfo)_target;
+
+                        if (target.Thunk != null)
+                        {
+                            encoder.Builder.EmitReloc(target.Thunk, RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                        else
+                        {
+                            Debug.Assert(target.Constructor.Method.Signature.Length == 2);
+                        }
+
+                        encoder.Builder.EmitReloc(target.Constructor, RelocType.IMAGE_REL_BASED_REL32);
+                    }
+                    break;
+
+                // These are all simple: do dependencies
+                case ReadyToRunHelperId.TypeHandle:
+                case ReadyToRunHelperId.MethodHandle:
+                case ReadyToRunHelperId.FieldHandle:
+                case ReadyToRunHelperId.MethodDictionary:
+                case ReadyToRunHelperId.MethodEntry:
+                case ReadyToRunHelperId.VirtualDispatchCell:
+                case ReadyToRunHelperId.DefaultConstructor:
+                case ReadyToRunHelperId.ObjectAllocator:
+                case ReadyToRunHelperId.TypeHandleForCasting:
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunGenericHelperNode.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using ILCompiler.DependencyAnalysis.Wasm;
+using Internal.IL;
 using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
@@ -71,7 +72,6 @@ namespace ILCompiler.DependencyAnalysis
                     }
                     break;
 
-                // These are all simple: do dependencies
                 case ReadyToRunHelperId.TypeHandle:
                 case ReadyToRunHelperId.MethodHandle:
                 case ReadyToRunHelperId.FieldHandle:
@@ -81,6 +81,7 @@ namespace ILCompiler.DependencyAnalysis
                 case ReadyToRunHelperId.DefaultConstructor:
                 case ReadyToRunHelperId.ObjectAllocator:
                 case ReadyToRunHelperId.TypeHandleForCasting:
+                    // TODO-LLVM: should use GetBadSlotHelper/ThrowUnavailableType in base class when merged
                     break;
                 default:
                     throw new NotImplementedException();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunHelperNode.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using ILCompiler.DependencyAnalysis.Wasm;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public partial class ReadyToRunHelperNode
+    {
+        protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
+        {
+            switch (Id)
+            {
+                case ReadyToRunHelperId.VirtualCall:
+                    break;
+
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)Target;
+
+                        bool hasLazyStaticConstructor = factory.PreinitializationManager.HasLazyStaticConstructor(target);
+                        encoder.Builder.EmitReloc(factory.TypeNonGCStaticsSymbol(target), RelocType.IMAGE_REL_BASED_REL32);
+
+                        if (hasLazyStaticConstructor)
+                        {
+                            encoder.Builder.EmitReloc(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnNonGCStaticBase), RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                    }
+                    break;
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    {
+                        MetadataType target = (MetadataType)Target;
+
+                        if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        {
+                            encoder.Builder.EmitReloc(factory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType), RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                        else
+                        {
+                            encoder.Builder.EmitReloc(factory.TypeNonGCStaticsSymbol(target), RelocType.IMAGE_REL_BASED_REL32);
+                            encoder.Builder.EmitReloc(factory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType), RelocType.IMAGE_REL_BASED_REL32);
+                            encoder.Builder.EmitReloc(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase), RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                    }
+                    break;
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)Target;
+
+                        encoder.Builder.EmitReloc(factory.TypeGCStaticsSymbol(target), RelocType.IMAGE_REL_BASED_REL32);
+
+                        if (factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                        {
+                            encoder.Builder.EmitReloc(factory.TypeNonGCStaticsSymbol(target), RelocType.IMAGE_REL_BASED_REL32);
+                            encoder.Builder.EmitReloc(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnGCStaticBase), RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                    }
+                    break;
+
+                case ReadyToRunHelperId.DelegateCtor:
+                    {
+                        DelegateCreationInfo target = (DelegateCreationInfo)Target;
+
+                        if (!target.TargetNeedsVTableLookup)
+                        {
+                            encoder.Builder.EmitReloc(target.GetTargetNode(factory), RelocType.IMAGE_REL_BASED_REL32);
+                        }
+
+                        if (target.Thunk != null)
+                        {
+                            Debug.Assert(target.Constructor.Method.Signature.Length == 3);
+                            encoder.Builder.EmitReloc(target.Thunk, RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                        else
+                        {
+                            //closed delegate, Wasm needs the constructor
+                            encoder.Builder.EmitReloc(target.Constructor, RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                    }
+                    break;
+
+                case ReadyToRunHelperId.ResolveVirtualFunction:
+                    {
+                        MethodDesc targetMethod = (MethodDesc)Target;
+                        if (targetMethod.OwningType.IsInterface)
+                        {
+                            encoder.Builder.EmitReloc(factory.InterfaceDispatchCell(targetMethod), RelocType.IMAGE_REL_BASED_REL32);
+                            encoder.Builder.EmitReloc(factory.ExternSymbol("RhpResolveInterfaceMethod"), RelocType.IMAGE_REL_BASED_REL32);
+                        }
+                    }
+                    break;
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmTentativeMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmTentativeMethodNode.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ILCompiler.DependencyAnalysis.Wasm;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public partial class TentativeMethodNode
+    {
+        protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
+        {
+            encoder.Builder.EmitReloc(GetTarget(factory), RelocType.IMAGE_REL_BASED_REL32);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmUnboxingStubNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmUnboxingStubNode.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using ILCompiler.DependencyAnalysis.Wasm;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public partial class UnboxingStubNode
+    {
+        protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
+        {
+            encoder.Builder.EmitReloc(GetUnderlyingMethodEntrypoint(factory), RelocType.IMAGE_REL_BASED_REL32);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -150,7 +150,6 @@ namespace ILCompiler.DependencyAnalysis
                         }
                         else
                         {
-                            ISymbolNode targetMethodNode = target.GetTargetNode(factory);
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg2, target.GetTargetNode(factory));
                         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -276,7 +276,7 @@ namespace ILCompiler
                 {
                     if (!_vtableSlices.TryGetValue(type, out IReadOnlyList<MethodDesc> slots))
                     {
-                        // If we couln't find the vtable slice information for this type, it's because the scanner
+                        // If we couldn't find the vtable slice information for this type, it's because the scanner
                         // didn't correctly predict what will be needed.
                         // To troubleshoot, compare the dependency graph of the scanner and the compiler.
                         // Follow the path from the node that requested this node to the root.
@@ -315,7 +315,7 @@ namespace ILCompiler
             {
                 if (!_layouts.TryGetValue(methodOrType, out IEnumerable<GenericLookupResult> layout))
                 {
-                    // If we couln't find the dictionary layout information for this, it's because the scanner
+                    // If we couldn't find the dictionary layout information for this, it's because the scanner
                     // didn't correctly predict what will be needed.
                     // To troubleshoot, compare the dependency graph of the scanner and the compiler.
                     // Follow the path from the node that requested this node to the root.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -370,7 +370,7 @@ namespace Internal.IL
                             TypeDesc canonDelegateType = method.OwningType.ConvertToCanonForm(CanonicalFormKind.Specific);
                             DelegateCreationInfo info = _compilation.GetDelegateCtor(canonDelegateType, delTargetMethod, previousOpcode == ILOpcode.ldvirtftn);
 
-                            if (info.NeedsRuntimeLookup)    
+                            if (info.NeedsRuntimeLookup)
                             {
                                 // TODO-LLVM: delete when IL->LLVM module is gone
                                 if (_compilation.TargetArchIsWasm())
@@ -651,14 +651,7 @@ namespace Internal.IL
                         }
                         else
                         {
-                            if (targetMethod.RequiresInstMethodTableArg())
-                            {
-                                _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandle, _constrained), reason);
-                            }
-                            else
-                            {
-                                _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.MethodDictionary, targetOfLookup), reason);
-                            }
+                            _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.MethodDictionary, targetOfLookup), reason);
                         }
                     }
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -429,14 +429,13 @@ namespace Internal.IL
                 }
             }
 
-
             // TODO-LLVM: delete when IL->LLVM module is gone
             if (_compilation.TargetArchIsWasm())
             {
                 if (!method.IsRuntimeDeterminedExactMethod && method.IsVirtual && !method.HasInstantiation &&
                     MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(method) == method)
                 {
-                    _dependencies.Add(_factory.VirtualMethodUse(method), "LLVM delegate Invoke");
+                    _dependencies.Add(_factory.VirtualMethodUse(method), "LLVM VTable slot");
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -207,6 +207,11 @@
     <Compile Include="Compiler\DependencyAnalysis\StructMarshallingDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_ARM64\ARM64TentativeMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_ARM\ARMTentativeMethodNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_Wasm\WasmEmitter.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_Wasm\WasmReadyToRunGenericHelperNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_Wasm\WasmReadyToRunHelperNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_Wasm\WasmTentativeMethodNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\Target_Wasm\WasmUnboxingStubNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X64\X64TentativeMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\Target_X86\X86TentativeMethodNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\TentativeInstanceMethodNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -689,9 +689,7 @@ namespace ILCompiler.DependencyAnalysis
 
             if (dummyFunc.Handle != IntPtr.Zero) return;
 
-            var startupFunc = Module.AddFunction("RhpInitialDynamicInterfaceDispatch", LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] {}));
-
-            //LLVMBuilderRef builder = Module.CreateBuilder();
+            Module.AddFunction("RhpInitialDynamicInterfaceDispatch", LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] {}));
         }
 
         public void EmitBlobWithRelocs(byte[] blob, Relocation[] relocs)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -370,7 +370,7 @@ namespace ILCompiler.DependencyAnalysis
             public LLVMValueRef ToLLVMValueRef(LLVMModuleRef module)
             {
                 // Dont know if symbol is for an extern function or a variable, so check both
-                LLVMValueRef valRef = module.GetNamedGlobal(SymbolName); 
+                LLVMValueRef valRef = module.GetNamedGlobal(SymbolName);
                 if (valRef.Handle == IntPtr.Zero) valRef = module.GetNamedFunction(SymbolName);
 
                 if (Offset != 0 && valRef.Handle != IntPtr.Zero)
@@ -673,8 +673,25 @@ namespace ILCompiler.DependencyAnalysis
                 EmitBlob(new byte[pointerSize]);
                 return pointerSize;
             }
+
+            if (realSymbolName == "RhpInitialDynamicInterfaceDispatch")
+            {
+                CreateDummyRhpInitialDynamicInterfaceDispatch();
+            }
+
             int offsetFromBase = GetNumericOffsetFromBaseSymbolValue(target) + target.Offset;
             return EmitSymbolRef(realSymbolName, offsetFromBase, relocType, delta);
+        }
+
+        private void CreateDummyRhpInitialDynamicInterfaceDispatch()
+        {
+            LLVMValueRef dummyFunc = Module.GetNamedFunction("RhpInitialDynamicInterfaceDispatch");
+
+            if (dummyFunc.Handle != IntPtr.Zero) return;
+
+            var startupFunc = Module.AddFunction("RhpInitialDynamicInterfaceDispatch", LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] {}));
+
+            //LLVMBuilderRef builder = Module.CreateBuilder();
         }
 
         public void EmitBlobWithRelocs(byte[] blob, Relocation[] relocs)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMMethodCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMMethodCodeNode.cs
@@ -118,6 +118,7 @@ namespace ILCompiler.DependencyAnalysis
         public LlvmMethodBodyNode(MethodDesc method)
             : base(method)
         {
+            Debug.Assert(!method.IsAbstract);
         }
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -142,8 +142,7 @@ namespace ILCompiler
                     corInfo.CompileMethod(methodCodeNodeNeedingCode);
                     methodCodeNodeNeedingCode.CompilationCompleted = true;
                     // TODO: delete this external function when old module is gone
-                    LLVMValueRef externFunc = Module.AddFunction(mangledName,
-                        GetLLVMSignatureForMethod(sig, method.RequiresInstArg()));
+                    LLVMValueRef externFunc = ILImporter.GetOrCreateLLVMFunction(Module, mangledName, GetLLVMSignatureForMethod(sig, method.RequiresInstArg()));
                     externFunc.Linkage = LLVMLinkage.LLVMExternalLinkage;
 
                     ILImporter.GenerateRuntimeExportThunk(this, method, externFunc);

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -195,7 +195,7 @@ namespace ILCompiler
                 syntax.DefineOption("completetypemetadata", ref _completeTypesMetadata, "Generate complete metadata for types");
                 syntax.DefineOption("reflectedonly", ref _reflectedOnly, "Generate metadata only for reflected members");
                 syntax.DefineOption("scanreflection", ref _scanReflection, "Scan IL for reflection patterns");
-                syntax.DefineOption("scan", ref _useScanner, "Use IL scanner to generate optimized code (implied by -O)");
+                syntax.DefineOption("scan", ref _useScanner, "Use IL scanner to generate optimized code (implied by -O).  For LLVM this has no effect because the scanner is always on");
                 syntax.DefineOption("noscan", ref _noScanner, "Do not use IL scanner to generate optimized code");
                 syntax.DefineOption("ildump", ref _ilDump, "Dump IL assembly listing for compiler-generated IL");
                 syntax.DefineOption("stacktracedata", ref _emitStackTraceData, "Emit data to support generating stack trace strings at runtime");
@@ -708,8 +708,9 @@ namespace ILCompiler
             // We also don't do this for multifile because scanner doesn't simulate inlining (this would be
             // fixable by using a CompilationGroup for the scanner that has a bigger worldview, but
             // let's cross that bridge when we get there).
-            bool useScanner = _useScanner ||
-                (_optimizationMode != OptimizationMode.None && !_isLlvmCodegen && !_multiFile);
+            // For LLVM the scanner is always on to enable precomputed vtable slots
+            bool useScanner = _useScanner || _isLlvmCodegen ||
+                (_optimizationMode != OptimizationMode.None && !_multiFile);
 
             useScanner &= !_noScanner;
 


### PR DESCRIPTION
This PR enables the IL scanner for LLVM.  The scanner is always on for LLVM to enable precomputed vtables slots.  

This will unblock the `CT_INDIRECT` work https://github.com/dotnet/runtimelab/pull/1768 .  At ComputeGenericLookup in `Compilation.cs`  you can see that it never takes the fixed lookup path for generic calls, so not sure that if that is going to be a problem.

There are some changes to the scanner to add dependencies required by the IL->LLVM compilation which should be removed when all code is generated by clrjit. Including

- The scanner has the same stubbing out of methods not implemented for LLVM, `GetRandomBytes` and `EnumCalendarInfo` 
- For expanding intrinsics, the scanner has to add dependencies for both expanding and not expanding as it doesn't know which module will compile the method.
- Adding dependencies for throwing exceptions and exception handling
- Various other places where the IL->LLVM compilation differs from the scanner

cc @SingleAccretion
Thanks @MichalStrehovsky 