### PR TITLE
Green thread objects

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/GreenThreadTasks.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/GreenThreadTasks.CoreCLR.cs
@@ -41,6 +41,7 @@ namespace System.Threading.Tasks
             try
             {
                 var action = (Action?)obj;
+                Thread.t_currentThread = null; // TODO Once we have Thread statics working we probably don't need to do this.
                 var suspendedThread = GreenThread_StartThread(&GreenThreadStartFunc, Unsafe.AsPointer(ref action));
                 Debug.Assert((GreenThreadStatics.t_TaskToWaitFor != null) == (suspendedThread != null));
                 if (suspendedThread != null)
@@ -54,6 +55,7 @@ namespace System.Threading.Tasks
             {
                 GreenThreadStatics.t_TaskToWaitFor = null;
                 Thread.t_IsGreenThread = false;
+                Thread.t_currentThread = null; // TODO Once we have Thread statics working we probably don't need to do this.
             }
         }
 
@@ -70,6 +72,7 @@ namespace System.Threading.Tasks
                 Thread.t_IsGreenThread = true;
                 try
                 {
+                    Thread.t_currentThread = null; // TODO Once we have Thread statics working we probably don't need to do this.
                     _suspendedThread = GreenThread_ResumeThread(_suspendedThread);
                     Debug.Assert((GreenThreadStatics.t_TaskToWaitFor != null) == (_suspendedThread != null));
                     if (_suspendedThread != null)
@@ -82,6 +85,7 @@ namespace System.Threading.Tasks
                 {
                     GreenThreadStatics.t_TaskToWaitFor = null;
                     Thread.t_IsGreenThread = false;
+                    Thread.t_currentThread = null; // TODO Once we have Thread statics working we probably don't need to do this.
                 }
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -58,6 +58,9 @@ namespace System.Threading
         // but those types of changes may race with the reset anyway, so this field doesn't need to be synchronized.
         private bool _mayNeedResetForThreadPool;
 
+        // Used to indicate if this thread is a green thread
+        private bool _isGreenThread;
+
         private Thread() { }
 
         public extern int ManagedThreadId

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -58,8 +58,10 @@ namespace System.Threading
         // but those types of changes may race with the reset anyway, so this field doesn't need to be synchronized.
         private bool _mayNeedResetForThreadPool;
 
+#pragma warning disable CA1823, 169 // These fields are not used from managed.
         // Used to indicate if this thread is a green thread
         private bool _isGreenThread;
+#pragma warning restore CA1823, 169
 
         private Thread() { }
 

--- a/src/coreclr/classlibnative/bcltype/objectnative.cpp
+++ b/src/coreclr/classlibnative/bcltype/objectnative.cpp
@@ -315,7 +315,7 @@ FCIMPL1(FC_BOOL_RET, ObjectNative::IsLockHeld, Object* pThisUNSAFE)
     //
     retVal = pThisUNSAFE->GetThreadOwningMonitorLock(&owningThreadId, &acquisitionCount);
     if (retVal)
-        retVal = GetThread()->GetThreadId() == owningThreadId;
+        retVal = GetThread()->GetActiveManagedThreadId() == owningThreadId;
 
     FC_RETURN_BOOL(retVal);
 }

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -5594,7 +5594,7 @@ ClrDataAccess::FindClrThreadByTaskId(ULONG64 taskId)
 
     while ((thread = ThreadStore::GetAllThreadList(thread, 0, 0)))
     {
-        if (thread->GetThreadId() == (DWORD)taskId)
+        if (thread->GetPermanentManagedThreadId() == (DWORD)taskId)
         {
             return thread;
         }

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -6265,7 +6265,7 @@ MonitorLockInfo DacDbiInterfaceImpl::GetThreadOwningMonitorLock(VMPTR_Object vmO
     Thread *pThread = ThreadStore::GetThreadList(NULL);
     while (pThread != NULL)
     {
-        if(pThread->GetThreadId() == threadId)
+        if(pThread->GetPermanentManagedThreadId() == threadId) // TODO This doesn't work for green threads
         {
             info.lockOwner.SetDacTargetPtr(PTR_HOST_TO_TADDR(pThread));
             info.acquisitionCount = acquisitionCount;

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -807,11 +807,13 @@ HRESULT ClrDataAccess::EnumMemWalkStackHelper(CLRDataEnumMemoryFlags flags,
                             break;
                         }
 
+#ifndef FEATURE_GREENTHREADS
                         if (!pThread->IsAddressInStack(currentSP))
                         {
                             _ASSERTE(!"Target stack has been corrupted, SP must in the stack range.");
                             break;
                         }
+#endif // FEATURE_GREENTHREADS
                     }
                 }
                 else

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -713,7 +713,7 @@ ClrDataAccess::GetThreadData(CLRDATA_ADDRESS threadAddr, struct DacpThreadData *
 
     // initialize our local copy from the marshaled target Thread instance
     ZeroMemory (threadData, sizeof(DacpThreadData));
-    threadData->corThreadId = thread->m_ThreadId;
+    threadData->corThreadId = thread->GetPermanentManagedThreadId();
     threadData->osThreadId = (DWORD)thread->m_OSThreadId;
     threadData->state = thread->m_State;
     threadData->preemptiveGCDisabled = thread->m_fPreemptiveGCDisabled;

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -644,7 +644,7 @@ ClrDataAccess::GetThreadFromThinlockID(UINT thinLockId, CLRDATA_ADDRESS *pThread
 
     SOSDacEnter();
 
-    Thread *thread = g_pThinLockThreadIdDispenser->IdToThread(thinLockId);
+    ThreadBase *thread = g_pThinLockThreadIdDispenser->IdToThread(thinLockId);
     *pThread = PTR_HOST_TO_TADDR(thread);
 
     SOSDacLeave();

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -183,7 +183,7 @@ ClrDataTask::GetUniqueID(
 
     EX_TRY
     {
-        *id = m_thread->GetThreadId();
+        *id = m_thread->GetPermanentManagedThreadId();
         status = S_OK;
     }
     EX_CATCH

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -9015,7 +9015,7 @@ void Debugger::ThreadCreated(Thread* pRuntimeThread)
 
     // Sanity check the thread.
     _ASSERTE(pRuntimeThread != NULL);
-    _ASSERTE(pRuntimeThread->GetThreadId() != 0);
+    _ASSERTE(pRuntimeThread->GetPermanentManagedThreadId() != 0);
 
 
     // Create a thread starter and enable its WillEnterManaged code

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -913,6 +913,13 @@ NESTED_ENTRY ResumeSuspendedThreadHelper2, _TEXT
                       ; as well as where to stash the stack_limit and stack_base data
         call GetResumptionStackPointerAndSaveOSStackPointer
 
+        ; Update stack limit and base to be in the green thread
+        mov             r11, [rbp - 030h] ; Load the new stack limit
+        mov             gs:[10h], r11
+        mov             r11, [rbp - 028h] ; Load the old stack base
+        mov             gs:[8h], r11
+        
+
         mov rsp, rax ; Set stack pointer to back into the green thread
         jmp resume_point  ; Now that the stack is in position, 
 

--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -108,12 +108,12 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__ComPlusCallInfo__m_pILStub
 
 #endif // FEATURE_COMINTEROP
 
-#define               OFFSETOF__Thread__m_fPreemptiveGCDisabled     0x0C
+#define               OFFSETOF__Thread__m_fPreemptiveGCDisabled     0x14
 ASMCONSTANTS_C_ASSERT(OFFSETOF__Thread__m_fPreemptiveGCDisabled
                     == offsetof(Thread, m_fPreemptiveGCDisabled));
 #define Thread_m_fPreemptiveGCDisabled OFFSETOF__Thread__m_fPreemptiveGCDisabled
 
-#define               OFFSETOF__Thread__m_pFrame                    0x10
+#define               OFFSETOF__Thread__m_pFrame                    0x18
 ASMCONSTANTS_C_ASSERT(OFFSETOF__Thread__m_pFrame
                     == offsetof(Thread, m_pFrame));
 #define Thread_m_pFrame OFFSETOF__Thread__m_pFrame

--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -136,6 +136,7 @@ typedef DPTR(class CoreLibBinder)      PTR_CoreLibBinder;
 typedef VPTR(class Module)              PTR_Module;
 typedef DPTR(class NDirectMethodDesc)   PTR_NDirectMethodDesc;
 typedef DPTR(class Thread)              PTR_Thread;
+typedef DPTR(class ThreadBase)          PTR_ThreadBase;
 typedef DPTR(class Object)              PTR_Object;
 typedef DPTR(PTR_Object)                PTR_PTR_Object;
 typedef DPTR(class DelegateObject)      PTR_DelegateObject;

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -336,6 +336,9 @@ FCIMPL1(INT32, ThreadNative::GetPriority, ThreadBaseObject* pThisUNSAFE)
     if (pThisUNSAFE==NULL)
         FCThrowRes(kNullReferenceException, W("NullReference_This"));
 
+    if (pThisUNSAFE->IsGreenThread())
+        FCThrowRes(kThreadStateException, W("ThreadState_GreenThread"));
+
     // validate the handle
     if (ThreadIsDead(pThisUNSAFE->GetInternal()))
         FCThrowRes(kThreadStateException, W("ThreadState_Dead_Priority"));
@@ -358,6 +361,9 @@ FCIMPL2(void, ThreadNative::SetPriority, ThreadBaseObject* pThisUNSAFE, INT32 iP
     {
         COMPlusThrow(kNullReferenceException, W("NullReference_This"));
     }
+
+    if (pThis->IsGreenThread())
+        COMPlusThrow(kThreadStateException, W("ThreadState_GreenThread"));
 
     // translate the priority (validating as well)
     priority = MapToNTPriority(iPriority);  // can throw; needs a frame
@@ -397,6 +403,9 @@ FCIMPL1(void, ThreadNative::Interrupt, ThreadBaseObject* pThisUNSAFE)
 
     Thread  *thread = pThisUNSAFE->GetInternal();
 
+    if (pThisUNSAFE->IsGreenThread())
+        FCThrowResVoid(kThreadStateException, W("ThreadState_GreenThread"));
+
     if (thread == 0)
         FCThrowExVoid(kThreadStateException, IDS_EE_THREAD_CANNOT_GET, NULL, NULL, NULL);
 
@@ -424,6 +433,9 @@ FCIMPL1(FC_BOOL_RET, ThreadNative::IsAlive, ThreadBaseObject* pThisUNSAFE)
     // consider both protecting thisRef and setting the managed object's
     // Thread* to NULL in the GC's ScanForFinalization method.
     HELPER_METHOD_FRAME_BEGIN_RET_1(thisRef);
+
+    if (thisRef->IsGreenThread())
+        COMPlusThrow(kThreadStateException, W("ThreadState_GreenThread"));
 
     Thread  *thread = thisRef->GetInternal();
 
@@ -588,6 +600,9 @@ FCIMPL2(void, ThreadNative::SetBackground, ThreadBaseObject* pThisUNSAFE, CLR_BO
     if (pThisUNSAFE==NULL)
         FCThrowResVoid(kNullReferenceException, W("NullReference_This"));
 
+    if (pThisUNSAFE->IsGreenThread())
+        FCThrowResVoid(kThreadStateException, W("ThreadState_GreenThread"));
+
     // validate the thread
     Thread  *thread = pThisUNSAFE->GetInternal();
 
@@ -609,6 +624,9 @@ FCIMPL1(FC_BOOL_RET, ThreadNative::IsBackground, ThreadBaseObject* pThisUNSAFE)
 
     if (pThisUNSAFE==NULL)
         FCThrowRes(kNullReferenceException, W("NullReference_This"));
+
+    if (pThisUNSAFE->IsGreenThread())
+        FC_RETURN_BOOL(TRUE);
 
     // validate the thread
     Thread  *thread = pThisUNSAFE->GetInternal();
@@ -634,6 +652,9 @@ FCIMPL1(INT32, ThreadNative::GetThreadState, ThreadBaseObject* pThisUNSAFE)
 
     if (pThisUNSAFE==NULL)
         FCThrowRes(kNullReferenceException, W("NullReference_This"));
+
+    if (pThisUNSAFE->IsGreenThread())
+        FCThrowRes(kThreadStateException, W("ThreadState_GreenThread"));
 
     // validate the thread.  Failure here implies that the thread was finalized
     // and then resurrected.
@@ -690,6 +711,9 @@ FCIMPL2(INT32, ThreadNative::SetApartmentState, ThreadBaseObject* pThisUNSAFE, I
     THREADBASEREF   pThis   = (THREADBASEREF) pThisUNSAFE;
 
     HELPER_METHOD_FRAME_BEGIN_RET_1(pThis);
+
+    if (pThis->IsGreenThread())
+        COMPlusThrow(kThreadStateException, W("ThreadState_GreenThread"));
 
     Thread  *thread = pThis->GetInternal();
     if (!thread)
@@ -748,6 +772,9 @@ FCIMPL1(INT32, ThreadNative::GetApartmentState, ThreadBaseObject* pThisUNSAFE)
         COMPlusThrow(kNullReferenceException, W("NullReference_This"));
     }
 
+    if (refThis->IsGreenThread())
+        COMPlusThrow(kThreadStateException, W("ThreadState_GreenThread"));
+
     Thread* thread = refThis->GetInternal();
 
     if (ThreadIsDead(thread))
@@ -799,6 +826,9 @@ BOOL ThreadNative::DoJoin(THREADBASEREF DyingThread, INT32 timeout)
         PRECONDITION((timeout >= 0) || (timeout == INFINITE_TIMEOUT));
     }
     CONTRACTL_END;
+
+    if (DyingThread->IsGreenThread())
+        COMPlusThrow(kThreadStateException, W("ThreadState_GreenThread"));
 
     Thread * DyingInternal = DyingThread->GetInternal();
 
@@ -934,6 +964,10 @@ FCIMPL1(void, ThreadNative::DisableComObjectEagerCleanup, ThreadBaseObject* pThi
 
     _ASSERTE(pThisUNSAFE != NULL);
     VALIDATEOBJECT(pThisUNSAFE);
+
+    if (pThisUNSAFE->IsGreenThread())
+        FCThrowResVoid(kThreadStateException, W("ThreadState_GreenThread"));
+
     Thread *pThread = pThisUNSAFE->GetInternal();
 
     HELPER_METHOD_FRAME_BEGIN_0();
@@ -1020,6 +1054,9 @@ FCIMPL1(FC_BOOL_RET, ThreadNative::IsThreadpoolThread, ThreadBaseObject* thread)
     if (thread==NULL)
         FCThrowRes(kNullReferenceException, W("NullReference_This"));
 
+    if (thread->IsGreenThread())
+        FC_RETURN_BOOL(TRUE);
+
     Thread *pThread = thread->GetInternal();
 
     if (pThread == NULL)
@@ -1039,6 +1076,9 @@ FCIMPL1(void, ThreadNative::SetIsThreadpoolThread, ThreadBaseObject* thread)
 
     if (thread == NULL)
         FCThrowResVoid(kNullReferenceException, W("NullReference_This"));
+
+    if (thread->IsGreenThread())
+        FCThrowResVoid(kThreadStateException, W("ThreadState_GreenThread"));
 
     Thread *pThread = thread->GetInternal();
 

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -526,7 +526,7 @@ NOINLINE static Object* GetCurrentThreadHelper()
 FCIMPL0(Object*, ThreadNative::GetCurrentThread)
 {
     FCALL_CONTRACT;
-    OBJECTHANDLE ExposedObject = GetThread()->m_ExposedObject;
+    OBJECTHANDLE ExposedObject = GetThread()->GetActiveThreadBase()->m_ExposedObject;
     _ASSERTE(ExposedObject != 0); //Thread's constructor always initializes its GCHandle
     Object* result = *((Object**) ExposedObject);
     if (result != 0)

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -581,7 +581,7 @@ FCIMPL1(void, ThreadNative::Initialize, ThreadBaseObject* pThisUNSAFE)
     }
 
     pThis->SetInternal(unstarted);
-    pThis->SetManagedThreadId(unstarted->GetThreadId());
+    pThis->SetManagedThreadId(unstarted->GetPermanentManagedThreadId());
     unstarted->SetExposedObject(pThis);
 
     // Initialize the thread priority to normal.

--- a/src/coreclr/vm/eedbginterfaceimpl.cpp
+++ b/src/coreclr/vm/eedbginterfaceimpl.cpp
@@ -1408,7 +1408,7 @@ void EEDbgInterfaceImpl::SetDebugState(Thread *pThread,
 
     _ASSERTE(state == THREAD_SUSPEND || state == THREAD_RUN);
 
-    LOG((LF_CORDB,LL_INFO10000,"EEDbg:Setting thread 0x%x (ID:0x%x) to 0x%x\n", pThread, pThread->GetThreadId(), state));
+    LOG((LF_CORDB,LL_INFO10000,"EEDbg:Setting thread 0x%x (ID:0x%x) to 0x%x\n", pThread, pThread->GetPermanentManagedThreadId(), state));
 
     if (state == THREAD_SUSPEND)
     {
@@ -1480,7 +1480,7 @@ CorDebugUserState EEDbgInterfaceImpl::GetPartialUserState(Thread *pThread)
     }
 
     LOG((LF_CORDB,LL_INFO1000, "EEDbgII::GUS: thread 0x%x (id:0x%x)"
-        " userThreadState is 0x%x\n", pThread, pThread->GetThreadId(), ret));
+        " userThreadState is 0x%x\n", pThread, pThread->GetPermanentManagedThreadId(), ret));
 
     return (CorDebugUserState)ret;
 }

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -2023,7 +2023,7 @@ ep_rt_thread_create (
 					thread_params->thread_params.thread->SetBackground (TRUE);
 					thread_params->thread_params.thread->StartThread ();
 					if (id)
-						*reinterpret_cast<DWORD *>(id) = thread_params->thread_params.thread->GetThreadId ();
+						*reinterpret_cast<DWORD *>(id) = thread_params->thread_params.thread->GetPermanentManagedThreadId ();
 					result = true;
 				}
 			} else if (thread_type == EP_THREAD_TYPE_SERVER) {

--- a/src/coreclr/vm/eventstore.hpp
+++ b/src/coreclr/vm/eventstore.hpp
@@ -17,7 +17,7 @@ typedef DPTR(WaitEventLink) PTR_WaitEventLink;
 struct WaitEventLink {
     SyncBlock         *m_WaitSB;
     CLREvent          *m_EventWait;
-    PTR_Thread         m_Thread;       // Owner of this WaitEventLink.
+    PTR_ThreadBase     m_Thread;       // Owner of this WaitEventLink.
     PTR_WaitEventLink  m_Next;         // Chain to the next waited SyncBlock.
     SLink              m_LinkSB;       // Chain to the next thread waiting on the same SyncBlock.
     DWORD              m_RefCount;     // How many times Object::Wait is called on the same SyncBlock.

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2593,7 +2593,7 @@ VOID ETW::ThreadLog::FireThreadCreated(Thread * pThread)
         (ULONGLONG)pThread,
         (ULONGLONG)pThread->GetDomain(),
         GetEtwThreadFlags(pThread),
-        pThread->GetThreadId(),
+        pThread->GetPermanentManagedThreadId(),
         pThread->GetOSThreadId(),
         GetClrInstanceId());
 }
@@ -2606,7 +2606,7 @@ VOID ETW::ThreadLog::FireThreadDC(Thread * pThread)
         (ULONGLONG)pThread,
         (ULONGLONG)pThread->GetDomain(),
         GetEtwThreadFlags(pThread),
-        pThread->GetThreadId(),
+        pThread->GetPermanentManagedThreadId(),
         pThread->GetOSThreadId(),
         GetClrInstanceId());
 }

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4856,7 +4856,7 @@ lDone: ;
 #ifdef _DEBUG
         char buffer[200];
         sprintf_s(buffer, 200, "\nInternal error: Uncaught exception was thrown from IP = %p in UnhandledExceptionFilter_Worker on thread 0x%08x\n",
-                param.ExceptionEIP, ((GetThreadNULLOk() == NULL) ? NULL : GetThread()->GetThreadId()));
+                param.ExceptionEIP, ((GetThreadNULLOk() == NULL) ? NULL : GetThread()->GetPermanentManagedThreadId()));
         PrintToStdErrA(buffer);
         _ASSERTE(!"Unexpected exception in UnhandledExceptionFilter_Worker");
 #endif

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2929,6 +2929,15 @@ public:
             dac_cast<TADDR>(dac_cast<PTR_InlinedCallFrame>(pFrame)->m_pCallerReturnAddress) != NULL;
     }
 
