### PR TITLE
Disable compProcedureSplittingEH in debug

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3247,8 +3247,10 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 #endif
     }
 
+#ifdef DEBUG
     // TODO: Implement support for EH splitting in Crossgen2.
     opts.compProcedureSplittingEH = false;
+#endif
 
 #ifdef DEBUG
 


### PR DESCRIPTION
Moving the code to disable `compProcedureSplittingEH` only in Debug mode (mea culpa).