### PR TITLE
NatvieAOT-LLVM: Update the image for prepare-signed-artifacts.yml

### DIFF
--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -10,7 +10,7 @@ jobs:
   dependsOn: ${{ parameters.dependsOn }}
   pool:
     name: NetCore1ESPool-Internal
-    demands: ImageOverride -equals build.windows.10.amd64.vs2019
+    demands: ImageOverride -equals 1es-windows-2022
   # Double the default timeout.
   timeoutInMinutes: 180
   workspace:

--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -17,10 +17,11 @@ stages:
   - template: /eng/common/templates/job/publish-build-assets.yml
     parameters:
       publishUsingPipelines: true
+      publishAssetsImmediately: true
       dependsOn: PrepareSignedArtifacts
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+        demands: ImageOverride -equals 1es-windows-2022
 
 # Stages-based publishing entry point
 - template: /eng/common/templates/post-build/post-build.yml
@@ -34,6 +35,7 @@ stages:
     enableSigningValidation: false
     enableNugetValidation: false
     enableSourceLinkValidation: false
+    publishAssetsImmediately: true
     SDLValidationParameters:
       enable: false
       artifactNames:


### PR DESCRIPTION
This PR takes the change from upstream/runtime for the image used for publishing the nuget packages.  Should unblock #2073.

cc @SingleAccretion
cc @jkotas