### PR TITLE
[NativeAOT-LLVM] Support some throwing operators via throw helper blocks

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5190,6 +5190,22 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     Rationalizer rat(this); // PHASE_RATIONALIZE
     rat.Run();
 
+    // Here we do "simple lowering".  When the RyuJIT backend works for all
+    // platforms, this will be part of the more general lowering phase.  For now, though, we do a separate
+    // pass of "final lowering."  We must do this before (final) liveness analysis, because this creates
+    // range check throw blocks, in which the liveness must be correct.
+    //
+    DoPhase(this, PHASE_SIMPLE_LOWERING, &Compiler::fgSimpleLowering);
+
+#ifdef DEBUG
+    fgDebugCheckBBlist();
+    fgDebugCheckLinks();
+#endif
+
+    // Enable this to gather statistical data such as
+    // call and register argument info, flowgraph and loop info, etc.
+    compJitStats();
+
 #if defined(TARGET_WASM)
     if (opts.OptimizationEnabled())
     {
@@ -5214,22 +5230,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     DoPhase(this, PHASE_BUILD_LLVM, buildLlvmPhase);
     delete llvm;
 #else
-
-    // Here we do "simple lowering".  When the RyuJIT backend works for all
-    // platforms, this will be part of the more general lowering phase.  For now, though, we do a separate
-    // pass of "final lowering."  We must do this before (final) liveness analysis, because this creates
-    // range check throw blocks, in which the liveness must be correct.
-    //
-    DoPhase(this, PHASE_SIMPLE_LOWERING, &Compiler::fgSimpleLowering);
-
-#ifdef DEBUG
-    fgDebugCheckBBlist();
-    fgDebugCheckLinks();
-#endif
-
-    // Enable this to gather statistical data such as
-    // call and register argument info, flowgraph and loop info, etc.
-    compJitStats();
 
 #ifdef TARGET_ARM
     if (compLocallocUsed)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6536,9 +6536,9 @@ private:
 
     BasicBlock* fgRngChkTarget(BasicBlock* block, SpecialCodeKind kind);
 
+public:
     BasicBlock* fgAddCodeRef(BasicBlock* srcBlk, unsigned refData, SpecialCodeKind kind);
 
-public:
     AddCodeDsc* fgFindExcptnTarget(SpecialCodeKind kind, unsigned refData);
 
     bool fgUseThrowHelperBlocks();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1230,6 +1230,16 @@ public:
         assert(lowerBound <= upperBound);
     }
 
+    SymbolicIntegerValue GetLowerBound()
+    {
+        return m_lowerBound;
+    }
+
+    SymbolicIntegerValue GetUpperBound()
+    {
+        return m_upperBound;
+    }
+
     bool Contains(int64_t value) const;
 
     bool Contains(IntegralRange other) const

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -94,7 +94,7 @@ Llvm::Llvm(Compiler* compiler)
     _sigInfo(compiler->info.compMethodInfo->args),
     _builder(_llvmContext),
     _prologBuilder(_llvmContext),
-    _blkToLlvmBlkVectorMap(compiler->getAllocator(CMK_Codegen)),
+    _blkToLlvmBlksMap(compiler->getAllocator(CMK_Codegen)),
     _sdsuMap(compiler->getAllocator(CMK_Codegen)),
     _localsMap(compiler->getAllocator(CMK_Codegen)),
     _debugMetadataMap(compiler->getAllocator(CMK_Codegen)),

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -97,6 +97,9 @@ private:
     JitHashTable<SSAName, SSAName, Value*> _localsMap;
     std::vector<PhiPair> _phiPairs;
     std::vector<Value*> m_allocas;
+#ifdef DEBUG
+    unsigned m_currentInlineLlvmBlockIndex;
+#endif // DEBUG
 
     // DWARF
     llvm::DILocation* _currentOffsetDiLocation;
@@ -217,8 +220,7 @@ public:
 private:
     void generateProlog();
     void initializeLocals();
-    void startImportingBasicBlock(BasicBlock* block);
-    void endImportingBasicBlock(BasicBlock* block);
+    void generateBlock(BasicBlock* block);
     void fillPhis();
 
     Value* getGenTreeValue(GenTree* node);
