### PR TITLE
[NativeAOT-LLVM] Add math helpers for Wasm

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/MathHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/MathHelpers.cs
@@ -286,7 +286,7 @@ namespace Internal.Runtime.CompilerHelpers
             return ThrowIntOvf();
         }
 
-#if TARGET_ARM
+#if TARGET_ARM || TARGET_WASM // TODO-LLVM: include TARGET_WASM at least until we copy over the implementations from IL to RyuJit
         [RuntimeImport(RuntimeLibrary, "RhpIDiv")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern int RhpIDiv(int i, int j);
@@ -336,7 +336,7 @@ namespace Internal.Runtime.CompilerHelpers
             else
                 return RhpUMod(i, j);
         }
-#endif // TARGET_ARM
+#endif // TARGET_ARM || TARGET_WASM
 
         //
         // Matching return types of throw helpers enables tailcalling them. It improves performance
@@ -367,7 +367,7 @@ namespace Internal.Runtime.CompilerHelpers
             throw new OverflowException();
         }
 
-#if TARGET_ARM
+#if TARGET_ARM || TARGET_WASM // TODO-LLVM: include TARGET_WASM at least until we copy over the implementations from IL to RyuJit
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static int ThrowIntDivByZero()
         {
@@ -385,6 +385,6 @@ namespace Internal.Runtime.CompilerHelpers
         {
             throw new ArithmeticException();
         }
-#endif // TARGET_ARM
+#endif // TARGET_ARM || TARGET_WASM
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -1232,7 +1232,8 @@ namespace Internal.IL
                     break;
                 case ILOpcode.mul_ovf:
                 case ILOpcode.mul_ovf_un:
-                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM)
+                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM
+                        || _compilation.TargetArchIsWasm())
                     {
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.LMulOfv), "_lmulovf");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.ULMulOvf), "_ulmulovf");
@@ -1242,7 +1243,8 @@ namespace Internal.IL
                     break;
                 case ILOpcode.div:
                 case ILOpcode.div_un:
-                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM)
+                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM
+                        || _compilation.TargetArchIsWasm())
                     {
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.ULDiv), "_uldiv");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.LDiv), "_ldiv");
@@ -1256,7 +1258,8 @@ namespace Internal.IL
                     break;                    
                 case ILOpcode.rem:
                 case ILOpcode.rem_un:
-                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM)
+                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM
+                        || _compilation.TargetArchIsWasm())
                     {
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.ULMod), "_ulmod");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.LMod), "_lmod");


### PR DESCRIPTION
This PR enables the Math helpers for Wasm targets.  The IL backend has implementations of these in LLVM, but until they are ported to the RyuJIT backend, we need the helpers.

cc @SingleAccretion