### PR TITLE
Swap to OS thread for special cases

### DIFF
--- a/src/coreclr/vm/callcounting.cpp
+++ b/src/coreclr/vm/callcounting.cpp
@@ -743,8 +743,13 @@ bool CallCountingManager::SetCodeEntryPoint(
 
 extern "C" PCODE STDCALL OnCallCountThresholdReached(TransitionBlock *transitionBlock, TADDR stubIdentifyingToken)
 {
+    PCODE result = NULL;
     WRAPPER_NO_CONTRACT;
-    return CallCountingManager::OnCallCountThresholdReached(transitionBlock, stubIdentifyingToken);
+    ENSURE_ON_OS_THREAD();
+    result = CallCountingManager::OnCallCountThresholdReached(transitionBlock, stubIdentifyingToken);
+    END_ENSURE_ON_OS_THREAD();
+
+    return result;
 }
 
 PCODE CallCountingManager::OnCallCountThresholdReached(TransitionBlock *transitionBlock, TADDR stubIdentifyingToken)

--- a/src/coreclr/vm/clrtocomcall.cpp
+++ b/src/coreclr/vm/clrtocomcall.cpp
@@ -686,6 +686,9 @@ UINT32 CLRToCOMLateBoundWorker(
 /*static*/
 UINT32 STDCALL CLRToCOMWorker(TransitionBlock * pTransitionBlock, ComPlusCallMethodDesc * pMD)
 {
+    UINT32 returnValue = 0;
+
+    ENSURE_ON_OS_THREAD();
     CONTRACTL
     {
         THROWS;
@@ -696,7 +699,6 @@ UINT32 STDCALL CLRToCOMWorker(TransitionBlock * pTransitionBlock, ComPlusCallMet
     }
     CONTRACTL_END;
 
-    UINT32 returnValue = 0;
 
     // This must happen before the UnC handler is setup.  Otherwise, an exception will
     // cause the UnC handler to pop this frame, leaving a GC hole a mile wide.
@@ -748,6 +750,7 @@ UINT32 STDCALL CLRToCOMWorker(TransitionBlock * pTransitionBlock, ComPlusCallMet
 
     pFrame->Pop(CURRENT_THREAD);
 
+    END_ENSURE_ON_OS_THREAD();
     return returnValue;
 }
 

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -395,7 +395,10 @@ bool IsOleAutDispImplRequiredForClass(MethodTable *pClass)
 //--------------------------------------------------------------------------
 extern "C" PCODE ComPreStubWorker(ComPrestubMethodFrame *pPFrame, UINT64 *pErrorReturn)
 {
-    CONTRACT (PCODE)
+    PCODE retAddr = NULL;
+    ENSURE_ON_OS_THREAD();
+
+    CONTRACT_VOID
     {
         NOTHROW;
         GC_TRIGGERS;
@@ -407,7 +410,6 @@ extern "C" PCODE ComPreStubWorker(ComPrestubMethodFrame *pPFrame, UINT64 *pError
     CONTRACT_END;
 
     HRESULT hr = S_OK;
-    PCODE retAddr = NULL;
 
     BEGIN_ENTRYPOINT_VOIDRET;
 
@@ -602,8 +604,9 @@ extern "C" PCODE ComPreStubWorker(ComPrestubMethodFrame *pPFrame, UINT64 *pError
 Exit:
 
     END_ENTRYPOINT_VOIDRET;
-
-    RETURN retAddr;
+    RETURN;
+    END_ENSURE_ON_OS_THREAD();
+    return retAddr;
 }
 
 FORCEINLINE void CPListRelease(CQuickArray<ConnectionPoint*>* value)

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5823,6 +5823,7 @@ void MarshalStructViaILStubCode(PCODE pStubCode, void* pManagedData, void* pNati
 EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
 {
     LPVOID ret = NULL;
+    ENSURE_ON_OS_THREAD();
 
     BEGIN_PRESERVE_LAST_ERROR;
 
@@ -5876,6 +5877,7 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
     UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
 
     END_PRESERVE_LAST_ERROR;
+    END_ENSURE_ON_OS_THREAD();
 
     return ret;
 }
@@ -5887,6 +5889,7 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
 
 EXTERN_C void STDCALL VarargPInvokeStubWorker(TransitionBlock * pTransitionBlock, VASigCookie *pVASigCookie, MethodDesc *pMD)
 {
+    ENSURE_ON_OS_THREAD();
     BEGIN_PRESERVE_LAST_ERROR;
 
     STATIC_CONTRACT_THROWS;
@@ -5913,10 +5916,12 @@ EXTERN_C void STDCALL VarargPInvokeStubWorker(TransitionBlock * pTransitionBlock
     pFrame->Pop(CURRENT_THREAD);
 
     END_PRESERVE_LAST_ERROR;
+    END_ENSURE_ON_OS_THREAD();
 }
 
 EXTERN_C void STDCALL GenericPInvokeCalliStubWorker(TransitionBlock * pTransitionBlock, VASigCookie * pVASigCookie, PCODE pUnmanagedTarget)
 {
+    ENSURE_ON_OS_THREAD();
     BEGIN_PRESERVE_LAST_ERROR;
 
     STATIC_CONTRACT_THROWS;
@@ -5942,6 +5947,7 @@ EXTERN_C void STDCALL GenericPInvokeCalliStubWorker(TransitionBlock * pTransitio
     pFrame->Pop(CURRENT_THREAD);
 
     END_PRESERVE_LAST_ERROR;
+    END_ENSURE_ON_OS_THREAD();
 }
 
 PCODE GetILStubForCalli(VASigCookie *pVASigCookie, MethodDesc *pMD)

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1855,6 +1855,7 @@ static PCODE PreStubWorker_Preemptive(
 extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, MethodDesc* pMD)
 {
     PCODE pbRetVal = NULL;
+    ENSURE_ON_OS_THREAD();
 
     BEGIN_PRESERVE_LAST_ERROR;
 
@@ -1955,6 +1956,7 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
 
     END_PRESERVE_LAST_ERROR;
 
+    END_ENSURE_ON_OS_THREAD();
     return pbRetVal;
 }
 
@@ -2364,6 +2366,7 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
     //
 
     PCODE         pCode   = NULL;
+    ENSURE_ON_OS_THREAD();
 
     BEGIN_PRESERVE_LAST_ERROR;
 
@@ -2647,7 +2650,7 @@ EXTERN_C PCODE STDCALL ExternalMethodFixupWorker(TransitionBlock * pTransitionBl
     pEMFrame->Pop(CURRENT_THREAD);          // Pop the ExternalMethodFrame from the frame stack
 
     END_PRESERVE_LAST_ERROR;
-
+    END_ENSURE_ON_OS_THREAD();
     return pCode;
 }
 
@@ -3296,6 +3299,7 @@ PCODE DynamicHelperFixup(TransitionBlock * pTransitionBlock, TADDR * pCell, DWOR
 extern "C" SIZE_T STDCALL DynamicHelperWorker(TransitionBlock * pTransitionBlock, TADDR * pCell, DWORD sectionIndex, Module * pModule, INT frameFlags)
 {
     PCODE pHelper = NULL;
+    ENSURE_ON_OS_THREAD();
     SIZE_T result = NULL;
 
     STATIC_CONTRACT_THROWS;
@@ -3419,6 +3423,8 @@ extern "C" SIZE_T STDCALL DynamicHelperWorker(TransitionBlock * pTransitionBlock
 
     if (pHelper == NULL)
         *(SIZE_T *)((TADDR)pTransitionBlock + TransitionBlock::GetOffsetOfArgumentRegisters()) = result;
+
+    END_ENSURE_ON_OS_THREAD();
     return pHelper;
 }
 

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -1412,6 +1412,8 @@ PCODE VSD_ResolveWorker(TransitionBlock * pTransitionBlock,
 #endif
                         )
 {
+    PCODE target = NULL;
+    ENSURE_ON_OS_THREAD();
     CONTRACTL {
         THROWS;
         GC_TRIGGERS;
@@ -1436,8 +1438,6 @@ PCODE VSD_ResolveWorker(TransitionBlock * pTransitionBlock,
     OBJECTREF *protectedObj = pSDFrame->GetThisPtr();
     _ASSERTE(protectedObj != NULL);
     OBJECTREF pObj = *protectedObj;
-
-    PCODE target = NULL;
 
     if (pObj == NULL) {
         pSDFrame->SetForNullReferenceException();
@@ -1465,7 +1465,7 @@ PCODE VSD_ResolveWorker(TransitionBlock * pTransitionBlock,
             pMgr->BackPatchWorker(&callSite);
         }
 
-        return target;
+        return;
     }
 #endif
 
@@ -1521,6 +1521,7 @@ PCODE VSD_ResolveWorker(TransitionBlock * pTransitionBlock,
     UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
     UNINSTALL_MANAGED_EXCEPTION_DISPATCHER;
     pSDFrame->Pop(CURRENT_THREAD);
+    END_ENSURE_ON_OS_THREAD();
 
     return target;
 }


### PR DESCRIPTION
- where we don't use an FCall or standard P/Invoke transition to go to C++ code
- Do so by generalizing the C++ lambda technique used for the FCall transitions and make it available as a macro for these other transitions to use

Fixes #2051