### PR TITLE
[NativeAOT-LLVM] Change importance of missing EMSDK Message task to High so it appears on the console

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -431,7 +431,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Exec Command="&quot;$(EMSDK)/upstream/emscripten/emcc.bat&quot; $(EmccArgs)" Condition="'$(TargetOS)' == 'browser' and '$(EMSDK)' != '' and '$(OS)' == 'Windows_NT'" />
     <Exec Command="&quot;$(EMSDK)/upstream/emscripten/emcc&quot; $(EmccArgs)" Condition="'$(TargetOS)' == 'browser' and '$(EMSDK)' != '' and '$(OS)' != 'Windows_NT'" />
     <Message Text="Emscripten not found, not linking WebAssembly. To enable WebAssembly linking, install Emscripten and ensure the EMSDK environment variable points to the directory containing upstream/emscripten/emcc.bat"
-             Condition="'$(NativeCodeGen)' == 'llvm' and '$(EMSDK)' == ''" />
+             Condition="'$(NativeCodeGen)' == 'llvm' and '$(EMSDK)' == ''" Importance="High" />
   </Target>
   
   <Target Name="LinkNative"


### PR DESCRIPTION
This PR just does what it says in the title.  Fixes #1839 

It's not super visible, but better than nothing:

![image](https://user-images.githubusercontent.com/2720041/152247354-5ebd9033-9d4f-40e3-8ec7-118d0719da79.png)
