### PR TITLE
[NativeAOT-LLVM] Support for storing locals of type struct

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -67,7 +67,7 @@ stages:
         - OSX_x64
         - Browser_wasm_win
         jobParameters:
-          timeoutInMinutes: 200
+          timeoutInMinutes: 300
           testGroup: innerloop
           buildArgs: -s nativeaot+libs+nativeaot.packages -lc Release -rc Debug
           extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -84,7 +84,7 @@ stages:
         - Linux_x64
         - windows_x64
         jobParameters:
-          timeoutInMinutes: 200
+          timeoutInMinutes: 300
           testGroup: innerloop
           buildArgs: -s nativeaot+libs+nativeaot.packages -lc Release -rc Checked
           extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -105,7 +105,7 @@ stages:
       - OSX_x64
       - Browser_wasm_win
       jobParameters:
-        timeoutInMinutes: 200
+        timeoutInMinutes: 300
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         testGroup: innerloop
         buildArgs: -s nativeaot.objwriter+nativeaot+libs+nativeaot.packages -c Release

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1766,14 +1766,13 @@ bool Llvm::isLlvmFrameLocal(LclVarDsc* varDsc)
 
 void Llvm::storeLocalVar(GenTreeLclVar* lclVar)
 {
-    Type* destLlvmType = getLlvmTypeForLclVar(lclVar);
-
-    Value*   localValue;
+    Type*  destLlvmType = getLlvmTypeForLclVar(lclVar);
+    Value* localValue   = nullptr;
 
     // zero initialization check
-    if (lclVar->TypeGet() == TYP_STRUCT && lclVar->gtGetOp1()->IsIntegralConst(0))
+    if (lclVar->TypeIs(TYP_STRUCT) && lclVar->gtGetOp1()->IsIntegralConst(0))
     {
-        localValue = llvm::Constant::getNullValue(getLlvmTypeForStruct(_compiler->lvaGetDesc(lclVar)->GetLayout()));
+        localValue = llvm::Constant::getNullValue(destLlvmType);
     }
     else
     {
@@ -2431,7 +2430,7 @@ void Llvm::convertLclStructToLoad(GenTreeLclVarCommon* lclNode, ClassLayout* cls
     GenTree* lclAddr = _compiler->gtNewLclVarAddrNode(lclNode->GetLclNum());
 
     lclNode->ChangeOper(GT_OBJ);
-    lclNode->gtOp1 = lclAddr;
+    lclNode->AsObj()->SetAddr(lclAddr);
     lclNode->AsObj()->SetLayout(clsLayout);
 
     _currentRange->InsertBefore(lclNode, lclAddr);

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1227,7 +1227,24 @@ void Llvm::buildCnsInt(GenTree* node)
 {
     if (node->gtType == TYP_INT)
     {
-        mapGenTreeToValue(node, _builder.getInt32(node->AsIntCon()->IconValue()));
+        if (node->IsIconHandle())
+        {
+            if (node->IsIconHandle(GTF_ICON_TOKEN_HDL))
+            {
+                const char* symbolName = (*_getMangledSymbolName)(_thisPtr, (void*)(node->AsIntCon()->IconValue()));
+                (*_addCodeReloc)(_thisPtr, (void*)node->AsIntCon()->IconValue());
+                mapGenTreeToValue(node, _builder.CreateLoad(getOrCreateExternalSymbol(symbolName)));
+            }
+            else
+            {
+                //TODO-LLVML: other ICON handle types
+                failFunctionCompilation();
+            }
+        }
+        else
+        {
+            mapGenTreeToValue(node, _builder.getInt32(node->AsIntCon()->IconValue()));
+        }
         return;
     }
     if (node->gtType == TYP_REF)

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -2452,20 +2452,17 @@ void Llvm::lowerStoreLcl(GenTreeLclVarCommon* storeLclNode)
             else if (dataOp->OperIs(GT_LCL_VAR)) // can get icon 0 here
             {
                 GenTreeLclVarCommon* dataLcl = dataOp->AsLclVarCommon();
-                if (dataLcl->TypeGet() == TYP_STRUCT)
-                {
-                    LclVarDsc* dataVarDsc = _compiler->lvaGetDesc(dataLcl->GetLclNum());
+                LclVarDsc* dataVarDsc = _compiler->lvaGetDesc(dataLcl->GetLclNum());
 
-                    dataVarDsc->lvHasLocalAddr = 1;
+                dataVarDsc->lvHasLocalAddr = 1;
 
-                    GenTree* dataAddrNode = _compiler->gtNewLclVarAddrNode(dataLcl->GetLclNum());
+                GenTree* dataAddrNode = _compiler->gtNewLclVarAddrNode(dataLcl->GetLclNum());
 
-                    dataLcl->ChangeOper(GT_OBJ);
-                    dataLcl->AsObj()->SetAddr(dataAddrNode);
-                    dataLcl->AsObj()->SetLayout(addrVarDsc->GetLayout());
+                dataLcl->ChangeOper(GT_OBJ);
+                dataLcl->AsObj()->SetAddr(dataAddrNode);
+                dataLcl->AsObj()->SetLayout(addrVarDsc->GetLayout());
 
-                    _currentRange->InsertBefore(dataLcl, dataAddrNode);
-                }
+                CurrentRange().InsertBefore(dataLcl, dataAddrNode);
             }
         }
     }

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -2497,7 +2497,7 @@ void Llvm::lowerToShadowStack()
                         }
                     }
                 }