@@ -258,7 +260,9 @@ private:
 
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
+
     void emitDoNothingCall();
+    void emitJumpToThrowHelper(Value* jumpCondValue, SpecialCodeKind throwKind);
     void emitNullCheckForIndir(GenTreeIndir* indir, Value* addrValue);
     void buildThrowException(llvm::IRBuilder<>& builder, const char* helperClass, const char* helperMethodName, Value* shadowStack);
     void buildLlvmCallOrInvoke(llvm::Function* callee, llvm::ArrayRef<Value*> args);
@@ -282,6 +286,7 @@ private:
     DebugMetadata getOrCreateDebugMetadata(const char* documentFileName);
     llvm::DILocation* createDebugFunctionAndDiLocation(struct DebugMetadata debugMetadata, unsigned int lineNo);
 
+    llvm::BasicBlock* createInlineLlvmBlock();
     llvm::BasicBlock* getLLVMBasicBlockForBlock(BasicBlock* block);
 
     bool isLlvmFrameLocal(LclVarDsc* varDsc);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -277,7 +277,7 @@ private:
     Function* getOrCreateLlvmFunction(const char* symbolName, GenTreeCall* call);
     FunctionType* createFunctionTypeForCall(GenTreeCall* call);
     FunctionType* buildHelperLlvmFunctionType(GenTreeCall* call, bool withShadowStack);
-    bool helperRequiresShadowStack(CORINFO_METHOD_HANDLE corinfoMethodHnd);
+    bool helperRequiresShadowStack(CorInfoHelpFunc helperFunc);
 
     Value* getOrCreateExternalSymbol(const char* symbolName, Type* symbolType = nullptr);
     Function* getOrCreateRhpAssignRef();

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -257,6 +257,7 @@ private:
     void buildReturn(GenTree* node);
     void buildJTrue(GenTree* node, Value* opValue);    
     void buildNullCheck(GenTreeIndir* nullCheckNode);
+    void buildBoundsCheck(GenTreeBoundsChk* boundsCheck);
 
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -67,6 +67,12 @@ struct PhiPair
     llvm::PHINode* llvmPhiNode;
 };
 
+struct LlvmBlockRange
+{
+    llvm::BasicBlock* FirstBlock;
+    llvm::BasicBlock* LastBlock;
+};
+
 // TODO: We should create a Static... class to manage the globals and their lifetimes.
 // Note we declare all statics here, and define them in llvm.cpp, for documentation and
 // visibility purposes even as some are only needed in other compilation units.
@@ -92,14 +98,11 @@ private:
     DebugInfo _currentOffset;
     llvm::IRBuilder<> _builder;
     llvm::IRBuilder<> _prologBuilder;
-    JitHashTable<BasicBlock*, JitPtrKeyFuncs<BasicBlock>, llvm::BasicBlock*> _blkToLlvmBlkVectorMap;
+    JitHashTable<BasicBlock*, JitPtrKeyFuncs<BasicBlock>, LlvmBlockRange> _blkToLlvmBlksMap;
     JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, Value*> _sdsuMap;
     JitHashTable<SSAName, SSAName, Value*> _localsMap;
     std::vector<PhiPair> _phiPairs;
     std::vector<Value*> m_allocas;
-#ifdef DEBUG
-    unsigned m_currentInlineLlvmBlockIndex;
-#endif // DEBUG
 
     // DWARF
     llvm::DILocation* _currentOffsetDiLocation;
@@ -293,7 +296,9 @@ private:
     llvm::DILocation* createDebugFunctionAndDiLocation(struct DebugMetadata debugMetadata, unsigned int lineNo);
 
     llvm::BasicBlock* createInlineLlvmBlock();
-    llvm::BasicBlock* getLLVMBasicBlockForBlock(BasicBlock* block);
+    llvm::BasicBlock* getFirstLlvmBlockForBlock(BasicBlock* block);
+    llvm::BasicBlock* getLastLlvmBlockForBlock(BasicBlock* block);
+    void setLastLlvmBlockForBlock(BasicBlock* block, llvm::BasicBlock* llvmBlock);
 
     bool isLlvmFrameLocal(LclVarDsc* varDsc);
     unsigned int getTotalLocalOffset();

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -127,6 +127,10 @@ private:
     {
         return *_currentRange;
     }
