### PR TITLE
[NativeAOT-LLMV] Implement `GT_LCLHEAP` codegen

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -228,6 +228,7 @@ private:
     void buildAdd(GenTreeOp* node);
     void buildDiv(GenTree* node);
     void buildCast(GenTreeCast* cast);
+    void buildLclHeap(GenTreeUnOp* lclHeap);
     void buildCmp(GenTreeOp* node);
     void buildCnsDouble(GenTreeDblCon* node);
     void buildCnsInt(GenTree* node);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -778,7 +778,7 @@ void Llvm::buildCmp(GenTreeOp* node)
                                    : (isUnordered ? Predicate::FCMP_UGE : Predicate::FCMP_OGE);
             break;
         case GT_GT:
-            predicate = isIntOrPtr ? (isUnordered ? Predicate::ICMP_UGT : Predicate::ICMP_SGT)
+            predicate = isIntOrPtr ? (isUnsigned ? Predicate::ICMP_UGT : Predicate::ICMP_SGT)
                                    : (isUnordered ? Predicate::FCMP_UGT : Predicate::FCMP_OGT);
             break;
         default:

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -31,6 +31,13 @@ void Llvm::Compile()
         return;
     }
 
+    // TODO-LLVM: enable. Currently broken because RyuJit inserts RPI helpers for RPI methods, then we
+    // also create an RPI wrapper stub, resulting in a double transition.
+    if (_compiler->opts.IsReversePInvoke())
+    {
+        failFunctionCompilation();
+    }
+
     if (_compiler->opts.compDbgInfo)
     {
         const char* documentFileName = GetDocumentFileName();

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -11,6 +11,13 @@
 //
 void Llvm::Lower()
 {
+    // TODO-LLVM: enable. Currently broken because RyuJit inserts RPI helpers for RPI methods, then we
+    // also create an RPI wrapper stub, resulting in a double transition.
+    if (_compiler->opts.IsReversePInvoke())
+    {
+        failFunctionCompilation();
+    }
+
     populateLlvmArgNums();
 
     _shadowStackLocalsSize = 0;

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -11,13 +11,6 @@
 //
 void Llvm::Lower()
 {
-    // TODO-LLVM: enable. Currently broken because RyuJit inserts RPI helpers for RPI methods, then we
-    // also create an RPI wrapper stub, resulting in a double transition.
-    if (_compiler->opts.IsReversePInvoke())
-    {
-        failFunctionCompilation();
-    }
-
     populateLlvmArgNums();
 
     _shadowStackLocalsSize = 0;

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -233,14 +233,11 @@ Type* Llvm::getLlvmTypeForLclVar(LclVarDsc* varDsc)
     {
         return getLlvmTypeForStruct(varDsc->GetLayout());
     }
-    // TODO-LLVM: enable. Currently broken because RyuJit inserts RPI helpers for RPI methods,
-    // with a TYP_BLK frame variable, and then we also create an RPI wrapper stub, resulting
-    // in a double transition.
-    // if (varDsc->TypeGet() == TYP_BLK)
-    // {
-    //     assert(varDsc->lvExactSize != 0);
-    //     return llvm::ArrayType::get(Type::getInt8Ty(_llvmContext), varDsc->lvExactSize);
-    // }
+    if (varDsc->TypeGet() == TYP_BLK)
+    {
+        assert(varDsc->lvExactSize != 0);
+        return llvm::ArrayType::get(Type::getInt8Ty(_llvmContext), varDsc->lvExactSize);
+    }
     if (varDsc->lvCorInfoType != CORINFO_TYPE_UNDEF)
     {
         return getLlvmTypeForCorInfoType(varDsc->lvCorInfoType, varDsc->lvClassHnd);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetRandomBytes.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -15,6 +16,7 @@ internal static partial class Interop
         internal static extern unsafe int GetCryptographicallySecureRandomBytes(byte* buffer, int length);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)] // TODO-LLVM: workaround for https://github.com/dotnet/runtimelab/issues/2095.
     internal static unsafe void GetRandomBytes(byte* buffer, int length)
     {
         Sys.GetNonCryptographicallySecureRandomBytes(buffer, length);


### PR DESCRIPTION
I. e. `stackalloc` in C# or `localloc` in IL. Reference implementation can be found in e. g. `codegenxarch.cpp, genLclHeap`. The tricky bit is ensuring we return a null pointer for zero-sized allocations.

Example C#/codegen:
```cs
[MethodImpl(MethodImplOptions.NoInlining)]
private static byte Problem(int size)
{
    var p = stackalloc byte[size];
    return *p;
}
```
```llvm
=============== Generating BB01 [000..006) (return), preds={} succs={} flags=0x00000000.20000020: i LIR
Generating:                [000004] ------------                 IL_OFFSET void   IL offset: 0x0
Generating: N001 (  3,  2) [000000] ------------         t0 =    LCL_VAR   int    V00 arg0         u:1 (last use) $80
                                                              /--*  t0     int
Generating: N002 (  4,  3) [000001] ---X---N----         t1 = *  LCLHEAP   int    $81
  %4 = alloca i8, i32 %1, align 8
  call void @llvm.memset.p0i8.i32(i8* align 8 %4, i8 0, i32 %1, i1 false)
  %5 = icmp ne i32 %1, 0
  %6 = select i1 %5, i8* %4, i8* null
                                                              /--*  t1     int
Generating: N003 (  8,  6) [000002] *--XG-------         t2 = *  IND       ubyte  <l:$1c1, c:$1c0>
  %7 = load i8, i8* %6, align 1
                                                              /--*  t2     ubyte
Generating: N004 (  9,  7) [000003] ---XG-------              *  RETURN    int    $82
  ret i8 %7
```

cc @yowl 