### PR TITLE
Conservative GC reporting for suspended green threads

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -7868,18 +7868,12 @@ bool gc_heap::is_in_condemned_gc (uint8_t* o)
     return true;
 }
 
-// REGIONS TODO -
-// This method can be called by GCHeap::Promote/Relocate which means
-// it could be in the heap range but not actually in a valid region.
-// This would return true but find_object will return 0. But this
-// seems counter-intuitive so we should consider a better implementation.
+// This needs to check the range that's covered by bookkeeping because find_object will
+// need to look at the brick table.
 inline
-bool gc_heap::is_in_condemned (uint8_t* o)
+bool gc_heap::is_in_bookkeeping_range (uint8_t* o)
 {
-    if ((o >= g_gc_lowest_address) && (o < g_gc_highest_address))
-        return is_in_condemned_gc (o);
-    else
-        return false;
+    return ((o >= g_gc_lowest_address) && (o < bookkeeping_covered_committed));
 }
 
 inline
@@ -45433,7 +45427,7 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, uint32_t flags)
     gc_heap* hp = gc_heap::heap_of (o);
 
 #ifdef USE_REGIONS
-    if (!gc_heap::is_in_condemned (o))
+    if (!gc_heap::is_in_bookkeeping_range (o) || !gc_heap::is_in_condemned_gc (o))
 #else //USE_REGIONS
     if ((o < hp->gc_low) || (o >= hp->gc_high))
 #endif //USE_REGIONS
@@ -45492,7 +45486,12 @@ void GCHeap::Relocate (Object** ppObject, ScanContext* sc,
     //dprintf (3, ("Relocate location %Ix\n", (size_t)ppObject));
     dprintf (3, ("R: %Ix", (size_t)ppObject));
 
-    if (!object || !((object >= g_gc_lowest_address) && (object < g_gc_highest_address)))
+    if (!object 
+#ifdef USE_REGIONS
+        || !gc_heap::is_in_bookkeeping_range (object))
+#else //USE_REGIONS
+        || !((object >= g_gc_lowest_address) && (object < g_gc_highest_address)))
+#endif //USE_REGIONS
         return;
 
     gc_heap* hp = gc_heap::heap_of (object);
@@ -45947,17 +45946,16 @@ GCHeap::GetContainingObject (void *pInteriorPtr, bool fCollectedGenOnly)
     gc_heap* hp = gc_heap::heap_of (o);
 
 #ifdef USE_REGIONS
-    if (fCollectedGenOnly)
+    if (gc_heap::is_in_bookkeeping_range (o))
     {
-        if (!gc_heap::is_in_condemned (o))
+        if (fCollectedGenOnly && !gc_heap::is_in_condemned_gc (o))
         {
             return NULL;
         }
     }
     else
     {
-        if (!((o >= g_gc_lowest_address) && (o < g_gc_highest_address)))
-            return NULL;
+        return NULL;
     }
 #else //USE_REGIONS
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -52,7 +52,7 @@ inline void FATAL_GC_ERROR()
 // This means any empty regions can be freely used for any generation. For
 // Server GC we will balance regions between heaps.
 // For now disable regions for StandAlone GC, NativeAOT and MacOS builds
-#if defined (HOST_64BIT) && !defined (BUILD_AS_STANDALONE) && !defined(__APPLE__) && !defined(FEATURE_NATIVEAOT)
+#if defined (HOST_64BIT) && !defined (BUILD_AS_STANDALONE) && !defined(__APPLE__)
 #define USE_REGIONS
 #endif //HOST_64BIT && BUILD_AS_STANDALONE
 
@@ -3127,7 +3127,7 @@ protected:
     bool is_in_condemned_gc (uint8_t* o);
     // requires checking if o is in the heap range first.
     PER_HEAP_ISOLATED
-    bool is_in_condemned (uint8_t* o);
+    bool is_in_bookkeeping_range (uint8_t* o);
     PER_HEAP_ISOLATED
     bool should_check_brick_for_reloc (uint8_t* o);
 #endif //USE_REGIONS

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -274,6 +274,36 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
         STRESS_LOG2(LF_GC | LF_GCROOTS, LL_INFO100, "Ending scan of Thread %p ID = 0x%x }\n", pThread, pThread->GetThreadId());
     }
 