+    BasicBlock* CurrentBlock() const
+    {
+        return _currentBlock;
+    }
 
     GCInfo* getGCInfo();
 
@@ -198,6 +202,7 @@ private:
     void lowerFieldOfDependentlyPromotedStruct(GenTree* node);
     void ConvertShadowStackLocalNode(GenTreeLclVarCommon* node);
     void lowerStoreBlk(GenTreeBlk* storeBlkNode);
+    void lowerDivMod(GenTreeOp* divModNode);
     void lowerReturn(GenTreeUnOp* retNode);
 
     void lowerCallToShadowStack(GenTreeCall* callNode);
@@ -236,7 +241,7 @@ private:
     void buildLocalField(GenTreeLclFld* lclFld);
     void buildLocalVarAddr(GenTreeLclVarCommon* lclVar);
     void buildAdd(GenTreeOp* node);
-    void buildDiv(GenTree* node);
+    void buildDivMod(GenTree* node);
     void buildCast(GenTreeCast* cast);
     void buildLclHeap(GenTreeUnOp* lclHeap);
     void buildCmp(GenTreeOp* node);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1139,7 +1139,6 @@ void Llvm::buildHelperFuncCall(GenTreeCall* call)
         fgArgTabEntry** argTable = argInfo->ArgTable();
         std::vector<OperandArgNum> sortedArgs = std::vector<OperandArgNum>(argCount);
         OperandArgNum* sortedData = sortedArgs.data();
-        bool requiresShadowStack = helperRequiresShadowStack(call->gtCallMethHnd);
 
         //TODO-LLVM: refactor calling code with user calls.
         for (unsigned i = 0; i < argCount; i++)
@@ -1150,13 +1149,13 @@ void Llvm::buildHelperFuncCall(GenTreeCall* call)
             sortedData[argNum] = opAndArg;
         }
 
-        void* pAddr = nullptr;
-
         CorInfoHelpFunc helperNum = _compiler->eeGetHelperNum(call->gtCallMethHnd);
+        void* pAddr = nullptr;
         void* addr = _compiler->compGetHelperFtn(helperNum, &pAddr);
         const char* symbolName = GetMangledSymbolName(addr);
         Function* llvmFunc = _module->getFunction(symbolName);
 
