### PR TITLE
Emit cold nodes last without relying on ClassCode

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/CodeGen/ReadyToRunObjectWriter.cs
@@ -239,11 +239,21 @@ namespace ILCompiler.DependencyAnalysis
                 ISymbolDefinitionNode lastImportThunk = null;
                 ObjectNode lastWrittenObjectNode = null;
 
+                // Save cold method nodes here, and emit them to execution section last.
+                List<ObjectNode> methodColdCodeNodes = new List<ObjectNode>();
+
                 int nodeIndex = -1;
                 foreach (var depNode in _nodes)
                 {
-                    ++nodeIndex;
                     ObjectNode node = depNode as ObjectNode;
+
+                    if (node is MethodColdCodeNode)
+                    {
+                        methodColdCodeNodes.Add(node);
+                        continue;
+                    }
+
+                    ++nodeIndex;
 
                     if (node == null)
                     {
@@ -281,22 +291,7 @@ namespace ILCompiler.DependencyAnalysis
                         lastImportThunk = importThunkNode;
                     }
 
-                    string name = null;
-
-                    if (_mapFileBuilder != null)
-                    {
-                        name = depNode.GetType().ToString();
-                        int firstGeneric = name.IndexOf('[');
-                        if (firstGeneric < 0)
-                        {
-                            firstGeneric = name.Length;
-                        }
-                        int lastDot = name.LastIndexOf('.', firstGeneric - 1, firstGeneric);
-                        if (lastDot > 0)
-                        {
-                            name = name.Substring(lastDot + 1);
-                        }
-                    }
+                    string name = GetDependencyNodeName(depNode);
 
                     EmitObjectData(r2rPeBuilder, nodeContents, nodeIndex, name, node.Section);
                     lastWrittenObjectNode = node;
@@ -305,6 +300,22 @@ namespace ILCompiler.DependencyAnalysis
                     {
                         _outputInfoBuilder.AddMethod(methodNode, nodeContents.DefinedSymbols[0]);
                     }
+                }
+
+                // Emit cold method nodes to end of execution section.
+                foreach (ObjectNode node in methodColdCodeNodes)
+                {
+                    ++nodeIndex;
+
+                    if (node == null)
+                    {
+                        continue;
+                    }
+
+                    ObjectData nodeContents = node.GetData(_nodeFactory);
+                    string name = GetDependencyNodeName(node);
+
+                    EmitObjectData(r2rPeBuilder, nodeContents, nodeIndex, name, node.Section);
                 }
 
                 r2rPeBuilder.SetCorHeader(_nodeFactory.CopiedCorHeaderNode, _nodeFactory.CopiedCorHeaderNode.Size);
@@ -427,6 +438,36 @@ namespace ILCompiler.DependencyAnalysis
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Helper method to generate the name of a given DependencyNode. Returns null if a name is not needed.
+        /// A name is needed only when the executable generator should output a map file.
+        /// </summary>
+        /// <param name="depNode">The DependencyNode to return a name for, if one is needed.</param>
+        private string GetDependencyNodeName(DependencyNode depNode)
+        {
+            if (_mapFileBuilder == null)
+            {
+                return null;
+            }
+
+            string name = depNode.GetType().ToString();
+            int firstGeneric = name.IndexOf('[');
+
+            if (firstGeneric < 0)
+            {
+                firstGeneric = name.Length;
+            }
+
+            int lastDot = name.LastIndexOf('.', firstGeneric - 1, firstGeneric);
+
+            if (lastDot > 0)
+            {
+                name = name.Substring(lastDot + 1);
+            }
+
+            return name;
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodColdCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodColdCodeNode.cs
@@ -31,7 +31,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override bool IsShareable => false;
 
-        // This ClassCode must be larger than that of MethodCodeNode to ensure it got sorted at the end of the code
         public override int ClassCode => 788492408;
 
         public override bool StaticDependenciesAreComputed => _methodColdCode != null;


### PR DESCRIPTION
This PR addresses #1912 by removing `MethodColdCodeNode`'s dependency on its ClassCode to be emitted after all hot nodes in the PE execution section. When emitting `ObjectNodes`, `MethodColdCodeNodes` are stashed in a list, and all other `ObjectNodes` are emitted first. Finally, all `MethodColdCodeNodes` in the list are emitted to the end of the execution section. This implementation removes the need for another execution section.