### PR TITLE
[NativeAOT-LLVM] To support helper functions that return structs....

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -623,7 +623,7 @@ Function* getOrCreateRhpAssignRef()
     return llvmFunc;
 }
 
-Type* Llvm::getLlvmTypeForVarType(var_types type)
+Type* Llvm::getLlvmTypeForVarType(var_types type, CORINFO_CLASS_HANDLE classHandle)
 {
     // TODO: Fill out with missing type mappings and when all code done via clrjit, default should fail with useful
     // message
@@ -651,6 +651,9 @@ Type* Llvm::getLlvmTypeForVarType(var_types type)
             return Type::getInt8PtrTy(_llvmContext);
         case TYP_VOID:
             return Type::getVoidTy(_llvmContext);
+        case TYP_STRUCT:
+            assert(classHandle);
+            return getLlvmTypeForStruct(classHandle);
         default:
             failFunctionCompilation();
     }
@@ -1017,7 +1020,7 @@ llvm::Value* Llvm::buildUserFuncCall(GenTreeCall* call)
 
 FunctionType* Llvm::buildHelperLlvmFunctionType(GenTreeCall* call, bool withShadowStack)
 {
-    Type* retLlvmType = getLlvmTypeForVarType(call->TypeGet());
+    Type* retLlvmType = getLlvmTypeForVarType(call->TypeGet(), call->gtRetClsHnd);
     std::vector<llvm::Type*> argVec;
 
     if (withShadowStack)

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -180,7 +180,7 @@ private:
     Type* getLlvmTypeForStruct(ClassLayout* classLayout);
     Type* getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle);
 
-    Type* getLlvmTypeForVarType(var_types type);
+    Type* getLlvmTypeForVarType(var_types type, CORINFO_CLASS_HANDLE classHandle = nullptr);
     int getLocalOffsetAtIndex(GenTreeLclVar* lclVar);
     Value* getLocalVarAddress(GenTreeLclVar* lclVar);
     struct DebugMetadata getOrCreateDebugMetadata(const char* documentFileName);


### PR DESCRIPTION
... change `getLlvmTypeForVarType` to accept an optional `CORINFO_CLASS_HANDLE`
