### PR TITLE
Initial hot cold splitting support for crossgen2/VM

### DIFF
--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -83,6 +83,7 @@ enum class ReadyToRunSectionType : uint32_t
     OwnerCompositeExecutable    = 116, // Added in V4.1
     PgoInstrumentationData      = 117, // Added in V5.2
     ManifestAssemblyMvids       = 118, // Added in V5.3
+    Scratch                     = 119, // This is meant to be a scratch area just for prototyping
 
     // If you add a new section consider whether it is a breaking or non-breaking change.
     // Usually it is non-breaking, but if it is preferable to have older runtimes fail

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -67,6 +67,7 @@ namespace Internal.Runtime
         OwnerCompositeExecutable = 116, // Added in 4.1
         PgoInstrumentationData = 117, // Added in 5.2
         ManifestAssemblyMvids = 118, // Added in 5.3
+        Scratch = 119, // This is meant to be a scratch area for prototyping only
 
         //
         // NativeAOT ReadyToRun sections

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodColdCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodColdCodeNode.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using Internal.Text;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class MethodColdCodeNode : ObjectNode, ISymbolDefinitionNode
+    {
+        private ObjectData _methodColdCode;
+        private MethodDesc _owningMethod;
+
+        public MethodColdCodeNode(MethodDesc owningMethod)
+        {
+            _owningMethod = owningMethod;
+        }
+
+        public int Offset => 0;
+
+        public override ObjectNodeSection Section
+        {
+            get
+            {
+                // TODO, Unix
+                return ObjectNodeSection.ManagedCodeWindowsContentSection;
+            }
+        }
+
+        public override bool IsShareable => false;
+
+        // This ClassCode must be larger than that of MethodCodeNode to ensure it got sorted at the end of the code
+        public override int ClassCode => 788492408;
+
+        public override bool StaticDependenciesAreComputed => _methodColdCode != null;
+
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("__coldcode_" + nameMangler.GetMangledMethodName(_owningMethod));
+        }
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            MethodColdCodeNode otherNode = (MethodColdCodeNode)other;
+            return comparer.Compare(_owningMethod, otherNode._owningMethod);
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false) => _methodColdCode;
+
+        protected override string GetName(NodeFactory context) => throw new NotImplementedException();
+
+        public void SetCode(ObjectData data)
+        {
+            Debug.Assert(_methodColdCode == null);
+            _methodColdCode = data;
+        }
+
+        public int GetColdCodeSize()
+        {
+            return _methodColdCode.Data.Length;
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-
+using System.Linq;
 using Internal.JitInterface;
 using Internal.Text;
 using Internal.TypeSystem;
@@ -19,6 +19,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private readonly MethodDesc _method;
 
         private ObjectData _methodCode;
+#if READYTORUN
+        private MethodColdCodeNode _methodColdCodeNode;
+#endif
         private FrameInfo[] _frameInfos;
         private byte[] _gcInfo;
         private ObjectData _ehInfo;
@@ -129,10 +132,26 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
         }
 
