### PR TITLE
NativeAOT-LLVM: Add option to disable the RyuJIT backend

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -23,6 +23,7 @@ namespace ILCompiler
     {
         private readonly ConditionalWeakTable<Thread, CorInfoImpl> _corinfos = new ConditionalWeakTable<Thread, CorInfoImpl>();
         private string _outputFile;
+        bool _disableRyuJit;
 
         internal LLVMCodegenConfigProvider Options { get; }
         // the LLVM Module generated from IL, can only be one.
@@ -60,6 +61,7 @@ namespace ILCompiler
             ILImporter.Context = Module.Context;
             NativeLib = nativeLib;
             ConfigurableWasmImportPolicy = configurableWasmImportPolicy;
+            _disableRyuJit = Options.DisableRyuJit == "1"; // TODO-LLVM: delete when all code is compiled via RyuJIT
         }
 
         private static IEnumerable<ICompilationRootProvider> GetCompilationRoots(IEnumerable<ICompilationRootProvider> existingRoots, NodeFactory factory)
@@ -142,7 +144,7 @@ namespace ILCompiler
                     return;
                 }
 
-                if (methodIL.GetExceptionRegions().Length == 0)
+                if (methodIL.GetExceptionRegions().Length == 0 && !_disableRyuJit)
                 {
                     var mangledName = NodeFactory.NameMangler.GetMangledMethodName(method).ToString();
                     var sig = method.Signature;

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -23,7 +23,7 @@ namespace ILCompiler
     {
         private readonly ConditionalWeakTable<Thread, CorInfoImpl> _corinfos = new ConditionalWeakTable<Thread, CorInfoImpl>();
         private string _outputFile;
-        bool _disableRyuJit;
+        private readonly bool _disableRyuJit;
 
         internal LLVMCodegenConfigProvider Options { get; }
         // the LLVM Module generated from IL, can only be one.

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
@@ -124,6 +124,7 @@ namespace ILCompiler
 
         public string Target => ValueOrDefault("Target", "wasm32-unknown-emscripten");
         public string ModuleName => ValueOrDefault("ModuleName", "netscripten");
+        public string DisableRyuJit => ValueOrDefault("DisableRyuJit", "0");
 
         // https://llvm.org/docs/LangRef.html#langref-datalayout
         // e litte endian, mangled names


### PR DESCRIPTION
This PR adds a codegenopt:

```
--codegenopt:DisableRyuJit=1
```
This will turn off the RyuJIT backend and force all compilation through the old IL->LLVM backend.  This can be helpful if a user encounters a problem with the evolving RyuJIT backend that is not present in the IL backend.

cc @SingleAccretion