### PR TITLE
[NativeAOT-LLVM] Add support CT_INDIRECT calls

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8799,7 +8799,11 @@ GenTreeCall* Compiler::gtCloneExprCallHelper(GenTreeCall* tree,
     // we only really need one physical copy of it. Therefore a shallow pointer copy will suffice.
     // (Note that this still holds even if the tree we are cloning was created by an inlinee compiler,
     // because the inlinee still uses the inliner's memory allocator anyway.)
+#if TARGET_WASM
+    copy->callSig = tree->callSig;
+#else
     INDEBUG(copy->callSig = tree->callSig;)
+#endif // TARGET_WASM
 
     // The tail call info does not change after it is allocated, so for the same reasons as above
     // a shallow copy suffices.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8799,11 +8799,9 @@ GenTreeCall* Compiler::gtCloneExprCallHelper(GenTreeCall* tree,
     // we only really need one physical copy of it. Therefore a shallow pointer copy will suffice.
     // (Note that this still holds even if the tree we are cloning was created by an inlinee compiler,
     // because the inlinee still uses the inliner's memory allocator anyway.)
-#if TARGET_WASM
+#if defined(DEBUG) || defined(TARGET_WASM)
     copy->callSig = tree->callSig;
-#else
-    INDEBUG(copy->callSig = tree->callSig;)
-#endif // TARGET_WASM
+#endif // DEBUG || TARGET_WASM
 
     // The tail call info does not change after it is allocated, so for the same reasons as above
     // a shallow copy suffices.

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4211,10 +4211,10 @@ struct GenTreeCall final : public GenTree
     regList regArgList;
 #endif
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(TARGET_WASM)
     // Used to register callsites with the EE
     CORINFO_SIG_INFO* callSig;
-#endif
+#endif // defined(DEBUG) || defined(TARGET_WASM)
 
     union {
         TailCallSiteInfo* tailCallInfo;
@@ -4749,7 +4749,7 @@ struct GenTreeCall final : public GenTree
 
 #if defined(TARGET_WASM)
     CorInfoType gtCorInfoType; // the precise return type used to construct the signature
-#endif
+#endif // defined(TARGET_WASM)
 
     CORINFO_CLASS_HANDLE gtRetClsHnd; // The return type handle of the call if it is a struct; always available
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8645,8 +8645,9 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 assert((sig->callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_VARARG &&
                        (sig->callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_NATIVEVARARG);
 
+#if TARGET_WASM
                 call->AsCall()->callSig = new (this, CMK_Generic) CORINFO_SIG_INFO(*sig);
-
+#endif
                 goto DONE;
             }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8645,10 +8645,8 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 assert((sig->callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_VARARG &&
                        (sig->callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_NATIVEVARARG);
 
-#if TARGET_WASM // TODO-LLVM
-                call->AsCall()->callSig  = new (this, CMK_Generic) CORINFO_SIG_INFO;
-                *call->AsCall()->callSig = *sig;
-#endif 
+                call->AsCall()->callSig = new (this, CMK_Generic) CORINFO_SIG_INFO(*sig);
+
                 goto DONE;
             }
 
@@ -8744,8 +8742,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
 #if TARGET_WASM
     assert(call->AsCall()->callSig == nullptr);
-    call->AsCall()->callSig  = new (this, CMK_Generic) CORINFO_SIG_INFO;
-    *call->AsCall()->callSig = *sig;
+    call->AsCall()->callSig = new (this, CMK_Generic) CORINFO_SIG_INFO(*sig);
 #endif
 
     /*-------------------------------------------------------------------------

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8644,6 +8644,11 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 // Sine we are jumping over some code, check that its OK to skip that code
                 assert((sig->callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_VARARG &&
                        (sig->callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_NATIVEVARARG);
+
+#if TARGET_WASM // TODO-LLVM
+                call->AsCall()->callSig  = new (this, CMK_Generic) CORINFO_SIG_INFO;
+                *call->AsCall()->callSig = *sig;
+#endif 
                 goto DONE;
             }
 

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -924,29 +924,27 @@ Value* Llvm::consumeValue(GenTree* node, Type* targetLlvmType)
             switch (node->OperGet())
             {
                 case GT_CALL:
-                {
                     trueNodeType = static_cast<var_types>(node->AsCall()->gtReturnType);
                     break;
-                }
+
                 case GT_LCL_VAR:
-                {
-                    LclVarDsc* varDsc = _compiler->lvaGetDesc(node->AsLclVarCommon());
-                    trueNodeType = varDsc->TypeGet();
+                    trueNodeType = _compiler->lvaGetDesc(node->AsLclVarCommon())->TypeGet();
                     break;
-                }
-                default :
-                {
-                    if (node->OperIsRelop())
-                    {
-                        // This is the special case for relops. Ordinary codegen "just knows" they need zero-extension.
-                        assert(nodeValue->getType() == Type::getInt1Ty(_llvmContext));
-                        trueNodeType = TYP_BOOL;
-                    }
-                    else
-                    {
-                        trueNodeType = node->TypeGet();
-                    }
-                }
+
+                case GT_EQ:
+                case GT_NE:
+                case GT_LT:
+                case GT_LE:
+                case GT_GE:
+                case GT_GT:
+                    // This is the special case for relops. Ordinary codegen "just knows" they need zero-extension.
+                    assert(nodeValue->getType() == Type::getInt1Ty(_llvmContext));
+                    trueNodeType = TYP_UBYTE;
+                    break;
+
+                default:
+                    trueNodeType = node->TypeGet();
+                    break;
             }
 
             assert(varTypeIsSmall(trueNodeType));

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -164,7 +164,7 @@ private:
     void emitDoNothingCall();
     void endImportingBasicBlock(BasicBlock* block);
     [[noreturn]] void   failFunctionCompilation();
-    void failUnsupportedCalls(GenTreeCall* callNode, CORINFO_SIG_INFO* calleeSigInfo);
+    void failUnsupportedCalls(GenTreeCall* callNode);
     void fillPhis();
     llvm::Instruction* getCast(llvm::Value* source, Type* targetType);
     void generateProlog();
@@ -198,8 +198,8 @@ private:
     Value* localVar(GenTreeLclVar* lclVar);
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
 
-    GenTreeCall::Use* lowerCallReturn(GenTreeCall* callNode, CORINFO_SIG_INFO* calleeSigInfo, GenTreeCall::Use* lastArg);
-    void lowerCallToShadowStack(GenTreeCall* callNode, CORINFO_SIG_INFO* calleeSigInfo);
+    GenTreeCall::Use* lowerCallReturn(GenTreeCall* callNode, GenTreeCall::Use* lastArg);
+    void lowerCallToShadowStack(GenTreeCall* callNode);
     void lowerToShadowStack();
 
     Value* mapGenTreeToValue(GenTree* genTree, Value* valueRef);


### PR DESCRIPTION
This PR adds support for CT_INDIRECT calls.  It promotes `GenTree`'s `callSig` to a non DEBUG only field for `TARGET_WASM`   Doesn't add a huge amount of methods to the clrjit coverage, about a 1% increase.

cc @SingleAccretion

Closes #1862  #1860 