### PR TITLE
Disable the EH Continuations feature fully

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -566,6 +566,7 @@ if (CLR_CMAKE_BUILD_LLVM_JIT)
 
     # We'll be linking against LLVM built without /guard:ehcont, so disable it.
     string(REPLACE "/guard:ehcont" "" CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
+    string(REPLACE "/guard:ehcont" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 
     create_standalone_jit(TARGET clrjit_browser_wasm32_${ARCH_HOST_NAME} OS browser ARCH wasm32 DESTINATIONS .)
     install_clr(TARGETS clrjit_browser_wasm32_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT wasmjit)


### PR DESCRIPTION
The issue was that for the MSBuild-based configuration (i. e. `./build wasmjit -msbuild`), we were still setting `/guard:ehcont`, failing to link with LLVM afterwards.