### PR TITLE
NativeAOT-LLVM: Change all cases of RhpAssignRef to RhpCheckedAssignRef 

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -150,6 +150,13 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern unsafe void RhpAssignRef(ref object address, object obj);
 
+#if TARGET_WASM
+        // TODO-LLVM: the IL backend needs this for store indirect, when all code is through the RyuJIT backend, remove it
+        [RuntimeImport(Redhawk.BaseName, "RhpCheckedAssignRef")]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern unsafe void RhpCheckedAssignRef(ref object address, object obj);
+#endif
+
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(Redhawk.BaseName, "RhpInitMultibyte")]
         internal static extern unsafe ref byte RhpInitMultibyte(ref byte dmem, int c, nuint size);

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1082,7 +1082,7 @@ namespace Internal.IL
         {
             if (withGCBarrier && targetType.IsGCPointer)
             {
-                CallRuntime(_method.Context, "InternalCalls", "RhpAssignRef", new StackEntry[]
+                CallRuntime(_method.Context, "InternalCalls", "RhpCheckedAssignRef", new StackEntry[]
                 {
                     new ExpressionEntry(StackValueKind.Int32, "address", address), value
                 });
@@ -1136,7 +1136,7 @@ namespace Internal.IL
                         // single field IL structs are not LLVM structs
                         fieldValue = llvmValue;
                     }
-                    CallRuntime(_method.Context, "InternalCalls", "RhpAssignRef",
+                    CallRuntime(_method.Context, "InternalCalls", "RhpCheckedAssignRef",
                         new StackEntry[]
                         {
                             new ExpressionEntry(StackValueKind.Int32, "targetAddress", targetAddress),
@@ -1146,7 +1146,7 @@ namespace Internal.IL
             }
             if (!childStruct)
             {
-                _builder.BuildStore(llvmValue, typedStoreLocation); // just copy all the fields again for simplicity, if all the fields were set using RhpAssignRef then a possible optimisation would be to skip this line
+                _builder.BuildStore(llvmValue, typedStoreLocation); // just copy all the fields again for simplicity, if all the fields were set using RhpCheckedAssignRef then a possible optimisation would be to skip this line
             }
         }
 
@@ -3629,7 +3629,7 @@ namespace Internal.IL
             }
             if (requireWriteBarrier)
             {
-                CallRuntime(_method.Context, "InternalCalls", "RhpAssignRef", new StackEntry[]
+                CallRuntime(_method.Context, "InternalCalls", "RhpCheckedAssignRef", new StackEntry[]
                 {
                     new ExpressionEntry(StackValueKind.Int32, "typedPointer", typedPointer), value
                 });


### PR DESCRIPTION
This PR address one cause of memory corruption where the IL->LLVM backend is using `RhpAssignRef` for addresses that may be outside of the heap, e.g. on the shadow stack.  This at least partially addresses #1984 .    All three instances of `RhpAssignRef` are changed as it was observed that they are all culprits.

I didn't create a test as this is difficult to make consistently fail.

The RyuJIT->LLVM backend is also doing this, which is why I've not added the assert mentioned in the above issue.  The RyuJIT problem can be looked at separately, #1987 