+#ifdef FEATURE_GREENTHREADS
+    {
+        if (sc->promotion && green_head.next)
+        {
+            SuspendedGreenThread* current_green_thread = green_head.next;
+            while (current_green_thread != &green_tail)
+            {
+                GreenThreadStackList* current_thread_stack_segment = current_green_thread->currentThreadStackSegment;
+                while (current_thread_stack_segment->prev != nullptr)
+                {
+                    current_thread_stack_segment = current_thread_stack_segment->prev;
+                }
+                while (current_thread_stack_segment != nullptr)
+                {
+                    PTR_PTR_Object green_object_base = (PTR_PTR_Object)current_thread_stack_segment->stackRange.stackBase;
+                    PTR_PTR_Object green_object_limit = (PTR_PTR_Object)current_thread_stack_segment->stackRange.stackLimit;
+                    PTR_PTR_Object green_current = green_object_base;
+                    while (green_current > green_object_limit)
+                    {
+                        fn(green_current, sc, GC_CALL_INTERIOR|GC_CALL_PINNED);
+                        green_current--;
+                    }
+                    current_thread_stack_segment = current_thread_stack_segment->next;
+                }
+                current_green_thread = current_green_thread->next;
+            }
+        }
+    }
+#endif //FEATURE_GREENTHREADS
+
     // In server GC, we should be competing for marking the statics
     // It's better to do this *after* stack scanning, because this way
     // we can make up for imbalances in stack scanning

--- a/src/coreclr/vm/gcenv.ee.standalone.cpp
+++ b/src/coreclr/vm/gcenv.ee.standalone.cpp
@@ -17,6 +17,8 @@
 #include "genanalysis.h"
 #include "eventpipeadapter.h"
 
+#include "greenthreads.h"
+
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;
 

--- a/src/coreclr/vm/gcenv.ee.static.cpp
+++ b/src/coreclr/vm/gcenv.ee.static.cpp
@@ -17,6 +17,8 @@
 #include "genanalysis.h"
 #include "eventpipeadapter.h"
 
+#include "greenthreads.h"
+
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;
 

--- a/src/coreclr/vm/greenthreads.h
+++ b/src/coreclr/vm/greenthreads.h
@@ -22,8 +22,10 @@ struct GreenThreadStackList
 struct SuspendedGreenThread
 {
     uint8_t* currentStackPointer;
-    GreenThreadStackList *currentThreadStackSegment;
+    GreenThreadStackList* currentThreadStackSegment;
     Frame* greenThreadFrame;
+    SuspendedGreenThread* prev;
+    SuspendedGreenThread* next;
 };
 
 typedef uintptr_t (*TakesOneParam)(uintptr_t param);
@@ -40,5 +42,9 @@ SuspendedGreenThread* GreenThread_ResumeThread(SuspendedGreenThread* pSuspendedT
 void DestroyGreenThread(SuspendedGreenThread* pSuspendedThread); // 
 
 bool GreenThread_IsGreenThread();
+
+// TODO: AndrewAu: Better naming
+extern SuspendedGreenThread green_head;
+extern SuspendedGreenThread green_tail;
 
 #endif // GREENTHREADS_H

--- a/src/tests/baseservices/threading/greenthreads/delay/simple.cs
+++ b/src/tests/baseservices/threading/greenthreads/delay/simple.cs
@@ -9,14 +9,23 @@ public class Test_greenthread_delay {
 
     public static int Main() {
 
-        var t = Task.RunAsGreenThread(() =>
-        {
-            Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
-            Task.Delay(2000).Wait();
-            Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
-        });
+        var t = Task.RunAsGreenThread(GreenWork);
 
         t.Wait();
         return 100;
+    }
+
+    private static void GreenWork()
+    {
+        Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
+        var red = new Task(RedWork);
+        red.Start();
+        red.Wait();
+        Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
+    }
+
+    private static void RedWork() {
+        GC.Collect();
+        Thread.Sleep(2000);
     }
 }

--- a/src/tests/baseservices/threading/greenthreads/delay/simple.cs
+++ b/src/tests/baseservices/threading/greenthreads/delay/simple.cs
@@ -9,23 +9,14 @@ public class Test_greenthread_delay {
 
     public static int Main() {
 
-        var t = Task.RunAsGreenThread(GreenWork);
+        var t = Task.RunAsGreenThread(() =>
+        {
+            Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
+            Task.Delay(2000).Wait();
+            Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
+        });
 
         t.Wait();
         return 100;
-    }
-
-    private static void GreenWork()
-    {
-        Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
-        var red = new Task(RedWork);
-        red.Start();
-        red.Wait();
-        Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
-    }
-
-    private static void RedWork() {
-        GC.Collect();
-        Thread.Sleep(2000);
     }
 }


### PR DESCRIPTION
The GC changes come from https://github.com/dotnet/runtime/pull/76737 which is required for conservative reporting. Once we have that PR merged, we should take an FI instead to avoid unnecessary conflicts.

The green thread changes slightly extended the lifetime of the `SuspendedGreenThread` object so that I can use it for GC reporting. The change simply loop through all of them and reported all the stack segments conservatively.

In debug mode, the process terminates with an exit code `1073807370` == `0x4001000a`, this is because we hit an assert [here](https://github.com/dotnet/runtimelab/blob/5074833015a2f1bce6539c4bcd8b641699726d27/src/coreclr/vm/jithelpers.cpp#L5951). I assume this will be handled as part of #2018

