### PR TITLE
R2RDump dump scratch table

### DIFF
--- a/src/coreclr/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/tools/r2rdump/TextDumper.cs
@@ -512,6 +512,16 @@ namespace R2RDump
                         _writer.WriteLine("MVID[{0}] = {1:b}", mvidIndex, _r2r.GetAssemblyMvid(mvidIndex));
                     }
                     break;
+                case ReadyToRunSectionType.Scratch:
+                    int count = section.Size / 8;
+                    int scratchOffset = _r2r.GetOffset(section.RelativeVirtualAddress);
+                    for (int i = 0; i < count; i++)
+                    {
+                        _writer.Write(NativeReader.ReadInt32(_r2r.Image, ref scratchOffset));
+                        _writer.Write(",");
+                        _writer.WriteLine(NativeReader.ReadInt32(_r2r.Image, ref scratchOffset));
+                    }
+                    break;
                 default:
                     _writer.WriteLine("Unsupported section type {0}", section.Type);
                     break;


### PR DESCRIPTION
Here is a really simple implementation to dump the scratch table in R2RDump.

Hopefully it can help with debugging issues.