### PR TITLE
[NativeAOT-LLVM] map runtimeimports to their native name for ldftn

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -3069,47 +3069,7 @@ namespace Internal.IL
 
         private ExpressionEntry ImportRawPInvoke(MethodDesc method, StackEntry[] arguments, LLVMBuilderRef builder, TypeDesc forcedReturnType = null)
         {
-            string realMethodName = method.Name;
-
-            if (method.IsPInvoke)
-            {
-                string entrypointName = method.GetPInvokeMethodMetadata().Name;
-                if (!String.IsNullOrEmpty(entrypointName))
-                {
-                    realMethodName = entrypointName;
-                }
-            }
-            else if (!method.IsPInvoke && method is TypeSystem.Ecma.EcmaMethod)
-            {
-                realMethodName = ((TypeSystem.Ecma.EcmaMethod)method).GetRuntimeImportName() ?? method.Name;
-            }
-            MethodDesc existantDesc;
-            LLVMValueRef nativeFunc;
-            LLVMValueRef realNativeFunc = Module.GetNamedFunction(realMethodName);
-            if (_pinvokeMap.TryGetValue(realMethodName, out existantDesc))
-            {
-                if (existantDesc != method)
-                {
-                    // Set up native parameter types
-                    nativeFunc = MakeExternFunction(method, realMethodName, realNativeFunc);
-                }
-                else
-                {
-                    nativeFunc = realNativeFunc;
-                }
-            }
-            else
-            {
-                _pinvokeMap.Add(realMethodName, method);
-                nativeFunc = realNativeFunc;
-            }
-
-            // Create an import if we haven't already
-            if (nativeFunc.Handle == IntPtr.Zero)
-            {
-                // Set up native parameter types
-                nativeFunc = MakeExternFunction(method, realMethodName);
-            }
+            LLVMValueRef nativeFunc = GetInternalNativeFunction(method);
 
             LLVMValueRef[] llvmArguments = new LLVMValueRef[method.Signature.Length];
             for (int i = 0; i < arguments.Length; i++)
@@ -3290,7 +3250,13 @@ namespace Internal.IL
             }
             else
             {
-                if (canonMethod.IsSharedByGenericInstantiations && (canonMethod.HasInstantiation || canonMethod.Signature.IsStatic))
+                if (IsInternalRuntimeImport(method) && method is EcmaMethod)
+                {
+                    // TODO-LLVM: Suspect this is going to crash if its ever called as we've lost the information that it's an unmanaged call
+                    // Can we live with this for the IL->LLVM compilation and address it in RyuJIT?
+                    targetLLVMFunction = GetInternalNativeFunction(method);
+                }
+                else if (canonMethod.IsSharedByGenericInstantiations && (canonMethod.HasInstantiation || canonMethod.Signature.IsStatic))
                 {
                     var exactContextNeedsRuntimeLookup = method.HasInstantiation
                         ? method.IsSharedByGenericInstantiations
@@ -3347,6 +3313,54 @@ namespace Internal.IL
 
             var entry = new FunctionPointerEntry("ldftn", runtimeDeterminedMethod, targetLLVMFunction, GetWellKnownType(WellKnownType.IntPtr), opCode == ILOpcode.ldvirtftn);
             _stack.Push(entry);
+        }
+
+        LLVMValueRef GetInternalNativeFunction(MethodDesc method)
+        {
+            string realMethodName = method.Name;
+
+            if (method.IsPInvoke)
+            {
+                string entrypointName = method.GetPInvokeMethodMetadata().Name;
+                if (!String.IsNullOrEmpty(entrypointName))
+                {
+                    realMethodName = entrypointName;
+                }
+            }
+            else if (!method.IsPInvoke && method is TypeSystem.Ecma.EcmaMethod)
+            {
+                realMethodName = ((TypeSystem.Ecma.EcmaMethod)method).GetRuntimeImportName() ?? method.Name;
+            }
+
+            MethodDesc existantDesc;
+            LLVMValueRef nativeFunc;
+            LLVMValueRef realNativeFunc = Module.GetNamedFunction(realMethodName);
+            if (_pinvokeMap.TryGetValue(realMethodName, out existantDesc))
+            {
+                if (existantDesc != method)
+                {
+                    // Set up native parameter types
+                    nativeFunc = MakeExternFunction(method, realMethodName, realNativeFunc);
+                }
+                else
+                {
+                    nativeFunc = realNativeFunc;
+                }
+            }
+            else
+            {
+                _pinvokeMap.Add(realMethodName, method);
+                nativeFunc = realNativeFunc;
+            }
+
+            // Create an import if we haven't already
+            if (nativeFunc.Handle == IntPtr.Zero)
+            {
+                // Set up native parameter types
+                nativeFunc = MakeExternFunction(method, realMethodName);
+            }
+
+            return nativeFunc;
         }
 
         ISymbolNode GetAndAddFatFunctionPointer(MethodDesc method, bool isUnboxingStub = false)


### PR DESCRIPTION
This PR partially addresses a problem with ldftn for RuntimeImports, i.e. from

https://github.com/dotnet/runtimelab/blob/3dd23bfdd00013b38bbc9b8de27cc9a2dd7cce12/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs#L455


Right now these are reported as undefined as they are not translated to the native names:
```
warning: undefined symbol: S_P_CoreLib_System_Runtime_InternalCalls__RhpNewArray (referenced by top-level compiled C/C++ code)
```
Emscripten will create imports for these in the wasm module, and stub them in JS.  However a WASI host like wasmtime cannot satisfy these imports and just refuses to start.  This PR at least lets the module run in a WASI host, although if these function pointers were ever called, they might be treated as managed calls, get a shadow stack arg, and fail.  I propose to not solve that in the IL->LLVM compilation, but leave it until it's hit in the RyuJIT compilation.

There is still one undefined symbol preventing wasmtime starting, `dotnet_browser_entropy`, but that can be tackled in it's own PR.

cc @SingleAccretion