### PR TITLE
[NativeAOT-LLVM] Add support for GT_NULLCHECK

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -24,6 +24,8 @@ using llvm::LLVMContext;
 using llvm::ArrayRef;
 using llvm::Module;
 
+
+// TODO: We should create a Static... class to manage the statics and their lifetimes
 static Module*          _module    = nullptr;
 static llvm::DIBuilder* _diBuilder = nullptr;
 static LLVMContext _llvmContext;

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -45,7 +45,7 @@ static const uint32_t (*_padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned);
 static const CorInfoTypeWithMod (*_getArgTypeIncludingParameterized)(void*, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_HANDLE, CORINFO_CLASS_HANDLE*);
 static const CorInfoTypeWithMod (*_getParameterType)(void*, CORINFO_CLASS_HANDLE, CORINFO_CLASS_HANDLE*);
 static const TypeDescriptor (*_getTypeDescriptor)(void*, CORINFO_CLASS_HANDLE);
-static CORINFO_METHOD_HANDLE (*_getCompilerHelpersMethodHandle)(void*, const char*, unsigned, const char*, unsigned);
+static CORINFO_METHOD_HANDLE (*_getCompilerHelpersMethodHandle)(void*, const char*, const char*);
 
 static char*                              _outputFileName;
 static Function*                          _doNothingFunction;
