### PR TITLE
allow TYP_STRUCT for GT_RETURN - special case CNS_INT 0 initialization

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1629,12 +1629,12 @@ void Llvm::buildReturn(GenTree* node)
             }
             if (node->gtGetOp1()->IsIntegralConst(0))
             {
-                // special case returning 0 initialized structs
+                // Special-case returning zero-initialized structs.
                 Type* structLlvmType = getLlvmTypeForCorInfoType(_sigInfo.retType, _sigInfo.retTypeClass);
                 Value* structAddrValue = _builder.CreateAlloca(structLlvmType, 0U);
-                _builder.CreateMemSet(structAddrValue, _builder.getInt8(0), _builder.getInt32(structLlvmType->getScalarSizeInBits() >> 3), {});
+                Value* structSizeValue = _builder.getInt32(structLlvmType->getScalarSizeInBits() / BITS_PER_BYTE);
+                _builder.CreateMemSet(structAddrValue, _builder.getInt8(0), structSizeValue, {});
                 _builder.CreateRet(_builder.CreateLoad(structAddrValue));
-
                 return;
             }
             _builder.CreateRet(consumeValue(node->gtGetOp1(), getLlvmTypeForCorInfoType(_sigInfo.retType, _sigInfo.retTypeClass)));

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1627,7 +1627,7 @@ void Llvm::buildReturn(GenTree* node)
                 // https://github.com/dotnet/runtimelab/pull/2007#issuecomment-1264715441
                 failFunctionCompilation();
             }
-            if (node->gtGetOp1()->IsIntegralConst(0))
+            if (node->TypeGet() == TYP_STRUCT && node->gtGetOp1()->IsIntegralConst(0))
             {
                 // special case returning 0 initialized structs
                 Type* structLlvmType = getLlvmTypeForCorInfoType(_sigInfo.retType, _sigInfo.retTypeClass);


### PR DESCRIPTION
This PR is pretty much just as per the title.  Added a case for `TYP_STRUCT` in `buildReturn` with special handling for 0 initialization.

Slight difference to the other location where we 0 initialize structs is that the size here is taken from the LLVM type not the `ClassLayout->GetSize` as we dont have a `GenTreeBlk`

cc @SingleAccretion