+        public MethodColdCodeNode GetColdCodeNode() => _methodColdCodeNode;
 
         public byte[] GetFixupBlob(NodeFactory factory)
         {
             Relocation[] relocations = GetData(factory, relocsOnly: true).Relocs;
+
+#if READYTORUN
+            if (_methodColdCodeNode != null)
+            {
+                Relocation[] coldRelocations = _methodColdCodeNode.GetData(factory, relocsOnly: true).Relocs;
+                if (relocations == null)
+                {
+                    relocations = coldRelocations;
+                }
+                else if (coldRelocations != null)
+                {
+                    relocations = Enumerable.Concat(relocations, coldRelocations).ToArray();
+                }
+            }
+#endif
 
             if (relocations == null)
             {
@@ -358,5 +377,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public override bool ShouldSkipEmittingObjectNode(NodeFactory factory) => IsEmpty;
 
         public override string ToString() => _method.ToString();
+
+#if READYTORUN
+        public void SetColdCodeNode(MethodColdCodeNode methodColdCodeNode)
+        {
+            _methodColdCodeNode = methodColdCodeNode;
+        }
+#endif
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ScratchNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ScratchNode.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+using Internal.Text;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public class ScratchNode : HeaderTableNode
+    {
+        public uint[] mapping;
+
+        public ScratchNode(NodeFactory nodeFactory)
+            : base(nodeFactory.Target)
+        {
+        }
+
+        public override int ClassCode => 28963035;
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append("__Scratch");
+        }
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            // This node does not trigger generation of other nodes.
+            if (relocsOnly)
+                return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
+
+            ObjectDataBuilder builder = new ObjectDataBuilder(factory, relocsOnly);
+            builder.AddSymbol(this);
+            foreach (uint m in this.mapping)
+            {
+                builder.EmitUInt(m);
+            }
+            return builder.ToObjectData();
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -319,6 +319,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public RuntimeFunctionsTableNode RuntimeFunctionsTable;
 
+        public ScratchNode Scratch;
+
         public RuntimeFunctionsGCInfoNode RuntimeFunctionsGCInfo;
 
         public DelayLoadMethodCallThunkNodeRange DelayLoadMethodCallThunks;
@@ -608,6 +610,11 @@ namespace ILCompiler.DependencyAnalysis
 
             RuntimeFunctionsTable = new RuntimeFunctionsTableNode(this);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.RuntimeFunctions, RuntimeFunctionsTable, RuntimeFunctionsTable);
+
+            Scratch = new ScratchNode(this);
+            Header.Add(Internal.Runtime.ReadyToRunSectionType.Scratch, Scratch, Scratch);
+            // TODO, this should be dependent on the existence of cold code blocks.
+            graph.AddRoot(Scratch, "Scratch is always there!");
 
             RuntimeFunctionsGCInfo = new RuntimeFunctionsGCInfoNode();
             graph.AddRoot(RuntimeFunctionsGCInfo, "GC info is always generated");

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -38,6 +38,7 @@ namespace ILCompiler
         private ReadyToRunFileLayoutAlgorithm _r2rFileLayoutAlgorithm;
         private int _customPESectionAlignment;
         private bool _verifyTypeAndFieldLayout;
+        private bool _hotColdSplitting;
         private CompositeImageSettings _compositeImageSettings;
         private ulong _imageBase;
 
@@ -186,6 +187,12 @@ namespace ILCompiler
             return this;
         }
 
+        public ReadyToRunCodegenCompilationBuilder UseHotColdSplitting(bool hotColdSplitting)
+        {
+            _hotColdSplitting = hotColdSplitting;
+            return this;
+        }
+
         public ReadyToRunCodegenCompilationBuilder UseCompositeImageSettings(CompositeImageSettings compositeImageSettings)
         {
             _compositeImageSettings = compositeImageSettings;
@@ -249,7 +256,12 @@ namespace ILCompiler
             IComparer<DependencyNodeCore<NodeFactory>> comparer = new SortableDependencyNode.ObjectNodeComparer(CompilerComparer.Instance);
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, comparer);
 
+            
             List<CorJitFlag> corJitFlags = new List<CorJitFlag> { CorJitFlag.CORJIT_FLAG_DEBUG_INFO };
+            if (_hotColdSplitting)
+            {
+                corJitFlags.Add(CorJitFlag.CORJIT_FLAG_PROCSPLIT);
+            }
 
             switch (_optimizationMode)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\PrecodeMethodImport.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DelayLoadMethodImport.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ManifestMetadataTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodColdCodeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodEntryPointTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodFixupSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodGCInfoNode.cs" />
@@ -169,6 +170,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ReadyToRunInstructionSetSupportSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RuntimeFunctionsGCInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\RuntimeFunctionsTableNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ScratchNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Signature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\SignatureBuilder.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\SignatureContext.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -359,6 +359,7 @@ namespace Internal.JitInterface
 
         private readonly ReadyToRunCodegenCompilation _compilation;
         private MethodWithGCInfo _methodCodeNode;
+        private MethodColdCodeNode _methodColdCodeNode;
         private OffsetMapping[] _debugLocInfos;
         private NativeVarInfo[] _debugVarInfos;
         private HashSet<MethodDesc> _inlinedMethods;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/UnwindInfo.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
         public UnwindCode() { }
 
         /// <summary>
