### PR TITLE
NativeAOT-LLVM: Fix order of catch and second pass + calling finally twice

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -121,7 +121,7 @@ jobs:
 
         # OSX Build Pool (we don't have on-prem OSX BuildPool
         ${{ if in(parameters.osGroup, 'OSX', 'MacCatalyst', 'iOS', 'iOSSimulator', 'tvOS', 'tvOSSimulator') }}:
-          vmImage: 'macOS-10.15'
+          vmImage: 'macOS-11'
 
         # Official Build Windows Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.hostedOs, 'windows')), ne(variables['System.TeamProject'], 'public')) }}:

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -92,7 +92,6 @@ namespace System.Runtime
                 }
                 else
                 {
-                    tryRegionIdx = MaxTryRegionIdx;
                     bool shouldInvokeHandler = InternalCalls.RhpCallFilterFunclet(exception, ehClause._filterAddress, shadowStack);
                     if (shouldInvokeHandler)
                     {

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -92,7 +92,7 @@ namespace System.Runtime
                 }
                 else
                 {
-                    tryRegionIdx = 0;
+                    tryRegionIdx = MaxTryRegionIdx;
                     bool shouldInvokeHandler = InternalCalls.RhpCallFilterFunclet(exception, ehClause._filterAddress, shadowStack);
                     if (shouldInvokeHandler)
                     {
@@ -106,40 +106,22 @@ namespace System.Runtime
             return false;
         }
 
-        private static void InvokeSecondPassWasm(uint idxStart, uint idxTryLandingStart, ref EHClauseIterator clauseIter, uint idxLimit, void* shadowStack)
+        private static void InvokeSecondPassWasm(uint idxStart, uint idxTryLandingStart /* we do dont have the PC, so use the start of the block */, ref EHClauseIterator clauseIter, uint idxLimit, void* shadowStack)
         {
-            uint lastTryStart = 0, lastTryEnd = 0;
             // Search the clauses for one that contains the current offset.
             RhEHClauseWasm ehClause = new RhEHClauseWasm();
             for (uint curIdx = 0; clauseIter.Next(ref ehClause) && curIdx < idxLimit; curIdx++)
             {
-                //
-                // Skip to the starting try region.  This is used by collided unwinds and rethrows to pickup where
-                // the previous dispatch left off.
-                //
-                if (idxStart != MaxTryRegionIdx)
+
+                if (curIdx > idxStart)
                 {
-                    if (curIdx <= idxStart)
-                    {
-                        lastTryStart = ehClause._tryStartOffset;
-                        lastTryEnd = ehClause._tryEndOffset;
-                        continue;
-                    }
-
-                    // Now, we continue skipping while the try region is identical to the one that invoked the
-                    // previous dispatch.
-                    if ((ehClause._tryStartOffset == lastTryStart) && (ehClause._tryEndOffset == lastTryEnd))
-                        continue;
-
-                    // We are done skipping. This is required to handle empty finally block markers that are used
-                    // to separate runs of different try blocks with same native code offsets.
-                    idxStart = MaxTryRegionIdx;
+                    break; // these blocks are after the catch
                 }
 
                 EHClauseIterator.RhEHClauseKindWasm clauseKind = ehClause._clauseKind;
 
                 if ((clauseKind != EHClauseIterator.RhEHClauseKindWasm.RH_EH_CLAUSE_FAULT)
-                    || !ehClause.TryStartsAt(idxTryLandingStart))
+                    || !ehClause.ContainsCodeOffset(idxTryLandingStart))
                 {
                     continue;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -1364,6 +1364,7 @@ namespace Internal.IL
             _thisType = GetWellKnownType(WellKnownType.Void);
             _pointerSize = compilation.NodeFactory.Target.PointerSize;
             _exceptionRegions = new ExceptionRegion[0];
+            _handlerRegionsForOffsetLookup = new ExceptionRegion[0];
         }
 
         internal void OutputCodeForTriggerCctor(TypeDesc type, LLVMValueRef staticBaseValueRef)

--- a/src/libraries/Native/Unix/System.Globalization.Native/configure.cmake
+++ b/src/libraries/Native/Unix/System.Globalization.Native/configure.cmake
@@ -20,6 +20,11 @@ else()
             "unicode/ucol.h"
             HAVE_SET_MAX_VARIABLE)
 
+        check_symbol_exists(
+            ucol_clone
+            "unicode/ucol.h"
+            HAVE_UCOL_CLONE)
+
         unset(CMAKE_REQUIRED_LIBRARIES)
         unset(CMAKE_REQUIRED_INCLUDES)
     endif()

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c
@@ -321,7 +321,24 @@ static UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t o
 
     if (customRuleLength == 0)
     {
+#if !defined(STATIC_ICU)
+        if (ucol_clone_ptr != NULL)
+        {
+            pClonedCollator = ucol_clone(pCollator, pErr);
+        }
+        else
+        {
+            pClonedCollator = ucol_safeClone_ptr(pCollator, NULL, NULL, pErr);
+        }
+#else // !defined(STATIC_ICU)
+
+#if HAVE_UCOL_CLONE
+        pClonedCollator = ucol_clone(pCollator, pErr);
+#else
         pClonedCollator = ucol_safeClone(pCollator, NULL, NULL, pErr);
+#endif // HAVE_UCOL_CLONE
+
+#endif // !defined(STATIC_ICU)
     }
     else
     {

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
@@ -29,7 +29,6 @@ FOR_ALL_ICU_FUNCTIONS
 #define SYMBOL_NAME_SIZE (128 + SYMBOL_CUSTOM_SUFFIX_SIZE)
 #define MaxICUVersionStringWithSuffixLength (MaxICUVersionStringLength + SYMBOL_CUSTOM_SUFFIX_SIZE)
 
-
 #if defined(TARGET_WINDOWS) || defined(TARGET_OSX) || defined(TARGET_ANDROID)
 
 #define MaxICUVersionStringLength 33
@@ -39,6 +38,7 @@ FOR_ALL_ICU_FUNCTIONS
 static void* libicuuc = NULL;
 static void* libicui18n = NULL;
 ucol_setVariableTop_func ucol_setVariableTop_ptr = NULL;
+ucol_safeClone_func ucol_safeClone_ptr = NULL;
 
 #if defined (TARGET_UNIX)
 
@@ -381,6 +381,30 @@ static void ValidateICUDataCanLoad()
     }
 }
 
+static void InitializeUColClonePointers(char* symbolVersion)
+{
+    if (ucol_clone_ptr != NULL)
+    {
+        return;
+    }
+
+#if defined(TARGET_WINDOWS)
+    char symbolName[SYMBOL_NAME_SIZE];
+    sprintf_s(symbolName, SYMBOL_NAME_SIZE, "ucol_safeClone%s", symbolVersion);
+    ucol_safeClone_ptr = (ucol_safeClone_func)GetProcAddress((HMODULE)libicui18n, symbolName);
+#else
+    char symbolName[SYMBOL_NAME_SIZE];
+    sprintf(symbolName, "ucol_safeClone%s", symbolVersion);
+    ucol_safeClone_ptr = (ucol_safeClone_func)dlsym(libicui18n, symbolName);
+#endif // defined(TARGET_WINDOWS)
+
+    if (ucol_safeClone_ptr == NULL)
+    {
+        fprintf(stderr, "Cannot get the symbols of ICU APIs ucol_safeClone or ucol_clone.\n");
+        abort();
+    }
+}
+
 static void InitializeVariableMaxAndTopPointers(char* symbolVersion)
 {
     if (ucol_setMaxVariable_ptr != NULL)
@@ -444,6 +468,7 @@ int32_t GlobalizationNative_LoadICU()
     ValidateICUDataCanLoad();
 
     InitializeVariableMaxAndTopPointers(symbolVersion);
+    InitializeUColClonePointers(symbolVersion);
 
     return true;
 }

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -66,7 +66,29 @@ extern ucol_setVariableTop_func ucol_setVariableTop_ptr;
 U_CAPI void U_EXPORT2 ucol_setMaxVariable(UCollator* coll, UColReorderCode group, UErrorCode* pErrorCode);
 U_CAPI int32_t U_EXPORT2 ucal_getTimeZoneIDForWindowsID(const UChar* winid, int32_t len, const char* region, UChar* id, int32_t idCapacity, UErrorCode* status);
 U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len, UChar* winid, int32_t winidCapacity, UErrorCode* status);
