### PR TITLE
Generated the cold code in the proper session

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodColdCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodColdCodeNode.cs
@@ -24,8 +24,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             get
             {
-                // TODO, Unix
-                return ObjectNodeSection.ManagedCodeWindowsContentSection;
+                return _method.Context.Target.IsWindows ? ObjectNodeSection.ManagedCodeWindowsContentSection : ObjectNodeSection.ManagedCodeUnixContentSection;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodColdCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodColdCodeNode.cs
@@ -24,7 +24,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             get
             {
-                return _method.Context.Target.IsWindows ? ObjectNodeSection.ManagedCodeWindowsContentSection : ObjectNodeSection.ManagedCodeUnixContentSection;
+                return _owningMethod.Context.Target.IsWindows ? ObjectNodeSection.ManagedCodeWindowsContentSection : ObjectNodeSection.ManagedCodeUnixContentSection;            
+                
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtimelab/issues/1901

Validated the correct OS target to generate the code in the proper session depending on whether it's Unix or Windows.