### PR TITLE
Disable ReadyToRunFileLayoutOptimizer

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -339,7 +339,7 @@ namespace ILCompiler
             _dependencyGraph.ComputeMarkedNodes();
             var nodes = _dependencyGraph.MarkedNodeList;
 
-            nodes = _fileLayoutOptimizer.ApplyProfilerGuidedMethodSort(nodes);
+            // nodes = _fileLayoutOptimizer.ApplyProfilerGuidedMethodSort(nodes);
 
             using (PerfEventSource.StartStopEvents.EmittingEvents())
             {


### PR DESCRIPTION
In a crossgen2 test run, the flag `--method-layout:random` is specified and it impacts the correctness of `--hot-cold-splitting`. Eventually, we need to fix that in #1954, disabling it for now.