### PR TITLE
[NativeAOT-LLVM] Build and cache struct types in llvm.cpp

### DIFF
--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -44,7 +44,8 @@ steps:
     - ${{ if eq(parameters.platform, 'Browser_wasm_win') }}:
       - script: |
           call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}
+          # Run sequential as we are getting Out of Memory errors
+          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} sequential
         displayName: Run WebAssembly tests in single file mode
     - ${{ elseif eq(parameters.osGroup, 'windows') }}:
       - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -44,8 +44,7 @@ steps:
     - ${{ if eq(parameters.platform, 'Browser_wasm_win') }}:
       - script: |
           call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-          # Run sequential as we are getting Out of Memory errors
-          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} sequential
+          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}
         displayName: Run WebAssembly tests in single file mode
     - ${{ elseif eq(parameters.osGroup, 'windows') }}:
       - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}

--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -230,6 +230,7 @@ if (CLR_CMAKE_TARGET_WIN32)
     jitstd.h
     jittelemetry.h
     lir.h
+    llvm_types.h
     llvm.h
     loopcloning.h
     loopcloningopts.h

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -281,14 +281,15 @@ llvm::Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
                 const char* name = _getTypeName(_thisPtr, structHandle);
                 llvm::StructType* llvmStructType = llvm::StructType::create(_llvmContext, name);
                 llvmType = llvmStructType;
-                StructDesc* structDesc = getStructDesc(structHandle) ;
+                StructDesc* structDesc = getStructDesc(structHandle);
                 unsigned    fieldCnt   = structDesc->getFieldCount();
 
 
                 unsigned lastOffset = 0;
                 unsigned totalSize = 0;
                 std::vector<Type*> llvmFields = std::vector<Type*>();
-                int prevElementSize = 0;
+                unsigned prevElementSize = 0;
+
 
                 for (unsigned fieldIx = 0; fieldIx < fieldCnt; fieldIx++)
                 {
@@ -304,7 +305,7 @@ llvm::Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
 
                     CorInfoType fieldCorType = fieldDesc->getCorType();
                     
-                    int fieldSize = getElementSize(fieldDesc->getClassHandle(), fieldCorType);
+                    unsigned fieldSize = getElementSize(fieldDesc->getClassHandle(), fieldCorType);
 
                     llvmFields.push_back(getLlvmTypeForCorInfoType(fieldCorType, fieldDesc->getClassHandle()));
 

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -202,7 +202,8 @@ StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
             }
         }
 
-        StructDesc* structDesc = new StructDesc(fieldCount, new FieldDesc[fieldCount]);
+        FieldDesc*  fields     = new FieldDesc[fieldCount];
+        StructDesc* structDesc = new StructDesc(fieldCount, fields);
 
         unsigned fieldIx = 0;
         for (unsigned fldOffset = 0; fldOffset < structSize; fldOffset++)
@@ -212,13 +213,11 @@ StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
                 continue;
             }
 
-            FieldDesc* fieldDesc = structDesc->getFieldDesc(fieldIx);
-
-            CORINFO_FIELD_HANDLE fieldHandle = structTypeDescriptor.fields[fieldIx];
+            CORINFO_FIELD_HANDLE fieldHandle = sparseFields[fldOffset];
             CORINFO_CLASS_HANDLE fieldClassHandle = NO_CLASS_HANDLE;
 
-            fieldDesc->setFieldData(_info.compCompHnd->getFieldOffset(fieldHandle),
-                                    _info.compCompHnd->getFieldType(fieldHandle, &fieldClassHandle), fieldClassHandle);
+            const CorInfoType corInfoType = _info.compCompHnd->getFieldType(fieldHandle, &fieldClassHandle);
+            fields[fieldIx] = FieldDesc(fldOffset, corInfoType, fieldClassHandle);
             fieldIx++;
         }
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -201,7 +201,6 @@ private:
     CORINFO_CLASS_HANDLE tryGetStructClassHandle(LclVarDsc* varDsc);
     void visitNode(GenTree* node);
     Value* zextIntIfNecessary(Value* intValue);
-    TypeDescriptor getTypeDescriptor(CORINFO_CLASS_HANDLE structHandle);
     StructDesc* getStructDesc(CORINFO_CLASS_HANDLE structHandle);
 
 public:

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -8,6 +8,7 @@
 
 #include "alloc.h"
 #include "jitpch.h"
+#include "llvm_types.h"
 #include <new>
 
 // these break std::min/max in LLVM's headers