+#ifdef FEATURE_GREENTHREADS
+#ifndef DACCESS_COMPILE
+    void UNSAFE_UpdateThreadPointer(Thread* pThread)
+    {
+        m_pThread = (PVOID)pThread;
+    }
+#endif // !DACCESS_COMPILE
+#endif // FEATURE_GREENTHREADS
+
     // Marks the frame as inactive.
     void Reset()
     {

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -256,7 +256,7 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
     Thread* pThread = NULL;
     while ((pThread = ThreadStore::GetThreadList(pThread)) != NULL)
     {
-        STRESS_LOG2(LF_GC | LF_GCROOTS, LL_INFO100, "{ Starting scan of Thread %p ID = %x\n", pThread, pThread->GetThreadId());
+        STRESS_LOG2(LF_GC | LF_GCROOTS, LL_INFO100, "{ Starting scan of Thread %p ID = %x\n", pThread, pThread->GetPermanentManagedThreadId());
 
         if (GCHeapUtilities::GetGCHeap()->IsThreadUsingAllocationContextHeap(
             pThread->GetAllocContext(), sc->thread_number))
@@ -271,7 +271,7 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
             sc->dwEtwRootKind = kEtwGCRootKindOther;
 #endif // FEATURE_EVENT_TRACE
         }
-        STRESS_LOG2(LF_GC | LF_GCROOTS, LL_INFO100, "Ending scan of Thread %p ID = 0x%x }\n", pThread, pThread->GetThreadId());
+        STRESS_LOG2(LF_GC | LF_GCROOTS, LL_INFO100, "Ending scan of Thread %p ID = 0x%x }\n", pThread, pThread->GetPermanentManagedThreadId());
     }
 
     // In server GC, we should be competing for marking the statics

