### PR TITLE
NativeAOT-LLVM: add declares for internal methods that are only used from the clrjit module

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1728,7 +1728,7 @@ void Llvm::buildNullCheck(GenTreeUnOp* nullCheckNode)
         builder.CreateRetVoid();
     }
 
-    buildLlvmCallOrInvoke(_nullCheckFunction, {getShadowStackForCallee(), getGenTreeValue(nullCheckNode->gtGetOp1())});
+    buildLlvmCallOrInvoke(_nullCheckFunction, {getShadowStackForCallee(), consumeValue(nullCheckNode->gtGetOp1(),  Type::getInt8PtrTy(_llvmContext))});
 }
 
 void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -140,6 +140,14 @@ namespace ILCompiler
 
                 if (methodIL == null)
                 {
+                    if (method.IsInternalCall)
+                    {
+                        // this might have been the subject of a call in the clrjit module.  We need the function here so we can populate the symbol
+                        var mangledName = NodeFactory.NameMangler.GetMangledMethodName(method).ToString();
+                        var sig = method.Signature;
+                        ILImporter.GetOrCreateLLVMFunction(Module, mangledName, GetLLVMSignatureForMethod(sig, method.RequiresInstArg()));
+                    }
+
                     methodCodeNodeNeedingCode.CompilationCompleted = true;
                     return;
                 }


### PR DESCRIPTION
This PR fixes a bug where an internal method, e.g 

https://github.com/dotnet/runtimelab/blob/cfc3ee70c528b216674c4e5189bda1020b64faee/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs#L15-L16

that is only called from the clrjit module never gets a symbol in the IL module - which then fails generating symbol nodes - the dependency node exists, but has no `LLVMValueRef`

cc @SingleAccretion