### PR TITLE
NativeAOT-LLVM: cast unsigned ints to floats using uitofp

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/ILImporter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/ILImporter.cs
@@ -581,7 +581,7 @@ namespace Internal.IL
                         ImportConvert(WellKnownType.Double, false, false);
                         break;
                     case ILOpcode.conv_u4:
-                        ImportConvert(WellKnownType.UInt32, false, false);
+                        ImportConvert(WellKnownType.UInt32, false, true);
                         break;
                     case ILOpcode.conv_u8:
                         ImportConvert(WellKnownType.UInt64, false, true);

--- a/src/coreclr/tools/Common/TypeSystem/IL/ILImporter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/ILImporter.cs
@@ -825,7 +825,7 @@ namespace Internal.IL
                         ImportStoreIndirect(WellKnownType.IntPtr);
                         break;
                     case ILOpcode.conv_u:
-                        ImportConvert(WellKnownType.UIntPtr, false, false);
+                        ImportConvert(WellKnownType.UIntPtr, false, true);
                         break;
                     case ILOpcode.prefix1:
                         opCode = (ILOpcode)(0x100 + ReadILByte());

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -4034,6 +4034,7 @@ namespace Internal.IL
             // Load the value and then convert it instead of using ValueAsType to avoid loading the incorrect size
             LLVMValueRef loadedValue = value.ValueAsType(value.Type, _builder);
             LLVMValueRef widenedStackValue = CastIfNecessary(loadedValue, GetLLVMTypeForTypeDesc(WidenBytesAndShorts(value.Type)), value.Name(),
+                stackType.IsWellKnownType(WellKnownType.Boolean) ||
                 stackType.IsWellKnownType(WellKnownType.Byte) ||
                 stackType.IsWellKnownType(WellKnownType.UInt16) ||
                 stackType.IsWellKnownType(WellKnownType.UInt32)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1216,7 +1216,6 @@ namespace Internal.IL
             }
             else if (toStoreKind == LLVMTypeKind.LLVMIntegerTypeKind && (valueTypeKind == LLVMTypeKind.LLVMDoubleTypeKind || valueTypeKind == LLVMTypeKind.LLVMFloatTypeKind))
             {
-                //TODO: keep track of the TypeDesc so we can call BuildUIToFP when the integer is unsigned
                 typedToStore = unsigned
                     ? builder.BuildUIToFP(source, valueType, "CastUIToFloat" + (name ?? ""))
                     : builder.BuildSIToFP(source, valueType, "CastSIToFloat" + (name ?? ""));
@@ -4017,10 +4016,17 @@ namespace Internal.IL
         {
             //TODO checkOverflow - r_un & r_4, i & i_un
             StackEntry value = _stack.Pop();
+            TypeDesc stackType = value.Type;
+
             TypeDesc destType = GetWellKnownType(wellKnownType);
 
             // Load the value and then convert it instead of using ValueAsType to avoid loading the incorrect size
             LLVMValueRef loadedValue = value.ValueAsType(value.Type, _builder);
+            LLVMValueRef widenedStackValue = CastIfNecessary(loadedValue, GetLLVMTypeForTypeDesc(WidenBytesAndShorts(value.Type)), value.Name(),
+                stackType.IsWellKnownType(WellKnownType.Byte) ||
+                stackType.IsWellKnownType(WellKnownType.UInt16) ||
+                stackType.IsWellKnownType(WellKnownType.UInt32)
+                );
 
             ExpressionEntry expressionEntry;
             if (checkOverflow)
@@ -4028,24 +4034,16 @@ namespace Internal.IL
                 Debug.Assert(destType is EcmaType);
                 if (IsLlvmReal(loadedValue.TypeOf))
                 {
-                    expressionEntry = BuildConvOverflowFromReal(value, loadedValue, (EcmaType)destType, wellKnownType, unsigned, value.Type);
+                    expressionEntry = BuildConvOverflowFromReal(value, widenedStackValue, (EcmaType)destType, wellKnownType, unsigned, value.Type);
                 }
                 else
                 {
-                    expressionEntry = BuildConvOverflow(value.Name(), loadedValue, (EcmaType)destType, wellKnownType, unsigned, value.Type);
+                    expressionEntry = BuildConvOverflow(value.Name(), widenedStackValue, (EcmaType)destType, wellKnownType, unsigned, value.Type);
                 }
             }
             else
             {
-                TypeDesc sourceType = value.Type;
-
-                LLVMValueRef converted = CastIfNecessary(loadedValue, GetLLVMTypeForTypeDesc(destType), value.Name(),
-                    wellKnownType == WellKnownType.UInt64 /* unsigned is always false, so check for the type explicitly */
-                    || sourceType.IsWellKnownType(WellKnownType.Byte)
-                    || sourceType.IsWellKnownType(WellKnownType.UInt16)
-                    || sourceType.IsWellKnownType(WellKnownType.UInt32)
-                    || sourceType.IsWellKnownType(WellKnownType.UInt64)
-                    );
+                LLVMValueRef converted = CastIfNecessary(widenedStackValue, GetLLVMTypeForTypeDesc(destType), value.Name(), unsigned);
                 expressionEntry = new ExpressionEntry(GetStackValueKind(destType), "conv", converted, destType);
             }
             _stack.Push(expressionEntry);

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -1093,9 +1093,25 @@ internal static class Program
             FailTest("Expected 1f but didn't get it"); // TODO: float.ToString() is failing in DiyFP
         }
 
