### PR TITLE
[NativeAOT-LLVM] Expand support for indirections

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -11,7 +11,6 @@
 LLVMContext      _llvmContext;
 Module*          _module            = nullptr;
 llvm::DIBuilder* _diBuilder         = nullptr;
-Function*        _nullCheckFunction = nullptr;
 char*            _outputFileName;
 Function*        _doNothingFunction;
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -74,7 +74,6 @@ struct PhiPair
 extern Module*                                                _module;
 extern llvm::DIBuilder*                                       _diBuilder;
 extern LLVMContext                                            _llvmContext;
-extern Function*                                              _nullCheckFunction;
 extern Function*                                              _doNothingFunction;
 extern std::unordered_map<CORINFO_CLASS_HANDLE, Type*>*       _llvmStructs;
 extern std::unordered_map<CORINFO_CLASS_HANDLE, StructDesc*>* _structDescMap;
@@ -237,8 +236,8 @@ private:
     void buildHelperFuncCall(GenTreeCall* call);
     void buildUserFuncCall(GenTreeCall* call);
     Value* buildFieldList(GenTreeFieldList* fieldList, Type* llvmType);
-    void buildInd(GenTree* node, Value* ptr);
-    void buildObj(GenTreeObj* node);
+    void buildInd(GenTreeIndir* indNode);
+    void buildBlk(GenTreeBlk* blkNode);
     void buildStoreInd(GenTreeStoreInd* storeIndOp);
     void buildStoreBlk(GenTreeBlk* blockOp);
     void buildUnaryOperation(GenTree* node);
@@ -246,11 +245,12 @@ private:
     void buildShift(GenTreeOp* node);
     void buildReturn(GenTree* node);
     void buildJTrue(GenTree* node, Value* opValue);    
-    void buildNullCheck(GenTreeUnOp* nullCheckNode);
+    void buildNullCheck(GenTreeIndir* nullCheckNode);
 
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
     void emitDoNothingCall();
+    void emitNullCheckForIndir(GenTreeIndir* indir, Value* addrValue);
     void buildThrowException(llvm::IRBuilder<>& builder, const char* helperClass, const char* helperMethodName, Value* shadowStack);
     void buildLlvmCallOrInvoke(llvm::Function* callee, llvm::ArrayRef<Value*> args);
 
@@ -263,6 +263,7 @@ private:
     Value* getOrCreateExternalSymbol(const char* symbolName, Type* symbolType = nullptr);
     Function* getOrCreateRhpAssignRef();
     Function* getOrCreateRhpCheckedAssignRef();
+    Function* getOrCreateThrowIfNullFunction();
 
     llvm::Instruction* getCast(llvm::Value* source, Type* targetType);
     Value* castIfNecessary(Value* source, Type* targetType, llvm::IRBuilder<>* builder = nullptr);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -191,13 +191,16 @@ private:
     void lowerFieldOfDependentlyPromotedStruct(GenTree* node);
     void ConvertShadowStackLocalNode(GenTreeLclVarCommon* node);
     void lowerStoreBlk(GenTreeBlk* storeBlkNode);
+    void lowerReturn(GenTreeUnOp* retNode);
 
     void lowerCallToShadowStack(GenTreeCall* callNode);
     void failUnsupportedCalls(GenTreeCall* callNode);
     GenTreeCall::Use* lowerCallReturn(GenTreeCall* callNode, GenTreeCall::Use* lastArg);
 
-    GenTree* createStoreNode(var_types nodeType, GenTree* addr, GenTree* data, ClassLayout* structClassLayout = nullptr);
-    GenTree* createShadowStackStoreNode(var_types nodeType, GenTree* addr, GenTree* data, ClassLayout* structClassLayout);
+    void normalizeStructUse(GenTree* node, ClassLayout* layout);
+
+    GenTree* createStoreNode(var_types nodeType, GenTree* addr, GenTree* data);
+    GenTree* createShadowStackStoreNode(var_types storeType, GenTree* addr, GenTree* data);
 
     // ================================================================================================================
     // |                                                   Codegen                                                    |

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -190,6 +190,7 @@ private:
     void lowerStoreLcl(GenTreeLclVarCommon* storeLclNode);
     void lowerFieldOfDependentlyPromotedStruct(GenTree* node);
     void ConvertShadowStackLocalNode(GenTreeLclVarCommon* node);
