### PR TITLE
NativeAOT-LLVM: do not mark the shadow stack as a local on the llvm stack if not referenced

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -791,6 +791,13 @@ LlvmArgInfo Llvm::getLlvmArgInfoForArgIx(unsigned int lclNum)
                                                                                        the shadow stack */
     };
 
+    if (lclNum == _shadowStackLclNum)
+    {
+        llvmArgInfo.m_argIx             = 0;
+        llvmArgInfo.m_shadowStackOffset = 0;
+        return llvmArgInfo;
+    }
+
     if (_compiler->info.compRetBuffArg != BAD_VAR_NUM)
     {
         if (lclNum == 0)
@@ -1917,7 +1924,7 @@ Value* Llvm::zextIntIfNecessary(Value* intValue)
 bool Llvm::isLlvmFrameLocal(LclVarDsc* varDsc)
 {
     assert(canStoreLocalOnLlvmStack(varDsc) && (_compiler->fgSsaPassesCompleted >= 1));
-    return !varDsc->lvInSsa;
+    return !varDsc->lvInSsa && varDsc->lvRefCnt() > 0;
 }
 
 void Llvm::storeLocalVar(GenTreeLclVar* lclVar)


### PR DESCRIPTION
Continuing #1859 this PR addresses the first issue hit in that PR: https://github.com/dotnet/runtimelab/issues/1859#issue-1160716397

For the IL: 
```
// [S.P.CoreLib]System.Reflection.Module+<>c..ctor()
.method instance void .ctor() cil managed
{
  // Code size: 7
  .maxstack 8

  IL_0000:  ldarg.0
  IL_0001:  call        instance void System.Object::.ctor()
  IL_0006:  ret
}
```

We get the IR
```
------------ BB01 [000..007) (return), preds={} succs={}
N001 (  0,  0) [000002] ------------                 RETURN    void   $c0
```

The call is inlined if I read the log properly, and `$c0` is `{MemOpaque:NotInLoop}` <- I don't know what that means, is it the reason for inlining?

Anyway, that fails currently for the reason in the original disucssion: it tries to create an LLVM `alloca` for the shadow stack which is not referenced and `getLlvmArgInfoForArgIx` hits an assert.

With this change the final LLVM is
```
define void @S_P_CoreLib_System_Reflection_Module___c___ctor(i8* %0) {
Prolog:
  br label %1

1:                                                ; preds = %Prolog
  ret void
}
```

cc @SingleAccretion