### PR TITLE
NativeAOT-LLVM: add a dependency for the constructed eetype for newobj

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1909,16 +1909,9 @@ namespace Internal.IL
                         {
                             typeToAlloc = callee.OwningType;
 
-                            _dependencies.Add(_compilation.NodeFactory.ConstructedTypeSymbol(runtimeDeterminedRetType), "LLVM newobj");
+                            LLVMValueRef constructedEETypeValueRef = GetEETypePointerForTypeDesc(runtimeDeterminedRetType, true);
 
-                            MetadataType metadataType = (MetadataType)typeToAlloc;
-
-                            var helperId = _compilation.GetLdTokenHelperForType(metadataType);
-
-                            ISymbolNode node = _compilation.ComputeConstantLookup(helperId, metadataType);
-                            _dependencies.Add(node, "LLVM Type ptr");
-
-                            newObjResult = AllocateObject(new LoadExpressionEntry(StackValueKind.ValueType, "eeType", LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler), GetWellKnownType(WellKnownType.IntPtr)), typeToAlloc);
+                            newObjResult = AllocateObject(new LoadExpressionEntry(StackValueKind.ValueType, "eeType", constructedEETypeValueRef, GetWellKnownType(WellKnownType.IntPtr)), typeToAlloc);
                         }
 
                         //one for the real result and one to be consumed by ctor

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -1908,6 +1908,9 @@ namespace Internal.IL
                         else
                         {
                             typeToAlloc = callee.OwningType;
+
+                            _dependencies.Add(_compilation.NodeFactory.ConstructedTypeSymbol(runtimeDeterminedRetType), "LLVM newobj");
+
                             MetadataType metadataType = (MetadataType)typeToAlloc;
 
                             var helperId = _compilation.GetLdTokenHelperForType(metadataType);


### PR DESCRIPTION
This PR adds a dependency for the fully constructed EE type for a call to newobj.  Fixes the reflection free mode and #1992 