-#endif
+
+// (U_ICU_VERSION_MAJOR_NUM < 71)
+// The following API is not supported in the ICU versions less than 71. We need to define it manually.
+// We have to do runtime check before using the pointers to this API. That is why these are listed in the FOR_ALL_OPTIONAL_ICU_FUNCTIONS list.
+U_CAPI UCollator* U_EXPORT2 ucol_clone(const UCollator* coll, UErrorCode* status);
+
+// ucol_setVariableTop is a deprecated function on the newer ICU versions and ucol_setMaxVariable should be used instead.
+// As can run against ICU versions which not supported ucol_setMaxVariable, we'll dynamically try to get the pointer to ucol_setVariableTop
+// when we couldn't get a pointer to ucol_setMaxVariable.
+typedef uint32_t (U_EXPORT2 *ucol_setVariableTop_func)(UCollator* coll, const UChar* varTop, int32_t len, UErrorCode* status);
+
+// ucol_safeClone is deprecated in ICU version 71. We have to handle it manually to avoid getting a build break when referencing it in the code.
+typedef UCollator* (U_EXPORT2 *ucol_safeClone_func)(const UCollator* coll, void* stackBuffer, int32_t* pBufferSize, UErrorCode* status);
+
+#else // !defined(TARGET_ANDROID)
+
+typedef uint32_t (*ucol_setVariableTop_func)(UCollator* coll, const UChar* varTop, int32_t len, UErrorCode* status);
+typedef UCollator* (*ucol_safeClone_func)(const UCollator* coll, void* stackBuffer, int32_t* pBufferSize, UErrorCode* status);
+
+#endif // !defined(TARGET_ANDROID)
+
+extern ucol_setVariableTop_func ucol_setVariableTop_ptr;
+extern ucol_safeClone_func ucol_safeClone_ptr;
 
 // List of all functions from the ICU libraries that are used in the System.Globalization.Native.so
 #define FOR_ALL_UNCONDITIONAL_ICU_FUNCTIONS \
