### PR TITLE
Add green thread api skeleton

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -5382,6 +5382,7 @@ namespace System.Threading.Tasks
                 TaskCreationOptions.DenyChildAttach, InternalTaskOptions.None);
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static Task RunAsGreenThread(Action action, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -5409,6 +5410,7 @@ namespace System.Threading.Tasks
             return tcs.Task;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static Task RunAsGreenThread(Action action)
         {
             var tcs = new TaskCompletionSource();
@@ -5428,6 +5430,7 @@ namespace System.Threading.Tasks
             return tcs.Task;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static Task<TResult> RunAsGreenThread<TResult>(Func<TResult> function)
         {
             var tcs = new TaskCompletionSource<TResult>();
@@ -5446,6 +5449,7 @@ namespace System.Threading.Tasks
             return tcs.Task;
         }
 
+        [UnsupportedOSPlatform("browser")]
         public static Task<TResult> RunAsGreenThread<TResult>(Func<TResult> function, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -5405,6 +5405,29 @@ namespace System.Threading.Tasks
             return greenThreadTask;
         }
 
+        public static Task<TResult> RunAsGreenThread<TResult>(Func<TResult> function)
+        {
+            Task<TResult> greenThreadTask = new Task<TResult>(function);
+            new Thread(()=>
+            {
+                Thread.t_IsGreenThread = true;
+                greenThreadTask.RunSynchronously();
+            }).Start();
+            return greenThreadTask;
+        }
+
+        public static Task<TResult> RunAsGreenThread<TResult>(Func<TResult> function, CancellationToken cancellationToken)
+        {
+            Task<TResult> greenThreadTask = new Task<TResult>(function, cancellationToken);
+            new Thread(()=>
+            {
+                Thread.t_IsGreenThread = true;
+                // TODO? Do something like register the cancellation token as an AsyncLocal or something.
+                greenThreadTask.RunSynchronously();
+            }).Start();
+            return greenThreadTask;
+        }
+
         /// <summary>
         /// Queues the specified work to run on the ThreadPool and returns a Task(TResult) handle for that work.
         /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -5382,6 +5382,29 @@ namespace System.Threading.Tasks
                 TaskCreationOptions.DenyChildAttach, InternalTaskOptions.None);
         }
 
+        public static Task RunAsGreenThread(Action action, CancellationToken cancellationToken)
+        {
+            Task greenThreadTask = new Task(action, cancellationToken);
+            new Thread(()=>
+            {
+                Thread.t_IsGreenThread = true;
+                // TODO? Do something like register the cancellation token as an AsyncLocal or something.
+                greenThreadTask.RunSynchronously();
+            }).Start();
+            return greenThreadTask;
+        }
+
+        public static Task RunAsGreenThread(Action action)
+        {
+            Task greenThreadTask = new Task(action);
+            new Thread(()=>
+            {
+                Thread.t_IsGreenThread = true;
+                greenThreadTask.RunSynchronously();
+            }).Start();
+            return greenThreadTask;
+        }
+
         /// <summary>
         /// Queues the specified work to run on the ThreadPool and returns a Task(TResult) handle for that work.
         /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -19,6 +19,9 @@ namespace System.Threading
         [ThreadStatic]
         private static Thread? t_currentThread;
 
