### PR TITLE
NativeAOT-LLVM: upgrade DevOps agent as  win2016 is deprecated

### DIFF
--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -19,7 +19,8 @@ stages:
       publishUsingPipelines: true
       dependsOn: PrepareSignedArtifacts
       pool:
-        vmImage: vs2017-win2016
+        name: NetCore1ESPool-Internal
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
 
 # Stages-based publishing entry point
 - template: /eng/common/templates/post-build/post-build.yml


### PR DESCRIPTION
This PR attempts to address #1970 taking the commit https://github.com/dotnet/runtime/commit/e233b7b5b00d9b80f155cd484e246dfc24fdf801

Thanks @jkotas 
