### PR TITLE
Make FCall transition go through lambda that can be translated into a functionpointer + pointer arg parameter

### DIFF
--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -778,6 +778,7 @@ NESTED_ENTRY _more_stack, _TEXT
         call            r10 ; Call the core of the function with the new larger stack
 
         mov             rsp, rbx ; Bring back the old stack pointer
+        lea             rbp, [rsp + 0e0h]
 
         mov             r10, [rbp - 020h] ; Pull the old stack limit
         mov             gs:[10h], r10 ; Change stack limit to new value
@@ -924,6 +925,7 @@ NESTED_ENTRY ResumeSuspendedThreadHelper2, _TEXT
         jmp resume_point  ; Now that the stack is in position, 
 
     ALTERNATE_ENTRY yield_point ; When yielding, we will jmp back to this location with the registers back in their original config
+        lea             rbp, [rsp + 0e0h]
         ; We need to restore the stack limits, and registers such that we can effectively return from a _more_stack function without popping the stack segment stack
         mov             r10, [rbp - 020h] ; Pull the old stack limit
         mov             gs:[10h], r10 ; Change stack limit to new value

--- a/src/coreclr/vm/fcall.h
+++ b/src/coreclr/vm/fcall.h
@@ -623,7 +623,7 @@ struct PairOfPointers
 #define HELPER_METHOD_FRAME_END_EX(gcpoll,allowGC)                          \
             UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;                          \
             };                                                              \
-            void (decltype(helperFrameLambda)::*helperLambdaFunctionPointer)()const = &decltype(helperFrameLambda)::operator(); \
+            auto helperLambdaFunctionPointer = &decltype(helperFrameLambda)::operator(); \
             {struct { \
                 decltype(helperFrameLambda)* innerLambda;     \
                 decltype(helperLambdaFunctionPointer) innerLambdaFunctionPointer; \
@@ -640,7 +640,7 @@ struct PairOfPointers
 
 #define HELPER_METHOD_FRAME_END_EX_NOTHROW(gcpoll,allowGC)                  \
             };                                                              \
-            void (decltype(helperFrameLambda)::*helperLambdaFunctionPointer)()const = &decltype(helperFrameLambda)::operator(); \
+            auto helperLambdaFunctionPointer = &decltype(helperFrameLambda)::operator(); \
             {struct { \
                 decltype(helperFrameLambda)* innerLambda;     \
                 decltype(helperLambdaFunctionPointer) innerLambdaFunctionPointer; \

--- a/src/coreclr/vm/greenthreads.cpp
+++ b/src/coreclr/vm/greenthreads.cpp
@@ -40,6 +40,7 @@ uint8_t* AlignDown(uint8_t* address, size_t alignValue)
 }
 
 static const int stackSizeOfMoreStackFunction = 0xe8;
+static const int frameOffsetMoreStackFunction = 0xe0;
 extern "C" uintptr_t AllocateMoreStackHelper(int argumentStackSize, void* stackPointer)
 {
     const int offsetToReturnAddress = 8;
@@ -54,7 +55,7 @@ extern "C" uintptr_t AllocateMoreStackHelper(int argumentStackSize, void* stackP
     if (argumentStackSize < 0)
     {
         argumentStackSize = -(argumentStackSize + 1);
-        newArgsLocation = AlignDown(t_greenThread.osStackCurrent - (stackSizeOfMoreStackFunction + sizeOfShadowStore + sizeof(void*) + argumentStackSize), 16);
+        newArgsLocation = AlignDown(t_greenThread.osStackCurrent - (stackSizeOfMoreStackFunction + frameOffsetMoreStackFunction + sizeOfShadowStore + sizeof(void*) + argumentStackSize), 16);
         *pNewStackRange = t_greenThread.osStackRange;
     }
     else

--- a/src/coreclr/vm/greenthreads.cpp
+++ b/src/coreclr/vm/greenthreads.cpp
@@ -246,7 +246,8 @@ void CallOnOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param)
 {
     if (!t_greenThread.inGreenThread)
         functionToExecute(param);
-    TransitionToOSThread(functionToExecute, param);
+    else
+        TransitionToOSThread(functionToExecute, param);
 }
 
 void *TransitionToOSThreadAndCallMalloc(size_t memoryToAllocate)

--- a/src/coreclr/vm/greenthreads.cpp
+++ b/src/coreclr/vm/greenthreads.cpp
@@ -225,7 +225,7 @@ uintptr_t TransitionToOSThread(TakesOneParam functionToExecute, uintptr_t param)
     return result;
 }
 
-uintptr_t TransitionToOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param)
+void TransitionToOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param)
 {
     TransitionHelperStruct detailsAboutWhatToCall;
     detailsAboutWhatToCall.function = (TakesOneParam)functionToExecute;
@@ -240,11 +240,9 @@ uintptr_t TransitionToOSThread(TakesOneParamNoReturn functionToExecute, uintptr_
     TransitionToOSThreadHelper((uintptr_t)FirstFrameInOSThread, &detailsAboutWhatToCall);
     t_greenThread.transitionedToOSThreadOnGreenThread = oldtransitionedToOSThreadOnGreenThread;
     t_greenThread.inGreenThread = true;
-
-    return result;
 }
 
-uintptr_t CallOnOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param)
+void CallOnOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param)
 {
     if (!t_greenThread.inGreenThread)
         functionToExecute(param);

--- a/src/coreclr/vm/greenthreads.h
+++ b/src/coreclr/vm/greenthreads.h
@@ -30,7 +30,7 @@ typedef uintptr_t (*TakesOneParam)(uintptr_t param);
 typedef void (*TakesOneParamNoReturn)(uintptr_t param);
 SuspendedGreenThread* GreenThread_StartThread(TakesOneParam functionToExecute, uintptr_t param);
 uintptr_t TransitionToOSThread(TakesOneParam functionToExecute, uintptr_t param);
-uintptr_t TransitionToOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param);
+void TransitionToOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param);
 
 // Must be called from within a green thread.
 bool GreenThread_Yield(); // Attempt to yield out of green thread. If the yield fails, return false, else return true once the thread is resumed.