-        /// Unwinde code parsing is based on <a href="https://github.com/dotnet/coreclr/blob/master/src/jit/unwindamd64.cpp">src\jit\unwindamd64.cpp</a> DumpUnwindInfo
+        /// Unwind code parsing is based on <a href="https://github.com/dotnet/coreclr/blob/master/src/jit/unwindamd64.cpp">src\jit\unwindamd64.cpp</a> DumpUnwindInfo
         /// </summary>
         public UnwindCode(byte[] image, ref int frameOffset, ref int offset)
         {

--- a/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
@@ -63,6 +63,7 @@ namespace ILCompiler
         public string MethodLayout;
         public string FileLayout;
         public bool VerifyTypeAndFieldLayout;
+        public bool HotColdSplitting;
         public string CallChainProfileFile;
         public string ImageBase;
 
@@ -167,6 +168,7 @@ namespace ILCompiler
                 syntax.DefineOption("method-layout", ref MethodLayout, SR.MethodLayoutOption);
                 syntax.DefineOption("file-layout", ref FileLayout, SR.FileLayoutOption);
                 syntax.DefineOption("verify-type-and-field-layout", ref VerifyTypeAndFieldLayout, SR.VerifyTypeAndFieldLayoutOption);
+                syntax.DefineOption("hot-cold-splitting", ref HotColdSplitting, SR.HotColdSplittingOption);
                 syntax.DefineOption("callchain-profile", ref CallChainProfileFile, SR.CallChainProfileFile);
 
                 syntax.DefineOption("make-repro-path", ref MakeReproPath, SR.MakeReproPathHelp);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -747,6 +747,7 @@ namespace ILCompiler
                         .UseInstructionSetSupport(instructionSetSupport)
                         .UseCustomPESectionAlignment(_commandLineOptions.CustomPESectionAlignment)
                         .UseVerifyTypeAndFieldLayout(_commandLineOptions.VerifyTypeAndFieldLayout)
+                        .UseHotColdSplitting(_commandLineOptions.HotColdSplitting)
                         .GenerateOutputFile(outFile)
                         .UseImageBase(_imageBase)
                         .UseILProvider(ilProvider)

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -324,6 +324,9 @@
   <data name="VerifyTypeAndFieldLayoutOption" xml:space="preserve">
     <value>Verify that struct type layout and field offsets match between compile time and runtime. Use only for diagnostic purposes.</value>
   </data>
+  <data name="HotColdSplittingOption" xml:space="preserve">
+    <value>Turn on hot cold splitting optimization.</value>
+  </data>
   <data name="MapCsvFileOption" xml:space="preserve">
     <value>Generate a CSV formatted map file</value>
   </data>

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -787,7 +787,7 @@ public:
 
     virtual DWORD GetFuncletStartOffsets(const METHODTOKEN& MethodToken, DWORD* pStartFuncletOffsets, DWORD dwLength) = 0;
 
-    BOOL IsFunclet(EECodeInfo * pCodeInfo);
+    virtual BOOL IsFunclet(EECodeInfo * pCodeInfo);
     virtual BOOL IsFilterFunclet(EECodeInfo * pCodeInfo);
 #endif // FEATURE_EH_FUNCLETS
 
@@ -1559,6 +1559,7 @@ public:
 
     virtual TADDR                   GetFuncletStartAddress(EECodeInfo * pCodeInfo);
     virtual DWORD                   GetFuncletStartOffsets(const METHODTOKEN& MethodToken, DWORD* pStartFuncletOffsets, DWORD dwLength);
+    virtual BOOL                    IsFunclet(EECodeInfo * pCodeInfo);
     virtual BOOL                    IsFilterFunclet(EECodeInfo * pCodeInfo);
 #endif // FEATURE_EH_FUNCLETS
 

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -1154,7 +1154,11 @@ void DebugStackTrace::GetStackFramesFromException(OBJECTREF * e,
 
                 if (cur.ip)
                 {
-                    dwNativeOffset = (DWORD)(cur.ip - (UINT_PTR)pMD->GetNativeCode());
+                    EECodeInfo codeInfo(cur.ip);
+                    // As of now, EECodeInfo::GetRelOffset does not account for the gap
+                    // between hot and cold code, so it is still wrong to get the IL offset
+                    // using this value as the native offset.
+                    dwNativeOffset = codeInfo.GetRelOffset();
                 }
                 else
                 {

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -646,6 +646,17 @@ ReadyToRunInfo::ReadyToRunInfo(Module * pModule, LoaderAllocator* pLoaderAllocat
         m_nRuntimeFunctions = 0;
     }
 
+    IMAGE_DATA_DIRECTORY * pScratchDir = m_pComposite->FindSection(ReadyToRunSectionType::Scratch);
+    if (pScratchDir != NULL)
+    {
+        m_pScratch = (PTR_ULONG)m_pComposite->GetLayout()->GetDirectoryData(pScratchDir);
+        m_nScratch = pScratchDir->Size / sizeof(ULONG);
+    }
+    else
+    {
+        m_nScratch = 0;
+    }
+
     IMAGE_DATA_DIRECTORY * pImportSectionsDir = m_pComposite->FindSection(ReadyToRunSectionType::ImportSections);
     if (pImportSectionsDir != NULL)
     {

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -61,6 +61,9 @@ class ReadyToRunInfo
     PTR_RUNTIME_FUNCTION            m_pRuntimeFunctions;
     DWORD                           m_nRuntimeFunctions;
 
+    PTR_ULONG                       m_pScratch;
+    DWORD                           m_nScratch;
+
     PTR_IMAGE_DATA_DIRECTORY        m_pSectionDelayLoadMethodCallThunks;
 
     PTR_READYTORUN_IMPORT_SECTION   m_pImportSections;


### PR DESCRIPTION
This PR marks the start of the work to get crossgen2 to support hot/cold splitting.

Here are the changes:

1. Added a section named `Scratch`, to be described in (13) below for more detail.
2. Create the `_methodColdCode` from `_coldCode` and `_coldCodeRelocs` during `PublishCode`.
3. Null `_methodColdCode` and empty `_coldCodeRelocs` during `CompileMethodCleanup`.
4. Create `_methodColdCode` during `allocMem`.
5. Change `reserveUnwindInfo` to ignore unwind reservation for `coldCode`.
6. Change `allocUnwindInfo` to ignore unwindInfo allocation for 0 bytes.
7. Change `findKnownBlocks` to return `_coldCodeReloc` when `BlockType.ColdCode` is asked for.
8. Change `recordRelocation` to set `relocTarget` to `_methodColdCodeNode` when `BlockType.ColdCode` is asked for.
9. Implement `MethodColdCodeNode`
- Storing the cold code.
- Make sure sorting will place cold code blocks after hot code blocks.
- Make sure cold code blocks are ordered the same as the hot code blocks.
10. Change `MethodGCInfoNode` to 
- Emit the chained unwind info for the cold code block, after the hot code GCInfo, so the hot and cold code unwind info are currently mixed.
- Changed  `CalculateFuncletOffsets` so that the offset for the cold code chained unwind info is included if it exists.
11. Changed `MethodWithGCInfo` to:
- Have a reference to the `MethodColdCodeNode`.
- Changed `GetFixupBlob` to include relocation for the cold code.
12. Changed `RuntimeFunctionTableNode` to: 
- Emit the RuntimeFunction entries for the cold code block after the hot code blocks.
- Prepare the cold to hot code mapping for `ScratchNode`.
13. Implement `ScratchNode` - the session is simply an array of cold code runtime function index to hot code runtime function index, so all even entries (e.g. 0, 2, 4) are cold code runtime function index and the corresponding odd indexes (e.g. 1, 3, 5) are the corresponding runtime function index for the corresponding hot code. The array is sorted by the cold code indexes, by (9), the hot code indexes should be sorted as well.
14. Implemented the `--hot-cold-splitting` command-line option, and turn on the `CORJIT_FLAG_PROCSPLIT` flag as needed.
15. Implemented the various code manager contracts:
- `JitCodeToMethodInfo` already gave us a runtime function index, we do not know if it is hot or cold, so we use the scratch table to find it. If we got an even index, that would be cold code and therefore we map it back to the hot one.
- Change `GetFuncletStartOffsets` to return the cold code block as well - technically the cold block is not a funclet, but it appears that the debugger might want it.
- Override `IsFunclet` so that it avoids returning `true` for the cold code block, by searching the scratch table.
- Change `JitTokenToMethodRegionInfo` so that it will find and return the cold code block - again, by search the scratch table since we already have the hot part runtimeFunction.
- Change `DebugDebugger` so that it uses `EECodeInfo` to compute relative offset instead of a simple subtraction, that will allow us to account for the cold code.

This work is far from complete - here is a list of issues filed for the project - these are known issues for now:
- https://github.com/dotnet/runtimelab/issues/1901
- https://github.com/dotnet/runtimelab/issues/1902
- https://github.com/dotnet/runtimelab/issues/1903
- https://github.com/dotnet/runtimelab/issues/1904
- https://github.com/dotnet/runtimelab/issues/1905
- https://github.com/dotnet/runtimelab/issues/1906
- https://github.com/dotnet/runtimelab/issues/1907
- https://github.com/dotnet/runtimelab/issues/1908
- https://github.com/dotnet/runtimelab/issues/1909
- https://github.com/dotnet/runtimelab/issues/1910
- https://github.com/dotnet/runtimelab/issues/1911
- https://github.com/dotnet/runtimelab/issues/1912
- https://github.com/dotnet/runtimelab/issues/1913

@amanasifkhalid, @BruceForstall 

@dotnet/crossgen-contrib 