### PR TITLE
Add prolog stack check for green threads

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -522,6 +522,9 @@ protected:
 
     void genReserveProlog(BasicBlock* block); // currently unused
     void genReserveEpilog(BasicBlock* block);
+#if defined(TARGET_AMD64)
+    void genFnPreProlog();
+#endif // defined(TARGET_AMD64)
     void genFnProlog();
     void genFnEpilog(BasicBlock* block);
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5534,8 +5534,7 @@ void CodeGen::genFnPreProlog()
 
     int encodedSizes = (checkSizePower2 << bitsForArgSize) | argSize;
 
-    // put this in codegenamd64?  or remove specific registers?
-    emit->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SCRATCH, REG_RSP, -checkSize);
+    emit->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SCRATCH, REG_SPBASE, -checkSize);
     const int gsOffsetForStackLimit = 0x10;
     emit->emitIns_R_C(INS_cmp, EA_PTRSIZE, REG_SCRATCH, FLD_GLOBAL_GS, gsOffsetForStackLimit);
     emit->emitIns_J(INS_ja, nullptr, 2);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5483,6 +5483,8 @@ void CodeGen::genFinalizeFrame()
  *  genFnPreProlog is optional (currently only on for x64 but eventually
  *  some frames will likely skip it).
  *
+ *  Although currently only being used for TARGET_AMD64, this is eventually
+ *  intended for all architectures, so it is not in codegenxarch.cpp.
  */
 
 #if defined(TARGET_AMD64)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -6570,7 +6570,8 @@ void CodeGen::genGeneratePrologsAndEpilogs()
     gcInfo.gcResetForBB();
     genFnProlog();
 #if defined(TARGET_AMD64)
-    // See comment on genFnPreProlog for why this is after genFnProlog
+    // See comment on genFnPreProlog for why this is after genFnProlog.
+    // (Perhaps genFnProlog could call GenFnPreProlog to clean this up a bit?)
     genFnPreProlog();
 #endif // defined(TARGET_AMD64)
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5538,12 +5538,10 @@ void CodeGen::genFnPreProlog()
     emit->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SCRATCH, REG_RSP, -checkSize);
     const int gsOffsetForStackLimit = 0x10;
     emit->emitIns_R_C(INS_cmp, EA_PTRSIZE, REG_SCRATCH, FLD_GLOBAL_GS, gsOffsetForStackLimit);
-    //BasicBlock* pass = genCreateTempLabel();
     emit->emitIns_J(INS_ja, nullptr, 2);
     emit->emitIns_R_I(INS_mov, EA_4BYTE, REG_SCRATCH, encodedSizes);
     // wrong helper
     genEmitHelperCall(CORINFO_HELP_STACK_PROBE, 0, EA_UNKNOWN);
-    //genDefineTempLabel(pass);
 }
 #endif // defined(TARGET_AMD64)
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5516,14 +5516,8 @@ void CodeGen::genFnPreProlog()
 
     // put this in codegenamd64?  or remove specific registers?
     emit->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_RAX, REG_RSP, -0x250);
-    // cmp rax, qword ptr gs:[0]
-    // 65 GS:
-    // 48 REX.W
-    // 3B cmp r,r/m
-    // modrm -> sib
-    // sib -> [*] -> disp32
-    // should be GS
-    emit->emitIns_R_C(INS_cmp, EA_PTRSIZE, REG_RAX, FLD_GLOBAL_FS, 0);
+    const int gsOffsetForStackLimit = 0x10;
+    emit->emitIns_R_C(INS_cmp, EA_PTRSIZE, REG_RAX, FLD_GLOBAL_GS, gsOffsetForStackLimit);
     //BasicBlock* pass = genCreateTempLabel();
     emit->emitIns_J(INS_ja, nullptr, 2);
     emit->emitIns_R_I(INS_mov, EA_4BYTE, REG_RAX, 0x1000);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5535,12 +5535,12 @@ void CodeGen::genFnPreProlog()
     int encodedSizes = (checkSizePower2 << bitsForArgSize) | argSize;
 
     // put this in codegenamd64?  or remove specific registers?
-    emit->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_RAX, REG_RSP, -checkSize);
+    emit->emitIns_R_AR(INS_lea, EA_PTRSIZE, REG_SCRATCH, REG_RSP, -checkSize);
     const int gsOffsetForStackLimit = 0x10;
-    emit->emitIns_R_C(INS_cmp, EA_PTRSIZE, REG_RAX, FLD_GLOBAL_GS, gsOffsetForStackLimit);
+    emit->emitIns_R_C(INS_cmp, EA_PTRSIZE, REG_SCRATCH, FLD_GLOBAL_GS, gsOffsetForStackLimit);
     //BasicBlock* pass = genCreateTempLabel();
     emit->emitIns_J(INS_ja, nullptr, 2);
