### PR TITLE
[NativeAOT-LLVM] Initialize locals in codegen

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -214,7 +214,7 @@ private:
     void fillPhis();
 
     Value* getGenTreeValue(GenTree* node);
-    Value* consumeValue(GenTree* node, Type* targetLlvmType);
+    Value* consumeValue(GenTree* node, Type* targetLlvmType = nullptr);
     void mapGenTreeToValue(GenTree* node, Value* nodeValue);
 
     void startImportingNode();
@@ -225,10 +225,10 @@ private:
     void buildEmptyPhi(GenTreePhi* phi);
     void buildLocalField(GenTreeLclFld* lclFld);
     void buildLocalVarAddr(GenTreeLclVarCommon* lclVar);
-    void buildAdd(GenTree* node, Value* op1, Value* op2);
+    void buildAdd(GenTreeOp* node);
     void buildDiv(GenTree* node);
     void buildCast(GenTreeCast* cast);
-    void buildCmp(GenTree* node, Value* op1, Value* op2);
+    void buildCmp(GenTreeOp* node);
     void buildCnsDouble(GenTreeDblCon* node);
     void buildCnsInt(GenTree* node);
     void buildCnsLng(GenTree* node);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -171,7 +171,6 @@ private:
     Type* getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle);
     Type* getLlvmTypeForVarType(var_types type);
     Type* getLlvmTypeForLclVar(LclVarDsc* varDsc);
-    Type* getLlvmTypeForLclVar(GenTreeLclVar* lclVar);
     Type* getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
     Type* getLlvmTypeForParameterType(CORINFO_CLASS_HANDLE classHnd);
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -221,8 +221,8 @@ private:
     void startImportingNode();
     void visitNode(GenTree* node);
 
-    Value* localVar(GenTreeLclVar* lclVar);
-    void storeLocalVar(GenTreeLclVar* lclVar);
+    void buildLocalVar(GenTreeLclVar* lclVar);
+    void buildStoreLocalVar(GenTreeLclVar* lclVar);
     void buildEmptyPhi(GenTreePhi* phi);
     void buildLocalField(GenTreeLclFld* lclFld);
     void buildLocalVarAddr(GenTreeLclVarCommon* lclVar);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -47,17 +47,6 @@ struct OperandArgNum
     GenTree* operand;
 };
 
-struct LlvmArgInfo
-{
-    int          m_argIx; // -1 indicates not in the LLVM arg list, but on the shadow stack
-    unsigned int m_shadowStackOffset;
-
-    bool IsLlvmArg()
-    {
-        return m_argIx >= 0;
-    }
-};
-
 struct JitStdStringKeyFuncs : JitKeyFuncsDefEquals<std::string>
 {
     static unsigned GetHashCode(const std::string& val)
@@ -181,6 +170,7 @@ private:
     Type* getLlvmTypeForStruct(ClassLayout* classLayout);
     Type* getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle);
     Type* getLlvmTypeForVarType(var_types type);
+    Type* getLlvmTypeForLclVar(LclVarDsc* varDsc);
     Type* getLlvmTypeForLclVar(GenTreeLclVar* lclVar);
     Type* getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
     Type* getLlvmTypeForParameterType(CORINFO_CLASS_HANDLE classHnd);
@@ -219,7 +209,7 @@ public:
 
 private:
     void generateProlog();
-    void createAllocasForLocalsWithAddrOp();
+    void initializeLocals();
     void startImportingBasicBlock(BasicBlock* block);
     void endImportingBasicBlock(BasicBlock* block);
     void fillPhis();
@@ -287,7 +277,6 @@ private:
     bool isLlvmFrameLocal(LclVarDsc* varDsc);
     unsigned int getTotalRealLocalOffset();
     unsigned int getTotalLocalOffset();
-    LlvmArgInfo getLlvmArgInfoForArgIx(unsigned lclNum);
 };
 
 

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -444,7 +444,7 @@ void Llvm::visitNode(GenTree* node)
             buildLocalField(node->AsLclFld());
             break;
         case GT_LCL_VAR:
-            localVar(node->AsLclVar());
+            buildLocalVar(node->AsLclVar());
             break;
         case GT_LCL_VAR_ADDR:
         case GT_LCL_FLD_ADDR:
@@ -486,7 +486,7 @@ void Llvm::visitNode(GenTree* node)
             buildReturn(node);
             break;
         case GT_STORE_LCL_VAR:
-            storeLocalVar(node->AsLclVar());
+            buildStoreLocalVar(node->AsLclVar());
             break;
         case GT_STOREIND:
             buildStoreInd(node->AsStoreInd());
@@ -517,7 +517,7 @@ void Llvm::visitNode(GenTree* node)
 #endif // DEBUG
 }
 
