### PR TITLE
Add support for ThreadStatic variables to the green threads implementation

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -1640,9 +1640,9 @@ void Module::FreeModuleIndex()
         {
             ThreadStoreLockHolder tsLock;
             Thread *pThread = NULL;
-            while ((pThread = ThreadStore::GetThreadList(pThread)) != NULL)
+            while ((pThread = ThreadStore::GetThreadList(pThread)) != NULL) // TODO! This does not work for collectible assemblies today in the presence of Green Threads
             {
-                pThread->DeleteThreadStaticData(m_ModuleIndex);
+                pThread->GetActiveThreadBase()->DeleteThreadStaticData(m_ModuleIndex);
             }
         }
 

--- a/src/coreclr/vm/greenthreads.h
+++ b/src/coreclr/vm/greenthreads.h
@@ -34,10 +34,10 @@ SuspendedGreenThread* GreenThread_StartThread(TakesOneParam functionToExecute, u
 uintptr_t TransitionToOSThread(TakesOneParam functionToExecute, uintptr_t param);
 
 // Must be called from within a green thread.
-bool GreenThread_Yield(); // Attempt to yield out of green thread. If the yield fails, return false, else return true once the thread is resumed.
+uintptr_t GreenThread_Yield(); // Attempt to yield out of green thread. If the yield fails, return false, else return true once the thread is resumed.
 
 // Resume execution 
-SuspendedGreenThread* GreenThread_ResumeThread(SuspendedGreenThread* pSuspendedThread); // Resume suspended green thread, and destroy SuspendedGreenThread structure, or return a new one if the thread suspends again ... Note this is permitted to return the old one.
+SuspendedGreenThread* GreenThread_ResumeThread(SuspendedGreenThread* pSuspendedThread, uintptr_t yieldReturnValue); // Resume suspended green thread, and destroy SuspendedGreenThread structure, or return a new one if the thread suspends again ... Note this is permitted to return the old one.
 
 // Destroy suspended green thread
 void DestroyGreenThread(SuspendedGreenThread* pSuspendedThread); // 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -863,6 +863,16 @@ public:
 
     // Exposed object for Thread object
     OBJECTHANDLE    m_ExposedObject;
+
+    ThreadLocalBlock m_ThreadLocalBlock;
+
+    // Called during AssemblyLoadContext teardown to clean up all structures
+    // associated with thread statics for the specific Module
+    void DeleteThreadStaticData(ModuleIndex index);
+
+    // Called during Thread death to clean up all structures
+    // associated with thread statics
+    void DeleteThreadStaticData();
 };
 
 class GreenThread : public ThreadBase
@@ -948,10 +958,12 @@ public:
 
 public:
 
-    ThreadBase* m_curThreadBase = &m_coreThreadData;
+    PTR_ThreadBase m_curThreadBase;
 
-    ThreadBase* GetActiveThreadBase() { return m_curThreadBase; }
+    PTR_ThreadBase GetActiveThreadBase() { return m_curThreadBase; }
+#ifndef DACCESS_COMPILE
     void SetActiveThreadBase(ThreadBase* threadBase) { m_curThreadBase = threadBase; }
+#endif
     DWORD GetPermanentManagedThreadId() { return m_coreThreadData.GetThreadId(); }
     DWORD GetActiveManagedThreadId() { return GetActiveThreadBase()->GetThreadId(); }
 
@@ -3868,18 +3880,6 @@ public:
         return (pCtx == m_pSavedRedirectContext);
     }
 #endif //DACCESS_COMPILE
-
-    ThreadLocalBlock m_ThreadLocalBlock;
-
-    // Called during AssemblyLoadContext teardown to clean up all structures
-    // associated with thread statics for the specific Module
-    void DeleteThreadStaticData(ModuleIndex index);
-
-private:
-
-    // Called during Thread death to clean up all structures
-    // associated with thread statics
-    void DeleteThreadStaticData();
 
 private:
     TailCallTls m_tailCallTls;

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -576,7 +576,7 @@ void    ThreadLocalModule::AllocateDynamicClass(MethodTable *pMT)
         {
             if (!pMT->Collectible())
             {
-                GetThread()->m_ThreadLocalBlock.AllocateStaticFieldObjRefPtrs(dwNumHandleStatics,
+                GetThread()->GetActiveThreadBase()->m_ThreadLocalBlock.AllocateStaticFieldObjRefPtrs(dwNumHandleStatics,
                         &((NormalDynamicEntry *)pDynamicStatics)->m_pGCStatics);
             }
             else

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -542,7 +542,7 @@ class ThreadStatics
     {
         SUPPORTS_DAC;
 
-        return dac_cast<PTR_ThreadLocalBlock>(PTR_TO_MEMBER_TADDR(Thread, pThread, m_ThreadLocalBlock));
+        return dac_cast<PTR_ThreadLocalBlock>(PTR_TO_MEMBER_TADDR(ThreadBase, pThread->GetActiveThreadBase(), m_ThreadLocalBlock));
     }
 
 #ifndef DACCESS_COMPILE
@@ -550,7 +550,7 @@ class ThreadStatics
     {
         // Get the current thread
         Thread * pThread = GetThread();
-        return &pThread->m_ThreadLocalBlock;
+        return &pThread->GetActiveThreadBase()->m_ThreadLocalBlock;
     }
 
     FORCEINLINE static ThreadLocalModule* GetTLMIfExists(ModuleIndex index)


### PR DESCRIPTION
- Move thread statics into the ThreadBase type
- Update the green thread startup/suspension/resumption code to deal with the fact that managed thread locals are now truly local to the green thread.

Fixes #2012