### PR TITLE
NativeAOT-LLVM: remove an SSA assert for TARGET_WASM

### DIFF
--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -1184,8 +1184,10 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block)
     {
         if ((memoryKind == GcHeap) && m_pCompiler->byrefStatesMatchGcHeapStates)
         {
+#if !defined(TARGET_WASM)
             // ByrefExposed and GcHeap share any phi this block may have,
             assert(block->bbMemorySsaPhiFunc[memoryKind] == block->bbMemorySsaPhiFunc[ByrefExposed]);
+#endif // !defined(TARGET_WASM)
             // so we will have already allocated a defnum for it if needed.
             assert(memoryKind > ByrefExposed);
 

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -1184,6 +1184,8 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block)
     {
         if ((memoryKind == GcHeap) && m_pCompiler->byrefStatesMatchGcHeapStates)
         {
+            // memory liveness for LIR has upstream problems, causing TARGET_WASM to trigger this assert.
+            // TODO-LLVM: reinstate when fixed.
 #if !defined(TARGET_WASM)
             // ByrefExposed and GcHeap share any phi this block may have,
             assert(block->bbMemorySsaPhiFunc[memoryKind] == block->bbMemorySsaPhiFunc[ByrefExposed]);


### PR DESCRIPTION
This PR removes an assert we hit in optimized code.  Would you like the full dump for an example method or is it obvious (it's not to me..)?

cc @SingleAccretion