### PR TITLE
NativeAOT-LLVM: stelem always use unsigned cast

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -5100,7 +5100,7 @@ namespace Internal.IL
             StackEntry index = _stack.Pop();
             StackEntry arrayReference = _stack.Pop();
             var nullSafeElementType = elementType ?? GetWellKnownType(WellKnownType.Object);
-            LLVMValueRef elementAddress = GetElementAddress(index.ValueAsInt32(_builder, true), arrayReference.ValueAsType(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), _builder), nullSafeElementType);
+            LLVMValueRef elementAddress = GetElementAddress(index.ValueAsInt32(_builder, false), arrayReference.ValueAsType(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), _builder), nullSafeElementType);
             CastingStore(elementAddress, value, nullSafeElementType, true);
         }
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -229,6 +229,8 @@ internal static class Program
         PrintLine(((BoxStubTest[])arrayCastingTest)[2].Value);
         EndTest(!(arrayCastingTest is CastingTestClass[]));
 
+        CastByteForIndex();
+
         ldindTest();
 
         InterfaceDispatchTest();
@@ -1077,6 +1079,15 @@ internal static class Program
         string intString = 42.ToString();
         PrintLine(intString);
         EndTest(intString == "42");
+    }
+
+    private static void CastByteForIndex()
+    {
+        StartTest("Implicit casting of byte for an index");
+        int[] someInts = new int[0xff];
+        byte byteIndex = 0xFF;
+        someInts[byteIndex] = 123;
+        EndTest(someInts[0xff] == 123, "Expected 123 at index 0xff but didn't get it");
     }
 
     private unsafe static void ldindTest()


### PR DESCRIPTION
This PR fixes a bug when using a byte > 0x7f for an index as it was using a signed cast to `i32`