### PR TITLE
Fix unwind info generation for EH funclets

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3443,6 +3443,8 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
     }
     else
     {
+        bool inFuncletSection = false;
+
         for (lblk = nullptr, block = fgFirstBB; block != nullptr; lblk = block, block = block->bbNext)
         {
             bool blockMustBeInHotSection = false;
@@ -3453,6 +3455,15 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                 blockMustBeInHotSection = true;
             }
 #endif // HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION
+
+#ifdef FEATURE_EH_FUNCLETS
+            // Make note of if we're in the funclet section,
+            // so we can stop the search early.
+            if (block == fgFirstFuncletBB)
+            {
+                inFuncletSection = true;
+            }
+#endif // FEATURE_EH_FUNCLETS
 
             // Do we have a candidate for the first cold block?
             if (firstColdBlock != nullptr)
@@ -3465,6 +3476,21 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                     // We have to restart the search for the first cold block
                     firstColdBlock       = nullptr;
                     prevToFirstColdBlock = nullptr;
+
+#ifdef FEATURE_EH_FUNCLETS
+                    // If we're already in the funclet section, try to split
+                    // at fgFirstFuncletBB, and stop the search.
+                    if (inFuncletSection)
+                    {
+                        if (fgFuncletsAreCold())
+                        {
+                            firstColdBlock       = fgFirstFuncletBB;
+                            prevToFirstColdBlock = fgFirstFuncletBB->bbPrev;
+                        }
+
+                        break;
+                    }
+#endif // FEATURE_EH_FUNCLETS
                 }
             }
             else // (firstColdBlock == NULL) -- we don't have a candidate for first cold block
@@ -3476,7 +3502,7 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                 // consider splitting at the first funclet; do not consider splitting between funclets,
                 // as this may break unwind info.
                 //