--- a/src/coreclr/vm/greenthreads.cpp
+++ b/src/coreclr/vm/greenthreads.cpp
@@ -166,6 +166,7 @@ SuspendedGreenThread* ProduceSuspendedGreenThreadStruct(GreenThread* pGreenThrea
         pNewSuspendedThread->currentThreadStackSegment = t_greenThread.pStackListCurrent;
         pNewSuspendedThread->greenThreadFrame = t_greenThread.pFrameInGreenThread;
         pNewSuspendedThread->pGreenThread = pGreenThread;
+        pGreenThread->m_currentThreadObj = NULL;
 
         CleanGreenThreadState();
         return pNewSuspendedThread;
@@ -204,6 +205,7 @@ SuspendedGreenThread* GreenThread_StartThread(TakesOneParam functionToExecute, u
 
     ThreadBase* pOldThreadBase = GetThread()->GetActiveThreadBase();
     GetThread()->SetActiveThreadBase(pGreenThread);
+    pGreenThread->m_currentThreadObj = GetThread();
 
     GreenThread_StartThreadHelper((uintptr_t)FirstFrameInGreenThread, &detailsAboutWhatToCall);
 
@@ -327,6 +329,7 @@ SuspendedGreenThread* GreenThread_ResumeThread(SuspendedGreenThread* pSuspendedT
     t_greenThread.greenThreadStackCurrent = pSuspendedThread->currentStackPointer;
 
     GreenThread* pGreenThread = pSuspendedThread->pGreenThread;
+    pGreenThread->m_currentThreadObj = GetThread();
 
     free(pSuspendedThread);
 

--- a/src/coreclr/vm/greenthreads.h
+++ b/src/coreclr/vm/greenthreads.h
@@ -24,6 +24,7 @@ struct SuspendedGreenThread
     uint8_t* currentStackPointer;
     GreenThreadStackList *currentThreadStackSegment;
     Frame* greenThreadFrame;
+    GreenThread* pGreenThread;
 };
 
 typedef uintptr_t (*TakesOneParam)(uintptr_t param);

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -3681,7 +3681,7 @@ HCIMPL3(void, JIT_MonTryEnter_Portable, Object* obj, INT32 timeOut, BYTE* pbLock
         goto FramedLockHelper;
     }
 
-    result = obj->EnterObjMonitorHelper(pCurThread);
+    result = obj->EnterObjMonitorHelper(pCurThread->GetActiveThreadBase());
     if (result == AwareLock::EnterHelperResult_Entered)
     {
         *pbLockTaken = 1;
@@ -3694,7 +3694,7 @@ HCIMPL3(void, JIT_MonTryEnter_Portable, Object* obj, INT32 timeOut, BYTE* pbLock
             return;
         }
 
-        result = obj->EnterObjMonitorHelperSpin(pCurThread);
+        result = obj->EnterObjMonitorHelperSpin(pCurThread->GetActiveThreadBase());
         if (result == AwareLock::EnterHelperResult_Entered)
         {
             *pbLockTaken = 1;
@@ -3771,7 +3771,7 @@ FCIMPL1(void, JIT_MonExit_Portable, Object* obj)
     }
 
     // Handle the simple case without erecting helper frame
-    action = obj->LeaveObjMonitorHelper(GetThread());
+    action = obj->LeaveObjMonitorHelper(GetThread()->GetActiveThreadBase());
     if (action == AwareLock::LeaveHelperAction_None)
     {
         return;
@@ -3801,7 +3801,7 @@ HCIMPL_MONHELPER(JIT_MonExitWorker_Portable, Object* obj)
     }
 
     // Handle the simple case without erecting helper frame
-    action = obj->LeaveObjMonitorHelper(GetThread());
+    action = obj->LeaveObjMonitorHelper(GetThread()->GetActiveThreadBase());
     if (action == AwareLock::LeaveHelperAction_None)
     {
         MONHELPER_STATE(*pbLockTaken = 0;)
@@ -3853,7 +3853,7 @@ HCIMPL_MONHELPER(JIT_MonEnterStatic_Portable, AwareLock *lock)
         goto FramedLockHelper;
     }
 
-    if (lock->TryEnterHelper(pCurThread))
+    if (lock->TryEnterHelper(pCurThread->GetActiveThreadBase()))
     {
 #if defined(_DEBUG) && defined(TRACK_SYNC)
         // The best place to grab this is from the ECall frame
@@ -3921,7 +3921,7 @@ HCIMPL_MONHELPER(JIT_MonExitStatic_Portable, AwareLock *lock)
     MONHELPER_STATE(if (*pbLockTaken == 0) return;)
 
     // Handle the simple case without erecting helper frame
-    AwareLock::LeaveHelperAction action = lock->LeaveHelper(GetThread());
+    AwareLock::LeaveHelperAction action = lock->LeaveHelper(GetThread()->GetActiveThreadBase());
     if (action == AwareLock::LeaveHelperAction_None)
     {
         MONHELPER_STATE(*pbLockTaken = 0;)
@@ -4783,7 +4783,7 @@ FCIMPL0(INT32, JIT_GetCurrentManagedThreadId)
     FC_GC_POLL_NOT_NEEDED();
 
     Thread * pThread = GetThread();
-    return pThread->GetThreadId();
+    return pThread->GetActiveManagedThreadId();
 }
 FCIMPLEND
 

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5925,6 +5925,11 @@ HCIMPLEND_RAW
 HCIMPL1_RAW(void, JIT_ReversePInvokeExitTrackTransitions, ReversePInvokeFrame* frame)
 {
     _ASSERTE(frame != NULL);
+
+#ifdef FEATURE_GREENTHREADS
+    // Updating the ReversePInvokeFrame on green thread suspend/resume needs to be done, but its tricky to implement, so instead, just update it here.
+    frame->currentThread = GetThreadNULLOk();
+#endif
     _ASSERTE(frame->currentThread == GetThread());
 
     // Manually inline the fast path in Thread::EnablePreemptiveGC().
@@ -5948,6 +5953,12 @@ HCIMPLEND_RAW
 HCIMPL1_RAW(void, JIT_ReversePInvokeExit, ReversePInvokeFrame* frame)
 {
     _ASSERTE(frame != NULL);
+
+#ifdef FEATURE_GREENTHREADS
+    // Updating the ReversePInvokeFrame on green thread suspend/resume needs to be done, but its tricky to implement, so instead, just update it here.
+    frame->currentThread = GetThreadNULLOk();
+#endif
+
     _ASSERTE(frame->currentThread == GetThread());
 
     // Manually inline the fast path in Thread::EnablePreemptiveGC().

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12478,8 +12478,9 @@ CorJitResult invokeCompileMethod(EEJitManager *jitMgr,
     }
 
     // HACK - No use of fully inlined pinvokes is acceptable right now
-    // Disable them in all cases for now.
-    flags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS);
+    // Disable them in all cases except for IL Stubs which need handling in StackFrameIterator::CheckForSkippedFrames and ExceptionTracker::InitializeCrawlFrameForExplicitFrame where computing GetActualInteropMethodDesc does not work correctly. See ExceptionTracker::InitializeCrawlFrameForExplicitFrame for the better comment as to what needs to be fixed
+    if (!ftn->IsILStub())
+        flags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS);
 #endif //FEATURE_GREENTHREADS
 
     return flags;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12476,6 +12476,10 @@ CorJitResult invokeCompileMethod(EEJitManager *jitMgr,
             flags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS);
         }
     }
+
+    // HACK - No use of fully inlined pinvokes is acceptable right now
+    // Disable them in all cases for now.
+    flags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS);
 #endif //FEATURE_GREENTHREADS
 
     return flags;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12462,6 +12462,22 @@ CorJitResult invokeCompileMethod(EEJitManager *jitMgr,
         }
     }
 