--- a/src/coreclr/vm/greenthreads.h
+++ b/src/coreclr/vm/greenthreads.h
@@ -27,8 +27,10 @@ struct SuspendedGreenThread
 };
 
 typedef uintptr_t (*TakesOneParam)(uintptr_t param);
+typedef void (*TakesOneParamNoReturn)(uintptr_t param);
 SuspendedGreenThread* GreenThread_StartThread(TakesOneParam functionToExecute, uintptr_t param);
 uintptr_t TransitionToOSThread(TakesOneParam functionToExecute, uintptr_t param);
+uintptr_t TransitionToOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param);
 
 // Must be called from within a green thread.
 bool GreenThread_Yield(); // Attempt to yield out of green thread. If the yield fails, return false, else return true once the thread is resumed.
@@ -40,5 +42,7 @@ SuspendedGreenThread* GreenThread_ResumeThread(SuspendedGreenThread* pSuspendedT
 void DestroyGreenThread(SuspendedGreenThread* pSuspendedThread); // 
 
 bool GreenThread_IsGreenThread();
+
+void CallOnOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param);
 
 #endif // GREENTHREADS_H

--- a/src/coreclr/vm/greenthreads.h
+++ b/src/coreclr/vm/greenthreads.h
@@ -19,6 +19,8 @@ struct GreenThreadStackList
     int size;
 };
 
+class GreenThread;
+
 struct SuspendedGreenThread
 {
     uint8_t* currentStackPointer;

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5925,6 +5925,11 @@ HCIMPLEND_RAW
 HCIMPL1_RAW(void, JIT_ReversePInvokeExitTrackTransitions, ReversePInvokeFrame* frame)
 {
     _ASSERTE(frame != NULL);
+
+#ifdef FEATURE_GREENTHREADS
+    // Updating the ReversePInvokeFrame on green thread suspend/resume needs to be done, but its tricky to implement, so instead, just update it here.
+    frame->currentThread = GetThreadNULLOk();
+#endif
     _ASSERTE(frame->currentThread == GetThread());
 
     // Manually inline the fast path in Thread::EnablePreemptiveGC().
@@ -5948,6 +5953,12 @@ HCIMPLEND_RAW
 HCIMPL1_RAW(void, JIT_ReversePInvokeExit, ReversePInvokeFrame* frame)
 {
     _ASSERTE(frame != NULL);
+
+#ifdef FEATURE_GREENTHREADS
+    // Updating the ReversePInvokeFrame on green thread suspend/resume needs to be done, but its tricky to implement, so instead, just update it here.
+    frame->currentThread = GetThreadNULLOk();
+#endif
+
     _ASSERTE(frame->currentThread == GetThread());
 
     // Manually inline the fast path in Thread::EnablePreemptiveGC().


### PR DESCRIPTION
Make FCall helper frames actual enclose a lambda, and if not on the OS thread, transition to it and call the lambda.

Fixes dotnet/runtimelab#2017