### PR TITLE
[NativeAOT-LLVM] FlushProcessWriteBuffers to a NOP

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -515,10 +515,10 @@ bool GCToOSInterface::CanGetCurrentProcessorNumber()
     return HAVE_SCHED_GETCPU;
 }
 
+#if !TARGET_WASM
 // Flush write buffers of processors that are executing threads of the current process
 void GCToOSInterface::FlushProcessWriteBuffers()
 {
-#if !defined(TARGET_WASM)
     if (s_flushUsingMemBarrier)
     {
         int status = membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0);
@@ -572,8 +572,8 @@ void GCToOSInterface::FlushProcessWriteBuffers()
         CHECK_MACH("vm_deallocate()", machret);
     }
 #endif // defined(TARGET_OSX) && defined(HOST_ARM64)
-#endif // !defined(TARGET_WASM)
 }
+#endif // !TARGET_WASM
 
 // Break into a debugger. Uses a compiler intrinsic if one is available,
 // otherwise raises a SIGTRAP.

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -518,6 +518,7 @@ bool GCToOSInterface::CanGetCurrentProcessorNumber()
 // Flush write buffers of processors that are executing threads of the current process
 void GCToOSInterface::FlushProcessWriteBuffers()
 {
+#if !defined(TARGET_WASM)
     if (s_flushUsingMemBarrier)
     {
         int status = membarrier(MEMBARRIER_CMD_PRIVATE_EXPEDITED, 0);
@@ -571,6 +572,7 @@ void GCToOSInterface::FlushProcessWriteBuffers()
         CHECK_MACH("vm_deallocate()", machret);
     }
 #endif // defined(TARGET_OSX) && defined(HOST_ARM64)
+#endif // !defined(TARGET_WASM)
 }
 
 // Break into a debugger. Uses a compiler intrinsic if one is available,

--- a/src/coreclr/gc/wasm/gcenv.wasm.cpp
+++ b/src/coreclr/gc/wasm/gcenv.wasm.cpp
@@ -4,6 +4,12 @@
 #include "common.h"
 #include "gcenv.h"
 
+
+// Flush write buffers of processors that are executing threads of the current process - a NOP for Wasm
+void GCToOSInterface::FlushProcessWriteBuffers()
+{
+}
+
 // Emscripten does not provide a complete implementation of mmap and munmap: munmap cannot unmap partial allocations
 // Emscripten does provide an implementation of posix_memalign which is used here.
 


### PR DESCRIPTION
This PR makes `FlushProcessWriteBuffers` a NOP for `TARGET_WASM` and removes a load of warnings about missing syscall for mprotect.

Closes #1861 

Thanks @jkotas 
cc @SingleAccretion