+#ifdef FEATURE_GREENTHREADS
+// Without this tweak the compiler will hold onto a pointer into the Thread* object across a transition between OS threads. This does not work well.
+// As a prototype for the green thread experiment, use the pinvoke helper based code gen which does not have this issue.
+    LPCUTF8 namespaceName;
+    LPCUTF8 className = ftn->GetMethodTable()->GetFullyQualifiedNameInfo(&namespaceName);
+    if (className != NULL && strcmp(className, "Task") == 0)
+    {
+        LPCUTF8 name = ftn->GetName();
+        if ((strcmp(name, "YieldGreenThread") == 0) ||
+            (strcmp(name, "GreenThread_Yield") == 0))
+        {
+            flags.Set(CORJIT_FLAGS::CORJIT_FLAG_USE_PINVOKE_HELPERS);
+        }
+    }
+#endif //FEATURE_GREENTHREADS
+
     return flags;
 }
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -4061,6 +4061,10 @@ void CallFinalizerOnThreadObject(Object *obj)
     STATIC_CONTRACT_MODE_COOPERATIVE;
 
     THREADBASEREF   refThis = (THREADBASEREF)ObjectToOBJECTREF(obj);
+
+    if (refThis->IsGreenThread())
+        return; // Green thread objects don't get finalized
+
     Thread*         thread  = refThis->GetInternal();
 
     // Prevent multiple calls to Finalize