+        [ThreadStatic]
+        internal static bool t_IsGreenThread;
+
         // State associated with starting new thread
         private sealed class StartHelper
         {
@@ -586,6 +589,8 @@ namespace System.Threading
         public static void VolatileWrite(ref ulong address, ulong value) => Volatile.Write(ref address, value);
         [CLSCompliant(false)]
         public static void VolatileWrite(ref UIntPtr address, UIntPtr value) => Volatile.Write(ref address, value);
+
+        public static bool IsGreenThread => t_IsGreenThread;
 
         /// <summary>
         /// Manages functionality required to support members of <see cref="Thread"/> dealing with thread-local data

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -14479,9 +14479,13 @@ namespace System.Threading.Tasks
         public static System.Threading.Tasks.Task Run(System.Action action, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task Run(System.Func<System.Threading.Tasks.Task?> function) { throw null; }
         public static System.Threading.Tasks.Task Run(System.Func<System.Threading.Tasks.Task?> function, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         public static System.Threading.Tasks.Task RunAsGreenThread(System.Action action) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         public static System.Threading.Tasks.Task RunAsGreenThread(System.Action action, System.Threading.CancellationToken cancellationToken) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         public static System.Threading.Tasks.Task<TResult> RunAsGreenThread<TResult>(System.Func<TResult> function) { throw null; }
+        [System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
         public static System.Threading.Tasks.Task<TResult> RunAsGreenThread<TResult>(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) { throw null; }
         public void RunSynchronously() { }
         public void RunSynchronously(System.Threading.Tasks.TaskScheduler scheduler) { }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -14481,6 +14481,8 @@ namespace System.Threading.Tasks
         public static System.Threading.Tasks.Task Run(System.Func<System.Threading.Tasks.Task?> function, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task RunAsGreenThread(System.Action action) { throw null; }
         public static System.Threading.Tasks.Task RunAsGreenThread(System.Action action, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public static System.Threading.Tasks.Task<TResult> RunAsGreenThread<TResult>(System.Func<TResult> function) { throw null; }
+        public static System.Threading.Tasks.Task<TResult> RunAsGreenThread<TResult>(System.Func<TResult> function, System.Threading.CancellationToken cancellationToken) { throw null; }
         public void RunSynchronously() { }
         public void RunSynchronously(System.Threading.Tasks.TaskScheduler scheduler) { }
         public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<System.Threading.Tasks.Task<TResult>?> function) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -14479,6 +14479,8 @@ namespace System.Threading.Tasks
         public static System.Threading.Tasks.Task Run(System.Action action, System.Threading.CancellationToken cancellationToken) { throw null; }
         public static System.Threading.Tasks.Task Run(System.Func<System.Threading.Tasks.Task?> function) { throw null; }
         public static System.Threading.Tasks.Task Run(System.Func<System.Threading.Tasks.Task?> function, System.Threading.CancellationToken cancellationToken) { throw null; }
+        public static System.Threading.Tasks.Task RunAsGreenThread(System.Action action) { throw null; }
+        public static System.Threading.Tasks.Task RunAsGreenThread(System.Action action, System.Threading.CancellationToken cancellationToken) { throw null; }
         public void RunSynchronously() { }
         public void RunSynchronously(System.Threading.Tasks.TaskScheduler scheduler) { }
         public static System.Threading.Tasks.Task<TResult> Run<TResult>(System.Func<System.Threading.Tasks.Task<TResult>?> function) { throw null; }

--- a/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Task\TaskFromAsyncTest2.cs" />
     <Compile Include="Task\TaskCancelWaitTests.cs" />
     <Compile Include="Task\TaskCancelWaitTest.cs" />
+    <Compile Include="Task\TaskGreenRtTests.cs" />
     <Compile Include="Task\TaskRtTests.cs" />
     <Compile Include="Task\TaskRtTests_Core.cs" />
     <Compile Include="Task\TaskAPMTest.cs" />

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskGreenRtTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskGreenRtTests.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using System.Collections.Generic;
+using System.Text;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace System.Threading.Tasks.Tests
+{
+    public static class TaskGreenRtTests
+    {
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [OuterLoop]
+        public static void RunRunTests()
+        {
+            //
+            // Test that AttachedToParent is ignored in Task.RunAsGreenThread delegate
+            //
+            {
+                Task tInner = null;
+
+                // Test Run(Action)
+                Task t1 = Task.RunAsGreenThread(() =>
+                {
+                    tInner = new Task(() => { }, TaskCreationOptions.AttachedToParent);
+                });
+                Debug.WriteLine("RunRunTests - AttachToParentIgnored:      -- Waiting on outer Task.  If we hang, that's a failure");
+                t1.Wait();
+                tInner.Start();
+                tInner.Wait();
+
+                // Test Run(Func<int>)
+                Task<int> f1 = Task.RunAsGreenThread(() =>
+                {
+                    tInner = new Task(() => { }, TaskCreationOptions.AttachedToParent);
+                    return 42;
+                });
+                Debug.WriteLine("RunRunTests - AttachToParentIgnored:      -- Waiting on outer Task<int>.  If we hang, that's a failure");
+                f1.Wait();
+                tInner.Start();
+                tInner.Wait();
+            }
+
+            //
+            // Test basic functionality w/o cancellation token
+            //
+            int count = 0;
+            Task task1 = Task.RunAsGreenThread(() => { count = 1; });
+            Debug.WriteLine("RunRunTests: waiting for a task.  If we hang, something went wrong.");
+            task1.Wait();
+            Assert.True(count == 1, "    > FAILED.  Task completed but did not run.");
+            Assert.True(task1.Status == TaskStatus.RanToCompletion, "    > FAILED.  Task did not end in RanToCompletion state.");
+
+            Task<int> future1 = Task.RunAsGreenThread(() => { return 7; });
+            Debug.WriteLine("RunRunTests - Basic w/o CT: waiting for a future.  If we hang, something went wrong.");
+            future1.Wait();
+            Assert.True(future1.Result == 7, "    > FAILED.  Future completed but did not run.");
+            Assert.True(future1.Status == TaskStatus.RanToCompletion, "    > FAILED.  Future did not end in RanToCompletion state.");
+            //
+            // Test basic functionality w/ uncancelled cancellation token
+            //
+            CancellationTokenSource cts = new CancellationTokenSource();
+            CancellationToken token = cts.Token;
+            Task task2 = Task.RunAsGreenThread(() => { count = 21; }, token);
+            Debug.WriteLine("RunRunTests: waiting for a task w/ uncanceled token.  If we hang, something went wrong.");
+            task2.Wait();
+            Assert.True(count == 21, "    > FAILED.  Task w/ uncanceled token completed but did not run.");
+            Assert.True(task2.Status == TaskStatus.RanToCompletion, "    > FAILED.  Task w/ uncanceled token did not end in RanToCompletion state.");
+
+            Task<int> future2 = Task.RunAsGreenThread(() => 27, token);
+            Debug.WriteLine("RunRunTests: waiting for a future w/ uncanceled token.  If we hang, something went wrong.");
+            future2.Wait();
+            Assert.True(future2.Result == 27, "    > FAILED.  Future w/ uncanceled token completed but did not run.");
+            Assert.True(future2.Status == TaskStatus.RanToCompletion, "    > FAILED.  Future w/ uncanceled token did not end in RanToCompletion state.");
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [OuterLoop]
+        public static void RunRunTests_Cancellation_Negative()
+        {
+            CancellationTokenSource cts = new CancellationTokenSource();
+            CancellationToken token = cts.Token;
+            int count = 0;
+            //
+            // Test that the right thing is done with a canceled cancellation token
+            //
+            cts.Cancel();
+            Task task3 = Task.RunAsGreenThread(() => { count = 41; }, token);
+            Debug.WriteLine("RunRunTests: waiting for a task w/ canceled token.  If we hang, something went wrong.");
+            Assert.Throws<AggregateException>(
+               () => { task3.Wait(); });
+            Assert.False(count == 41, "    > FAILED.  Task w/ canceled token ran when it should not have.");
+            Assert.True(task3.IsCanceled, "    > FAILED.  Task w/ canceled token should have ended in Canceled state");
+
+            Task future3 = Task.RunAsGreenThread(() => { count = 47; return count; }, token);
+            Debug.WriteLine("RunRunTests: waiting for a future w/ canceled token.  If we hang, something went wrong.");
+            Assert.Throws<AggregateException>(
+               () => { future3.Wait(); });
+            Assert.False(count == 47, "    > FAILED.  Future w/ canceled token ran when it should not have.");
+            Assert.True(future3.IsCanceled, "    > FAILED.  Future w/ canceled token should have ended in Canceled state");
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public static void IsGreenThread_Negative_NewThread()
+        {
+            bool checkIsGreenThread = false;
+
+            // Validate that newly constructed thread via new Thread is not a green thread
+            var thread = new Thread(()=>{ checkIsGreenThread = Thread.IsGreenThread; });
+            thread.Start();
+            thread.Join();
+            Assert.False(checkIsGreenThread);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public static void IsGreenThread_Negative_ThreadPoolItem()
+        {
+            bool checkIsGreenThread = false;
+            SemaphoreSlim semaphore = new SemaphoreSlim(0);
+
+            // Validate that newly constructed thread via new Thread is not a green thread
+            Assert.True(ThreadPool.QueueUserWorkItem((object o)=>{ checkIsGreenThread = Thread.IsGreenThread; semaphore.Release(); }));
+            semaphore.Wait();
+
+            Assert.False(checkIsGreenThread);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public static void IsGreenThread_Positive()
+        {
+            //
+            // Test basic functionality w/o cancellation token
+            //
+            int count = 0;
+            Task task1 = Task.RunAsGreenThread(() => { count = 1; Assert.True(Thread.IsGreenThread); });
+            Debug.WriteLine("RunRunTests: waiting for a task.  If we hang, something went wrong.");
+            task1.Wait();
+            Assert.True(count == 1, "    > FAILED.  Task completed but did not run.");
+            Assert.True(task1.Status == TaskStatus.RanToCompletion, "    > FAILED.  Task did not end in RanToCompletion state.");
+
+            Task<int> future1 = Task.RunAsGreenThread(() => { Assert.True(Thread.IsGreenThread); return 7; });
+            Debug.WriteLine("RunRunTests - Basic w/o CT: waiting for a future.  If we hang, something went wrong.");
+            future1.Wait();
+            Assert.True(future1.Result == 7, "    > FAILED.  Future completed but did not run.");
+            Assert.True(future1.Status == TaskStatus.RanToCompletion, "    > FAILED.  Future did not end in RanToCompletion state.");
+            //
+            // Test basic functionality w/ uncancelled cancellation token
+            //
+            CancellationTokenSource cts = new CancellationTokenSource();
+            CancellationToken token = cts.Token;
+            Task task2 = Task.RunAsGreenThread(() => { count = 21; Assert.True(Thread.IsGreenThread); }, token);
+            Debug.WriteLine("RunRunTests: waiting for a task w/ uncanceled token.  If we hang, something went wrong.");
+            task2.Wait();
+            Assert.True(count == 21, "    > FAILED.  Task w/ uncanceled token completed but did not run.");
+            Assert.True(task2.Status == TaskStatus.RanToCompletion, "    > FAILED.  Task w/ uncanceled token did not end in RanToCompletion state.");
+
+            Task<int> future2 = Task.RunAsGreenThread(() => { Assert.True(Thread.IsGreenThread); return 27; }, token);
+            Debug.WriteLine("RunRunTests: waiting for a future w/ uncanceled token.  If we hang, something went wrong.");
+            future2.Wait();
+            Assert.True(future2.Result == 27, "    > FAILED.  Future w/ uncanceled token completed but did not run.");
+            Assert.True(future2.Status == TaskStatus.RanToCompletion, "    > FAILED.  Future w/ uncanceled token did not end in RanToCompletion state.");
+        }
+    }
+}

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -46,7 +46,7 @@ namespace System.Threading
         public bool IsAlive { get { throw null; } }
         public bool IsBackground { get { throw null; } set { } }
         public bool IsThreadPoolThread { get { throw null; } }
-        public bool IsGreenThread { get { throw null; } }
+        public static bool IsGreenThread { get { throw null; } }
         public int ManagedThreadId { get { throw null; } }
         public string? Name { get { throw null; } set { } }
         public System.Threading.ThreadPriority Priority { get { throw null; } set { } }

--- a/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
+++ b/src/libraries/System.Threading.Thread/ref/System.Threading.Thread.cs
@@ -46,6 +46,7 @@ namespace System.Threading
         public bool IsAlive { get { throw null; } }
         public bool IsBackground { get { throw null; } set { } }
         public bool IsThreadPoolThread { get { throw null; } }
+        public bool IsGreenThread { get { throw null; } }
         public int ManagedThreadId { get { throw null; } }
         public string? Name { get { throw null; } set { } }
         public System.Threading.ThreadPriority Priority { get { throw null; } set { } }


### PR DESCRIPTION
Provide a green thread api that just uses threads  (`Task.RunAsGreenThread`)
- This is probably not completely correct, but if users just call .Wait on the returned tasks, it'll probably be ok.

Also added `Thread.IsGreenThread` to check to see if a thread is green.