### PR TITLE
Add deep stack test, reduce standard stack depth, and fix the GC stackwalking problems

### DIFF
--- a/src/coreclr/inc/dacvars.h
+++ b/src/coreclr/inc/dacvars.h
@@ -229,5 +229,13 @@ DEFINE_DACVAR(SIZE_T, dac__g_clrNotificationArguments, ::g_clrNotificationArgume
 DEFINE_DACVAR(bool, dac__g_metadataUpdatesApplied, ::g_metadataUpdatesApplied)
 #endif
 
+#ifdef FEATURE_GREENTHREADS
+DEFINE_DACVAR(TADDR, dac__g_lowForceStackUnwind1, ::g_lowForceStackUnwind1)
+DEFINE_DACVAR(TADDR, dac__g_highForceStackUnwind1, ::g_highForceStackUnwind1)
+DEFINE_DACVAR(TADDR, dac__g_lowForceStackUnwind2, ::g_lowForceStackUnwind2)
+DEFINE_DACVAR(TADDR, dac__g_highForceStackUnwind2, ::g_highForceStackUnwind2)
+#endif
+
+
 #undef DEFINE_DACVAR
 #undef DEFINE_DACVAR_NO_DUMP

--- a/src/coreclr/inc/eetwain.h
+++ b/src/coreclr/inc/eetwain.h
@@ -35,7 +35,7 @@
 #define USE_GC_INFO_DECODER
 #endif
 
-#if (defined(TARGET_X86) && !defined(TARGET_UNIX)) || defined(TARGET_AMD64)
+#if (defined(TARGET_X86) && !defined(TARGET_UNIX)) // DISABLE FOR GREEN THREADS FOR NOW|| defined(TARGET_AMD64)
 #define HAS_QUICKUNWIND
 #endif
 

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -129,6 +129,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     versionresilienthashcode.cpp
     virtualcallstub.cpp
     zapsig.cpp
+    greenthreads.cpp
 )
 
 set(VM_HEADERS_DAC_AND_WKS_COMMON
@@ -371,7 +372,6 @@ set(VM_SOURCES_WKS
     typeparse.cpp
     weakreferencenative.cpp
     yieldprocessornormalized.cpp
-    greenthreads.cpp
     ${VM_SOURCES_GDBJIT}
 )
 

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -871,7 +871,7 @@ NESTED_END TransitionToOSThreadHelper, _TEXT
 ; onwards in execution with the green thread suspended. When the thread is resumed, it will jump to resume_point.
 NESTED_ENTRY YieldOutOfGreenThreadHelper, _TEXT
     PROLOG_WITH_TRANSITION_BLOCK
-    sub rdx, 0e8h         ; This should be the RSP before we did the transition to the OS thread
+    add rdx, 0e0h         ; This should be the RSP before we did the transition to the OS thread
     mov rbp, rdx          ; Set RBP to what it was before we transitioned to the green thread
 
     mov rdx, [rcx]        ; Get the latest OS thread stack limit from t_greenThread.osStackRange

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -815,6 +815,8 @@ NESTED_ENTRY _more_stack, _TEXT
         mov             rbp, [rbp - 50h]
         add rsp, 0e8h
         ret
+ALTERNATE_ENTRY _more_stack_end
+        nop
 NESTED_END _more_stack, _TEXT
 
 
@@ -1019,6 +1021,8 @@ JumpToMoreStack:
     add rsp, 28h
     ret
     jmp r11
+ALTERNATE_ENTRY JIT_GreenThreadMoreStack_end ; When yielding, we will jmp back to this location with the registers back in their original config
+    nop
 NESTED_END JIT_GreenThreadMoreStack, _TEXT
 
 

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -1021,7 +1021,7 @@ JumpToMoreStack:
     add rsp, 28h
     ret
     jmp r11
-ALTERNATE_ENTRY JIT_GreenThreadMoreStack_end ; When yielding, we will jmp back to this location with the registers back in their original config
+ALTERNATE_ENTRY JIT_GreenThreadMoreStack_end
     nop
 NESTED_END JIT_GreenThreadMoreStack, _TEXT
 

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -958,6 +958,9 @@ void SystemDomain::Attach()
 #ifdef FEATURE_TIERED_COMPILATION
     CallCountingStubManager::Init();
 #endif
+#ifdef FEATURE_GREENTHREADS
+    InitGreenThreads();
+#endif
 
     m_SystemDomainCrst.Init(CrstSystemDomain, (CrstFlags)(CRST_REENTRANCY | CRST_TAKEN_DURING_SHUTDOWN));
     m_DelayedUnloadCrst.Init(CrstSystemDomainDelayedUnloadList, CRST_UNSAFE_COOPGC);

--- a/src/coreclr/vm/greenthreads.cpp
+++ b/src/coreclr/vm/greenthreads.cpp
@@ -79,7 +79,7 @@ extern "C" uintptr_t AllocateMoreStackHelper(int argumentStackSize, void* stackP
                                                            // NOTE: This is putting a 64MB limit on argument size. I think this is OK.
         int stackSizeNeeded = 1 << stackSizeNeededSelector;
 
-        stackSizeNeeded = max(stackSizeNeeded, 0x200000);  // Hard code to 800KB for now. ... avoids dealing with actual segment overflows and GC stack walks and such.
+        stackSizeNeeded = max(stackSizeNeeded, 0x2000);  // Hard code to 8KB for now. ... avoids dealing with actual segment overflows and GC stack walks and such.
 
         int sizeOfRedZone = 0x1000;
 

--- a/src/coreclr/vm/greenthreads.h
+++ b/src/coreclr/vm/greenthreads.h
@@ -7,29 +7,50 @@
 
 struct StackRange
 {
-    uint8_t* stackLimit;
-    uint8_t* stackBase;
+    TADDR stackLimit;
+    TADDR stackBase;
 };
+
+struct GreenThreadStackList;
+typedef DPTR(GreenThreadStackList) PTR_GreenThreadStackList;
 
 struct GreenThreadStackList
 {
-    GreenThreadStackList *prev;
-    GreenThreadStackList *next;
+    PTR_GreenThreadStackList prev;
+    PTR_GreenThreadStackList next;
     StackRange stackRange;
-    int size;
+    int32_t size;
 };
 
 class GreenThread;
+typedef DPTR(GreenThread) PTR_GreenThread;
+
+struct SuspendedGreenThread;
+typedef DPTR(SuspendedGreenThread) PTR_SuspendedGreenThread;
 
 struct SuspendedGreenThread
 {
-    uint8_t* currentStackPointer;
-    GreenThreadStackList* currentThreadStackSegment;
-    Frame* greenThreadFrame;
-    GreenThread* pGreenThread;
-    SuspendedGreenThread* prev;
-    SuspendedGreenThread* next;
+    TADDR currentStackPointer;
+    PTR_GreenThreadStackList currentThreadStackSegment;
+    PTR_Frame greenThreadFrame;
+    PTR_GreenThread pGreenThread;
+    PTR_SuspendedGreenThread prev;
+    PTR_SuspendedGreenThread next;
 };
+
+struct GreenThreadData
+{
+    StackRange osStackRange;
+    TADDR osStackCurrent;
+    TADDR greenThreadStackCurrent;
+    PTR_Frame pFrameInGreenThread;
+    PTR_Frame pFrameInOSThread;
+    PTR_GreenThreadStackList pStackListCurrent;
+    bool greenThreadOnStack;
+    PTR_SuspendedGreenThread suspendedGreenThread;
+};
+
+typedef DPTR(GreenThreadData) PTR_GreenThreadData;
 
 typedef uintptr_t (*TakesOneParam)(uintptr_t param);
 typedef void (*TakesOneParamNoReturn)(uintptr_t param);
@@ -53,5 +74,9 @@ void CallOnOSThread(TakesOneParamNoReturn functionToExecute, uintptr_t param);
 // TODO: AndrewAu: Better naming
 extern SuspendedGreenThread green_head;
 extern SuspendedGreenThread green_tail;
+
+void InitGreenThreads();
+bool GreenThreadHelpersToSkip(TADDR code);
+bool stackPointerLessThan(Thread* thread, TADDR sp1, TADDR sp2);
 
 #endif // GREENTHREADS_H

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -611,6 +611,12 @@ PCODE Thread::VirtualUnwindCallFrame(T_CONTEXT* pContext,
     }
 #endif // !DACCESS_COMPILE
 
+    // ALWAYS skip past the morestack and JIT_GreenThreadMoreStack functions
+    if (GreenThreadHelpersToSkip(uControlPc))
+    {
+        uControlPc = VirtualUnwindCallFrame(pContext, pContextPointers, NULL);
+    }
+
     return uControlPc;
 }
 
@@ -1348,7 +1354,7 @@ BOOL StackFrameIterator::ResetRegDisp(PREGDISPLAY pRegDisp,
         while (m_crawl.pFrame != FRAME_TOP)
         {
             // this check is sufficient on WIN64
-            if (dac_cast<TADDR>(m_crawl.pFrame) >= curSP)
+            if (stackPointerLessThan(m_pThread, curSP, dac_cast<TADDR>(m_crawl.pFrame)))
             {
 #if defined(TARGET_X86)
                 // check the IP
@@ -2415,7 +2421,7 @@ StackWalkAction StackFrameIterator::NextRaw(void)
         // FaultingExceptionFrame is special case where it gets
         // pushed on the stack after the frame is running
         _ASSERTE((m_crawl.pFrame == FRAME_TOP) ||
-                 ((TADDR)GetRegdisplaySP(m_crawl.pRD) < dac_cast<TADDR>(m_crawl.pFrame)) ||
+                 (stackPointerLessThan(m_pThread, (TADDR)GetRegdisplaySP(m_crawl.pRD), dac_cast<TADDR>(m_crawl.pFrame))) ||
                  (m_crawl.pFrame->GetVTablePtr() == FaultingExceptionFrame::GetMethodFrameVPtr()));
 #endif // !defined(ELIMINATE_FEF)
 
@@ -2826,7 +2832,7 @@ void StackFrameIterator::ProcessCurrentFrame(void)
             //  the pContext.
             // There are still a few cases in which a FaultingExceptionFrame is linked in.  If
             //  the next frame is one of them, we don't want to override it.  THIS IS PROBABLY BAD!!!
-            if ( (pContextSP < dac_cast<TADDR>(m_crawl.pFrame)) &&
+            if ( (stackPointerLessThan(m_pThread, pContextSP, dac_cast<TADDR>(m_crawl.pFrame))) &&
                  ((m_crawl.GetFrame() == FRAME_TOP) ||
                   (m_crawl.GetFrame()->GetVTablePtr() != FaultingExceptionFrame::GetMethodFrameVPtr() ) ) )
             {
@@ -2977,7 +2983,7 @@ BOOL StackFrameIterator::CheckForSkippedFrames(void)
 #endif // PROCESS_EXPLICIT_FRAME_BEFORE_MANAGED_FRAME
 
     if ( !( (m_crawl.pFrame != FRAME_TOP) &&
-            (dac_cast<TADDR>(m_crawl.pFrame) < pvReferenceSP) )
+            (stackPointerLessThan(m_pThread, dac_cast<TADDR>(m_crawl.pFrame), pvReferenceSP)) )
        )
     {
         return FALSE;
@@ -2988,7 +2994,7 @@ BOOL StackFrameIterator::CheckForSkippedFrames(void)
     // We might have skipped past some Frames.
     // This happens with InlinedCallFrames.
     while ( (m_crawl.pFrame != FRAME_TOP) &&
-            (dac_cast<TADDR>(m_crawl.pFrame) < pvReferenceSP)
+            (stackPointerLessThan(m_pThread, dac_cast<TADDR>(m_crawl.pFrame), pvReferenceSP))
           )
     {
         BOOL fReportInteropMD =

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1429,6 +1429,7 @@ Thread::Thread()
     }
     CONTRACTL_END;
 
+    m_greenThreadData = NULL;
     m_curThreadBase = &m_coreThreadData;
     m_coreThreadData.m_currentThreadObj = this;
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2622,6 +2622,8 @@ public:
         m_ThrewControlForThread = 0;
     }
 
+    PTR_GreenThreadData m_greenThreadData;
+
     PTR_CONTEXT m_OSContext;    // ptr to a Context structure used to record the OS specific ThreadContext for a thread
                                 // this is used for thread stop/abort and is initialized on demand
 

--- a/src/coreclr/vm/vars.hpp
+++ b/src/coreclr/vm/vars.hpp
@@ -467,6 +467,12 @@ EXTERN Volatile<BOOL> g_fEEStarted;
 EXTERN BOOL g_fComStarted;
 #endif
 
+#ifdef FEATURE_GREENTHREADS
+GVAL_DECL(TADDR, g_lowForceStackUnwind1);
+GVAL_DECL(TADDR, g_lowForceStackUnwind2);
+GVAL_DECL(TADDR, g_highForceStackUnwind1);
+GVAL_DECL(TADDR, g_highForceStackUnwind2);
+#endif
 
 //
 // Global state variables indicating which stage of shutdown we are in

--- a/src/tests/baseservices/threading/greenthreads/deep/greenthread_deep.csproj
+++ b/src/tests/baseservices/threading/greenthreads/deep/greenthread_deep.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="simple.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/deep/simple.cs
+++ b/src/tests/baseservices/threading/greenthreads/deep/simple.cs
@@ -19,18 +19,43 @@ public class Test_greenthread_delay {
     }
 
     static int printedout = 0;
+    class TempObj
+    {
+        static int tempObjs;
+        public TempObj()
+        {
+            o = Interlocked.Increment(ref tempObjs);
+        }
+        public object o;
+    }
+
+    static TempObj tmpObjStore;
+
     static void Deep(int moredeep)
     {
+        TempObj tmp = new TempObj();
+        tmpObjStore = tmp;
+        object objLocal = tmp.o;
+        int localNumVal = (int)objLocal;
+
         if (moredeep <= 0)
         {
             printedout++;
             Console.WriteLine("SuperDeep");
+            GC.Collect();
             Task.Delay(2000).Wait();
             Console.WriteLine("SuperDeepResumed");
             return;
         }
+
         Deep(moredeep - 1);
         if (printedout < 10)
             Deep(moredeep - 1);
+
+        if (localNumVal != (int)objLocal)
+            Console.WriteLine("GC fail");
+
+        if (!Object.ReferenceEquals(objLocal, tmp.o))
+            Console.WriteLine("GC fail2");
     }
 }

--- a/src/tests/baseservices/threading/greenthreads/deep/simple.cs
+++ b/src/tests/baseservices/threading/greenthreads/deep/simple.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_delay {
+
+    public static int Main() {
+
+        var t = Task.RunAsGreenThread(() =>
+        {
+            Deep(2000);
+        });
+
+        t.Wait();
+        return 100;
+    }
+
+    static int printedout = 0;
+    static void Deep(int moredeep)
+    {
+        if (moredeep <= 0)
+        {
+            printedout++;
+            Console.WriteLine("SuperDeep");
+            Task.Delay(2000).Wait();
+            Console.WriteLine("SuperDeepResumed");
+            return;
+        }
+        Deep(moredeep - 1);
+        if (printedout < 10)
+            Deep(moredeep - 1);
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/delay/simple.cs
+++ b/src/tests/baseservices/threading/greenthreads/delay/simple.cs
@@ -14,6 +14,8 @@ public class Test_greenthread_delay {
             Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
             Task.Delay(2000).Wait();
             Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
+            Task.Delay(2000).Wait();
+            Console.WriteLine($"In GreenThread {Thread.IsGreenThread}");
         });
 
         t.Wait();


### PR DESCRIPTION
- Reduce the minimum stack size for a green thread stack segment
  - This caused broken stackwalking to become evident, so I then fixed THAT
  - 
- Add new concept for stack pointer comparison (courtesy of @cshung)
- Always unwind through _more_stack and JIT_GreenThreadMoreStack
 - To simplify the implementation, I've disabled QuickUnwind (I'm not sure if this is necessary, but it appears like it might be)
 - This allows the stackwalker to ignore the existence of these frames
- DACize a bunch of the green thread data structures so that the updates to the stackwalker work