### PR TITLE
Support cold EH funclets in VM

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3247,11 +3247,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 #endif
     }
 
-// #ifdef DEBUG
-//     // TODO: Implement support for EH splitting in Crossgen2.
-//     opts.compProcedureSplittingEH = false;
-// #endif
-
 #ifdef DEBUG
 
     // Now, set compMaxUncheckedOffsetForNullObject for STRESS_NULL_OBJECT_CHECK


### PR DESCRIPTION
This PR closes out the remaining tasks in #1918 by adding support for hot/cold splitting of EH funclets in the VM. This support requires the following changes:
* In `ReadyToRunJitManager::JitCodeToMethodInfo`, when searching the Scratch table for the corresponding hot MethodIndex of a given cold MethodIndex, we now handle MethodIndices of cold EH funclets that aren't in the table (i.e. when part of the main body is split).
* `ReadyToRunJitManager::IsFunclet` now returns true for cold EH funclets that are in the Scratch table.