### PR TITLE
NativeAOT-LLVM: extern globals should not be constant 

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -637,7 +637,7 @@ Value* getOrCreateExternalSymbol(const char* symbolName, Type* symbolType = null
     Value* symbol = _module->getGlobalVariable(symbolName);
     if (symbol == nullptr)
     {
-        symbol = new llvm::GlobalVariable(*_module, symbolType, true, llvm::GlobalValue::LinkageTypes::ExternalLinkage, (llvm::Constant*)nullptr, symbolName);
+        symbol = new llvm::GlobalVariable(*_module, symbolType, false, llvm::GlobalValue::LinkageTypes::ExternalLinkage, (llvm::Constant*)nullptr, symbolName);
     }
     return symbol;
 }


### PR DESCRIPTION
This PR fixes an optimisation problem where clang will remove the externs if they are constant and there are only `store`s in the input and optimisation is on

cc @SingleAccretion.