### PR TITLE
[NativeAOT] Remove unused var, typos

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -150,7 +150,6 @@ namespace ILCompiler.DependencyAnalysis
                         }
                         else
                         {
-                            ISymbolNode targetMethodNode = target.GetTargetNode(factory);
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg2, target.GetTargetNode(factory));
                         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -270,7 +270,7 @@ namespace ILCompiler
                 {
                     if (!_vtableSlices.TryGetValue(type, out IReadOnlyList<MethodDesc> slots))
                     {
-                        // If we couln't find the vtable slice information for this type, it's because the scanner
+                        // If we couldn't find the vtable slice information for this type, it's because the scanner
                         // didn't correctly predict what will be needed.
                         // To troubleshoot, compare the dependency graph of the scanner and the compiler.
                         // Follow the path from the node that requested this node to the root.
@@ -318,7 +318,7 @@ namespace ILCompiler
             {
                 if (!_layouts.TryGetValue(methodOrType, out IEnumerable<GenericLookupResult> layout))
                 {
-                    // If we couln't find the dictionary layout information for this, it's because the scanner
+                    // If we couldn't find the dictionary layout information for this, it's because the scanner
                     // didn't correctly predict what will be needed.
                     // To troubleshoot, compare the dependency graph of the scanner and the compiler.
                     // Follow the path from the node that requested this node to the root.


### PR DESCRIPTION
This PR just cleans up an unused var and some typos.