### PR TITLE
NativeAOT-LLVM: Allow inlining to handle SPK_ByValue for TARGET_WASM

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -618,6 +618,9 @@ Compiler::fgWalkResult Compiler::fgUpdateInlineReturnExpressionPlaceHolder(GenTr
 
 #endif // FEATURE_MULTIREG_RET
 
+#ifdef TARGET_WASM
+            case SPK_ByValue:
+#endif // TARGET_WASM
             case SPK_EnclosingType:
             case SPK_PrimitiveType:
                 // No work needs to be done, the call has struct type and should keep it.


### PR DESCRIPTION
Continuing https://github.com/dotnet/runtimelab/issues/1859 this PR allows for return types of `SPK_ByValue` when inlining.

For this IL
```cs
// [S.P.CoreLib]System.DateTimeOffset..cctor()
.method void .cctor() cil managed
{
  // Code size: 66
  .maxstack 2

  IL_0000:  ldc.i4.0
  IL_0001:  conv.i8
  IL_0002:  ldsfld      valuetype System.TimeSpan System.TimeSpan::Zero
  IL_0007:  newobj      instance void System.DateTimeOffset::.ctor(int64, valuetype System.TimeSpan)
  IL_000C:  stsfld      valuetype System.DateTimeOffset System.DateTimeOffset::MinValue
  IL_0011:  ldc.i8      3155378975999999999
  IL_001A:  ldsfld      valuetype System.TimeSpan System.TimeSpan::Zero
  IL_001F:  newobj      instance void System.DateTimeOffset::.ctor(int64, valuetype System.TimeSpan)
  IL_0024:  stsfld      valuetype System.DateTimeOffset System.DateTimeOffset::MaxValue
  IL_0029:  ldc.i8      621355968000000000
  IL_0032:  ldsfld      valuetype System.TimeSpan System.TimeSpan::Zero
  IL_0037:  newobj      instance void System.DateTimeOffset::.ctor(int64, valuetype System.TimeSpan)
  IL_003C:  stsfld      valuetype System.DateTimeOffset System.DateTimeOffset::UnixEpoch
  IL_0041:  ret
}

```
We get in the  IR during inlining: a call to `System.DateTimeOffset.ValidateDate` 
```
    [ 4]  14 (0x00e) call 06000A93
In Compiler::impImportCall: opcode is call, kind=0, callRetType is struct, structSize is 8
Calling impNormStructVal on:
               [000075] ------------              *  LCL_VAR   struct<System.TimeSpan, 8> V03 tmp3
resulting tree:
               [000078] n-----------              *  OBJ       struct<System.TimeSpan, 8>
               [000077] ------------              \--*  ADDR      byref
               [000075] -------N----                 \--*  LCL_VAR   struct<System.TimeSpan, 8> V03 tmp3
Calling impNormStructVal on:
               [000074] ------------              *  LCL_VAR   struct<System.DateTime, 8> V04 tmp4
resulting tree:
               [000080] n-----------              *  OBJ       struct<System.DateTime, 8>
               [000079] ------------              \--*  ADDR      byref
               [000074] -------N----                 \--*  LCL_VAR   struct<System.DateTime, 8> V04 tmp4


               [000076] I-C-G-------              *  CALL      struct System.DateTimeOffset.ValidateDate (exactContextHnd=0x4000000000420029)
               [000080] n----------- arg0         +--*  OBJ       struct<System.DateTime, 8>
               [000079] ------------              |  \--*  ADDR      byref
               [000074] -------N----              |     \--*  LCL_VAR   struct<System.DateTime, 8> V04 tmp4
               [000078] n----------- arg1         \--*  OBJ       struct<System.TimeSpan, 8>
               [000077] ------------                 \--*  ADDR      byref
               [000075] -------N----                    \--*  LCL_VAR   struct<System.TimeSpan, 8> V03 tmp3
```

which hits the assert at [fginline.cpp 635](https://github.com/dotnet/runtimelab/blob/d6e61cf66532f2741f26123bbe5228dfcd33449d/src/coreclr/jit/fginline.cpp#L632) as `SPK_ByValue`, for node 76, is not an option for TARGET_WASM. LLVM/Wasm should be able to do that. 
I enabled `SPK_ByValue` as a return type that requires no work in `fgUpdateInlineReturnExpressionPlaceHolder`

That's not enough to compile the input IL: we hit the promoted struct problem, but I can do that separately.

cc @SingleAccretion