### PR TITLE
[NativeAOT-LLVM] Call methods with byref parameters, e.g. this

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12837,7 +12837,7 @@ void Compiler::gtGetLateArgMsg(GenTreeCall* call, GenTree* argx, int lateArgInde
     assert(curArgTabEntry);
     regNumber argReg = curArgTabEntry->GetRegNum();
 
-#if !FEATURE_FIXED_OUT_ARGS
+#if !defined(FEATURE_FIXED_OUT_ARGS) && !defined(TARGET_WASM)
     assert(lateArgIndex < call->regArgListCount);
     assert(argReg == call->regArgList[lateArgIndex]);
 #else

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -48,7 +48,6 @@ static Function*                          _doNothingFunction;
 
 static std::unordered_map<CORINFO_CLASS_HANDLE, Type*>* _llvmStructs = new std::unordered_map<CORINFO_CLASS_HANDLE, Type*>();
 static std::unordered_map<CORINFO_CLASS_HANDLE, StructDesc*>* _structDescMap = new std::unordered_map<CORINFO_CLASS_HANDLE, StructDesc*>();
-static GCInfo* _gcInfo = nullptr;
 
 extern "C" DLLEXPORT void registerLlvmCallbacks(void*       thisPtr,
                                                 const char* outputFileName,

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -101,7 +101,7 @@ GCInfo* Llvm::getGCInfo()
 {
     if (_gcInfo == nullptr)
     {
-        _gcInfo = new GCInfo(_compiler);
+        _gcInfo = new (_compiler->getAllocator(CMK_GC)) GCInfo(_compiler);
     }
     return _gcInfo;
 }

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -8,6 +8,7 @@
 
 #include "alloc.h"
 #include "jitpch.h"
+#include "jitgcinfo.h"
 #include "llvm_types.h"
 #include <new>
 
@@ -131,6 +132,8 @@ private:
         return *_currentRange;
     }
 
+    GCInfo* getGCInfo();
+
     void populateLlvmArgNums();
 
     void buildAdd(GenTree* node, Value* op1, Value* op2);
@@ -156,8 +159,6 @@ private:
     void createAllocasForLocalsWithAddrOp();
     bool canStoreArgOnLlvmStack(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
     Value* castIfNecessary(Value* source, Type* targetType, llvm::IRBuilder<>* builder = nullptr);
-    void castingStore(Value* toStore, Value* address, llvm::Type* llvmType);
-    void castingStore(Value* toStore, Value* address, var_types type);
     Value* castToPointerToLlvmType(Value* address, llvm::Type* llvmType);
     Value* consumeValue(GenTree* node, llvm::Type* targetLlvmType);
     llvm::DILocation* createDebugFunctionAndDiLocation(struct DebugMetadata debugMetadata, unsigned int lineNo);
@@ -212,7 +213,6 @@ private:
     unsigned int padOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned int atOffset);
     void startImportingBasicBlock(BasicBlock* block);
     void startImportingNode();
-    void storeOnShadowStack(GenTree* operand, Value* shadowStackForCallee, unsigned int offset);
     void storeLocalVar(GenTreeLclVar* lclVar);
     CorInfoType toCorInfoType(var_types varType);
     CORINFO_CLASS_HANDLE tryGetStructClassHandle(LclVarDsc* varDsc);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -103,6 +103,8 @@ class Llvm
 private:
     Compiler* _compiler;
     Compiler::Info _info;
+    GCInfo* _gcInfo = nullptr;
+
     llvm::Function* _function;
     CORINFO_SIG_INFO _sigInfo; // sigInfo of function being compiled
     LIR::Range* _currentRange;

--- a/src/coreclr/jit/reglist.h
+++ b/src/coreclr/jit/reglist.h
@@ -8,7 +8,7 @@
 #include "tinyarray.h"
 
 // The "regList" type is a small set of registerse
-#ifdef TARGET_X86
+#if defined(TARGET_X86) || defined(TARGET_WASM)
 typedef TinyArray<unsigned short, regNumber, REGNUM_BITS> regList;
 #else
 // The regList is unused for all other targets.

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -276,7 +276,9 @@ typedef unsigned char   regNumberSmall;
 #define FEATURE_PARTIAL_SIMD_CALLEE_SAVE 1 // Whether SIMD registers are partially saved at calls
 #endif // !UNIX_AMD64_ABI
 #endif
+#ifndef TARGET_WASM
 #define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
+#endif // TARGET_WASM
 #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
 #define FEATURE_FASTTAILCALL     1       // Tail calls made as epilog+jmp
 #define FEATURE_TAILCALL_OPT     1       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.


### PR DESCRIPTION
This PR enables `TYP_BYREF` args, basically by just removing the blocks on them and disabling `FEATURE_FIXED_OUT_ARGS`

cc @SingleAccretion  