@@ -192,7 +214,8 @@ U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len,
 #define FOR_ALL_OPTIONAL_ICU_FUNCTIONS \
     PER_FUNCTION_BLOCK(ucal_getWindowsTimeZoneID, libicui18n, false) \
     PER_FUNCTION_BLOCK(ucal_getTimeZoneIDForWindowsID, libicui18n, false) \
-    PER_FUNCTION_BLOCK(ucol_setMaxVariable, libicui18n, false)
+    PER_FUNCTION_BLOCK(ucol_setMaxVariable, libicui18n, false) \
+    PER_FUNCTION_BLOCK(ucol_clone, libicui18n, false)
 
 #define FOR_ALL_ICU_FUNCTIONS \
     FOR_ALL_UNCONDITIONAL_ICU_FUNCTIONS \
@@ -231,6 +254,7 @@ FOR_ALL_ICU_FUNCTIONS
 #define ucal_openTimeZoneIDEnumeration(...) ucal_openTimeZoneIDEnumeration_ptr(__VA_ARGS__)
 #define ucal_set(...) ucal_set_ptr(__VA_ARGS__)
 #define ucal_setMillis(...) ucal_setMillis_ptr(__VA_ARGS__)
+#define ucol_clone(...) ucol_clone_ptr(__VA_ARGS__)
 #define ucol_close(...) ucol_close_ptr(__VA_ARGS__)
 #define ucol_closeElements(...) ucol_closeElements_ptr(__VA_ARGS__)
 #define ucol_getOffset(...) ucol_getOffset_ptr(__VA_ARGS__)
@@ -243,7 +267,6 @@ FOR_ALL_ICU_FUNCTIONS
 #define ucol_open(...) ucol_open_ptr(__VA_ARGS__)
 #define ucol_openElements(...) ucol_openElements_ptr(__VA_ARGS__)
 #define ucol_openRules(...) ucol_openRules_ptr(__VA_ARGS__)
-#define ucol_safeClone(...) ucol_safeClone_ptr(__VA_ARGS__)
 #define ucol_setAttribute(...) ucol_setAttribute_ptr(__VA_ARGS__)
 #define ucol_setMaxVariable(...) ucol_setMaxVariable_ptr(__VA_ARGS__)
 #define ucol_strcoll(...) ucol_strcoll_ptr(__VA_ARGS__)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -105,7 +105,6 @@ U_CAPI int32_t U_EXPORT2 ucal_getWindowsTimeZoneID(const UChar* id, int32_t len,
     PER_FUNCTION_BLOCK(ucol_open, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucol_openElements, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucol_openRules, libicui18n, true) \
