### PR TITLE
Convert Scratch lookup to binary search

### DIFF
--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -1499,6 +1499,19 @@ public:
                                          int EndIndex);
 };
 
+class HotColdMappingLookupTable
+{
+public:
+    // ***************************************************************************
+    // Binary searches pInfo->m_pScratch for the given hot/cold MethodIndex, and
+    // returns the index in pInfo->m_pScratch of its corresponding cold/hot MethodIndex.
+    // If MethodIndex is cold and at index i, returns i + 1.
+    // If MethodIndex is hot and at index i, returns i - 1.
+    // If MethodIndex is not in pInfo->m_pScratch, returns -1.
+    //
+    static int LookupMappingForMethod(ReadyToRunInfo* pInfo, ULONG MethodIndex);
+};
+
 #endif // FEATURE_READYTORUN
 
 #ifdef FEATURE_READYTORUN

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -49,6 +49,9 @@ class ReadyToRunInfo
 {
     friend class ReadyToRunJitManager;
 
+    // HotColdMappingLookupTable::LookupMappingForMethod searches m_pScratch, and thus needs access.
+    friend class HotColdMappingLookupTable;
+
     PTR_Module                      m_pModule;
     PTR_READYTORUN_HEADER           m_pHeader;
     bool                            m_isComponentAssembly;


### PR DESCRIPTION
Preliminary work for #1903: Before making any design changes, we should try using binary search over the Scratch table, and profile the performance gain. I likely won't have time to fully pursue this task, but we can at least get rid of the linear search for now.