### PR TITLE
NativeAOT-LLVM: make sure address is an i8* for memset

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1809,7 +1809,7 @@ void Llvm::buildStoreBlk(GenTreeBlk* blockOp)
 
     ClassLayout* structLayout = blockOp->GetLayout();
 
-    Value* baseAddressValue = getGenTreeValue(blockOp->Addr());
+    Value* baseAddressValue = consumeValue(blockOp->Addr(), Type::getInt8Ty(_llvmContext)->getPointerTo());
 
     // zero initialization  check
     GenTree* dataOp = blockOp->Data();


### PR DESCRIPTION
This PR ensures that the address passed to `memset` is an `i8*`.  For

```c#
public unsafe static void FreeAll(UnmanagedMemoryPool* pool)
{
    void** pCur = (void**)pool->Alloc;
    byte* pNext = pool->Alloc + pool->BlockSize;

    for (int i = 0, count = pool->NumBlocks - 1; i < count; ++i)
    {
        *pCur = pNext;
        pCur = (void**)pNext;
        pNext += pool->BlockSize;
    }

    *pCur = default(void*);
```

We can get for the `*pCur = default(void*);` an int in the IR:

```
------------ BB03 [038..04C) (return), preds={BB01,BB02} succs={}
     (  0,  0) [000107] ------------       t107 =    PHI_ARG   int    V01 loc0         u:5
     (  0,  0) [000106] ------------       t106 =    PHI_ARG   int    V01 loc0         u:2
                                                  /--*  t107   int
                                                  +--*  t106   int
               [000095] ------------        t95 = *  PHI       int
                                                  /--*  t95    int
               [000096] DA----------              *  STORE_LCL_VAR int    V01 loc0         d:3
N001 (  1,  1) [000042] ------------        t42 =    LCL_VAR   int    V01 loc0         u:3 (last use) $107
N003 (  1,  1) [000043] ------------        t43 =    CNS_INT   int    0 $40
                                                  /--*  t42    int
                                                  +--*  t43    int
N002 (  3,  2) [000044] -A-X--------              *  STORE_BLK struct<4> (init) $147
```
This changes uses `consumeValue` to ensure we pass an `i8*` to `memset` in LLVM

cc @SingleAccretion