-    emit->emitIns_R_I(INS_mov, EA_4BYTE, REG_RAX, encodedSizes);
+    emit->emitIns_R_I(INS_mov, EA_4BYTE, REG_SCRATCH, encodedSizes);
     // wrong helper
     genEmitHelperCall(CORINFO_HELP_STACK_PROBE, 0, EA_UNKNOWN);
     //genDefineTempLabel(pass);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8975,6 +8975,7 @@ public:
 
     bool compUsesThrowHelper; // There is a call to a THROW_HELPER for the compiled method.
 
+    bool compGeneratingPreProlog;
     bool compGeneratingProlog;
     bool compGeneratingEpilog;
     bool compNeedsGSSecurityCookie; // There is an unsafe buffer (or localloc) on the stack.

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3705,12 +3705,12 @@ inline bool Compiler::IsGcSafePoint(GenTreeCall* call)
 // Note that we want to have two special FIELD_HANDLES that will both
 // be considered non-Data Offset handles
 //
-// The special values that we use are FLD_GLOBAL_DS and FLD_GLOBAL_FS
+// The special values that we use are FLD_GLOBAL_DS, FLD_GLOBAL_FS, and FLD_GLOBAL_GS
 //
 
 inline bool jitStaticFldIsGlobAddr(CORINFO_FIELD_HANDLE fldHnd)
 {
-    return (fldHnd == FLD_GLOBAL_DS || fldHnd == FLD_GLOBAL_FS);
+    return (fldHnd == FLD_GLOBAL_DS) || (fldHnd == FLD_GLOBAL_FS) || (fldHnd == FLD_GLOBAL_GS);
 }
 
 #if defined(DEBUG) || defined(FEATURE_JIT_METHOD_PERF) || defined(FEATURE_SIMD) || defined(FEATURE_TRACELOGGING)

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3702,7 +3702,7 @@ inline bool Compiler::IsGcSafePoint(GenTreeCall* call)
 }
 
 //
