### PR TITLE
[NativeAOT-LLVM] Zero-init locals on the shadow stack, simplify lowering code, allow STRUCT-typed PHIs

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6451,11 +6451,10 @@ GenTree* Compiler::gtNewOneConNode(var_types type)
 GenTreeLclVar* Compiler::gtNewStoreLclVar(unsigned dstLclNum, GenTree* src)
 {
     LclVarDsc*     varDsc = lvaGetDesc(dstLclNum);
-    var_types      type   = varDsc->lvNormalizeOnStore() ? genActualType(varDsc) : varDsc->TypeGet();
+    var_types      type   = varDsc->lvNormalizeOnLoad() ? varDsc->TypeGet() : genActualType(varDsc);
     GenTreeLclVar* store  = new (this, GT_STORE_LCL_VAR) GenTreeLclVar(GT_STORE_LCL_VAR, type, dstLclNum);
     store->gtOp1          = src;
-    store->gtFlags        = (src->gtFlags & GTF_COMMON_MASK);
-    store->gtFlags |= GTF_VAR_DEF | GTF_ASG;
+    store->gtFlags |= (GTF_VAR_DEF | GTF_ASG | (src->gtFlags & GTF_ALL_EFFECT));
     return store;
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6450,9 +6450,11 @@ GenTree* Compiler::gtNewOneConNode(var_types type)
 
 GenTreeLclVar* Compiler::gtNewStoreLclVar(unsigned dstLclNum, GenTree* src)
 {
-    GenTreeLclVar* store = new (this, GT_STORE_LCL_VAR) GenTreeLclVar(GT_STORE_LCL_VAR, src->TypeGet(), dstLclNum);
-    store->gtOp1         = src;
-    store->gtFlags       = (src->gtFlags & GTF_COMMON_MASK);
+    LclVarDsc*     varDsc = lvaGetDesc(dstLclNum);
+    var_types      type   = varDsc->lvNormalizeOnStore() ? genActualType(varDsc) : varDsc->TypeGet();
+    GenTreeLclVar* store  = new (this, GT_STORE_LCL_VAR) GenTreeLclVar(GT_STORE_LCL_VAR, type, dstLclNum);
+    store->gtOp1          = src;
+    store->gtFlags        = (src->gtFlags & GTF_COMMON_MASK);
     store->gtFlags |= GTF_VAR_DEF | GTF_ASG;
     return store;
 }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -7618,13 +7618,13 @@ void Compiler::lvaTableDump(FrameLayoutState curState)
         printf(" [%2s%1s0x%02X]\n", isFramePointerUsed() ? STR_FPBASE : STR_SPBASE, (offset < 0 ? "-" : "+"),
                (offset < 0 ? -offset : offset));
     }
+#endif // !TARGET_WASM
 
     if (curState >= TENTATIVE_FRAME_LAYOUT)
     {
         printf(";\n");
         printf("; Lcl frame size = %d\n", compLclFrameSize);
     }
-#endif // !TARGET_WASM
 }
 #endif // DEBUG
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -205,6 +205,7 @@ private:
 
     GenTree* createStoreNode(var_types nodeType, GenTree* addr, GenTree* data);
     GenTree* createShadowStackStoreNode(var_types storeType, GenTree* addr, GenTree* data);
+    GenTree* insertShadowStackAddr(GenTree* insertBefore, ssize_t offset);
 
     // ================================================================================================================
     // |                                                   Codegen                                                    |

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -285,7 +285,6 @@ private:
     llvm::BasicBlock* getLLVMBasicBlockForBlock(BasicBlock* block);
 
     bool isLlvmFrameLocal(LclVarDsc* varDsc);
-    unsigned int getTotalRealLocalOffset();
     unsigned int getTotalLocalOffset();
 };
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -184,8 +184,12 @@ public:
     void Lower();
 
 private:
-    void populateLlvmArgNums();
+    void lowerLocals();
     void lowerBlocks();
+
+    void populateLlvmArgNums();
+    void assignShadowStackOffsets(std::vector<LclVarDsc*>& shadowStackLocals, unsigned shadowStackParamCount);
+    void initializeLocalInProlog(unsigned lclNum, GenTree* value);
 
     void lowerStoreLcl(GenTreeLclVarCommon* storeLclNode);
     void lowerFieldOfDependentlyPromotedStruct(GenTree* node);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -596,8 +596,12 @@ void Llvm::buildStoreLocalVar(GenTreeLclVar* lclVar)
 // in case we haven't seen the phi args yet, create just the phi nodes and fill in the args at the end
 void Llvm::buildEmptyPhi(GenTreePhi* phi)
 {
-    llvm::PHINode* llvmPhiNode = _builder.CreatePHI(getLlvmTypeForVarType(phi->TypeGet()), 2);
+    LclVarDsc* varDsc = _compiler->lvaGetDesc(phi->Uses().begin()->GetNode()->AsPhiArg());
+    Type* lclLlvmType = getLlvmTypeForLclVar(varDsc);
+
+    llvm::PHINode* llvmPhiNode = _builder.CreatePHI(lclLlvmType, 2);
     _phiPairs.push_back({ phi, llvmPhiNode });
+
     mapGenTreeToValue(phi, llvmPhiNode);
 }
 

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1785,13 +1785,8 @@ bool Llvm::isLlvmFrameLocal(LclVarDsc* varDsc)
     return !varDsc->lvInSsa && varDsc->lvRefCnt() > 0;
 }
 
-unsigned int Llvm::getTotalRealLocalOffset()
-{
-    return _shadowStackLocalsSize;
-}
-
 unsigned int Llvm::getTotalLocalOffset()
 {
-    unsigned int offset = getTotalRealLocalOffset();
-    return AlignUp(offset, TARGET_POINTER_SIZE);
+    assert((_shadowStackLocalsSize % TARGET_POINTER_SIZE) == 0);
+    return _shadowStackLocalsSize;
 }

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1309,6 +1309,13 @@ void Llvm::buildReturn(GenTree* node)
     }
     else
     {
+        retValValue = getGenTreeValue(retValNode);
+        // TODO-LLVM: lower these cases away.
+        if (retValValue->getType()->isStructTy() && (retValValue->getType() != retLlvmType))
+        {
+            failFunctionCompilation();
+        }
+
         retValValue = consumeValue(retValNode, retLlvmType);
     }
 

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1313,13 +1313,6 @@ void Llvm::buildReturn(GenTree* node)
     }
     else
     {
-        retValValue = getGenTreeValue(retValNode);
-        // TODO-LLVM: lower these cases away.
-        if (retValValue->getType()->isStructTy() && (retValValue->getType() != retLlvmType))
-        {
-            failFunctionCompilation();
-        }
-
         retValValue = consumeValue(retValNode, retLlvmType);
     }
 


### PR DESCRIPTION
A few changes enhancing our support for locals:
1) Allow struct PHIs (simple fix to use the right `getLlvmTypeFor*` method).
2) Zero-initialize locals on the shadow stack.
3) Do not create no-op `ADD(SS, 0)` nodes: centralize and simplify code.
4) Finally, fix the layout dumping code to not print locals not on the shadow stack as `[SS+00H]`, as well as print the total size of the shadow frame.