### PR TITLE
NativeAOT-LLVM: Emsdk update to 3.1.8

### DIFF
--- a/eng/pipelines/runtimelab/install-emscripten.cmd
+++ b/eng/pipelines/runtimelab/install-emscripten.cmd
@@ -5,13 +5,13 @@ git clone https://github.com/emscripten-core/emsdk.git
 
 cd emsdk
 rem Checkout a known good version to avoid a random break when emscripten changes the top of tree.
-git checkout 447aa44
+git checkout 2346baa
 
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 
-call python emsdk.py install 2.0.33
+call python emsdk.py install 3.1.8
 if %errorlevel% NEQ 0 goto fail
-call emsdk activate 2.0.33
+call emsdk activate 3.1.8
 if %errorlevel% NEQ 0 goto fail
 
 rem We key off of this variable in the common/build.ps1 script.

--- a/eng/pipelines/runtimelab/install-emscripten.cmd
+++ b/eng/pipelines/runtimelab/install-emscripten.cmd
@@ -5,7 +5,7 @@ git clone https://github.com/emscripten-core/emsdk.git
 
 cd emsdk
 rem Checkout a known good version to avoid a random break when emscripten changes the top of tree.
-git checkout 2346baa
+git checkout e23aac7
 
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0update-machine-certs.ps1""" %*"
 

--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -40,8 +40,8 @@ else()
 endif()
 
 if(CLR_CMAKE_TARGET_BROWSER)
-    # NativeAOT-LLVM needs to suppress these warnings, mono doesn't somehow.
-    add_compile_options(-Wno-unused-parameter)
+    # NativeAOT-LLVM enables -Weverything but these will cause failures so disable individually
+    add_compile_options(-Wno-unused-parameter -Wno-declaration-after-statement)
     set(GEN_SHARED_LIB 0)
     set(STATIC_LIB_DESTINATION .)
 endif()


### PR DESCRIPTION
This PR updates the version of emscripten to the latest.  Disables the warning (adds):

`-Wno-declaration-after-statement`

Because of clang change : https://reviews.llvm.org/D114787

cc @SingleAccretion