### PR TITLE
More stackwalking fixes

### DIFF
--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -2264,6 +2264,10 @@ HRESULT CordbThread::CreateStackWalk(ICorDebugStackWalk ** ppStackWalk)
     FAIL_IF_NEUTERED(this);
     ATT_REQUIRE_STOPPED_MAY_FAIL(GetProcess());
 
+    // TODO: AndrewAu, It is observed that sometimes a thread was cached with the wrong
+    // Frame, but why?
+    GetProcess()->ForceDacFlush();
+
     VALIDATE_POINTER_TO_OBJECT(ppStackWalk, ICorDebugStackWalk **);
 
     HRESULT hr = S_OK;

--- a/src/coreclr/vm/greenthreads.cpp
+++ b/src/coreclr/vm/greenthreads.cpp
@@ -163,7 +163,8 @@ extern "C" uintptr_t FirstFrameInGreenThreadCpp(TransitionHelperFunction functio
     uintptr_t result = param->function(param->param);
 
     {
-        // TODO: Pop()
+        GCX_COOP();
+        f.Pop(GetThread());
     }
 
     t_greenThread.greenThreadStackCurrent = NULL;


### PR DESCRIPTION
Fixing more stack-walking related issues.

[This](https://github.com/dotnet/runtimelab/commit/be2df4a1e76cc1e44d9b1b702812232145982edd) commit was accidentally pushed to the feature branch directly, it wasn't ready. Please take a look at that change as well. This change in particular fixed some holes in that commit.

After this change, I tested invoking `!clrstack` like this `bm coreclr!*green* "k;!clrstack;g"`, it worked fine in the sense that upon manual inspection, the managed stack looks right that it includes the part before `GreenThreadStartFunc`.

This will require an SOS binary later than [this](https://github.com/dotnet/diagnostics/commit/6f412a6132d8517a196b696f98650e9e6bcb8dbe) commit.