+        bool trueBool = true;
+        nuint nativeUnsignedFromBool = trueBool;
+        if (nativeUnsignedFromBool != 1)
+        {
+            FailTest($"Expected 1 but got {nativeUnsignedFromBool}");
+            return;
+        }
+
         byte msbByte = 0xff;
-        nuint nativeUnsigned = msbByte;
-        EndTest(nativeUnsigned == 0xff, $"Expected 0xff but got {nativeUnsigned}");
+        nuint nativeUnsignedFromByte = msbByte;
+        if (nativeUnsignedFromByte != 0xff)
+        {
+            FailTest($"Expected 0xff but got {nativeUnsignedFromByte}");
+            return;
+        }
+
+        ushort msbUshort = 0x8000;
+        nuint nativeUnsignedFromUshort = msbUshort;
+        EndTest(nativeUnsignedFromUshort == 0x8000, $"Expected 0x8000 but got {nativeUnsignedFromUshort}");
     }
 
     private static void CastByteForIndex()

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -229,6 +229,8 @@ internal static class Program
         PrintLine(((BoxStubTest[])arrayCastingTest)[2].Value);
         EndTest(!(arrayCastingTest is CastingTestClass[]));
 
+        CastByteToFloat();
+
         ldindTest();
 
         InterfaceDispatchTest();
@@ -1077,6 +1079,14 @@ internal static class Program
         string intString = 42.ToString();
         PrintLine(intString);
         EndTest(intString == "42");
+    }
+
+    private static void CastByteToFloat()
+    {
+        StartTest("Implicit casting of byte to float");
+        byte alpha = 0xFF;
+        float f = alpha / 255f;
+        EndTest(f == 1f, "Expected 1f but didn't get it");
     }
 
     private unsafe static void ldindTest()

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -229,7 +229,7 @@ internal static class Program
         PrintLine(((BoxStubTest[])arrayCastingTest)[2].Value);
         EndTest(!(arrayCastingTest is CastingTestClass[]));
 
-        CastByteToFloat();
+        ConvUTest();
 
         ldindTest();
 
@@ -1081,12 +1081,19 @@ internal static class Program
         EndTest(intString == "42");
     }
 
-    private static void CastByteToFloat()
+    private static void ConvUTest()
     {
-        StartTest("Implicit casting of byte to float");
+        StartTest("Implicit casting using ConvU");
         byte alpha = 0xFF;
         float f = alpha / 255f;
-        EndTest(f == 1f, "Expected 1f but didn't get it");
+        if (f != 1f)
+        {
+            FailTest("Expected 1f but didn't get it"); // TODO: float.ToString() is failing in DiyFP
+        }
+
+        byte msbByte = 0xff;
+        nuint nativeUnsigned = msbByte;
+        EndTest(nativeUnsigned == 0xff, $"Expected 0xff but got {nativeUnsigned}");
     }
 
     private unsafe static void ldindTest()

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -1093,14 +1093,6 @@ internal static class Program
             FailTest("Expected 1f but didn't get it"); // TODO: float.ToString() is failing in DiyFP
         }
 
-        bool trueBool = true;
-        nuint nativeUnsignedFromBool = trueBool;
-        if (nativeUnsignedFromBool != 1)
-        {
-            FailTest($"Expected 1 but got {nativeUnsignedFromBool}");
-            return;
-        }
-
         byte msbByte = 0xff;
         nuint nativeUnsignedFromByte = msbByte;
         if (nativeUnsignedFromByte != 0xff)


### PR DESCRIPTION
This PR fixes a bug when casting ints to floating points.  It assumed signed.  If the source is an unsigned int, then make the cast unsigned (https://llvm.org/docs/LangRef.html#uitofp-to-instruction) .

Adds a test using a byte > 0x7f

cc @SingleAccretion