### PR TITLE
NativeAOT-LLVM: Add support for GT_CNS_LNG

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1384,27 +1384,7 @@ void Llvm::buildCnsInt(GenTree* node)
 
 void Llvm::buildCnsLng(GenTree* node)
 {
-    if (node->gtType == TYP_LONG)
-    {
-        mapGenTreeToValue(node, _builder.getInt64(node->AsLngCon()->LngValue()));
-        return;
-    }
-    // TODO-LLVM: TYP_REF does not occur, but will it for Wasm64?
-    if (node->gtType == TYP_REF)
-    {
-        ssize_t longCon = node->AsLngCon()->LngValue();
-        // TODO: delete this check, just null ptr stores for now, other TYP_REFs not
-        // implemented yet
-        if (longCon != 0)
-        {
-            failFunctionCompilation();
-        }
-
-        mapGenTreeToValue(node, _builder.CreateIntToPtr(_builder.getInt64(longCon),
-                                                        Type::getInt8PtrTy(_llvmContext))); // TODO: wasm64
-        return;
-    }
-    failFunctionCompilation();
+    mapGenTreeToValue(node, _builder.getInt64(node->AsLngCon()->LngValue()));
 }
 
 void Llvm::buildInd(GenTree* node, Value* ptr)

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1393,7 +1393,7 @@ void Llvm::buildCnsLng(GenTree* node)
     if (node->gtType == TYP_REF)
     {
         ssize_t longCon = node->AsLngCon()->LngValue();
-        // TODO: delete this check, just handling string constants and null ptr stores for now, other TYP_REFs not
+        // TODO: delete this check, just null ptr stores for now, other TYP_REFs not
         // implemented yet
         if (longCon != 0)
         {

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -149,6 +149,7 @@ private:
     void buildCmp(GenTree* node, Value* op1, Value* op2);
     void buildCnsDouble(GenTreeDblCon* node);
     void buildCnsInt(GenTree* node);
+    void buildCnsLng(GenTree* node);
     void buildHelperFuncCall(GenTreeCall* call);
     llvm::FunctionType* buildHelperLlvmFunctionType(GenTreeCall* call, bool withShadowStack);
     void buildInd(GenTree* node, Value* ptr);


### PR DESCRIPTION
This PR add support for `GT_CNS_LNG`.  I've left in the the possibilty of `node->gtType == TYP_REF` in case this could happen with Wasm64?

cc @SingleAccretion