-                else if (dataOp->OperIs(GT_IND))
+                else if (dataOp->OperIs(GT_IND) && addrLcl->TypeGet() == TYP_STRUCT && dataOp->TypeGet() == TYP_STRUCT)
                 {
                     dataOp->ChangeOper(GT_OBJ);
                     LclVarDsc* addrVarDsc = _compiler->lvaGetDesc(addrLcl->GetLclNum());

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -2497,6 +2497,12 @@ void Llvm::lowerToShadowStack()
                         }
                     }
                 }
+                else if (dataOp->OperIs(GT_IND))
+                {
+                    dataOp->ChangeOper(GT_OBJ);
+                    LclVarDsc* addrVarDsc = _compiler->lvaGetDesc(addrLcl->GetLclNum());
+                    dataOp->AsObj()->SetLayout(addrVarDsc->GetLayout());
+                }
             }   
         }
     }

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -2411,7 +2411,7 @@ void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
 
 void Llvm::convertLclStructToLoad(GenTreeLclVarCommon* lclNode, ClassLayout* clsLayout)
 {
-    GenTree* lclAddr = _compiler->gtNewLclVarAddrNode(lclNode->GetLclNum(), TYP_STRUCT);
+    GenTree* lclAddr = _compiler->gtNewLclVarAddrNode(lclNode->GetLclNum());
 
     lclNode->ChangeOper(GT_OBJ);
     lclNode->gtOp1 = lclAddr;

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -656,15 +656,15 @@ Type* Llvm::getLlvmTypeForVarType(var_types type)
     }
 }
 
-Type* Llvm::getLlvmTypeForLclVar(GenTreeLclVarCommon* lclVar)
+Type* Llvm::getLlvmTypeForLclVar(GenTreeLclVar* lclVar)
 {
-    var_types varType = lclVar->TypeGet();
+    var_types nodeType = lclVar->TypeGet();
 
-    if (varType == TYP_STRUCT)
+    if (nodeType == TYP_STRUCT)
     {
         return getLlvmTypeForStruct(_compiler->lvaGetDesc(lclVar)->GetLayout());
     }
-    return getLlvmTypeForVarType(varType);
+    return getLlvmTypeForVarType(nodeType);
 }
 
 llvm::Instruction* Llvm::getCast(llvm::Value* source, Type* targetType)