+    void lowerStoreBlk(GenTreeBlk* storeBlkNode);
 
     void lowerCallToShadowStack(GenTreeCall* callNode);
     void failUnsupportedCalls(GenTreeCall* callNode);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1135,7 +1135,6 @@ void Llvm::buildInd(GenTreeIndir* indNode)
 
 void Llvm::buildBlk(GenTreeBlk* blkNode)
 {
-    // TODO-LLVM: lower away zero-sized BLKs.
     Type* blkLlvmType = getLlvmTypeForStruct(blkNode->GetLayout());
     Value* addrValue = consumeValue(blkNode->Addr(), blkLlvmType->getPointerTo());
 
@@ -1183,7 +1182,6 @@ void Llvm::buildStoreBlk(GenTreeBlk* blockOp)
     GenTree* dataNode = blockOp->Data();
     Value* addrValue = consumeValue(addrNode, Type::getInt8PtrTy(_llvmContext));
 
-    // TODO-LLVM: lower away zero-sized STORE_BLKs.
     emitNullCheckForIndir(blockOp, addrValue);
 
     // Check for the "initblk" operation ("dataNode" is either INIT_VAL or constant zero).

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -378,6 +378,7 @@ void Llvm::ConvertShadowStackLocalNode(GenTreeLclVarCommon* node)
         {
             node->ChangeOper(indirOper);
             node->AsIndir()->SetAddr(lclAddress);
+            node->gtFlags |= GTF_IND_NONFAULTING;
         }
         if (GenTree::OperIsStore(indirOper))
         {
@@ -680,13 +681,15 @@ GenTree* Llvm::createStoreNode(var_types nodeType, GenTree* addr, GenTree* data,
     {
         storeNode = new (_compiler, GT_STOREIND) GenTreeStoreInd(nodeType, addr, data);
     }
+    storeNode->gtFlags |= GTF_ASG;
+
     return storeNode;
 }
 
 GenTree* Llvm::createShadowStackStoreNode(var_types nodeType, GenTree* addr, GenTree* data, ClassLayout* structClassLayout)
 {
     GenTree* storeNode = createStoreNode(nodeType, addr, data, structClassLayout);
-    storeNode->gtFlags |= GTF_IND_TGT_NOT_HEAP;
+    storeNode->gtFlags |= (GTF_IND_TGT_NOT_HEAP | GTF_IND_NONFAULTING);
 
     return storeNode;
 }

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -400,6 +400,16 @@ void Llvm::lowerStoreBlk(GenTreeBlk* storeBlkNode)
             }
         }
     }
