### PR TITLE
Validation for RuntimeFunctions and change to unwindinfo

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -306,6 +306,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 this._runtimeFunctions = new List<RuntimeFunction>();
                 this.ParseRuntimeFunctions(false);
+                _readyToRunReader.ValidateRuntimeFunctions(_runtimeFunctions);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1119,6 +1119,11 @@ namespace ILCompiler.Reflection.ReadyToRun
             RuntimeFunction firstRuntimeFunction = runtimeFunctions[0];
             BaseUnwindInfo firstUnwindInfo = firstRuntimeFunction.UnwindInfo;
             var x64UnwindInfo = firstUnwindInfo as Amd64.UnwindInfo;
+            System.Collections.Generic.HashSet<uint> hashPersonalityRoutines = new System.Collections.Generic.HashSet<uint>();
+            if (x64UnwindInfo != null)
+            {
+                hashPersonalityRoutines.Add(x64UnwindInfo.PersonalityRoutineRVA);
+            }
 
             for (int i = 1; i < runtimeFunctions.Count; i++)
             {
@@ -1128,12 +1133,12 @@ namespace ILCompiler.Reflection.ReadyToRun
                 if (x64UnwindInfo != null && ((x64UnwindInfo.Flags & (int)ILCompiler.Reflection.ReadyToRun.Amd64.UnwindFlags.UNW_FLAG_CHAININFO) == 0))
                 {
                     Amd64.UnwindInfo x64UnwindInfoCurr = (Amd64.UnwindInfo) runtimeFunctions[i].UnwindInfo;
-                    uint firstPersonalityRoutineRVA = x64UnwindInfo.PersonalityRoutineRVA;
-                    uint currPersonalityRoutineRVA = x64UnwindInfoCurr.PersonalityRoutineRVA;
                 
                     if ((x64UnwindInfoCurr.Flags & (int)ILCompiler.Reflection.ReadyToRun.Amd64.UnwindFlags.UNW_FLAG_CHAININFO) == 0)
                     {
-                        Debug.Assert(firstPersonalityRoutineRVA == currPersonalityRoutineRVA, "RuntimeFunctions don't share the same PersonalityRoutineRVA");
+                        uint currPersonalityRoutineRVA = x64UnwindInfoCurr.PersonalityRoutineRVA;
+                        hashPersonalityRoutines.Add(currPersonalityRoutineRVA);
+                        Debug.Assert(hashPersonalityRoutines.Count < 3, "There are more than two different runtimefunctions PersonalityRVAs");
                     }
                 }
             } 

--- a/src/coreclr/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/tools/r2rdump/Extensions.cs
@@ -211,7 +211,7 @@ namespace R2RDump
                 writer.WriteLine($"CountOfUnwindCodes: {amd64UnwindInfo.CountOfUnwindCodes}");
                 writer.WriteLine($"FrameRegister:      {((amd64UnwindInfo.FrameRegister == 0) ? "None" : amd64UnwindInfo.FrameRegister.ToString())}");
                 writer.WriteLine($"FrameOffset:        0x{amd64UnwindInfo.FrameOffset}");
-                if (!options.Naked)
+                if (!options.Naked && ((amd64UnwindInfo.Flags & (int)ILCompiler.Reflection.ReadyToRun.Amd64.UnwindFlags.UNW_FLAG_CHAININFO) == 0))
                 {
                     writer.WriteLine($"PersonalityRVA:     0x{amd64UnwindInfo.PersonalityRoutineRVA:X4}");
                 }


### PR DESCRIPTION
Added a function to validate the information for RuntimeFunctions via asserts that make sure they're correctly sorted, their intervals don't overlap, and their PersonalityRoutineRVA is the same, as stated in issue #1955. Also modified UnwindInfo so that whenever the CHAININFO flag is on we don't generate the personality routine, as it was showing the RVA to the hot function instead of the Personality Routine.