### PR TITLE
Fix duplicate Scratch generation

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -67,10 +67,14 @@ namespace ILCompiler.DependencyAnalysis
 
         public bool MarkingComplete => _markingComplete;
 
-        public void GenerateScratch()
+        public void GenerateScratch(DependencyAnalyzerBase<NodeFactory> dependencyGraph)
         {
-            Scratch = new ScratchNode(this);
-            Header.Add(Internal.Runtime.ReadyToRunSectionType.Scratch, Scratch, Scratch);
+            if (Scratch == null)
+            {
+                Scratch = new ScratchNode(this);
+                Header.Add(Internal.Runtime.ReadyToRunSectionType.Scratch, Scratch, Scratch);
+                dependencyGraph.AddRoot(Scratch, "Scratch is generated because there is cold code");
+            }
         }
 
         public void SetMarkingComplete()


### PR DESCRIPTION
This PR fixes a bug where the Scratch table could be generated multiple times when the dependency graph computes its dependencies in parallel. `NodeFactory.GenerateScratch()` has been updated to prevent duplicate generation.