### PR TITLE
NativeAOT-LLVM: remove load expressions from expression stack when not immediately used

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -471,6 +471,7 @@ namespace Internal.IL
             return typeDesc.IsWellKnownType(WellKnownType.SByte) ||
                    typeDesc.IsWellKnownType(WellKnownType.Int16);
         }
+
         private void PushLoadExpression(StackValueKind kind, string name, LLVMValueRef rawLLVMValue, TypeDesc type)
         {
             Debug.Assert(kind != StackValueKind.Unknown, "Unknown stack kind");
@@ -3618,6 +3619,7 @@ namespace Internal.IL
 
             LLVMValueRef loadValue = LoadValue(_builder, pointerElementType, type,
                 GetLLVMTypeForTypeDesc(type), SignExtendTypeDesc(type), $"loadIndirect{pointer.Name()}");
+
             _stack.Push(new ExpressionEntry(pointerStackValueKind, $"Indirect{pointer.Name()}", loadValue, type));
         }
 
@@ -5114,6 +5116,7 @@ namespace Internal.IL
             LLVMValueRef elementValue = LoadValue(_builder, GetElementAddress(index.ValueAsInt32(_builder, false), arrayReference.ValueAsType(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), _builder), nullSafeElementType),
                 nullSafeElementType,
                 GetLLVMTypeForTypeDesc(nullSafeElementType), SignExtendTypeDesc(nullSafeElementType), $"load{arrayReference.Name()}Element");
+
             _stack.Push(new ExpressionEntry(GetStackValueKind(nullSafeElementType), $"{arrayReference.Name()}Element", elementValue, nullSafeElementType));
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -5113,9 +5113,10 @@ namespace Internal.IL
             StackEntry arrayReference = _stack.Pop();
             var nullSafeElementType = elementType ?? GetWellKnownType(WellKnownType.Object);
 
+            // ldelem pushes ints to the evaluation stack, so widen small ints
             LLVMValueRef elementValue = LoadValue(_builder, GetElementAddress(index.ValueAsInt32(_builder, false), arrayReference.ValueAsType(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), _builder), nullSafeElementType),
                 nullSafeElementType,
-                GetLLVMTypeForTypeDesc(nullSafeElementType), SignExtendTypeDesc(nullSafeElementType), $"load{arrayReference.Name()}Element");
+                GetLLVMTypeForTypeDesc(WidenBytesAndShorts(nullSafeElementType)), SignExtendTypeDesc(nullSafeElementType), $"load{arrayReference.Name()}Element");
 
             _stack.Push(new ExpressionEntry(GetStackValueKind(nullSafeElementType), $"{arrayReference.Name()}Element", elementValue, nullSafeElementType));
         }

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -385,6 +385,8 @@ internal static class Program
 
         TestJitUseStruct();
 
+        TestReadByteArray();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -3728,6 +3730,16 @@ internal static class Program
         bool expected = true;
         bool actual = true;
         EndTest(expected.Equals(actual));
+    }
+
+    private static byte[] bytes = { 0xff };
+
+    static void TestReadByteArray()
+    {
+        StartTest("Test ldelemt from byte arry");
+
+        int i = (int)bytes[0];
+        EndTest(i == 0xff);
     }
 
     static ushort ReadUInt16()


### PR DESCRIPTION
This PR removes the use of the LoadExpression stack entry for cases where the use or pop of the expression may occur after the value in the address being loaded is modified.  This bug looks to have been present for some time, but has been highlighted by recent versions of Roslyn which appear to eliminate more locals in exchange for leaving expressions on the stack.