### PR TITLE
Generate Scratch only if there is cold code

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/RuntimeFunctionsTableNode.cs
@@ -59,8 +59,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
-            // This node does not trigger generation of other nodes.
-            // TODO: Make this generate the generation of the Scratch node
             if (relocsOnly)
                 return new ObjectData(Array.Empty<byte>(), Array.Empty<Relocation>(), 1, new ISymbolDefinitionNode[] { this });
 
@@ -143,7 +141,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
             }
 
-            _nodeFactory.Scratch.mapping = mapping.ToArray();
+            // Scratch should not be null if there is cold code
+            if (_nodeFactory.Scratch != null)
+            {
+                _nodeFactory.Scratch.mapping = mapping.ToArray();
+            }
+            else
+            {
+                Debug.Assert((mapping.Count == 0), "Scratch is null, but mapping is not empty");
+            }
 
             // Emit sentinel entry
             runtimeFunctionsBuilder.EmitUInt(~0u);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -67,6 +67,12 @@ namespace ILCompiler.DependencyAnalysis
 
         public bool MarkingComplete => _markingComplete;
 
+        public void GenerateScratch()
+        {
+            Scratch = new ScratchNode(this);
+            Header.Add(Internal.Runtime.ReadyToRunSectionType.Scratch, Scratch, Scratch);
+        }
+
         public void SetMarkingComplete()
         {
             _markingComplete = true;
@@ -610,11 +616,6 @@ namespace ILCompiler.DependencyAnalysis
 
             RuntimeFunctionsTable = new RuntimeFunctionsTableNode(this);
             Header.Add(Internal.Runtime.ReadyToRunSectionType.RuntimeFunctions, RuntimeFunctionsTable, RuntimeFunctionsTable);
-
-            Scratch = new ScratchNode(this);
-            Header.Add(Internal.Runtime.ReadyToRunSectionType.Scratch, Scratch, Scratch);
-            // TODO, this should be dependent on the existence of cold code blocks.
-            graph.AddRoot(Scratch, "Scratch is always there!");
 
             RuntimeFunctionsGCInfo = new RuntimeFunctionsGCInfoNode();
             graph.AddRoot(RuntimeFunctionsGCInfo, "GC info is always generated");

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -582,6 +582,13 @@ namespace ILCompiler
                             // This allows SuperPMI to rely on non-reuse of handles in ObjectToHandle
                             CorInfoImpl corInfoImpl = _corInfoImpls.GetValue(Thread.CurrentThread, thread => new CorInfoImpl(this));
                             corInfoImpl.CompileMethod(methodCodeNodeNeedingCode, Logger);
+
+                            // If we generated cold code, we will need Scratch
+                            if ((_nodeFactory.Scratch == null) && corInfoImpl.HasColdCode())
+                            {
+                                _nodeFactory.GenerateScratch();
+                                _dependencyGraph.AddRoot(_nodeFactory.Scratch, "Scratch is generated because there is cold code");
+                            }
                         }
                     }
                     catch (TypeSystemException ex)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -365,6 +365,12 @@ namespace Internal.JitInterface
         private HashSet<MethodDesc> _inlinedMethods;
         private UnboxingMethodDescFactory _unboxingThunkFactory = new UnboxingMethodDescFactory();
         private List<ISymbolNode> _precodeFixups;
+        private bool _hasColdCode;
+
+        public bool HasColdCode()
+        {
+            return _hasColdCode;
+        }
 
         public CorInfoImpl(ReadyToRunCodegenCompilation compilation)
             : this()
@@ -502,6 +508,8 @@ namespace Internal.JitInterface
                 {
                     PublishEmptyCode();
                 }
+
+                _hasColdCode = (_methodColdCodeNode != null);
                 CompileMethodCleanup();
             }
         }


### PR DESCRIPTION
Fixes #1906 by generating the Scratch table only if a call to `CorInfoImpl.CompileMethod()` results in cold code being generated. This work does not require any changes in the VM, as iterations over the Scratch table already check the table's size before accessing it, thus avoiding any null pointer dereferences.

Below is an excerpt from the R2R dump for `CoreLab`, showcasing the Scratch table exists:
```
Type:  ManifestAssemblyMvids (118)
RelativeVirtualAddress: 0x0000180C
Size: 0 bytes

_______________________________________________

Type:  Scratch (119)
RelativeVirtualAddress: 0x00001853
Size: 8 bytes
1,0


======================== R2R Methods ========================
```

After editing `CoreLab\Program.cs` so that the sole function is empty (and thus does not have any cold code), the R2R dump excerpt looks like this:

```
Type:  ManifestAssemblyMvids (118)
RelativeVirtualAddress: 0x000017C4
Size: 0 bytes


======================== R2R Methods ========================
```