### PR TITLE
NativeAOT-LLVM: consume pointer for NULLCHECK to i8*

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1728,7 +1728,7 @@ void Llvm::buildNullCheck(GenTreeUnOp* nullCheckNode)
         builder.CreateRetVoid();
     }
 
-    buildLlvmCallOrInvoke(_nullCheckFunction, {getShadowStackForCallee(), getGenTreeValue(nullCheckNode->gtGetOp1())});
+    buildLlvmCallOrInvoke(_nullCheckFunction, {getShadowStackForCallee(), consumeValue(nullCheckNode->gtGetOp1(),  Type::getInt8PtrTy(_llvmContext))});
 }
 
 void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc)


### PR DESCRIPTION
This PR consumes as `i8*` the pointer for the null check function.
With this IR
```
                                                  /--*  t32    int
N004 (  4,  3) [000033] ---X---N----              *  NULLCHECK byte
```
we assert as the LLVM null check function expects `i8*` .  So we `consumeValue` to cast the pointer if necessary.

cc @SingleAccretion