### PR TITLE
Disable EH splitting by default

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3239,6 +3239,9 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 #endif
     }
 
+    // TODO: Implement support for EH splitting in Crossgen2.
+    opts.compProcedureSplittingEH = false;
+
 #ifdef DEBUG
 
     // Now, set compMaxUncheckedOffsetForNullObject for STRESS_NULL_OBJECT_CHECK


### PR DESCRIPTION
To avoid blocking the `feature/hot-cold-splitting` branch while implementing support for EH splitting, disable it by default.