-    PER_FUNCTION_BLOCK(ucol_safeClone, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucol_setAttribute, libicui18n, true) \
     PER_FUNCTION_BLOCK(ucol_strcoll, libicui18n, true) \
     PER_FUNCTION_BLOCK(udat_close, libicui18n, true) \

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal_android.h
@@ -470,7 +470,7 @@ int32_t ucol_previous(UCollationElements * elems, UErrorCode * status);
 UCollator * ucol_open(const char * loc, UErrorCode * status);
 UCollationElements * ucol_openElements(const UCollator * coll, const UChar * text, int32_t textLength, UErrorCode * status);
 UCollator * ucol_openRules(const UChar * rules, int32_t rulesLength, UColAttributeValue normalizationMode, UCollationStrength strength, UParseError * parseError, UErrorCode * status);
-UCollator * ucol_safeClone(const UCollator * coll, void * stackBuffer, int32_t * pBufferSize, UErrorCode * status);
+UCollator * ucol_clone(const UCollator * coll, UErrorCode * status);
 void ucol_setAttribute(UCollator * coll, UColAttribute attr, UColAttributeValue value, UErrorCode * status);
 UCollationResult ucol_strcoll(const UCollator * coll, const UChar * source, int32_t sourceLength, const UChar * target, int32_t targetLength);
 int32_t ucurr_forLocale(const char * locale, UChar * buff, int32_t buffCapacity, UErrorCode * ec);

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -1825,6 +1825,10 @@ internal static class Program
 
         TestTryFinallyThrowException();
 
+        TestTryFinallyCatchException();
+
+        TestInnerTryFinallyOrder();
+
         TestTryCatchWithCallInIf();
 
         TestThrowInCatch();
@@ -1876,10 +1880,10 @@ internal static class Program
         EndTest(caught);
     }
 
-    static bool finallyCalled;
+    static string clauseExceution;
     private static void TestTryFinallyThrowException()
     {
-        finallyCalled = false;
+        clauseExceution = "";
         StartTest("Try/Finally calls finally when exception thrown test");
         try
         {
@@ -1887,9 +1891,17 @@ internal static class Program
         }
         catch (Exception)
         {
-
+            clauseExceution += "COuter";
         }
-        EndTest(finallyCalled);
+
+        if (clauseExceution != "CInnerFCOuter")
+        {
+            FailTest("Expected CInnerFCOuter, but was " + clauseExceution);
+        }
+        else
+        {
+            PassTest();
+        }
     }
 
     private static void TryFinally()
@@ -1898,9 +1910,95 @@ internal static class Program
         {
             throw new Exception();
         }
+        catch
+        {
+            clauseExceution += "CInner";
+            throw;
+        }
         finally
         {
-            finallyCalled = true;
+            clauseExceution += "F";
+        }
+    }
+
+
+    private static void TestTryFinallyCatchException()
+    {
+        clauseExceution = "";
+        StartTest("Try/Finally calls finally once when exception thrown and caught test");
+
+        TryFinallyWithCatch();
+
+        if (clauseExceution != "CF")
+        {
+            FailTest("Expected CF, but was " + clauseExceution);
+        }
+        else
+        {
+            PassTest();
+        }
+    }
+
+    private static void TryFinallyWithCatch()
+    {
+        try
+        {
+            throw new Exception();
+        }
+        catch
+        {
+            clauseExceution += "C";
+        }
+        finally
+        {
+            clauseExceution += "F";
+        }
+    }
+
+    private static void TestInnerTryFinallyOrder()
+    {
+        clauseExceution = "";
+        StartTest("Inner try finally called before outer catch");
+
+        try
+        {
+            try
+            {
+                try
+                {
+                    throw new Exception();
+                }
+                finally
+                {
+                    clauseExceution += "F1";
+                }
+            }
+            finally
+            {
+                clauseExceution += "F2";
+            }
+
+            // not reached
+            try
+            {
+            }
+            finally
+            {
+                clauseExceution += "F3";
+            }
+        }
+        catch
+        {
+            clauseExceution += "C";
+        }
+
+        if (clauseExceution != "F1F2C")
+        {
+            FailTest("Expected F1F2C, but was " + clauseExceution);
+        }
+        else
+        {
+            PassTest();
         }
     }
 


### PR DESCRIPTION
This PR fixes a couple of issues with the LLVM IL backend for exception handling.  The second pass handler is now called before the catch (oops), and the finally block when adjacent to a catch, is only now called once.

I expect there are other problems, but at least this fixes 2 big ones and allows 

https://github.com/dotnet/runtimelab/blob/f9cf5b0e52c4645c0a76ad3770d0c63c712c3a05/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs#L109-L115

to throw without dying in the `Release`

Long term wasm-exceptions may help depending on how close the semantics are to .net I guess.

cc @SingleAccretion