+
+    // A zero-sized block store is a no-op. Lower it away.
+    if (storeBlkNode->Size() == 0)
+    {
+        assert(storeBlkNode->OperIsInitBlkOp() || storeBlkNode->Data()->OperIs(GT_BLK));
+
+        storeBlkNode->Addr()->SetUnusedValue();
+        CurrentRange().Remove(storeBlkNode->Data(), /* markOperandsUnused */ true);
+        CurrentRange().Remove(storeBlkNode);
+    }
 }
 
 void Llvm::lowerReturn(GenTreeUnOp* retNode)

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -636,7 +636,9 @@ GenTreeCall::Use* Llvm::lowerCallReturn(GenTreeCall*      callNode,
         {
             indirNode = _compiler->gtNewIndir(callReturnType, returnAddrLclAfterCall);
         }
-        indirNode->gtFlags |= GTF_IND_TGT_NOT_HEAP; // No RhpAssignRef required
+        indirNode->gtFlags |= GTF_IND_NONFAULTING;
+        indirNode->SetAllEffectsFlags(GTF_EMPTY);
+
         LIR::Use callUse;
         if (CurrentRange().TryGetUse(callNode, &callUse))
         {

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -209,22 +209,9 @@ void Llvm::lowerBlocks()
             {
                 lowerStoreBlk(node->AsBlk());
             }
-            else if (node->OperIs(GT_RETURN) && (_retAddressLclNum != BAD_VAR_NUM))
+            else if (node->OperIs(GT_RETURN))
             {
-                var_types originalReturnType = node->TypeGet();
-                LclVarDsc* retAddressVarDsc = _compiler->lvaGetDesc(_retAddressLclNum);
-                retAddressVarDsc->lvIsParam = 1;
-                retAddressVarDsc->lvType = TYP_I_IMPL;
-
-                GenTreeLclVar* retAddressLocal = _compiler->gtNewLclvNode(_retAddressLclNum, TYP_I_IMPL);
-                GenTree* storeNode = createShadowStackStoreNode(originalReturnType, retAddressLocal, node->AsOp()->gtGetOp1(),
-                                                                originalReturnType == TYP_STRUCT ? _compiler->typGetObjLayout(_sigInfo.retTypeClass) : nullptr);
-
-                GenTreeOp* retNode = node->AsOp();
-                retNode->gtOp1 = nullptr;
-                node->ChangeType(TYP_VOID);
-
-                CurrentRange().InsertBefore(node, retAddressLocal, storeNode);
+                lowerReturn(node->AsUnOp());
             }
 
             if (node->OperIsLocalAddr() || node->OperIsLocalField())
@@ -241,11 +228,11 @@ void Llvm::lowerBlocks()
 void Llvm::lowerStoreLcl(GenTreeLclVarCommon* storeLclNode)
 {
     LclVarDsc* addrVarDsc = _compiler->lvaGetDesc(storeLclNode->GetLclNum());
+    GenTree* data = storeLclNode->gtGetOp1();
 
     if (addrVarDsc->CanBeReplacedWithItsField(_compiler))
     {
         ClassLayout* layout      = addrVarDsc->GetLayout();
-        GenTree*     data        = storeLclNode->gtGetOp1();
         var_types    addrVarType = addrVarDsc->TypeGet();
 
         storeLclNode->SetOper(GT_LCL_VAR_ADDR);
@@ -258,40 +245,9 @@ void Llvm::lowerStoreLcl(GenTreeLclVarCommon* storeLclNode)
         CurrentRange().InsertAfter(storeLclNode, storeObjNode);
     }
 
-    if (storeLclNode->TypeIs(TYP_STRUCT))
+    if (storeLclNode->TypeIs(TYP_STRUCT) && data->TypeIs(TYP_STRUCT))
     {
-        GenTree* dataOp = storeLclNode->gtGetOp1();
-        CORINFO_CLASS_HANDLE dataHandle = _compiler->gtGetStructHandleIfPresent(dataOp);
-        if (dataOp->OperIs(GT_IND))
-        {
-            // Special case: "gtGetStructHandleIfPresent" sometimes guesses the handle from
-            // field sequences, but we will always need to transform TYP_STRUCT INDs into OBJs.
-            dataHandle = NO_CLASS_HANDLE;
-        }
-
-        if (addrVarDsc->GetStructHnd() != dataHandle)
-        {
-            if (dataOp->OperIsIndir())
-            {
-                dataOp->SetOper(GT_OBJ);
-                dataOp->AsObj()->SetLayout(addrVarDsc->GetLayout());
-            }
-            else if (dataOp->OperIs(GT_LCL_VAR)) // can get icon 0 here
-            {
-                GenTreeLclVarCommon* dataLcl = dataOp->AsLclVarCommon();
-                LclVarDsc* dataVarDsc = _compiler->lvaGetDesc(dataLcl->GetLclNum());
-
-                dataVarDsc->lvHasLocalAddr = 1;
-
-                GenTree* dataAddrNode = _compiler->gtNewLclVarAddrNode(dataLcl->GetLclNum());
-
-                dataLcl->ChangeOper(GT_OBJ);
-                dataLcl->AsObj()->SetAddr(dataAddrNode);
-                dataLcl->AsObj()->SetLayout(addrVarDsc->GetLayout());
-
-                CurrentRange().InsertBefore(dataLcl, dataAddrNode);
-            }
-        }
+        normalizeStructUse(data, addrVarDsc->GetLayout());
     }
 }
 
@@ -446,6 +402,27 @@ void Llvm::lowerStoreBlk(GenTreeBlk* storeBlkNode)
     }
 }
 