@@ -71,7 +71,7 @@ extern "C" DLLEXPORT void registerLlvmCallbacks(void*       thisPtr,
                                                 const CorInfoTypeWithMod(*getArgTypeIncludingParameterized)(void*, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_HANDLE, CORINFO_CLASS_HANDLE*),
                                                 const CorInfoTypeWithMod(*getParameterType)(void*, CORINFO_CLASS_HANDLE, CORINFO_CLASS_HANDLE*),
                                                 const TypeDescriptor(*getTypeDescriptor)(void*, CORINFO_CLASS_HANDLE),
-                                                CORINFO_METHOD_HANDLE (*getCompilerHelpersMethodHandle)(void*, const char*, unsigned, const char*, unsigned))
+                                                CORINFO_METHOD_HANDLE (*getCompilerHelpersMethodHandle)(void*, const char*, const char*))
 {
     _thisPtr = thisPtr;
     _getMangledMethodName         = getMangledMethodNamePtr;
@@ -1647,8 +1647,7 @@ unsigned Llvm::buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned en
 
 void Llvm::buildThrowException(llvm::IRBuilder<>& builder, const char* helperClass, const char * helperMethodName, Value* shadowStack)
 {
-    CORINFO_METHOD_HANDLE methodHandle = _getCompilerHelpersMethodHandle(_thisPtr, helperClass, strlen(helperClass),
-                                                                         helperMethodName, strlen(helperMethodName));
+    CORINFO_METHOD_HANDLE methodHandle = _getCompilerHelpersMethodHandle(_thisPtr, helperClass, helperMethodName);
     const char* mangledName = (*_getMangledMethodName)(_thisPtr, methodHandle);
 
     Function* llvmFunc = _module->getFunction(mangledName);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -87,7 +87,8 @@ extern "C" void registerLlvmCallbacks(void*       thisPtr,
                                       const uint32_t(*padOffset)(void*, CORINFO_CLASS_STRUCT_*, unsigned),
                                       const CorInfoTypeWithMod(*_getArgTypeIncludingParameterized)(void*, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_HANDLE, CORINFO_CLASS_HANDLE*),
                                       const CorInfoTypeWithMod(*_getParameterType)(void*, CORINFO_CLASS_HANDLE, CORINFO_CLASS_HANDLE*),
-                                      const TypeDescriptor(*getTypeDescriptor)(void*, CORINFO_CLASS_HANDLE));
+                                      const TypeDescriptor(*getTypeDescriptor)(void*, CORINFO_CLASS_HANDLE),
+                                      CORINFO_METHOD_HANDLE (*_getCompilerHelpersMethodHandle)(void*, const char*, unsigned, const char*, unsigned));
 
 struct PhiPair
 {
@@ -216,6 +217,10 @@ private:
     Value* zextIntIfNecessary(Value* intValue);
     StructDesc* getStructDesc(CORINFO_CLASS_HANDLE structHandle);
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
+    void buildNullCheck(GenTreeUnOp* nullCheckNode);
+    void buildThrowException(llvm::IRBuilder<>& builder, const char*        helperClass, const char*        helperMethodName, Value* shadowStack);
+    void buildLlvmCallOrInvoke(llvm::Function* callee, llvm::ArrayRef<Value*> args);
+
     void buildLocalVarAddr(GenTreeLclVarCommon* lclVar);
     bool isLlvmFrameLocal(LclVarDsc* varDsc);
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -225,7 +225,7 @@ private:
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
     void buildLocalField(GenTreeLclFld* lclFld);
     void buildNullCheck(GenTreeUnOp* nullCheckNode);
-    void buildThrowException(llvm::IRBuilder<>& builder, const char*        helperClass, const char*        helperMethodName, Value* shadowStack);
+    void buildThrowException(llvm::IRBuilder<>& builder, const char* helperClass, const char* helperMethodName, Value* shadowStack);
     void buildLlvmCallOrInvoke(llvm::Function* callee, llvm::ArrayRef<Value*> args);
 
     void buildLocalVarAddr(GenTreeLclVarCommon* lclVar);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -89,7 +89,7 @@ extern "C" void registerLlvmCallbacks(void*       thisPtr,
                                       const CorInfoTypeWithMod(*_getArgTypeIncludingParameterized)(void*, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_HANDLE, CORINFO_CLASS_HANDLE*),
                                       const CorInfoTypeWithMod(*_getParameterType)(void*, CORINFO_CLASS_HANDLE, CORINFO_CLASS_HANDLE*),
                                       const TypeDescriptor(*getTypeDescriptor)(void*, CORINFO_CLASS_HANDLE),
-                                      CORINFO_METHOD_HANDLE (*_getCompilerHelpersMethodHandle)(void*, const char*, unsigned, const char*, unsigned));
+                                      CORINFO_METHOD_HANDLE (*_getCompilerHelpersMethodHandle)(void*, const char*, const char*));
 
 struct PhiPair
 {

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -270,5 +270,11 @@ namespace ILCompiler
         {
             return ILImporter.PadOffset(type, (int)atOffset);
         }
+
+        public override MethodDesc GetCompilerHelpersMethodDesc(string className, string helperMethodName)
+        {
+            MetadataType helperType = TypeSystemContext.SystemModule.GetKnownType("Internal.Runtime.CompilerHelpers", className);
+            return helperType.GetKnownMethod(helperMethodName, null);
+        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -226,6 +226,11 @@ namespace ILCompiler
         {
             throw new NotImplementedException();
         }
+
+        public virtual MethodDesc GetCompilerHelpersMethodDesc(string className, string methodName)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     [Flags]

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -363,11 +363,11 @@ namespace Internal.JitInterface
         }
 
         [UnmanagedCallersOnly]
-        public static CORINFO_METHOD_STRUCT_* getCompilerHelpersMethodHandle(IntPtr thisHandle, byte* className, uint classNameLength, byte* methodName, uint methodNameLength)
+        public static CORINFO_METHOD_STRUCT_* getCompilerHelpersMethodHandle(IntPtr thisHandle, byte* className, byte* methodName)
         {
             var _this = GetThis(thisHandle);
 
-            return _this.ObjectToHandle(_this._compilation.GetCompilerHelpersMethodDesc(Encoding.UTF8.GetString(className, (int)classNameLength), Encoding.UTF8.GetString(methodName, (int)methodNameLength)));
+            return _this.ObjectToHandle(_this._compilation.GetCompilerHelpersMethodDesc(Marshal.PtrToStringAnsi((IntPtr)className), Marshal.PtrToStringAnsi((IntPtr)methodName)));
         }
 
         [DllImport(JitLibrary)]
@@ -386,7 +386,7 @@ namespace Internal.JitInterface
             delegate* unmanaged<IntPtr, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_STRUCT_*, CORINFO_CLASS_STRUCT_**, CorInfoTypeWithMod> getArgTypeIncludingParameterized,
             delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CORINFO_CLASS_STRUCT_**, CorInfoTypeWithMod> getParameterType,
             delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor> getTypeDescriptor,
-            delegate* unmanaged<IntPtr, byte*, uint, byte*, uint, CORINFO_METHOD_STRUCT_*> getCompilerHelpersMethodHandle
+            delegate* unmanaged<IntPtr, byte*, byte*, CORINFO_METHOD_STRUCT_*> getCompilerHelpersMethodHandle
             );
 
         public void RegisterLlvmCallbacks(IntPtr corInfoPtr, string outputFileName, string triple, string dataLayout)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -367,7 +367,7 @@ namespace Internal.JitInterface
         {
             var _this = GetThis(thisHandle);
 
-            return _this.ObjectToHandle(_this._compilation.GetCompilerHelpersMethodDesc(Marshal.PtrToStringAnsi((IntPtr)className), Marshal.PtrToStringAnsi((IntPtr)methodName)));
+            return _this.ObjectToHandle(_this._compilation.GetCompilerHelpersMethodDesc(Marshal.PtrToStringUTF8((IntPtr)className), Marshal.PtrToStringUTF8((IntPtr)methodName)));
         }
 
         [DllImport(JitLibrary)]

--- a/src/coreclr/tools/aot/ObjWriter/build.sh
+++ b/src/coreclr/tools/aot/ObjWriter/build.sh
@@ -43,7 +43,7 @@ if [ ! -d llvm-project ]; then
     cd llvm-project || exit 1
     # Purposefuly ignoring exit codes of sparse-checkout so that this works with git lower than 2.26
     git sparse-checkout init
-    git sparse-checkout set /llvm/\* !/llvm/test/\*
+    git sparse-checkout set llvm/\* !llvm/test/\*
     git checkout $LLVMBranch || exit 1
     cd llvm || exit 1
 else

--- a/src/coreclr/tools/aot/ObjWriter/build.sh
+++ b/src/coreclr/tools/aot/ObjWriter/build.sh
@@ -43,7 +43,7 @@ if [ ! -d llvm-project ]; then
     cd llvm-project || exit 1
     # Purposefuly ignoring exit codes of sparse-checkout so that this works with git lower than 2.26
     git sparse-checkout init
-    git sparse-checkout set llvm/\* !llvm/test/\*
+    git sparse-checkout set --no-cone /llvm/\* !/llvm/test/\*
     git checkout $LLVMBranch || exit 1
     cd llvm || exit 1
 else


### PR DESCRIPTION
This PR adds support for `GT_NULLCHECK` using the the compiler helper  `ThrowNullReferenceException`.  


I thought there was an outside chance this would fail in a more interesting way than #1866, but it doesn't seem to .

cc @SingleAccretion