### PR TITLE
Fixed indexing error

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -6199,12 +6199,14 @@ BOOL ReadyToRunJitManager::JitCodeToMethodInfo(RangeSection * pRangeSection,
     ULONG UMethodIndex = (ULONG)MethodIndex;
 
     // If the MethodIndex happens to be the cold code block, turn it into the associated hot code block
-    const int lookupIndex = HotColdMappingLookupTable::LookupMappingForMethod(pInfo, (ULONG)MethodIndex);
-
-    // If indexLookup is odd, then MethodIndex has a corresponding hot block in the lookup table.
-    if ((lookupIndex % 2) == 1)
+    if (pInfo->m_nScratch != 0)
     {
-        MethodIndex = pInfo->m_pScratch[lookupIndex];
+        const int lookupIndex = HotColdMappingLookupTable::LookupMappingForMethod(pInfo, (ULONG)MethodIndex);
+        // If indexLookup is odd, then MethodIndex has a corresponding hot block in the lookup table.
+        if ((lookupIndex % 2) == 1)
+        {
+            MethodIndex = pInfo->m_pScratch[lookupIndex];
+        }
     }
 
     MethodDesc *pMethodDesc;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -5764,10 +5764,7 @@ int HotColdMappingLookupTable::LookupMappingForMethod(ReadyToRunInfo* pInfo, ULO
         SUPPORTS_DAC;
     } CONTRACTL_END;
 
-    if (pInfo->m_nScratch == 0)
-    {
-        return -1;
-    }
+    _ASSERTE(pInfo->m_nScratch != 0);
 
     // Casting the lookup table's size to an int is safe:
     // We index the RUNTIME_FUNCTION table with ints, and the lookup table


### PR DESCRIPTION
Fixed an indexing error that would cause the index to be -1, which would cause some test failures when reproducing the steps stated on issue #1950. Did this by validating that the number of functions in the scratch map wasn't 0 before calling `HotColdMappingLookupTable::LookupMappingForMethod`.