+void Llvm::lowerReturn(GenTreeUnOp* retNode)
+{
+    GenTree* retVal = retNode->gtGetOp1();
+    if (retNode->TypeIs(TYP_STRUCT) && retVal->TypeIs(TYP_STRUCT))
+    {
+        normalizeStructUse(retVal, _compiler->typGetObjLayout(_sigInfo.retTypeClass));
+    }
+
+    if (_retAddressLclNum != BAD_VAR_NUM)
+    {
+        LclVarDsc* retAddressVarDsc = _compiler->lvaGetDesc(_retAddressLclNum);
+        GenTreeLclVar* retAddressLocal = _compiler->gtNewLclvNode(_retAddressLclNum, TYP_I_IMPL);
+        GenTree* storeNode = createShadowStackStoreNode(retNode->TypeGet(), retAddressLocal, retVal);
+
+        retNode->gtOp1 = nullptr;
+        retNode->ChangeType(TYP_VOID);
+
+        CurrentRange().InsertBefore(retNode, retAddressLocal, storeNode);
+    }
+}
+
 //------------------------------------------------------------------------
 // lowerCallToShadowStack: Lower the call, rewriting its arguments.
 //
@@ -551,7 +528,7 @@ void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
                                                  TYP_I_IMPL);
                     GenTree* fieldSlotAddr =
                         _compiler->gtNewOperNode(GT_ADD, TYP_I_IMPL, lclShadowStack, fieldOffset);
-                    GenTree* fieldStoreNode = createShadowStackStoreNode(use.GetType(), fieldSlotAddr, use.GetNode(), nullptr);
+                    GenTree* fieldStoreNode = createShadowStackStoreNode(use.GetType(), fieldSlotAddr, use.GetNode());
 
                     CurrentRange().InsertBefore(callNode, lclShadowStack, fieldOffset, fieldSlotAddr,
                                                 fieldStoreNode);
@@ -566,10 +543,7 @@ void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
                     _compiler->gtNewIconNode(_shadowStackLocalsSize + shadowStackUseOffest, TYP_I_IMPL);
                 GenTree* slotAddr  = _compiler->gtNewOperNode(GT_ADD, TYP_I_IMPL, lclShadowStack, offset);
 
-                GenTree* storeNode = createShadowStackStoreNode(opAndArg.operand->TypeGet(), slotAddr, opAndArg.operand,
-                                                                corInfoType == CORINFO_TYPE_VALUECLASS
-                                                                ? _compiler->typGetObjLayout(clsHnd)
-                                                                : nullptr);
+                GenTree* storeNode = createShadowStackStoreNode(opAndArg.operand->TypeGet(), slotAddr, opAndArg.operand);
                 CurrentRange().InsertBefore(callNode, lclShadowStack, offset, slotAddr, storeNode);
             }
 
@@ -714,25 +688,110 @@ GenTreeCall::Use* Llvm::lowerCallReturn(GenTreeCall*      callNode,
     return lastArg;
 }
 