--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -1123,7 +1123,7 @@ HRESULT MulticoreJitProfilePlayer::PlayProfile()
 
     {
         // 1 marks background thread
-        FireEtwThreadCreated((ULONGLONG) pThread, (ULONGLONG) GetAppDomain(), 1, pThread->GetThreadId(), pThread->GetOSThreadId(), GetClrInstanceId());
+        FireEtwThreadCreated((ULONGLONG) pThread, (ULONGLONG) GetAppDomain(), 1, pThread->GetPermanentManagedThreadId(), pThread->GetOSThreadId(), GetClrInstanceId());
     }
 
     const BYTE * pBuffer = m_pFileBuffer;

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -285,13 +285,13 @@ class Object
 
     bool TryEnterObjMonitorSpinHelper();
 
-    FORCEINLINE AwareLock::EnterHelperResult EnterObjMonitorHelper(Thread* pCurThread)
+    FORCEINLINE AwareLock::EnterHelperResult EnterObjMonitorHelper(ThreadBase* pCurThread)
     {
         WRAPPER_NO_CONTRACT;
         return GetHeader()->EnterObjMonitorHelper(pCurThread);
     }
 
-    FORCEINLINE AwareLock::EnterHelperResult EnterObjMonitorHelperSpin(Thread* pCurThread)
+    FORCEINLINE AwareLock::EnterHelperResult EnterObjMonitorHelperSpin(ThreadBase* pCurThread)
     {
         WRAPPER_NO_CONTRACT;
         return GetHeader()->EnterObjMonitorHelperSpin(pCurThread);
@@ -312,7 +312,7 @@ class Object
         return GetHeader()->LeaveObjMonitorAtException();
     }
 
-    FORCEINLINE AwareLock::LeaveHelperAction LeaveObjMonitorHelper(Thread* pCurThread)
+    FORCEINLINE AwareLock::LeaveHelperAction LeaveObjMonitorHelper(ThreadBase* pCurThread)
     {
         WRAPPER_NO_CONTRACT;
         return GetHeader()->LeaveObjMonitorHelper(pCurThread);
@@ -1351,6 +1351,9 @@ private:
     // Only used by managed code, see comment there
     bool          m_MayNeedResetForThreadPool;
 
+    // Does this thread object represent a Green Thread?
+    uint8_t       m_isGreenThread;
+
 protected:
     // the ctor and dtor can do no useful work.
     ThreadBaseObject() {LIMITED_METHOD_CONTRACT;};
@@ -1365,6 +1368,11 @@ public:
 
     void SetInternal(Thread *it);
     void ClearInternal();
+
+    bool IsGreenThread()
+    {
+        return !!m_isGreenThread;
+    }
 
     INT32 GetManagedThreadId()
     {

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -1374,6 +1374,11 @@ public:
         return !!m_isGreenThread;
     }
 
+    void SetIsGreenThread()
+    {
+        m_isGreenThread = 1;
+    }
+
     INT32 GetManagedThreadId()
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/object.inl
+++ b/src/coreclr/vm/object.inl
@@ -119,14 +119,14 @@ FORCEINLINE bool Object::TryEnterObjMonitorSpinHelper()
         return false;
     }
 
