### PR TITLE
Move inline switch table check to fginline.cpp

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2656,7 +2656,7 @@ unsigned Compiler::fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, F
                 jmpKind     = BBJ_SWITCH;
                 fgHasSwitch = true;
 
-                if (impInlineRoot()->opts.compProcedureSplitting)
+                if (opts.compProcedureSplitting)
                 {
                     // TODO-CQ: We might need to create a switch table; we won't know for sure until much later.
                     // However, switch tables don't work with hot/cold splitting, currently. The switch table data needs
@@ -2668,8 +2668,7 @@ unsigned Compiler::fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, F
                     // (maybe immediately after the switch jump), and make the "base" address be also in that section,
                     // probably the address after the switch jump.
 
-                    // In case this function is being inlined, disable splitting in root compiler.
-                    impInlineRoot()->opts.compProcedureSplitting = false;
+                    opts.compProcedureSplitting = false;
                     JITDUMP("Turning off procedure splitting for this method, as it might need switch tables; "
                             "implementation limitation.\n");
                 }

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1342,6 +1342,15 @@ _Done:
 
     lvaGenericsContextInUse |= InlineeCompiler->lvaGenericsContextInUse;
 
+    // If the inlinee compiler encounters switch tables, disable hot/cold splitting in the root compiler.
+    // TODO-CQ: Implement hot/cold splitting of methods with switch tables.
+    if (InlineeCompiler->fgHasSwitch && opts.compProcedureSplitting)
+    {
+        opts.compProcedureSplitting = false;
+        JITDUMP("Turning off procedure splitting for this method, as inlinee compiler encountered switch tables; "
+                "implementation limitation.\n");
+    }
+
 #ifdef FEATURE_SIMD
     if (InlineeCompiler->usesSIMDTypes())
     {


### PR DESCRIPTION
Follow-up to #1937 : According to @AndyAyersMS, we should disable hot/cold splitting in the root compiler if its inlinee compiler finds a switch table only if the inline succeeds. Thus, the logic to disable `opts.compProcedureSplitting` in the root compiler has been moved to a common place in `fginline.cpp` for propagating compiler arguments. This change does not reproduce the related regression exposed by #1937 when stress-splitting `System.Private.CoreLib`. 