@@ -64,27 +65,6 @@ struct SsaPairHash
     }
 };
 
-struct TypeDescriptor
-{
-    size_t                fieldCount;
-    CORINFO_FIELD_HANDLE* fields;
-};
-
-struct StructDesc;
-
-struct FieldDesc
-{
-    int                  fieldOffset;
-    CORINFO_CLASS_HANDLE classHandle;
-    CorInfoType          corType;
-};
-
-struct StructDesc
-{
-    size_t     fieldCount;
-    FieldDesc* fieldDesc;
-};
-
 extern "C" void registerLlvmCallbacks(void*       thisPtr,
                                       const char* outputFileName,
                                       const char* triple,
@@ -127,7 +107,6 @@ private:
     llvm::IRBuilder<> _prologBuilder;
     std::unordered_map<GenTree*, Value*>* _sdsuMap;
     std::unordered_map<SsaPair, Value*, SsaPairHash>* _localsMap;
-    std::unordered_map<CORINFO_CLASS_HANDLE, TypeDescriptor>* _typeDescriptorsMap;
     std::vector<PhiPair> _phiPairs;
 
     // DWARF

--- a/src/coreclr/jit/llvm_types.h
+++ b/src/coreclr/jit/llvm_types.h
@@ -58,7 +58,7 @@ private:
     FieldDesc* _fieldDesc;
 
 public:
-    // deleting the StructDesc will also delete the fieldDesc array
+    // This constructor takes the ownership of the passed in array of field descriptors.
     StructDesc(size_t fieldCount, FieldDesc* fieldDesc)
         : _fieldCount(fieldCount), _fieldDesc(fieldDesc)
     {

--- a/src/coreclr/jit/llvm_types.h
+++ b/src/coreclr/jit/llvm_types.h
@@ -8,7 +8,7 @@
 #ifndef _LLVM_TYPES_H_
 #define _LLVM_TYPES_H_
 
-#include "corinfo.h"
+#include "jitpch.h"
 
 struct TypeDescriptor
 {
@@ -19,64 +19,62 @@ struct TypeDescriptor
 struct FieldDesc
 {
 private:
-    int                  _fieldOffset;
-    CORINFO_CLASS_HANDLE _classHandle;
-    CorInfoType          _corType;
+    unsigned             m_fieldOffset;
+    CorInfoType          m_corType;
+    CORINFO_CLASS_HANDLE m_classHandle;
 
 public:
     FieldDesc()
     {
     }
 
+    FieldDesc(unsigned fieldOffset, CorInfoType corType, CORINFO_CLASS_HANDLE classHandle)
+        : m_fieldOffset(fieldOffset), m_corType(corType), m_classHandle(classHandle)
+    {
+    }
+
     int getFieldOffset()
     {
-        return _fieldOffset;
+        return m_fieldOffset;
     }
 
     CORINFO_CLASS_HANDLE getClassHandle()
     {
-        return _classHandle;
+        return m_classHandle;
     }
 
     CorInfoType getCorType()
     {
-        return _corType;
-    }
-
-    void setFieldData(int fieldOffset, CorInfoType corType, CORINFO_CLASS_HANDLE classHandle)
-    {
-        _fieldOffset = fieldOffset;
-        _corType     = corType;
-        _classHandle = classHandle;
+        return m_corType;
     }
 };
 
 struct StructDesc
 {
 private:
-    size_t     _fieldCount;
-    FieldDesc* _fieldDesc;
+    size_t     m_fieldCount;
+    FieldDesc* m_fields;
 
 public:
     // deleting the StructDesc will also delete the fieldDesc array
     StructDesc(size_t fieldCount, FieldDesc* fieldDesc)
-        : _fieldCount(fieldCount), _fieldDesc(fieldDesc)
+        : m_fieldCount(fieldCount), m_fields(fieldDesc)
     {
     }
 
     ~StructDesc()
     {
-        delete[] _fieldDesc;
+        delete[] m_fields;
     }
 
     size_t getFieldCount()
     {
-        return _fieldCount;
+        return m_fieldCount;
     }
 
     FieldDesc* getFieldDesc(unsigned index)
     {
-        return &_fieldDesc[index];
+        return &m_fields[index];
     }
 };
 

--- a/src/coreclr/jit/llvm_types.h
+++ b/src/coreclr/jit/llvm_types.h
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-/*
- * Types used in LLVM compilation that are abstractions of the VM types
-*/
+//
+// Types used in LLVM compilation that are abstractions of the VM types.
+//
 
 #ifndef _LLVM_TYPES_H_
 #define _LLVM_TYPES_H_

--- a/src/coreclr/jit/llvm_types.h
+++ b/src/coreclr/jit/llvm_types.h
@@ -12,7 +12,7 @@
 
 struct TypeDescriptor
 {
-    size_t                fieldCount;
+    unsigned              fieldCount;
     CORINFO_FIELD_HANDLE* fields;
 };
 

--- a/src/coreclr/jit/llvm_types.h
+++ b/src/coreclr/jit/llvm_types.h
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*
+ * Types used in LLVM compilation that are abstractions of the VM types
+*/
+
+#ifndef _LLVM_TYPES_H_
+#define _LLVM_TYPES_H_
+
+#include "corinfo.h"
+
+struct TypeDescriptor
+{
+    size_t                fieldCount;
+    CORINFO_FIELD_HANDLE* fields;
+};
+
+struct FieldDesc
+{
+private:
+    int                  _fieldOffset;
+    CORINFO_CLASS_HANDLE _classHandle;
+    CorInfoType          _corType;
+
+public:
+    FieldDesc()
+    {
+    }
+
+    int getFieldOffset()
+    {
+        return _fieldOffset;
+    }
+
+    CORINFO_CLASS_HANDLE getClassHandle()
+    {
+        return _classHandle;
+    }
+
+    CorInfoType getCorType()
+    {
+        return _corType;
+    }
+
+    void setFieldData(int fieldOffset, CorInfoType corType, CORINFO_CLASS_HANDLE classHandle)
+    {
+        _fieldOffset = fieldOffset;
+        _corType     = corType;
+        _classHandle = classHandle;
+    }
+};
+
+struct StructDesc
+{
+private:
+    size_t     _fieldCount;
+    FieldDesc* _fieldDesc;
+
+public:
+    // deleting the StructDesc will also delete the fieldDesc array
+    StructDesc(size_t fieldCount, FieldDesc* fieldDesc)
+        : _fieldCount(fieldCount), _fieldDesc(fieldDesc)
+    {
+    }
+
+    ~StructDesc()
+    {
+        delete[] _fieldDesc;
+    }
+
+    size_t getFieldCount()
+    {
+        return _fieldCount;
+    }
+
+    FieldDesc* getFieldDesc(unsigned index)
+    {
+        return &_fieldDesc[index];
+    }
+};
+
+#endif // _LLVM_TYPES_H_

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -76,6 +76,7 @@ namespace ILCompiler
             var nodes = _dependencyGraph.MarkedNodeList;
 
             CorInfoImpl.Shutdown(); // writes the LLVM bitcode
+            CorInfoImpl.FreeUnmanagedResources();
 
             LLVMObjectWriter.EmitObject(outputFile, nodes, NodeFactory, this, dumper);
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -318,14 +318,14 @@ namespace Internal.JitInterface
                 }
             }
 
-            //TODO-LLVM: change to NativeMemory.Alloc when upgrade to .net6
-            IntPtr allocedMemory = Marshal.AllocHGlobal((int)(sizeof(CORINFO_FIELD_STRUCT_*) * fieldCount));
-            _allocedMemory.Add(allocedMemory);
+            //TODO-LLVM: change to NativeMemory.Alloc when upgraded to .net6
+            IntPtr fieldArray = Marshal.AllocHGlobal((int)(sizeof(CORINFO_FIELD_STRUCT_*) * fieldCount));
+            _allocedMemory.Add(fieldArray);
 
             typeDescriptor = new TypeDescriptor
             {
                 FieldCount = fieldCount,
-                Fields = (CORINFO_FIELD_STRUCT_**)allocedMemory
+                Fields = (CORINFO_FIELD_STRUCT_**)fieldArray
             };
 
             fieldCount = 0;


### PR DESCRIPTION
This PR caches struct `CORINFO_CLASS_STRUCT_` fields and replicates some fields of `FieldDesc` in llvm.cpp facilitating the eventual reuse of the struct definitions for  GT_STORE_OBJ and GT_OBJ (to come in #1825 )

cc @SingleAccretion

Possibly coincidentally I've noticed that on my desktop with 16GB RAM I can no longer run the tests in parallel (x4) as it runs out of memory.  I did print the structs as they were cached and that does appear to be fine: it doesn't `new`multiple storage for the same struct, so maybe I was just close to the limit previously.