-    AwareLock::EnterHelperResult result = EnterObjMonitorHelper(pCurThread);
+    AwareLock::EnterHelperResult result = EnterObjMonitorHelper(pCurThread->GetActiveThreadBase());
     if (result == AwareLock::EnterHelperResult_Entered)
     {
         return true;
     }
     if (result == AwareLock::EnterHelperResult_Contention)
     {
-        result = EnterObjMonitorHelperSpin(pCurThread);
+        result = EnterObjMonitorHelperSpin(pCurThread->GetActiveThreadBase());
         if (result == AwareLock::EnterHelperResult_Entered)
         {
             return true;

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -439,7 +439,7 @@ private:
     LockState m_lockState;
 
     ULONG           m_Recursion;
-    PTR_Thread      m_HoldingThread;
+    PTR_ThreadBase  m_HoldingThread;
 
     LONG            m_TransientPrecious;
 
@@ -458,7 +458,7 @@ private:
     AwareLock(DWORD indx)
         : m_Recursion(0),
 #ifndef DACCESS_COMPILE
-// PreFAST has trouble with initializing a NULL PTR_Thread.
+// PreFAST has trouble with initializing a NULL PTR_ThreadBase.
           m_HoldingThread(NULL),
 #endif // DACCESS_COMPILE
           m_TransientPrecious(0),
@@ -517,7 +517,7 @@ public:
         return m_Recursion;
     }
 
-    PTR_Thread GetHoldingThread() const
+    PTR_ThreadBase GetHoldingThread() const
     {
         LIMITED_METHOD_CONTRACT;
         return m_HoldingThread;
@@ -529,7 +529,7 @@ private:
     bool ShouldStopPreemptingWaiters() const;
 
 private: // friend access is required for this unsafe function
-    void InitializeToLockedWithNoWaiters(ULONG recursionLevel, PTR_Thread holdingThread)
+    void InitializeToLockedWithNoWaiters(ULONG recursionLevel, PTR_ThreadBase holdingThread)
     {
         WRAPPER_NO_CONTRACT;
 
@@ -542,20 +542,20 @@ public:
     static void SpinWait(const YieldProcessorNormalizationInfo &normalizationInfo, DWORD spinIteration);
 
     // Helper encapsulating the fast path entering monitor. Returns what kind of result was achieved.
-    bool TryEnterHelper(Thread* pCurThread);
+    bool TryEnterHelper(ThreadBase* pCurThread);
 
-    EnterHelperResult TryEnterBeforeSpinLoopHelper(Thread *pCurThread);
-    EnterHelperResult TryEnterInsideSpinLoopHelper(Thread *pCurThread);
-    bool TryEnterAfterSpinLoopHelper(Thread *pCurThread);
+    EnterHelperResult TryEnterBeforeSpinLoopHelper(ThreadBase *pCurThread);
+    EnterHelperResult TryEnterInsideSpinLoopHelper(ThreadBase *pCurThread);
+    bool TryEnterAfterSpinLoopHelper(ThreadBase *pCurThread);
 
     // Helper encapsulating the core logic for leaving monitor. Returns what kind of
     // follow up action is necessary
-    AwareLock::LeaveHelperAction LeaveHelper(Thread* pCurThread);
+    AwareLock::LeaveHelperAction LeaveHelper(ThreadBase* pCurThread);
 
     void    Enter();
     BOOL    TryEnter(INT32 timeOut = 0);
-    BOOL    EnterEpilog(Thread *pCurThread, INT32 timeOut = INFINITE);
-    BOOL    EnterEpilogHelper(Thread *pCurThread, INT32 timeOut);
+    BOOL    EnterEpilog(ThreadBase *pCurThread, INT32 timeOut = INFINITE);
+    BOOL    EnterEpilogHelper(ThreadBase *pCurThread, INT32 timeOut);
     BOOL    Leave();
 
     void    Signal()
@@ -596,7 +596,7 @@ public:
 
     // Provide access to the Thread object that owns this awarelock.  This is used
     // to provide a host to find out owner of a lock.
-    inline PTR_Thread GetOwningThread()
+    inline PTR_ThreadBase GetOwningThread()
     {
         LIMITED_METHOD_CONTRACT;
         return m_HoldingThread;
@@ -1248,7 +1248,7 @@ class SyncBlock
     // This should ONLY be called when initializing a SyncBlock (i.e. ONLY from
     // ObjHeader::GetSyncBlock()), otherwise we'll have a race condition.
     // </NOTE>
-    void InitState(ULONG recursionLevel, PTR_Thread holdingThread)
+    void InitState(ULONG recursionLevel, PTR_ThreadBase holdingThread)
     {
         WRAPPER_NO_CONTRACT;
         m_Monitor.InitializeToLockedWithNoWaiters(recursionLevel, holdingThread);
@@ -1617,11 +1617,11 @@ class ObjHeader
     BOOL TryEnterObjMonitor(INT32 timeOut = 0);
 
     // Inlineable fast path of EnterObjMonitor/TryEnterObjMonitor. Must be called before EnterObjMonitorHelperSpin.
-    AwareLock::EnterHelperResult EnterObjMonitorHelper(Thread* pCurThread);
+    AwareLock::EnterHelperResult EnterObjMonitorHelper(ThreadBase* pCurThread);
 
     // Typically non-inlined spin loop for some fast paths of EnterObjMonitor/TryEnterObjMonitor. EnterObjMonitorHelper must be
     // called before this function.
-    AwareLock::EnterHelperResult EnterObjMonitorHelperSpin(Thread* pCurThread);
+    AwareLock::EnterHelperResult EnterObjMonitorHelperSpin(ThreadBase* pCurThread);
 
     // leaves the monitor of an object
     BOOL LeaveObjMonitor();
@@ -1631,7 +1631,7 @@ class ObjHeader
 
     // Helper encapsulating the core logic for releasing monitor. Returns what kind of
     // follow up action is necessary
-    AwareLock::LeaveHelperAction LeaveObjMonitorHelper(Thread* pCurThread);
+    AwareLock::LeaveHelperAction LeaveObjMonitorHelper(ThreadBase* pCurThread);
 
     // Returns TRUE if the lock is owned and FALSE otherwise
     // threadId is set to the ID (Thread::GetThreadId()) of the thread which owns the lock
@@ -1703,7 +1703,7 @@ struct ThreadQueue
 
     // Wade through the SyncBlock's list of waiting threads and remove the
     // specified thread.
-    static BOOL          RemoveThread (Thread *pThread, SyncBlock *psb);
+    static BOOL          RemoveThread (ThreadBase *pThread, SyncBlock *psb);
 
 #ifdef DACCESS_COMPILE
     // Enumerates the threads in the queue from front to back by calling

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -1668,7 +1668,7 @@ typedef DPTR(class ObjHeader) PTR_ObjHeader;
 
 #ifdef DACCESS_COMPILE
 // A visitor function used to enumerate threads in the ThreadQueue below
-typedef void (*FP_TQ_THREAD_ENUMERATION_CALLBACK)(PTR_Thread pThread, VOID* pUserData);
+typedef void (*FP_TQ_THREAD_ENUMERATION_CALLBACK)(PTR_ThreadBase pThread, VOID* pUserData);
 #endif
 
 // A SyncBlock contains an m_Link field that is used for two purposes.  One

--- a/src/coreclr/vm/syncblk.inl
+++ b/src/coreclr/vm/syncblk.inl
@@ -467,7 +467,7 @@ FORCEINLINE void AwareLock::SpinWait(const YieldProcessorNormalizationInfo &norm
     YieldProcessorWithBackOffNormalized(normalizationInfo, spinIteration);
 }
 
-FORCEINLINE bool AwareLock::TryEnterHelper(Thread* pCurThread)
+FORCEINLINE bool AwareLock::TryEnterHelper(ThreadBase* pCurThread)
 {
     CONTRACTL{
         NOTHROW;
@@ -490,7 +490,7 @@ FORCEINLINE bool AwareLock::TryEnterHelper(Thread* pCurThread)
     return false;
 }
 
-FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterBeforeSpinLoopHelper(Thread *pCurThread)
+FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterBeforeSpinLoopHelper(ThreadBase *pCurThread)
 {
     CONTRACTL{
         NOTHROW;
@@ -532,7 +532,7 @@ FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterBeforeSpinLoopHelper
     return EnterHelperResult_Entered;
 }
 
-FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterInsideSpinLoopHelper(Thread *pCurThread)
+FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterInsideSpinLoopHelper(ThreadBase *pCurThread)
 {
     CONTRACTL{
         NOTHROW;
@@ -558,7 +558,7 @@ FORCEINLINE AwareLock::EnterHelperResult AwareLock::TryEnterInsideSpinLoopHelper
     return EnterHelperResult_Entered;
 }
 
-FORCEINLINE bool AwareLock::TryEnterAfterSpinLoopHelper(Thread *pCurThread)
+FORCEINLINE bool AwareLock::TryEnterAfterSpinLoopHelper(ThreadBase *pCurThread)
 {
     CONTRACTL{
         NOTHROW;
@@ -580,7 +580,7 @@ FORCEINLINE bool AwareLock::TryEnterAfterSpinLoopHelper(Thread *pCurThread)
     return true;
 }
 
-FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread* pCurThread)
+FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(ThreadBase* pCurThread)
 {
     CONTRACTL{
         NOTHROW;
@@ -670,7 +670,7 @@ FORCEINLINE AwareLock::EnterHelperResult ObjHeader::EnterObjMonitorHelper(Thread
 
 // Helper encapsulating the core logic for releasing monitor. Returns what kind of
 // follow up action is necessary. This is FORCEINLINE to make it provide a very efficient implementation.
-FORCEINLINE AwareLock::LeaveHelperAction AwareLock::LeaveHelper(Thread* pCurThread)
+FORCEINLINE AwareLock::LeaveHelperAction AwareLock::LeaveHelper(ThreadBase* pCurThread)
 {
     CONTRACTL {
         NOTHROW;
@@ -709,7 +709,7 @@ FORCEINLINE AwareLock::LeaveHelperAction AwareLock::LeaveHelper(Thread* pCurThre
 
 // Helper encapsulating the core logic for releasing monitor. Returns what kind of
 // follow up action is necessary. This is FORCEINLINE to make it provide a very efficient implementation.
-FORCEINLINE AwareLock::LeaveHelperAction ObjHeader::LeaveObjMonitorHelper(Thread* pCurThread)
+FORCEINLINE AwareLock::LeaveHelperAction ObjHeader::LeaveObjMonitorHelper(ThreadBase* pCurThread)
 {
     CONTRACTL {
         NOTHROW;

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1390,6 +1390,7 @@ GreenThread::GreenThread()
 
     m_EventWait.CreateManualEvent(TRUE);
     m_ExposedObject = NULL;
+    m_currentThreadObj = NULL;
 }
 
 GreenThread::~GreenThread()
@@ -1418,6 +1419,8 @@ Thread::Thread()
         if (GetThreadNULLOk()) {GC_TRIGGERS;} else {DISABLED(GC_NOTRIGGER);}
     }
     CONTRACTL_END;
+
+    m_coreThreadData.m_currentThreadObj = this;
 
     m_pFrame                = FRAME_TOP;
     m_pGCFrame              = NULL;

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1383,6 +1383,16 @@ void Dbg_TrackSyncStack::LeaveSync(UINT_PTR caller, void *pAwareLock)
 
 static  DWORD dwHashCodeSeed = 123456789;
 
+GreenThread::GreenThread()
+{
+    g_pThinLockThreadIdDispenser->NewId(this, this->m_ThreadId);
+}
+
+GreenThread::~GreenThread()
+{
+    g_pThinLockThreadIdDispenser->DisposeId(this->m_ThreadId);
+}
+
 //--------------------------------------------------------------------
 // Thread construction
 //--------------------------------------------------------------------

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1388,14 +1388,17 @@ GreenThread::GreenThread()
 {
     g_pThinLockThreadIdDispenser->NewId(this, this->m_ThreadId);
 
-    // TODO Initialize m_EventWait
-    //      _ASSERTE(!m_EventWait.IsValid());
-
+    m_EventWait.CreateManualEvent(TRUE);
+    m_ExposedObject = NULL;
 }
 
 GreenThread::~GreenThread()
 {
+    this->CleanupWaitEventLink();
+    this->CleanupEventWait();
     g_pThinLockThreadIdDispenser->DisposeId(this->m_ThreadId);
+    if (m_ExposedObject != NULL)
+        DestroyStrongHandle(m_ExposedObject);
 }
 
 ThreadBase::ThreadBase()

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1406,7 +1406,9 @@ ThreadBase::ThreadBase()
 {
     m_WaitEventLink.m_Next = NULL;
     m_WaitEventLink.m_LinkSB.m_pNext = NULL;
+#ifdef _DEBUG
     m_ThreadId = UNINITIALIZED_THREADID;
+#endif // _DEBUG
 }
 
 //--------------------------------------------------------------------

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -866,6 +866,7 @@ public:
 
 class GreenThread : public ThreadBase
 {
+public:
     GreenThread();
     ~GreenThread();
 };
@@ -946,9 +947,10 @@ public:
 
 public:
 
-    DWORD dummyDword;
+    ThreadBase* m_curThreadBase = &m_coreThreadData;
 
-    ThreadBase* GetActiveThreadBase() { return &m_coreThreadData; }
+    ThreadBase* GetActiveThreadBase() { return m_curThreadBase; }
+    void SetActiveThreadBase(ThreadBase* threadBase) { m_curThreadBase = threadBase; }
     DWORD GetPermanentManagedThreadId() { return m_coreThreadData.GetThreadId(); }
     DWORD GetActiveManagedThreadId() { return GetActiveThreadBase()->GetThreadId(); }
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -859,6 +859,9 @@ public:
             m_EventWait.CloseEvent();
         }
     }
+
+    // Exposed object for Thread object
+    OBJECTHANDLE    m_ExposedObject;
 };
 
 class GreenThread : public ThreadBase
@@ -2202,7 +2205,7 @@ public:
     OBJECTHANDLE GetExposedObjectHandleForDebugger()
     {
         LIMITED_METHOD_CONTRACT;
-        return m_ExposedObject;
+        return m_coreThreadData.m_ExposedObject;
     }
 
     // Query whether the exposed object exists
@@ -2215,7 +2218,7 @@ public:
             MODE_COOPERATIVE;
         }
         CONTRACTL_END;
-        return (ObjectFromHandle(m_ExposedObject) != NULL) ;
+        return (ObjectFromHandle(m_coreThreadData.m_ExposedObject) != NULL) ;
     }
 
     void GetSynchronizationContext(OBJECTREF *pSyncContextObj)
@@ -3323,7 +3326,6 @@ private:
 
     BOOL CreateNewOSThread(SIZE_T stackSize, LPTHREAD_START_ROUTINE start, void *args);
 
-    OBJECTHANDLE    m_ExposedObject;
     OBJECTHANDLE    m_StrongHndToExposedObject;
 
     DWORD           m_Priority;     // initialized to INVALID_THREAD_PRIORITY, set to actual priority when a

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -810,6 +810,7 @@ public:
     // Unique thread id used for thin locks - kept as small as possible, as we have limited space
     // in the object header to store it.
     DWORD                m_ThreadId;
+    Thread*              m_currentThreadObj;
 
     DWORD       GetThreadId()
     {
@@ -818,7 +819,7 @@ public:
         return m_ThreadId;
     }
 
-    Thread* GetThreadObj() { return (Thread*)this; }
+    Thread* GetThreadObj() { return m_currentThreadObj; }
 
     // For Object::Wait, Notify and NotifyAll, we use an Event inside the
     // thread and we queue the threads onto the SyncBlock of the object they

--- a/src/coreclr/vm/threads.inl
+++ b/src/coreclr/vm/threads.inl
@@ -121,7 +121,7 @@ inline OBJECTREF Thread::GetExposedObjectRaw()
     }
     CONTRACTL_END;
 
-    return ObjectFromHandle(m_ExposedObject);
+    return ObjectFromHandle(GetActiveThreadBase()->m_ExposedObject);
 }
 
 #ifdef FEATURE_COMINTEROP

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3842,6 +3842,9 @@
   <data name="ThreadState_Dead_Priority" xml:space="preserve">
     <value>Thread is dead; priority cannot be accessed.</value>
   </data>
+  <data name="ThreadState_GreenThread" xml:space="preserve">
+    <value>Thread is a green thread. This api cannot be used.</value>
+  </data>
   <data name="ThreadState_Dead_State" xml:space="preserve">
     <value>Thread is dead; state cannot be accessed.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -17,7 +17,7 @@ namespace System.Threading
         private static AsyncLocal<IPrincipal?>? s_asyncLocalPrincipal;
 
         [ThreadStatic]
-        private static Thread? t_currentThread;
+        internal static Thread? t_currentThread;
 
         [ThreadStatic]
         internal static bool t_IsGreenThread;

--- a/src/tests/baseservices/threading/greenthreads/locking/greenthread_takecontendedlock.cs
+++ b/src/tests/baseservices/threading/greenthreads/locking/greenthread_takecontendedlock.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_takecontendedlock {
+
+    public static object s_lock = new object();
+    public static volatile bool s_holdLock;
+
+    public static int Main() {
+
+        var t = Task.RunAsGreenThread(() =>
+        {
+            Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
+            Task.Delay(2000).Wait();
+            lock(s_lock)
+            {
+                Console.WriteLine($"In GreenThread holding lock");
+            }
+        });
+
+        s_holdLock = true;
+
+        lock(s_lock)
+        {
+            Thread.Sleep(3000);
+            Console.ReadLine(); // Remove before checkin, but it should serve to keep things alive for now
+        }
+
+        t.Wait();
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/locking/greenthread_takecontendedlock.cs
+++ b/src/tests/baseservices/threading/greenthreads/locking/greenthread_takecontendedlock.cs
@@ -27,7 +27,6 @@ public class Test_greenthread_takecontendedlock {
         lock(s_lock)
         {
             Thread.Sleep(3000);
-            Console.ReadLine(); // Remove before checkin, but it should serve to keep things alive for now
         }
 
         t.Wait();

--- a/src/tests/baseservices/threading/greenthreads/locking/greenthread_takecontendedlock.csproj
+++ b/src/tests/baseservices/threading/greenthreads/locking/greenthread_takecontendedlock.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="greenthread_takecontendedlock.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/threadids/greenthread_threadids.csproj
+++ b/src/tests/baseservices/threading/greenthreads/threadids/greenthread_threadids.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="simple.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/threadids/simple.cs
+++ b/src/tests/baseservices/threading/greenthreads/threadids/simple.cs
@@ -11,7 +11,7 @@ public class Test_greenthread_delay
     [DllImport("kernel32.dll")]
     static extern uint GetCurrentThreadId();
 
-    static extern uint GetOSThreadID()
+    static uint GetOSThreadID()
     {
          if (OperatingSystem.IsWindows())
             return GetCurrentThreadId();
@@ -21,10 +21,10 @@ public class Test_greenthread_delay
 
     public static void TestFunction()
     {
-        Console.WriteLine($"In GreenThread {Thread.IsGreenThread} with ThreadID {Thread.CurrentThread.ManagedThreadId} on OS thread {GetCurrentThreadId()}");
+        Console.WriteLine($"In GreenThread {Thread.IsGreenThread} with ThreadID {Thread.CurrentThread.ManagedThreadId} on OS thread {GetOSThreadID()}");
         int oldId = Thread.CurrentThread.ManagedThreadId;
         Task.Delay(2000).Wait();
-        Console.WriteLine($"In GreenThread {Thread.IsGreenThread} with ThreadID {Thread.CurrentThread.ManagedThreadId} on OS thread {GetCurrentThreadId()} after wait");
+        Console.WriteLine($"In GreenThread {Thread.IsGreenThread} with ThreadID {Thread.CurrentThread.ManagedThreadId} on OS thread {GetOSThreadID()} after wait");
         if (oldId != Thread.CurrentThread.ManagedThreadId) throw new Exception();
     }
 

--- a/src/tests/baseservices/threading/greenthreads/threadids/simple.cs
+++ b/src/tests/baseservices/threading/greenthreads/threadids/simple.cs
@@ -36,7 +36,7 @@ public class Test_greenthread_delay
         Task t1 = Task.RunAsGreenThread(TestFunction);
         t1.Wait();
 
-        Task[] greenThreads = new Task[10];
+        Task[] greenThreads = new Task[100];
 
         Console.WriteLine("Launch a bunch of green threads. Some of these should share OS thread ID but have different managed thread ids. With luck, we will observe that some green threads have moved from one OS thread to another upon resume.");
         for (int i = 0; i < greenThreads.Length; i++)

--- a/src/tests/baseservices/threading/greenthreads/threadids/simple.cs
+++ b/src/tests/baseservices/threading/greenthreads/threadids/simple.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_delay
+{
+    [DllImport("kernel32.dll")]
+    static extern uint GetCurrentThreadId();
+
+    static extern uint GetOSThreadID()
+    {
+         if (OperatingSystem.IsWindows())
+            return GetCurrentThreadId();
+        else
+            return 0; // Non-Windows is not handled by thius test.
+    }
+
+    public static void TestFunction()
+    {
+        Console.WriteLine($"In GreenThread {Thread.IsGreenThread} with ThreadID {Thread.CurrentThread.ManagedThreadId} on OS thread {GetCurrentThreadId()}");
+        int oldId = Thread.CurrentThread.ManagedThreadId;
+        Task.Delay(2000).Wait();
+        Console.WriteLine($"In GreenThread {Thread.IsGreenThread} with ThreadID {Thread.CurrentThread.ManagedThreadId} on OS thread {GetCurrentThreadId()} after wait");
+        if (oldId != Thread.CurrentThread.ManagedThreadId) throw new Exception();
+    }
+
+    public static int Main() {
+        Console.WriteLine("This test is designed to test managed thread id behavior for green threads. In particular, that the thread id remains the same across a resume event, even if the thread hops from one OS thread to another.");
+
+        Console.WriteLine("Run warmup green thread.");
+        // Make sure that only 1 of these things has to wait on JITting and such.
+        Task t1 = Task.RunAsGreenThread(TestFunction);
+        t1.Wait();
+
+        Task[] greenThreads = new Task[10];
+
+        Console.WriteLine("Launch a bunch of green threads. Some of these should share OS thread ID but have different managed thread ids. With luck, we will observe that some green threads have moved from one OS thread to another upon resume.");
+        for (int i = 0; i < greenThreads.Length; i++)
+            greenThreads[i] = Task.RunAsGreenThread(TestFunction);
+
+        foreach (Task t in greenThreads)
+            t.Wait();
+
+        Console.WriteLine("Launch another bunch of green threads. We should see re-use of managed thread IDs in this set, thus verifying that free-ing of managed thread ids is working.");
+        for (int i = 0; i < greenThreads.Length; i++)
+            greenThreads[i] = Task.RunAsGreenThread(TestFunction);
+
+        foreach (Task t in greenThreads)
+            t.Wait();
+
+        Console.WriteLine("Validation of these behaviors is manual, as the behavior of the runtime here is non-deterministic, and difficult to make reliable.");
+
+        return 100;
+    }
+}


### PR DESCRIPTION
This adds managed `Thread` objects for green threads as well as unique managed thread ids. There is a test for that. 

In addition this adds logic to moves handling of Monitor locks to a per-green thread structure.

In addition it fixes a number of bugs

- In the reverse p/invoke logic where the current native `Thread*` pointer is cached, and when we hop threads isn't properly restored. (See change in jithelpers.cpp)
- This also fixes bugs where the stack limits were not properly updated on resume
- This fixes bugs where in the presence of optimization, when the thread was resumed on a different thread the Thread* was not refreshed from the underlying TLS data structure. This issue was found in several functions in C++ (which are now marked with optimizations disabled, and the GreenThread_Yield P/Invoke which has the same issue.)

Fixes #2014 