-// Note that we want to have two special FIELD_HANDLES that will both
+// Note that we want to have three special FIELD_HANDLES that will all
 // be considered non-Data Offset handles
 //
 // The special values that we use are FLD_GLOBAL_DS, FLD_GLOBAL_FS, and FLD_GLOBAL_GS

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1164,8 +1164,8 @@ void emitter::emitBegFN(bool hasFramePtr
     emitInInstrumentation = false;
 #endif // PSEUDORANDOM_NOP_INSERTION
 
-    /* Create the first IG, it will be used for the prolog */
-    // or preprolog?
+    // Create the first IG, it will be used for the preprolog if it exists.
+    // Otherwise it will be the prolog.
 
     emitNxtIGnum = 1;
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2024,7 +2024,10 @@ private:
     insGroup* emitIGlast; // last   instruction group
     insGroup* emitIGthis; // issued instruction group
 
-    insGroup* emitPrologIG; // prolog instruction group
+#if defined(TARGET_AMD64)
+    insGroup* emitPrePrologIG; // preprolog instruction group
+#endif // defined(TARGET_AMD64)
+    insGroup* emitPrologIG;    // prolog instruction group
 
     instrDescJmp* emitJumpList;       // list of local jumps in method
     instrDescJmp* emitJumpLast;       // last of local jumps in method

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2024,9 +2024,7 @@ private:
     insGroup* emitIGlast; // last   instruction group
     insGroup* emitIGthis; // issued instruction group
 
-#if defined(TARGET_AMD64)
     insGroup* emitPrePrologIG; // preprolog instruction group
-#endif // defined(TARGET_AMD64)
     insGroup* emitPrologIG;    // prolog instruction group
 
     instrDescJmp* emitJumpList;       // list of local jumps in method

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -4001,7 +4001,7 @@ void emitter::emitIns_R_C(instruction ins, emitAttr attr, regNumber reg, CORINFO
     {
         NYI_ARM("JitDataOffset static fields");
     }
-    else if (fldHnd == FLD_GLOBAL_FS)
+    else if ((fldHnd == FLD_GLOBAL_FS) || (fldHnd == FLD_GLOBAL_GS))
     {
         NYI_ARM("Thread-Local-Storage static fields");
     }

--- a/src/coreclr/jit/emitpub.h
+++ b/src/coreclr/jit/emitpub.h
@@ -43,6 +43,9 @@ unsigned emitGetEpilogCnt();
 template <typename Callback>
 bool emitGenNoGCLst(Callback& cb);
 
+#if defined(TARGET_AMD64)
+void     emitBegPreProlog();
+#endif // defined(TARGET_AMD64)
 void     emitBegProlog();
 unsigned emitGetPrologOffsetEstimate();
 void     emitMarkPrologEnd();

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11871,7 +11871,11 @@ BYTE* emitter::emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
         {
             if (jitStaticFldIsGlobAddr(fldh))
             {
-                // This is beyond a hack...
+                // This is a big hack.  This function doesn't accept a 3 byte code
+                // (for opcode / regr/m / sib).  If code has 3 used bytes, then the
+                // order is 0x113322 (and 22 might be patched with register numbers).
+                // We need 11 to be patched (or the order changed, or the overall
+                // interface changed, etc.)
 
                 // Change the 0x05 (disp32) encoding to 0x04 (SIB)
                 assert((code & 0xFF00) == 0x0500);
@@ -11883,7 +11887,7 @@ BYTE* emitter::emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
             {
                 // So is this...
 
-                // SIB 0x25 means disp32
+                // And add the SIB (0x25 means disp32)
                 dst += emitOutputByte(dst, 0x25);
             }
         }

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -7528,9 +7528,15 @@ void emitter::emitIns_J(instruction ins,
     }
     else
     {
-        /* Only allow non-label jmps in prolog */
-        assert(emitPrologIG);
-        assert(emitPrologIG == emitCurIG);
+        /* Only allow non-label jmps in prolog or pre-prolog */
+#ifdef DEBUG
+        bool isInPrologIG = emitPrologIG && (emitPrologIG == emitCurIG);
+        bool isInPrePrologIG = false;
+#if defined(TARGET_AMD64)
+        isInPrePrologIG = emitPrePrologIG && (emitPrePrologIG == emitCurIG);
+#endif // defined(TARGET_AMD64)
+        assert(isInPrologIG || isInPrePrologIG);
+#endif
         assert(instrCount != 0);
     }
 
@@ -11935,7 +11941,7 @@ BYTE* emitter::emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
 
 #ifdef TARGET_AMD64
         // All static field and data section constant accesses should be marked as relocatable
-        noway_assert(id->idIsDspReloc());
+        //noway_assert(id->idIsDspReloc());
         dst += emitOutputLong(dst, 0);
 #else  // TARGET_X86
         dst += emitOutputLong(dst, (int)(ssize_t)target);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -11951,7 +11951,7 @@ BYTE* emitter::emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
 
 #ifdef TARGET_AMD64
         // All static field and data section constant accesses should be marked as relocatable
-        //noway_assert(id->idIsDspReloc());
+        //noway_assert(id->idIsDspReloc()); //?????
         dst += emitOutputLong(dst, 0);
 #else  // TARGET_X86
         dst += emitOutputLong(dst, (int)(ssize_t)target);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -5737,7 +5737,7 @@ void emitter::emitIns_R_C(instruction ins, emitAttr attr, regNumber reg, CORINFO
         }
 
         // Special case: mov reg, fs:[ddd]
-        if (fldHnd == FLD_GLOBAL_FS)
+        if ((fldHnd == FLD_GLOBAL_FS) || fldHnd == FLD_GLOBAL_GS)
         {
             sz += 1;
         }
@@ -5809,7 +5809,7 @@ void emitter::emitIns_C_R(instruction ins, emitAttr attr, CORINFO_FIELD_HANDLE f
     }
 
     // Special case: mov reg, fs:[ddd]
-    if (fldHnd == FLD_GLOBAL_FS)
+    if ((fldHnd == FLD_GLOBAL_FS) || (fldHnd == FLD_GLOBAL_GS))
     {
         sz += 1;
     }
@@ -8410,6 +8410,12 @@ void emitter::emitDispClsVar(CORINFO_FIELD_HANDLE fldHnd, ssize_t offs, bool rel
     if (fldHnd == FLD_GLOBAL_FS)
     {
         printf("FS:[0x%04X]", (unsigned)offs);
+        return;
+    }
+
+    if (fldHnd == FLD_GLOBAL_GS)
+    {
+        printf("GS:[0x%04X]", (unsigned)offs);
         return;
     }
 
@@ -11653,6 +11659,10 @@ BYTE* emitter::emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
     if (fldh == FLD_GLOBAL_FS)
     {
         dst += emitOutputByte(dst, 0x64);
+    }
+    else if (fldh == FLD_GLOBAL_GS)
+    {
+        dst += emitOutputByte(dst, 0x65);
     }
 
     // Compute VEX prefix

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -356,9 +356,10 @@ typedef double weight_t;
 
 // For the following specially handled FIELD_HANDLES we need
 //   values that are negative and have the low two bits zero
-// See eeFindJitDataOffs and eeGetJitDataOffs in Compiler.hpp
+// See eeFindJitDataOffs and eeGetJitDataOffs in ee_il_dll.cpp
 #define FLD_GLOBAL_DS ((CORINFO_FIELD_HANDLE)-4)
 #define FLD_GLOBAL_FS ((CORINFO_FIELD_HANDLE)-8)
+#define FLD_GLOBAL_GS ((CORINFO_FIELD_HANDLE)-12)
 
 class GlobalJitOptions
 {


### PR DESCRIPTION
Adds a notion of a "pre-prolog" to functions that does a bounds check on the stack and conditionally calls a helper to grow (copy) the stack region.  For now, this avoids allowing more than one prolog IG, but the handling is messy.  The pre-prolog must be added to place that require prolog-like processing.

Add support for encoding GS accesses - include the offset and avoid RIP-relative addressing.  (not sure if FS worked before)

Fix encoding of forward branches by N instructions.  (all previous jumps were backwards by N instructions for forward/backwards to a label)

TODO:
- Make this conditional on green threads being enabled
- Fix the helper call
- Any external requirements (like unwind)