+        bool requiresShadowStack = helperRequiresShadowStack(helperNum);
         if (llvmFunc == nullptr)
         {
             llvmFunc = Function::Create(buildHelperLlvmFunctionType(call, requiresShadowStack), Function::ExternalLinkage, 0U, symbolName, _module);
@@ -1724,26 +1723,335 @@ FunctionType* Llvm::buildHelperLlvmFunctionType(GenTreeCall* call, bool withShad
     return FunctionType::get(retLlvmType, ArrayRef<llvm::Type*>(argVec), false);
 }
 
-bool Llvm::helperRequiresShadowStack(CORINFO_METHOD_HANDLE corinfoMethodHnd)
+bool Llvm::helperRequiresShadowStack(CorInfoHelpFunc helperFunc)
 {
-    //TODO-LLVM: is there a better way to identify managed helpers?
-    //Probably want to lower the math helpers to ordinary GT_CASTs and
-    //handle in the LLVM (as does ILToLLVMImporter) to avoid this overhead
-    return corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_GVMLOOKUP_FOR_SLOT) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_DBL2INT_OVF) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_DBL2LNG_OVF) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_DBL2UINT_OVF) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_DBL2ULNG_OVF) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_LMOD) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_LDIV) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_LMUL_OVF) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_ULMUL_OVF) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_ULDIV) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_ULMOD) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_OVERFLOW) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE) ||
-        corinfoMethodHnd == _compiler->eeFindHelper(CORINFO_HELP_THROW_PLATFORM_NOT_SUPPORTED);
+    // TODO-LLVM: communicate this through a Jit-EE API.
+    // Current version of the mappings taken primarily from "tools\aot\ILCompiler.Compiler\Compiler\JitHelper.cs" and
+    // "tools\aot\ILCompiler.RyuJit\JitInterface\CorInfoImpl.RyuJit.cs".
+    switch (helperFunc)
+    {
+        case CORINFO_HELP_DIV:
+        case CORINFO_HELP_MOD:
+        case CORINFO_HELP_UDIV:
+        case CORINFO_HELP_UMOD:
+        case CORINFO_HELP_LMUL_OVF:
+        case CORINFO_HELP_ULMUL_OVF:
+        case CORINFO_HELP_LDIV:
+        case CORINFO_HELP_LMOD:
+        case CORINFO_HELP_ULDIV:
+        case CORINFO_HELP_ULMOD:
+        case CORINFO_HELP_DBL2INT_OVF:
+        case CORINFO_HELP_DBL2LNG_OVF:
+        case CORINFO_HELP_DBL2UINT_OVF:
+        case CORINFO_HELP_DBL2ULNG_OVF:
+            // Implemented in "CoreLib\src\Internal\Runtime\CompilerHelpers\MathHelpers.cs".
+            return true;
+
+        case CORINFO_HELP_LLSH:
+        case CORINFO_HELP_LRSH:
+        case CORINFO_HELP_LRSZ:
+        case CORINFO_HELP_LMUL:
+        case CORINFO_HELP_LNG2DBL:
+        case CORINFO_HELP_ULNG2DBL:
+        case CORINFO_HELP_DBL2INT:
+        case CORINFO_HELP_DBL2LNG:
+        case CORINFO_HELP_DBL2UINT:
+        case CORINFO_HELP_DBL2ULNG:
+        case CORINFO_HELP_FLTREM:
+        case CORINFO_HELP_DBLREM:
+        case CORINFO_HELP_FLTROUND:
+        case CORINFO_HELP_DBLROUND:
+            // Implemented in "Runtime\MathHelpers.cpp".
+            return false;
+
+        case CORINFO_HELP_NEWFAST:
+        case CORINFO_HELP_NEWSFAST:
+        case CORINFO_HELP_NEWSFAST_FINALIZE:
+        case CORINFO_HELP_NEWSFAST_ALIGN8:
+        case CORINFO_HELP_NEWSFAST_ALIGN8_VC:
+        case CORINFO_HELP_NEWSFAST_ALIGN8_FINALIZE:
+        case CORINFO_HELP_NEW_MDARR:
+        case CORINFO_HELP_NEW_MDARR_NONVARARG:
+        case CORINFO_HELP_NEWARR_1_DIRECT:
+        case CORINFO_HELP_NEWARR_1_OBJ:
+        case CORINFO_HELP_NEWARR_1_VC:
+        case CORINFO_HELP_NEWARR_1_ALIGN8:
+            // Allocators, implemented in "Runtime\portable.cpp".
+            return false;
+
+        case CORINFO_HELP_STRCNS:
+        case CORINFO_HELP_STRCNS_CURRENT_MODULE:
+        case CORINFO_HELP_INITCLASS:
+        case CORINFO_HELP_INITINSTCLASS:
+            // NYI in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_ISINSTANCEOFINTERFACE:
+        case CORINFO_HELP_ISINSTANCEOFARRAY:
+        case CORINFO_HELP_ISINSTANCEOFCLASS:
+        case CORINFO_HELP_ISINSTANCEOFANY:
+        case CORINFO_HELP_CHKCASTINTERFACE:
+        case CORINFO_HELP_CHKCASTARRAY:
+        case CORINFO_HELP_CHKCASTCLASS:
+        case CORINFO_HELP_CHKCASTANY:
+        case CORINFO_HELP_CHKCASTCLASS_SPECIAL:
+        case CORINFO_HELP_BOX:
+        case CORINFO_HELP_BOX_NULLABLE:
+        case CORINFO_HELP_UNBOX:
+        case CORINFO_HELP_UNBOX_NULLABLE:
+        case CORINFO_HELP_ARRADDR_ST:
+        case CORINFO_HELP_LDELEMA_REF:
+            // Runtime exports, i. e. implemented in managed code with an unmanaged signature.
+            // See "Runtime.Base\src\System\Runtime\RuntimeExports.cs", "Runtime.Base\src\System\Runtime\TypeCast.cs",
+            return false;
+
+        case CORINFO_HELP_GETREFANY:
+            // Implemented in "CoreLib\src\Internal\Runtime\CompilerHelpers\TypedReferenceHelpers.cs".
+            return true;
+
+        case CORINFO_HELP_THROW:
+        case CORINFO_HELP_RETHROW:
+            // For WASM, currently implemented in the bootstrapper...
+            return false;
+
+        case CORINFO_HELP_USER_BREAKPOINT:
+            // Implemented in "Runtime\MiscHelpers.cpp".
+            return false;
+
+        case CORINFO_HELP_RNGCHKFAIL:
+        case CORINFO_HELP_OVERFLOW:
+        case CORINFO_HELP_THROWDIVZERO:
+        case CORINFO_HELP_THROWNULLREF:
+            // Implemented in "Runtime.Base\src\System\ThrowHelpers.cs".
+            // Note on "CORINFO_HELP_THROWNULLREF": ***this helpers has been deleted upstream***.
+            // We need it. When merging upstream, revert its deletion!
+            return true;
+
+        case CORINFO_HELP_VERIFICATION:
+            // Verification is in the process of being deleted from RyuJit.
+            unreached();
+
+        case CORINFO_HELP_FAIL_FAST:
+            // Implemented in "Runtime\EHHelpers.cpp".
+            return false;
+
+        case CORINFO_HELP_METHOD_ACCESS_EXCEPTION:
+        case CORINFO_HELP_FIELD_ACCESS_EXCEPTION:
+        case CORINFO_HELP_CLASS_ACCESS_EXCEPTION:
+            // NYI in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_ENDCATCH:
+            // Not used with funclet-based EH.
+            unreached();
+
+        case CORINFO_HELP_MON_ENTER:
+        case CORINFO_HELP_MON_EXIT:
+        case CORINFO_HELP_MON_ENTER_STATIC:
+        case CORINFO_HELP_MON_EXIT_STATIC:
+            // Implemented in "CoreLib\src\Internal\Runtime\CompilerHelpers\SynchronizedMethodHelpers.cs".
+            return true;
+
+        case CORINFO_HELP_GETCLASSFROMMETHODPARAM:
+        case CORINFO_HELP_GETSYNCFROMCLASSHANDLE:
+        case CORINFO_HELP_STOP_FOR_GC:
+            // Apparently NYI in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_POLL_GC:
+            // Implemented in "Runtime\portable.cpp".
+            return false;
+
+        case CORINFO_HELP_STRESS_GC:
+        case CORINFO_HELP_CHECK_OBJ:
+            // Debug-only helpers NYI in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_ASSIGN_REF:
+        case CORINFO_HELP_CHECKED_ASSIGN_REF:
+        case CORINFO_HELP_ASSIGN_REF_ENSURE_NONHEAP:
+        case CORINFO_HELP_ASSIGN_BYREF:
+            // Write barriers, implemented in "Runtime\portable.cpp".
+            return false;
+
+        case CORINFO_HELP_ASSIGN_STRUCT:
+        case CORINFO_HELP_GETFIELD8:
+        case CORINFO_HELP_SETFIELD8:
+        case CORINFO_HELP_GETFIELD16:
+        case CORINFO_HELP_SETFIELD16:
+        case CORINFO_HELP_GETFIELD32:
+        case CORINFO_HELP_SETFIELD32:
+        case CORINFO_HELP_GETFIELD64:
+        case CORINFO_HELP_SETFIELD64:
+        case CORINFO_HELP_GETFIELDOBJ:
+        case CORINFO_HELP_SETFIELDOBJ:
+        case CORINFO_HELP_GETFIELDSTRUCT:
+        case CORINFO_HELP_SETFIELDSTRUCT:
+        case CORINFO_HELP_GETFIELDFLOAT:
+        case CORINFO_HELP_SETFIELDFLOAT:
+        case CORINFO_HELP_GETFIELDDOUBLE:
+        case CORINFO_HELP_SETFIELDDOUBLE:
+        case CORINFO_HELP_GETFIELDADDR:
+        case CORINFO_HELP_GETSTATICFIELDADDR_TLS:
+        case CORINFO_HELP_GETGENERICS_GCSTATIC_BASE:
+        case CORINFO_HELP_GETGENERICS_NONGCSTATIC_BASE:
+        case CORINFO_HELP_GETSHARED_GCSTATIC_BASE:
+        case CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE:
+        case CORINFO_HELP_GETSHARED_GCSTATIC_BASE_NOCTOR:
+        case CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE_NOCTOR:
+        case CORINFO_HELP_GETSHARED_GCSTATIC_BASE_DYNAMICCLASS:
+        case CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE_DYNAMICCLASS:
+        case CORINFO_HELP_CLASSINIT_SHARED_DYNAMICCLASS:
+        case CORINFO_HELP_GETGENERICS_GCTHREADSTATIC_BASE:
+        case CORINFO_HELP_GETGENERICS_NONGCTHREADSTATIC_BASE:
+        case CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE:
+        case CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE:
+        case CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_NOCTOR:
+        case CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE_NOCTOR:
+        case CORINFO_HELP_GETSHARED_GCTHREADSTATIC_BASE_DYNAMICCLASS:
+        case CORINFO_HELP_GETSHARED_NONGCTHREADSTATIC_BASE_DYNAMICCLASS:
+            // Not used in NativeAOT (or at all in some cases).
+            unreached();
+
+        case CORINFO_HELP_DBG_IS_JUST_MY_CODE:
+        case CORINFO_HELP_PROF_FCN_ENTER:
+        case CORINFO_HELP_PROF_FCN_LEAVE:
+        case CORINFO_HELP_PROF_FCN_TAILCALL:
+        case CORINFO_HELP_BBT_FCN_ENTER:
+            // NYI in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_PINVOKE_CALLI:
+            // TODO-LLVM: this is not a real "helper"; investigate what needs to be done to enable it.
+            failFunctionCompilation();
+
+        case CORINFO_HELP_TAILCALL:
+            // NYI in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_GETCURRENTMANAGEDTHREADID:
+            // Implemented as "Environment.CurrentManagedThreadId".
+            return true;
+
+        case CORINFO_HELP_INIT_PINVOKE_FRAME:
+            // Part of the inlined PInvoke frame construction feature which is NYI in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_MEMSET:
+        case CORINFO_HELP_MEMCPY:
+            // Implemented as plain "memset"/"memcpy".
+            return false;
+
+        case CORINFO_HELP_RUNTIMEHANDLE_METHOD:
+        case CORINFO_HELP_RUNTIMEHANDLE_METHOD_LOG:
+        case CORINFO_HELP_RUNTIMEHANDLE_CLASS:
+        case CORINFO_HELP_RUNTIMEHANDLE_CLASS_LOG:
+            // Not used in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE:
+        case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE_MAYBENULL:
+            // Implemented in "CoreLib\src\Internal\Runtime\CompilerHelpers\TypedReferenceHelpers.cs".
+            return true;
+
+        case CORINFO_HELP_METHODDESC_TO_STUBRUNTIMEMETHOD:
+        case CORINFO_HELP_FIELDDESC_TO_STUBRUNTIMEFIELD:
+        case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE:
+            // Implemented in "CoreLib\src\Internal\Runtime\CompilerHelpers\LdTokenHelpers.cs".
+            return true;
+
+        case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE_MAYBENULL:
+            // Implemented in "CoreLib\src\Internal\Runtime\CompilerHelpers\TypedReferenceHelpers.cs".
+            return true;
+
+        case CORINFO_HELP_ARE_TYPES_EQUIVALENT:
+            // Another runtime export from "TypeCast.cs".
+            return false;
+
+        case CORINFO_HELP_VIRTUAL_FUNC_PTR:
+        case CORINFO_HELP_READYTORUN_NEW:
+        case CORINFO_HELP_READYTORUN_NEWARR_1:
+            // Not used in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_READYTORUN_ISINSTANCEOF:
+        case CORINFO_HELP_READYTORUN_CHKCAST:
+        case CORINFO_HELP_READYTORUN_STATIC_BASE:
+        case CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR:
+        case CORINFO_HELP_READYTORUN_GENERIC_HANDLE:
+        case CORINFO_HELP_READYTORUN_DELEGATE_CTOR:
+        case CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE:
+            // Not static methods; currently we "inline" them for LLVM.
+            // Should be "unreached" once all are handled.
+            failFunctionCompilation();
+
+        case CORINFO_HELP_EE_PRESTUB:
+        case CORINFO_HELP_EE_PRECODE_FIXUP:
+        case CORINFO_HELP_EE_PINVOKE_FIXUP:
+        case CORINFO_HELP_EE_VSD_FIXUP:
+        case CORINFO_HELP_EE_EXTERNAL_FIXUP:
+        case CORINFO_HELP_EE_VTABLE_FIXUP:
+        case CORINFO_HELP_EE_REMOTING_THUNK:
+        case CORINFO_HELP_EE_PERSONALITY_ROUTINE:
+        case CORINFO_HELP_EE_PERSONALITY_ROUTINE_FILTER_FUNCLET:
+            // NGEN/R2R-specific marker helpers.
+            unreached();
+
+        case CORINFO_HELP_ASSIGN_REF_EAX:
+        case CORINFO_HELP_ASSIGN_REF_EBX:
+        case CORINFO_HELP_ASSIGN_REF_ECX:
+        case CORINFO_HELP_ASSIGN_REF_ESI:
+        case CORINFO_HELP_ASSIGN_REF_EDI:
+        case CORINFO_HELP_ASSIGN_REF_EBP:
+        case CORINFO_HELP_CHECKED_ASSIGN_REF_EAX:
+        case CORINFO_HELP_CHECKED_ASSIGN_REF_EBX:
+        case CORINFO_HELP_CHECKED_ASSIGN_REF_ECX:
+        case CORINFO_HELP_CHECKED_ASSIGN_REF_ESI:
+        case CORINFO_HELP_CHECKED_ASSIGN_REF_EDI:
+        case CORINFO_HELP_CHECKED_ASSIGN_REF_EBP:
+            // x86-specific write barriers.
+            unreached();
+
+        case CORINFO_HELP_LOOP_CLONE_CHOICE_ADDR:
+        case CORINFO_HELP_DEBUG_LOG_LOOP_CLONING:
+            // Debug-only functionality NYI in NativeAOT.
+            unreached();
+
+        case CORINFO_HELP_THROW_ARGUMENTEXCEPTION:
+        case CORINFO_HELP_THROW_ARGUMENTOUTOFRANGEEXCEPTION:
+        case CORINFO_HELP_THROW_NOT_IMPLEMENTED:
+        case CORINFO_HELP_THROW_PLATFORM_NOT_SUPPORTED:
+            // Implemented in "Runtime.Base\src\System\ThrowHelpers.cs".
+            return true;
+
+        case CORINFO_HELP_THROW_TYPE_NOT_SUPPORTED:
+            // Dead code.
+            unreached();
+
+        case CORINFO_HELP_JIT_PINVOKE_BEGIN:
+        case CORINFO_HELP_JIT_PINVOKE_END:
+        case CORINFO_HELP_JIT_REVERSE_PINVOKE_ENTER:
+        case CORINFO_HELP_JIT_REVERSE_PINVOKE_ENTER_TRACK_TRANSITIONS:
+        case CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT:
+        case CORINFO_HELP_JIT_REVERSE_PINVOKE_EXIT_TRACK_TRANSITIONS:
+            // [R]PI helpers, implemented in "Runtime\thread.cpp".
+            return false;
+
+        case CORINFO_HELP_GVMLOOKUP_FOR_SLOT:
+            // TODO-LLVM: fix.
+            failFunctionCompilation();
+
+        case CORINFO_HELP_STACK_PROBE:
+        case CORINFO_HELP_PATCHPOINT:
+        case CORINFO_HELP_CLASSPROFILE32:
+        case CORINFO_HELP_CLASSPROFILE64:
+        case CORINFO_HELP_PARTIAL_COMPILATION_PATCHPOINT:
+            unreached();
+
+        default:
+            // Add new helpers to the above as necessary.
+            unreached();
+    }
 }
 
 Value* Llvm::getOrCreateExternalSymbol(const char* symbolName, Type* symbolType)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -186,6 +186,8 @@ GenTree* Compiler::fgMorphExpandCast(GenTreeCast* tree)
     var_types dstType = tree->CastToType();
     unsigned  dstSize = genTypeSize(dstType);
 
