### PR TITLE
NativeAOT-LLVM: fix conv.ovf.i when source is long

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -4100,6 +4100,7 @@ namespace Internal.IL
                     maxValue = uint.MaxValue;
                     break;
                 case WellKnownType.Int32:
+                case WellKnownType.IntPtr:  // TODO : 64bit.
                     maxValue = int.MaxValue;
                     minValue = int.MinValue;
                     break;

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -2949,6 +2949,15 @@ internal static class Program
         {
             thrown++;
         }
+        try
+        {
+            byte[] bytes = new byte[1];
+            var b = bytes[i];
+        }
+        catch (OverflowException)
+        {
+            EndTest(false, "implicit convertion of long to int should not throw when long has value == 1");
+        }
         if (thrown != 3) FailTest("Test I8 Conv_Ovf not all cases were thrown  " + thrown.ToString()); ;
         EndTest(true);
     }


### PR DESCRIPTION
The implementation in the IL compiler for 
```
  IL_000E:  conv.ovf.i
```
When the stack contains a `int64` was not picking any case as there was nothing for `IntPtr` and then always threw an overflow exception.  This PR fixes that and adds a test that does the conv via an array index which was the case that triggered this.

cc @SingleAccretion