-GenTree* Llvm::createStoreNode(var_types nodeType, GenTree* addr, GenTree* data, ClassLayout* structClassLayout)
+//------------------------------------------------------------------------
+// normalizeStructUse: Retype "node" to have the exact type of "layout".
+//
+// LLVM has a strict constraint on uses and users of structs: they must
+// have the exact same type, while IR only requires "layout compatibility".
+// So in lowering we retype uses (and users) to match LLVM's expectations.
+//
+// Arguments:
+//    node   - The struct node to retype
+//    layout - The target layout
+//
+void Llvm::normalizeStructUse(GenTree* node, ClassLayout* layout)
 {
-    GenTree* storeNode;
-    if (nodeType == TYP_STRUCT)
+    // Note on SIMD: we will support it in codegen via bitcasts.
+    assert(node->TypeIs(TYP_STRUCT));
+
+    // "IND<struct>" nodes always need to be normalized.
+    if (node->OperIs(GT_IND))
     {
-        storeNode = new (_compiler, GT_STORE_OBJ) GenTreeObj(nodeType, addr, data, structClassLayout);
+        node->SetOper(GT_BLK);
+        node->AsBlk()->SetLayout(layout);
+        node->AsBlk()->gtBlkOpKind = GenTreeBlk::BlkOpKindInvalid;
     }
     else
     {
-        storeNode = new (_compiler, GT_STOREIND) GenTreeStoreInd(nodeType, addr, data);
+        CORINFO_CLASS_HANDLE useHandle = _compiler->gtGetStructHandleIfPresent(node);
+
+        // Note both can be blocks ("NO_CLASS_HANDLE"), in which case we don't need to do anything.
+        if (useHandle != layout->GetClassHandle())
+        {
+            switch (node->OperGet())
+            {
+                case GT_BLK:
+                case GT_OBJ:
+                    node->AsBlk()->SetLayout(layout);
+                    if (layout->IsBlockLayout() && node->OperIs(GT_OBJ))
+                    {
+                        // OBJ nodes cannot have block layouts.
+                        node->SetOper(GT_BLK);
+                    }
+                    break;
+
+                case GT_LCL_VAR:
+                {
+                    unsigned lclNum = node->AsLclVarCommon()->GetLclNum();
+                    GenTree* lclAddrNode = _compiler->gtNewLclVarAddrNode(lclNum);
+                    _compiler->lvaGetDesc(lclNum)->lvHasLocalAddr = true;
+
+                    node->ChangeOper(GT_OBJ);
+                    node->AsObj()->SetAddr(lclAddrNode);
+                    node->AsObj()->SetLayout(layout);
+                    node->AsObj()->gtBlkOpKind = GenTreeBlk::BlkOpKindInvalid;
+
+                    CurrentRange().InsertBefore(node, lclAddrNode);
+                }
+                break;
+
+                case GT_CALL:
+                    // TODO-LLVM: implement by spilling to a local.
+                    failFunctionCompilation();
+
+                case GT_LCL_FLD:
+                    // TODO-LLVM: handle by altering the layout once enough of upstream is merged.
+                    failFunctionCompilation();
+
+                default:
+                    unreached();
+            }
+        }
+    }
+}
+
+GenTree* Llvm::createStoreNode(var_types storeType, GenTree* addr, GenTree* data)
+{
+    assert(data->TypeIs(TYP_STRUCT) == (storeType == TYP_STRUCT));
+
+    GenTree* storeNode;
+    if (storeType == TYP_STRUCT)
+    {
+        ClassLayout* layout;
+        // TODO-LLVM: use "GenTree::GetLayout" once enough of upstream is merged.
+        if (data->OperIsBlk())
+        {
+            layout = data->AsBlk()->GetLayout();
+        }
+        else
+        {
+            layout = _compiler->typGetObjLayout(_compiler->gtGetStructHandle(data));
+        }
+
+        storeNode = new (_compiler, GT_STORE_BLK) GenTreeBlk(GT_STORE_BLK, storeType, addr, data, layout);
+    }
+    else
+    {
+        storeNode = new (_compiler, GT_STOREIND) GenTreeStoreInd(storeType, addr, data);
     }
     storeNode->gtFlags |= GTF_ASG;
 
     return storeNode;
 }
 
-GenTree* Llvm::createShadowStackStoreNode(var_types nodeType, GenTree* addr, GenTree* data, ClassLayout* structClassLayout)
+GenTree* Llvm::createShadowStackStoreNode(var_types storeType, GenTree* addr, GenTree* data)
 {
-    GenTree* storeNode = createStoreNode(nodeType, addr, data, structClassLayout);
+    GenTree* storeNode = createStoreNode(storeType, addr, data);
     storeNode->gtFlags |= (GTF_IND_TGT_NOT_HEAP | GTF_IND_NONFAULTING);
 
     return storeNode;

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -85,6 +85,11 @@ StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
 
 Type* Llvm::getLlvmTypeForStruct(ClassLayout* classLayout)
 {
+    if (classLayout->IsBlockLayout())
+    {
+        return llvm::ArrayType::get(Type::getInt8Ty(_llvmContext), classLayout->GetSize());
+    }
+
     return getLlvmTypeForStruct(classLayout->GetClassHandle());
 }
 


### PR DESCRIPTION
1) Implement null checking for all types of indirs in codegen.
2) Implement complex `initblk`s, as well as simple `BLK`s.
3) Implement retyping for struct stores, including shadow stack ones.
4) Also remove zero-sized block stores in lowering.