-Value* Llvm::localVar(GenTreeLclVar* lclVar)
+void Llvm::buildLocalVar(GenTreeLclVar* lclVar)
 {
     Value*       llvmRef;
     unsigned int lclNum = lclVar->GetLclNum();
@@ -540,10 +540,9 @@ Value* Llvm::localVar(GenTreeLclVar* lclVar)
     }
 
     mapGenTreeToValue(lclVar, llvmRef);
-    return llvmRef;
 }
 
-void Llvm::storeLocalVar(GenTreeLclVar* lclVar)
+void Llvm::buildStoreLocalVar(GenTreeLclVar* lclVar)
 {
     Type*  destLlvmType = getLlvmTypeForLclVar(lclVar);
     Value* localValue   = nullptr;

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -233,11 +233,14 @@ Type* Llvm::getLlvmTypeForLclVar(LclVarDsc* varDsc)
     {
         return getLlvmTypeForStruct(varDsc->GetLayout());
     }
-    if (varDsc->TypeGet() == TYP_BLK)
-    {
-        assert(varDsc->lvExactSize != 0);
-        return llvm::ArrayType::get(Type::getInt8Ty(_llvmContext), varDsc->lvExactSize);
-    }
+    // TODO-LLVM: enable. Currently broken because RyuJit inserts RPI helpers for RPI methods,
+    // with a TYP_BLK frame variable, and then we also create an RPI wrapper stub, resulting
+    // in a double transition.
+    // if (varDsc->TypeGet() == TYP_BLK)
+    // {
+    //     assert(varDsc->lvExactSize != 0);
+    //     return llvm::ArrayType::get(Type::getInt8Ty(_llvmContext), varDsc->lvExactSize);
+    // }
     if (varDsc->lvCorInfoType != CORINFO_TYPE_UNDEF)
     {
         return getLlvmTypeForCorInfoType(varDsc->lvCorInfoType, varDsc->lvClassHnd);

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -92,8 +92,8 @@ Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
 {
     if (_llvmStructs->find(structHandle) == _llvmStructs->end())
     {
-        llvm::Type* llvmType;
-        unsigned    fieldAlignment;
+        Type* llvmType;
+        unsigned fieldAlignment;
 
         // LLVM thinks certain sizes of struct have a different calling convention than Clang does.
         // Treating them as ints fixes that and is more efficient in general
@@ -195,10 +195,10 @@ Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
 
 Type* Llvm::getLlvmTypeForVarType(var_types type)
 {
-    // TODO: Fill out with missing type mappings and when all code done via clrjit, default should fail with useful
-    // message
     switch (type)
     {
+        case TYP_VOID:
+            return Type::getVoidTy(_llvmContext);
         case TYP_BOOL:
         case TYP_BYTE:
         case TYP_UBYTE:
@@ -212,17 +212,18 @@ Type* Llvm::getLlvmTypeForVarType(var_types type)
         case TYP_LONG:
         case TYP_ULONG:
             return Type::getInt64Ty(_llvmContext);
-        case var_types::TYP_FLOAT:
+        case TYP_FLOAT:
             return Type::getFloatTy(_llvmContext);
-        case var_types::TYP_DOUBLE:
+        case TYP_DOUBLE:
             return Type::getDoubleTy(_llvmContext);
-        case TYP_BYREF:
         case TYP_REF:
+        case TYP_BYREF:
             return Type::getInt8PtrTy(_llvmContext);
-        case TYP_VOID:
-            return Type::getVoidTy(_llvmContext);
-        default:
+        case TYP_BLK:
+        case TYP_STRUCT:
             failFunctionCompilation();
+        default:
+            unreached();
     }
 }
 
@@ -232,6 +233,11 @@ Type* Llvm::getLlvmTypeForLclVar(LclVarDsc* varDsc)
     {
         return getLlvmTypeForStruct(varDsc->GetLayout());
     }
+    if (varDsc->TypeGet() == TYP_BLK)
+    {
+        assert(varDsc->lvExactSize != 0);
+        return llvm::ArrayType::get(Type::getInt8Ty(_llvmContext), varDsc->lvExactSize);
+    }
     if (varDsc->lvCorInfoType != CORINFO_TYPE_UNDEF)
     {
         return getLlvmTypeForCorInfoType(varDsc->lvCorInfoType, varDsc->lvClassHnd);
@@ -240,68 +246,22 @@ Type* Llvm::getLlvmTypeForLclVar(LclVarDsc* varDsc)
     return getLlvmTypeForVarType(varDsc->TypeGet());
 }
 
-Type* Llvm::getLlvmTypeForLclVar(GenTreeLclVar* lclVar)
-{
-    var_types nodeType = lclVar->TypeGet();
-
-    if (nodeType == TYP_STRUCT)
-    {
-        return getLlvmTypeForStruct(_compiler->lvaGetDesc(lclVar)->GetLayout());
-    }
-
-    return getLlvmTypeForVarType(nodeType);
-}
-
 Type* Llvm::getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd)
 {
     switch (corInfoType)
     {
-        case CorInfoType::CORINFO_TYPE_VOID:
-            return Type::getVoidTy(_llvmContext);
-
-        case CorInfoType::CORINFO_TYPE_BOOL:
-        case CorInfoType::CORINFO_TYPE_UBYTE:
-        case CorInfoType::CORINFO_TYPE_BYTE:
-            return Type::getInt8Ty(_llvmContext);
-
-        case CorInfoType::CORINFO_TYPE_SHORT:
-        case CorInfoType::CORINFO_TYPE_USHORT:
-            return Type::getInt16Ty(_llvmContext);
-
-        case CorInfoType::CORINFO_TYPE_INT:
-        case CorInfoType::CORINFO_TYPE_UINT:
-        case CorInfoType::CORINFO_TYPE_NATIVEINT:  // TODO: Wasm64 - what does NativeInt mean for Wasm64
-            return Type::getInt32Ty(_llvmContext);
-
-        case CorInfoType::CORINFO_TYPE_LONG:
-        case CorInfoType::CORINFO_TYPE_ULONG:
-            return Type::getInt64Ty(_llvmContext);
-
-        case CorInfoType::CORINFO_TYPE_FLOAT:
-            return Type::getFloatTy(_llvmContext);
-
-        case CorInfoType::CORINFO_TYPE_DOUBLE:
-            return Type::getDoubleTy(_llvmContext);
-
-        case CorInfoType::CORINFO_TYPE_PTR:
-        {
+        case CORINFO_TYPE_PTR:
             if (classHnd == NO_CLASS_HANDLE)
             {
                 return Type::getInt8Ty(_llvmContext)->getPointerTo();
             }
-
             return getLlvmTypeForParameterType(classHnd)->getPointerTo();
-        }
 
-        case CorInfoType::CORINFO_TYPE_BYREF:
-        case CorInfoType::CORINFO_TYPE_CLASS:
-            return Type::getInt8PtrTy(_llvmContext);
-
-        case CorInfoType::CORINFO_TYPE_VALUECLASS:
+        case CORINFO_TYPE_VALUECLASS:
             return getLlvmTypeForStruct(classHnd);
 
         default:
-            failFunctionCompilation();
+            return getLlvmTypeForVarType(JITtype2varType(corInfoType));
     }
 }
 

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -226,6 +226,20 @@ Type* Llvm::getLlvmTypeForVarType(var_types type)
     }
 }
 
+Type* Llvm::getLlvmTypeForLclVar(LclVarDsc* varDsc)
+{
+    if (varDsc->TypeGet() == TYP_STRUCT)
+    {
+        return getLlvmTypeForStruct(varDsc->GetLayout());
+    }
+    if (varDsc->lvCorInfoType != CORINFO_TYPE_UNDEF)
+    {
+        return getLlvmTypeForCorInfoType(varDsc->lvCorInfoType, varDsc->lvClassHnd);
+    }
+
+    return getLlvmTypeForVarType(varDsc->TypeGet());
+}
+
 Type* Llvm::getLlvmTypeForLclVar(GenTreeLclVar* lclVar)
 {
     var_types nodeType = lclVar->TypeGet();
@@ -234,6 +248,7 @@ Type* Llvm::getLlvmTypeForLclVar(GenTreeLclVar* lclVar)
     {
         return getLlvmTypeForStruct(_compiler->lvaGetDesc(lclVar)->GetLayout());
     }
+
     return getLlvmTypeForVarType(nodeType);
 }
 


### PR DESCRIPTION
When we have `opts.compInitMem` set to `true` (i. e. the default for C# without `SkipLocalsInit`), we need to zero-initialize non-temps. We also need to set the initial SSA values for use-before-def locals, and allocas, as otherwise we run into UB issues with LLVM.

This change fixes the above, modulo the requirement to zero-init locals with GC pointers, which will have to be done in lowering.

In doing this, it also cleans up the LLVM type system management a little and generalizes `buildAdd/buildCmp`, which gets us up to 70% coverage for the HellowWasm test.

Example C#/LLVM:
```cs
[MethodImpl(MethodImplOptions.NoInlining)]
private static double Problem()
{
    double a = *&a;
    double b = *&b;
    JitUse(&b);

    return a;
}
```
```llvm
define double @RyuJitReproduction_RyuJitReproduction_Program__Problem(i8* %0) {
Prolog:
  %1 = freeze double undef
  %2 = alloca double, align 8
  store double 0.000000e+00, double* %2, align 8
  br label %BB01

BB01:                                             ; preds = %Prolog
  %3 = load double, double* %2, align 8
  store double %3, double* %2, align 8
  %4 = getelementptr i8, i8* %0, i32 0
  call void @"RyuJitReproduction_RyuJitReproduction_Program__JitUse_0<Double>"(i8* %4, double* %2)
  ret double 0.000000e+00
}
```