@@ -1229,7 +1229,9 @@ void Llvm::buildCnsInt(GenTree* node)
     {
         if (node->IsIconHandle())
         {
-            if (node->IsIconHandle(GTF_ICON_TOKEN_HDL))
+            // TODO-LLVM : consider lowering these to "IND(CLS_VAR_ADDR)"
+            if (node->IsIconHandle(GTF_ICON_TOKEN_HDL) || node->IsIconHandle(GTF_ICON_CLASS_HDL) ||
+                node->IsIconHandle(GTF_ICON_METHOD_HDL) || node->IsIconHandle(GTF_ICON_FIELD_HDL))
             {
                 const char* symbolName = (*_getMangledSymbolName)(_thisPtr, (void*)(node->AsIntCon()->IconValue()));
                 (*_addCodeReloc)(_thisPtr, (void*)node->AsIntCon()->IconValue());
@@ -2436,6 +2438,44 @@ void Llvm::convertLclStructToLoad(GenTreeLclVarCommon* lclNode, ClassLayout* cls
     _currentRange->InsertBefore(lclNode, lclAddr);
 }
 
+void Llvm::lowerStoreLcl(GenTreeLclVarCommon* storeLclNode)
+{
+    GenTree* dataOp = storeLclNode->gtGetOp1();
+    CORINFO_CLASS_HANDLE dataHandle = _compiler->gtGetStructHandleIfPresent(dataOp);
+    if (dataOp->OperIs(GT_IND))
+    {
+        // Special case: "gtGetStructHandleIfPresent" sometimes guesses the handle from
+        // field sequences, but we will always need to transform TYP_STRUCT INDs into OBJs.
+        dataHandle = NO_CLASS_HANDLE;
+    }
+
+    LclVarDsc* addrVarDsc = _compiler->lvaGetDesc(storeLclNode->GetLclNum());
+
+    if (storeLclNode->TypeIs(TYP_STRUCT) && addrVarDsc->GetStructHnd() != dataHandle)
+    {
+        if (dataOp->OperIsIndir())
+        {
+            dataOp->SetOper(GT_OBJ);
+            dataOp->AsObj()->SetLayout(addrVarDsc->GetLayout());
+        }
+        else if (dataOp->OperIs(GT_LCL_VAR)) // can get icon 0 here
+        {
+            GenTreeLclVarCommon* dataLcl = dataOp->AsLclVarCommon();
+            if (storeLclNode->TypeGet() == TYP_STRUCT && dataLcl->TypeGet() == TYP_STRUCT)
+            {
+                LclVarDsc* dataVarDsc = _compiler->lvaGetDesc(dataLcl->GetLclNum());
+
+                if (tryGetStructClassHandle(addrVarDsc) != tryGetStructClassHandle(dataVarDsc))
+                {
+                    dataVarDsc->lvHasLocalAddr = 1;
+
+                    convertLclStructToLoad(dataLcl, addrVarDsc->GetLayout());
+                }
+            }
+        }
+    }
+}
+
 void Llvm::lowerToShadowStack()
 {
     for (BasicBlock* _currentBlock : _compiler->Blocks())
@@ -2493,32 +2533,7 @@ void Llvm::lowerToShadowStack()
             // check for implicit struct cast
             else if (node->OperIs(GT_STORE_LCL_VAR))
             {
-                GenTreeLclVarCommon* addrLcl = node->AsLclVarCommon();
-                GenTree* dataOp  = addrLcl->gtGetOp1();
-                if (dataOp->IsLocal())
-                {
-                    GenTreeLclVarCommon* dataLcl = dataOp->AsLclVarCommon();
-                    if (addrLcl->TypeGet() == TYP_STRUCT && dataLcl->TypeGet() == TYP_STRUCT)
-                    {
-                        LclVarDsc* addrVarDsc = _compiler->lvaGetDesc(addrLcl->GetLclNum());
-                        LclVarDsc* dataVarDsc = _compiler->lvaGetDesc(dataLcl->GetLclNum());
-
-                        if (tryGetStructClassHandle(addrVarDsc) != tryGetStructClassHandle(dataVarDsc))
-                        {
-                            // mark both as requiring lvHasLocalAddr as we will be doing a bitcast on the pointers
-                            addrVarDsc->lvHasLocalAddr = 1;
-                            dataVarDsc->lvHasLocalAddr = 1;
-
-                            convertLclStructToLoad(dataLcl, addrVarDsc->GetLayout());
-                        }
-                    }
-                }
-                else if (dataOp->OperIs(GT_IND) && addrLcl->TypeGet() == TYP_STRUCT && dataOp->TypeGet() == TYP_STRUCT)
-                {
-                    dataOp->ChangeOper(GT_OBJ);
-                    LclVarDsc* addrVarDsc = _compiler->lvaGetDesc(addrLcl->GetLclNum());
-                    dataOp->AsObj()->SetLayout(addrVarDsc->GetLayout());
-                }
+                lowerStoreLcl(node->AsLclVarCommon());
             }   
         }
     }

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -174,13 +174,15 @@ private:
     Value* getGenTreeValue(GenTree* node);
     LlvmArgInfo getLlvmArgInfoForArgIx(unsigned int lclNum);
     llvm::BasicBlock* getLLVMBasicBlockForBlock(BasicBlock* block);
-    Type* getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
-    Type* getLlvmTypeForParameterType(CORINFO_CLASS_HANDLE classHnd);
 
     Type* getLlvmTypeForStruct(ClassLayout* classLayout);
     Type* getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle);
 
     Type* getLlvmTypeForVarType(var_types type);
+    Type* getLlvmTypeForLclVar(GenTreeLclVarCommon* lclVar);
+    Type* getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
+    Type* getLlvmTypeForParameterType(CORINFO_CLASS_HANDLE classHnd);
+
     int getLocalOffsetAtIndex(GenTreeLclVar* lclVar);
     Value* getLocalVarAddress(GenTreeLclVar* lclVar);
     struct DebugMetadata getOrCreateDebugMetadata(const char* documentFileName);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -203,7 +203,6 @@ private:
     GenTreeCall::Use* lowerCallReturn(GenTreeCall* callNode, GenTreeCall::Use* lastArg);
     void lowerCallToShadowStack(GenTreeCall* callNode);
     void lowerToShadowStack();
-    void convertLclStructToLoad(GenTreeLclVarCommon* lclNode, ClassLayout* clsLayout);
     void lowerStoreLcl(GenTreeLclVarCommon* storeLclNode);
 
     Value* mapGenTreeToValue(GenTree* genTree, Value* valueRef);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -203,6 +203,7 @@ private:
     GenTreeCall::Use* lowerCallReturn(GenTreeCall* callNode, GenTreeCall::Use* lastArg);
     void lowerCallToShadowStack(GenTreeCall* callNode);
     void lowerToShadowStack();
+    void convertLclStructToLoad(GenTreeLclVarCommon* lclNode, ClassLayout* clsLayout);
 
     Value* mapGenTreeToValue(GenTree* genTree, Value* valueRef);
     bool needsReturnStackSlot(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -179,7 +179,7 @@ private:
     Type* getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle);
 
     Type* getLlvmTypeForVarType(var_types type);
-    Type* getLlvmTypeForLclVar(GenTreeLclVarCommon* lclVar);
+    Type* getLlvmTypeForLclVar(GenTreeLclVar* lclVar);
     Type* getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
     Type* getLlvmTypeForParameterType(CORINFO_CLASS_HANDLE classHnd);
 
@@ -204,6 +204,7 @@ private:
     void lowerCallToShadowStack(GenTreeCall* callNode);
     void lowerToShadowStack();
     void convertLclStructToLoad(GenTreeLclVarCommon* lclNode, ClassLayout* clsLayout);
+    void lowerStoreLcl(GenTreeLclVarCommon* storeLclNode);
 
     Value* mapGenTreeToValue(GenTree* genTree, Value* valueRef);
     bool needsReturnStackSlot(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);


### PR DESCRIPTION
This PR adds support for getting the LLVM type for locals of type `TYP_STRUCT` and moves local structs where an implicit cast appears to the LLVM frame.

(I believe `LCL_FLD` will be similar, but not done that here)

BTW, this enables the `TestStructStoreWithSignificantPadding` test from HelloWasm in the RyuJit module.

cc @SingleAccretion