-                if (block == fgFirstFuncletBB)
+                if (inFuncletSection)
                 {
                     if (fgFuncletsAreCold())
                     {

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -102,7 +102,15 @@ void Compiler::unwindGetFuncLocations(FuncInfoDsc*             func,
             assert(fgFirstColdBlock != nullptr); // There better be a cold section!
 
             *ppStartLoc = new (this, CMK_UnwindInfo) emitLocation(ehEmitCookie(fgFirstColdBlock));
-            *ppEndLoc   = nullptr; // nullptr end location means the end of the code
+
+            if (fgFirstFuncletBB != nullptr)
+            {
+                *ppEndLoc = new (this, CMK_UnwindInfo) emitLocation(ehEmitCookie(fgFirstFuncletBB));
+            }
+            else
+            {
+                *ppEndLoc = nullptr; // nullptr end location means the end of the code
+            }
         }
     }
     else

--- a/src/coreclr/jit/unwindamd64.cpp
+++ b/src/coreclr/jit/unwindamd64.cpp
@@ -796,7 +796,32 @@ void Compiler::unwindEmitFuncHelper(FuncInfoDsc* func, void* pHotCode, void* pCo
         {
             endOffset = func->endLoc->CodeOffset(GetEmitter());
         }
+    }
+    else
+    {
+        assert(fgFirstColdBlock != nullptr);
 
+        if (func->coldStartLoc == nullptr)
+        {
+            startOffset = 0;
+        }
+        else
+        {
+            startOffset = func->coldStartLoc->CodeOffset(GetEmitter());
+        }
+
+        if (func->coldEndLoc == nullptr)
+        {
+            endOffset = info.compNativeCodeSize;
+        }
+        else
+        {
+            endOffset = func->coldEndLoc->CodeOffset(GetEmitter());
+        }
+    }
+
+    if (isHotCode || (func->funKind != FUNC_ROOT))
+    {
 #ifdef UNIX_AMD64_ABI
         if (generateCFIUnwindCodes())
         {
@@ -822,28 +847,6 @@ void Compiler::unwindEmitFuncHelper(FuncInfoDsc* func, void* pHotCode, void* pCo
 #endif // DEBUG
 
             pUnwindBlock = &func->unwindCodes[func->unwindCodeSlot];
-        }
-    }
-    else
-    {
-        assert(fgFirstColdBlock != nullptr);
-
-        if (func->coldStartLoc == nullptr)
-        {
-            startOffset = 0;
-        }
-        else
-        {
-            startOffset = func->coldStartLoc->CodeOffset(GetEmitter());
-        }
-
-        if (func->coldEndLoc == nullptr)
-        {
-            endOffset = info.compNativeCodeSize;
-        }
-        else
-        {
-            endOffset = func->coldEndLoc->CodeOffset(GetEmitter());
         }
     }
 


### PR DESCRIPTION
This PR addresses the second task in #1918 by fixing unwind info generation for EH funclets in the JIT on x64. Additionally, a bug was found in `fgDetermineFirstColdBlock` where a block after `fgFirstFuncletBB` could be selected as a candidate for `fgFirstColdBlock`, potentially splitting the funclet section; this has been fixed by adding some additional logic to short-circuit the search if we reach the first funclet block.

Note that these changes apply specifically to x64; at some point, similar changes will be needed for ARM64, etc. I can do this work in a follow-up PR.

Below are some examples of unwind info generation for functions with EH, collected from various JIT dumps:

Function with no splitting, plus hot EH funclets:
```
Hot  code size = 0x263 bytes
Cold code size = 0x0 bytes
reserveUnwindInfo(isFunclet=false, isColdCode=false, unwindSize=0xe)
reserveUnwindInfo(isFunclet=true, isColdCode=false, unwindSize=0xe)
...
Unwind Info:
  >> Start offset   : 0x000000 (not in unwind data)
  >>   End offset   : 0x000230 (not in unwind data)
  Version           : 1
  Flags             : 0x00
  SizeOfProlog      : 0x08
  CountOfUnwindCodes: 5
  FrameRegister     : none (0)
  FrameOffset       : N/A (no FrameRegister) (Value=0)
  UnwindCodes       :
    CodeOffset: 0x08 UnwindOp: UWOP_ALLOC_SMALL (2)     OpInfo: 12 * 8 + 8 = 104 = 0x68
    CodeOffset: 0x04 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rbx (3)
    CodeOffset: 0x03 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rsi (6)
    CodeOffset: 0x02 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rdi (7)
    CodeOffset: 0x01 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rbp (5)
allocUnwindInfo(pHotCode=0x000001F9E1B23250, pColdCode=0x0000000000000000, startOffset=0x0, endOffset=0x230, unwindSize=0xe, pUnwindBlock=0x000001F9E3D63122, funKind=0 (main function))
Unwind Info:
  >> Start offset   : 0x000230 (not in unwind data)
  >>   End offset   : 0x000261 (not in unwind data)
  Version           : 1
  Flags             : 0x00
  SizeOfProlog      : 0x08
  CountOfUnwindCodes: 5
  FrameRegister     : none (0)
  FrameOffset       : N/A (no FrameRegister) (Value=0)
  UnwindCodes       :
    CodeOffset: 0x08 UnwindOp: UWOP_ALLOC_SMALL (2)     OpInfo: 4 * 8 + 8 = 40 = 0x28
    CodeOffset: 0x04 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rbx (3)
    CodeOffset: 0x03 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rsi (6)
    CodeOffset: 0x02 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rdi (7)
    CodeOffset: 0x01 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rbp (5)
allocUnwindInfo(pHotCode=0x000001F9E1B23250, pColdCode=0x0000000000000000, startOffset=0x230, endOffset=0x261, unwindSize=0xe, pUnwindBlock=0x000001F9E3D6335A, funKind=1 (handler))
```

Function with main body split, plus cold EH funclets:
```
Hot  code size = 0x35B bytes
Cold code size = 0x106 bytes
reserveUnwindInfo(isFunclet=false, isColdCode=false, unwindSize=0x18)
reserveUnwindInfo(isFunclet=false, isColdCode=true, unwindSize=0x0)
reserveUnwindInfo(isFunclet=true, isColdCode=true, unwindSize=0x16)
...
Unwind Info:
  >> Start offset   : 0x000000 (not in unwind data)
  >>   End offset   : 0x00035b (not in unwind data)
  Version           : 1
  Flags             : 0x00
  SizeOfProlog      : 0x13
  CountOfUnwindCodes: 10
  FrameRegister     : none (0)
  FrameOffset       : N/A (no FrameRegister) (Value=0)
  UnwindCodes       :
    CodeOffset: 0x13 UnwindOp: UWOP_ALLOC_LARGE (1)     OpInfo: 0 - Scaled small  
      Size: 17 * 8 = 136 = 0x00088
    CodeOffset: 0x0C UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rbx (3)
    CodeOffset: 0x0B UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rsi (6)
    CodeOffset: 0x0A UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rdi (7)
    CodeOffset: 0x09 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: r12 (12)
    CodeOffset: 0x07 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: r13 (13)
    CodeOffset: 0x05 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: r14 (14)
    CodeOffset: 0x03 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: r15 (15)
    CodeOffset: 0x01 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rbp (5)
allocUnwindInfo(pHotCode=0x000001F9E1BDF760, pColdCode=0x0000000000000000, startOffset=0x0, endOffset=0x35b, unwindSize=0x18, pUnwindBlock=0x000001F9E3D61168, funKind=0 (main function))
Unwind Info COLD:
  >> Start offset   : 0x00035b (not in unwind data)
  >>   End offset   : 0x000401 (not in unwind data)
allocUnwindInfo(pHotCode=0x000001F9E1BDF760, pColdCode=0x000001F9E1BDFB20, startOffset=0x0, endOffset=0xa6, unwindSize=0x0, pUnwindBlock=0x0000000000000000, funKind=0 (main function))
Unwind Info COLD:
  >> Start offset   : 0x000401 (not in unwind data)
  >>   End offset   : 0x000461 (not in unwind data)
allocUnwindInfo(pHotCode=0x000001F9E1BDF760, pColdCode=0x000001F9E1BDFB20, startOffset=0xa6, endOffset=0x106, unwindSize=0x0, pUnwindBlock=0x0000000000000000, funKind=1 (handler))
```

Function with main body NOT split, plus cold EH funclets:
```
Hot  code size = 0x467 bytes
Cold code size = 0x124 bytes
reserveUnwindInfo(isFunclet=false, isColdCode=false, unwindSize=0x10)
reserveUnwindInfo(isFunclet=true, isColdCode=true, unwindSize=0xe)
reserveUnwindInfo(isFunclet=true, isColdCode=true, unwindSize=0xe)
reserveUnwindInfo(isFunclet=true, isColdCode=true, unwindSize=0xe)
reserveUnwindInfo(isFunclet=true, isColdCode=true, unwindSize=0xe)
...
Unwind Info:
  >> Start offset   : 0x000000 (not in unwind data)
  >>   End offset   : 0x000467 (not in unwind data)
  Version           : 1
  Flags             : 0x00
  SizeOfProlog      : 0x0B
  CountOfUnwindCodes: 6
  FrameRegister     : none (0)
  FrameOffset       : N/A (no FrameRegister) (Value=0)
  UnwindCodes       :
    CodeOffset: 0x0B UnwindOp: UWOP_ALLOC_LARGE (1)     OpInfo: 0 - Scaled small  
      Size: 17 * 8 = 136 = 0x00088
    CodeOffset: 0x04 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rbx (3)
    CodeOffset: 0x03 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rsi (6)
    CodeOffset: 0x02 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rdi (7)
    CodeOffset: 0x01 UnwindOp: UWOP_PUSH_NONVOL (0)     OpInfo: rbp (5)
allocUnwindInfo(pHotCode=0x000001F9E3EBE480, pColdCode=0x0000000000000000, startOffset=0x0, endOffset=0x467, unwindSize=0x10, pUnwindBlock=0x000001F9E4178288, funKind=0 (main function))
Unwind Info COLD:
  >> Start offset   : 0x000467 (not in unwind data)
  >>   End offset   : 0x00049b (not in unwind data)
allocUnwindInfo(pHotCode=0x000001F9E3EBE480, pColdCode=0x000001F9E3989DB0, startOffset=0x0, endOffset=0x34, unwindSize=0x0, pUnwindBlock=0x0000000000000000, funKind=1 (handler))
Unwind Info COLD:
  >> Start offset   : 0x00049b (not in unwind data)
  >>   End offset   : 0x0004c5 (not in unwind data)
allocUnwindInfo(pHotCode=0x000001F9E3EBE480, pColdCode=0x000001F9E3989DB0, startOffset=0x34, endOffset=0x5e, unwindSize=0x0, pUnwindBlock=0x0000000000000000, funKind=1 (handler))
Unwind Info COLD:
  >> Start offset   : 0x0004c5 (not in unwind data)
  >>   End offset   : 0x000557 (not in unwind data)
allocUnwindInfo(pHotCode=0x000001F9E3EBE480, pColdCode=0x000001F9E3989DB0, startOffset=0x5e, endOffset=0xf0, unwindSize=0x0, pUnwindBlock=0x0000000000000000, funKind=1 (handler))
Unwind Info COLD:
  >> Start offset   : 0x000557 (not in unwind data)
  >>   End offset   : 0x00058b (not in unwind data)
allocUnwindInfo(pHotCode=0x000001F9E3EBE480, pColdCode=0x000001F9E3989DB0, startOffset=0xf0, endOffset=0x124, unwindSize=0x0, pUnwindBlock=0x0000000000000000, funKind=1 (handler))
```