+#if !defined(TARGET_WASM) // LLVM codegen supports all casts directly.
+
     // See if the cast has to be done in two steps.  R -> I
     if (varTypeIsFloating(srcType) && varTypeIsIntegral(dstType))
     {
@@ -412,7 +414,9 @@ GenTree* Compiler::fgMorphExpandCast(GenTreeCast* tree)
         }
     }
 #endif // TARGET_X86
-    else if (varTypeIsGC(srcType) != varTypeIsGC(dstType))
+    else
+#endif // !defined(TARGET_WASM)
+        if (varTypeIsGC(srcType) != varTypeIsGC(dstType))
     {
         // We are casting away GC information.  we would like to just
         // change the type to int, however this gives the emitter fits because

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -205,9 +205,11 @@ The .NET Foundation licenses this file to you under the MIT license.
     <MSBuild Projects="@(ProjectToBuild)" BuildInParallel="true" />
   </Target>
 
+  <!-- NativeAOT-LLVM note: 'BeforeTargets="_RunILLink"' should be deleted once https://github.com/dotnet/runtime/pull/63914 is merged from upstream -->
   <Target Name="IlcCompile"
       Inputs="@(IlcCompileInput);@(RdXmlFile)"
       Outputs="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename)$(IlcOutputFileExt)"
+      BeforeTargets="_RunILLink"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
     <!-- Set up default properties that have their defaults in the 6.0 SDK (Can be dropped once we drop 5.0 support) -->

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -1159,7 +1159,7 @@ internal static class Program
     private static void CastByteForIndex()
     {
         StartTest("Implicit casting of byte for an index");
-        int[] someInts = new int[0xff];
+        int[] someInts = new int[0xff + 1];
         byte byteIndex = 0xFF;
         someInts[byteIndex] = 123;
         EndTest(someInts[0xff] == 123, "Expected 123 at index 0xff but didn't get it");


### PR DESCRIPTION
With this change, we begin to support various throwing (casts, range checks, division, remainder) operators in codegen, under the "throw helper blocks" scheme, similar to what other backends do for optimized code. Inlined throws for the unoptimized case are not yet implemented, as are checked addition / subtraction / multiplication and null checks.

Closes #2061 (I decided to just do the simple thing and enable simple lowering; it will also provide MD array operator support once more of upstream has been merged).

Example IR for `checked((byte)floatValue)`:
```llvm
define i8 @RyuJitReproduction_RyuJitReproduction_Program__Problem(i8* %0, float %1) {
Prolog:
  br label %BB01.1

BB01.1:                                           ; preds = %Prolog
  %2 = fcmp ule float %1, -1.000000e+00
  %3 = fcmp uge float %1, 2.560000e+02
  %4 = or i1 %2, %3
  br i1 %4, label %BB02, label %BB01.2

BB01.2:                                           ; preds = %BB01.1
  %5 = fptoui float %1 to i8
  ret i8 %5

BB02:                                             ; preds = %BB01.1
  call void @S_P_CoreLib_Internal_Runtime_CompilerHelpers_ThrowHelpers__ThrowOverflowException(i8* %0)
  unreachable
}
```
For `a % b`:
```llvm
define i32 @RyuJitReproduction_RyuJitReproduction_Program__Problem(i8* %0, i32 %1, i32 %2) {
Prolog:
  br label %BB01.1

BB01.1:                                           ; preds = %Prolog
  %3 = icmp eq i32 %2, 0
  br i1 %3, label %BB02, label %BB01.2

BB01.2:                                           ; preds = %BB01.1
  %4 = icmp eq i32 %2, -1
  %5 = icmp eq i32 %1, -2147483648
  %6 = and i1 %4, %5
  br i1 %6, label %BB03, label %BB01.3

BB01.3:                                           ; preds = %BB01.2
  %7 = srem i32 %1, %2
  ret i32 %7

BB02:                                             ; preds = %BB01.1
  store i8* %0, i8** @t_pShadowStackTop, align 4
  call void @S_P_CoreLib_Internal_Runtime_CompilerHelpers_ThrowHelpers__ThrowDivideByZeroException()
  unreachable

BB03:                                             ; preds = %BB01.2
  call void @S_P_CoreLib_Internal_Runtime_CompilerHelpers_ThrowHelpers__ThrowOverflowException(i8* %0)
  unreachable
}
```