### PR TITLE
Add some perf tests and don't spin-wait on a task when on a green thread

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/GreenThreadTasks.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/GreenThreadTasks.CoreCLR.cs
@@ -33,19 +33,20 @@ namespace System.Threading.Tasks
 
             ThreadPoolWorkQueueThreadLocals? tl = DontReuseGreenThreads ? null : ThreadPoolWorkQueueThreadLocals.Current;
             executorObj.action!();
-            ExecutionContext.SendValueChangeNotificationsForResetToDefaultUnsafe();
             if (tl == null)
             {
+                ExecutionContext.SendValueChangeNotificationsForResetToDefaultUnsafe();
                 return;
             }
 
+            Thread currentThread = Thread.CurrentThread;
             while (true)
             {
+                ExecutionContext.ResetThreadPoolThread(currentThread);
                 var resumeTcs = new TaskCompletionSource();
                 tl.RegisterGreenThreadForResume(resumeTcs);
                 resumeTcs.Task.Wait();
                 tl.ResumeGreenThreadAction();
-                ExecutionContext.SendValueChangeNotificationsForResetToDefaultUnsafe();
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -3032,7 +3032,7 @@ namespace System.Threading.Tasks
         {
             bool infiniteWait = millisecondsTimeout == Timeout.Infinite;
             uint startTimeTicks = infiniteWait ? 0 : (uint)Environment.TickCount;
-            bool returnValue = SpinWait(millisecondsTimeout);
+            bool returnValue = !(infiniteWait && Thread.IsGreenThread) && SpinWait(millisecondsTimeout);
             if (!returnValue)
             {
                 var mres = new SetOnInvokeMres();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1011,7 +1011,7 @@ namespace System.Threading
             }
         }
 
-#if CORECLR
+#if CORECLR && TARGET_WINDOWS && TARGET_AMD64
         public static void RunAsGreenThread(Action action)
         {
             ThreadPoolWorkQueueThreadLocals? tl = ThreadPoolWorkQueueThreadLocals.Current;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1011,6 +1011,7 @@ namespace System.Threading
             }
         }
 
+#if CORECLR
         public static void RunAsGreenThread(Action action)
         {
             ThreadPoolWorkQueueThreadLocals? tl = ThreadPoolWorkQueueThreadLocals.Current;
@@ -1045,6 +1046,7 @@ namespace System.Threading
 
             Task.GreenThreadExecutorFunc(action);
         }
+#endif
     }
 
     internal struct SimpleSpinLock

--- a/src/tests/baseservices/threading/greenthreads/perf/RunAsGreenThread.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/RunAsGreenThread.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length < 1 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        ThreadPool.SetMinThreads(1, 1);
+        ThreadPool.SetMaxThreads(1, 1);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        Action greenThreadAction = null;
+        greenThreadAction = () =>
+        {
+            count++;
+            Task.RunAsGreenThread(greenThreadAction);
+        };
+        Task.RunAsGreenThread(greenThreadAction);
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/RunAsGreenThread.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/RunAsGreenThread.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="RunAsGreenThread.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/RunAsGreenThreadDeep.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/RunAsGreenThreadDeep.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length < 1 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        ThreadPool.SetMinThreads(1, 1);
+        ThreadPool.SetMaxThreads(1, 1);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        Action greenThreadAction = null;
+        greenThreadAction = () =>
+        {
+            Recurse(10000);
+            count++;
+            Task.RunAsGreenThread(greenThreadAction);
+        };
+        Task.RunAsGreenThread(greenThreadAction);
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Recurse(int depth)
+    {
+        if (depth > 0)
+        {
+            Recurse(depth - 1);
+        }
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/RunAsGreenThreadDeep.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/RunAsGreenThreadDeep.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="RunAsGreenThreadDeep.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketAwait.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketAwait.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length < 1 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        ThreadPool.SetMinThreads(2, 1);
+        ThreadPool.SetMaxThreads(2, 1);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        Task.Run(async () =>
+        {
+            var buffer = new byte[1];
+            var listener = new TcpListener(IPAddress.Loopback, 55555);
+            listener.Start();
+            var socket = await listener.AcceptSocketAsync();
+            listener.Stop();
+
+            while (true)
+            {
+                await socket.ReceiveAsync(buffer);
+                await socket.SendAsync(buffer);
+            }
+        });
+
+        Thread.Sleep(100);
+
+        Task.Run(async () =>
+        {
+            var buffer = new byte[1];
+            var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, 55555);
+            var socket = client.Client;
+
+            while (true)
+            {
+                await socket.SendAsync(buffer);
+                await socket.ReceiveAsync(buffer);
+                ++count;
+            }
+        });
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketAwait.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketAwait.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SocketAwait.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitGT.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitGT.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length < 1 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        ThreadPool.SetMinThreads(2, 1);
+        ThreadPool.SetMaxThreads(2, 1);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        Task.RunAsGreenThread(async () =>
+        {
+            var buffer = new byte[1];
+            var listener = new TcpListener(IPAddress.Loopback, 55555);
+            listener.Start();
+            var socket = await listener.AcceptSocketAsync();
+            listener.Stop();
+
+            while (true)
+            {
+                await socket.ReceiveAsync(buffer);
+                await socket.SendAsync(buffer);
+            }
+        });
+
+        Thread.Sleep(100);
+
+        Task.RunAsGreenThread(async () =>
+        {
+            var buffer = new byte[1];
+            var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, 55555);
+            var socket = client.Client;
+
+            while (true)
+            {
+                await socket.SendAsync(buffer);
+                await socket.ReceiveAsync(buffer);
+                ++count;
+            }
+        });
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitGT.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitGT.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SocketAwaitGT.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketWait.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketWait.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length < 1 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        var serverThread = new Thread(() =>
+        {
+            var buffer = new byte[1];
+            var listener = new TcpListener(IPAddress.Loopback, 55555);
+            listener.Start();
+            var socket = listener.AcceptSocket();
+            listener.Stop();
+
+            while (true)
+            {
+                socket.Receive(buffer);
+                socket.Send(buffer);
+            }
+        });
+        serverThread.IsBackground = true;
+        serverThread.Start();
+
+        Thread.Sleep(100);
+
+        var clientThread = new Thread(() =>
+        {
+            var buffer = new byte[1];
+            var client = new TcpClient();
+            client.Connect(IPAddress.Loopback, 55555);
+            var socket = client.Client;
+
+            while (true)
+            {
+                socket.Send(buffer);
+                socket.Receive(buffer);
+                ++count;
+            }
+        });
+        clientThread.IsBackground = true;
+        clientThread.Start();
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketWait.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketWait.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SocketWait.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketWaitGT.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketWaitGT.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length < 1 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        ThreadPool.SetMinThreads(2, 1);
+        ThreadPool.SetMaxThreads(2, 1);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        Task.RunAsGreenThread(() =>
+        {
+            var buffer = new byte[1];
+            var listener = new TcpListener(IPAddress.Loopback, 55555);
+            listener.Start();
+            var socket = listener.AcceptSocket();
+            listener.Stop();
+
+            while (true)
+            {
+                socket.Receive(buffer);
+                socket.Send(buffer);
+            }
+        });
+
+        Thread.Sleep(100);
+
+        Task.RunAsGreenThread(() =>
+        {
+            var buffer = new byte[1];
+            var client = new TcpClient();
+            client.Connect(IPAddress.Loopback, 55555);
+            var socket = client.Client;
+
+            while (true)
+            {
+                socket.Send(buffer);
+                socket.Receive(buffer);
+                ++count;
+            }
+        });
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketWaitGT.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketWaitGT.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SocketWaitGT.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/YieldResume.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/YieldResume.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static int Main(string[] args)
+    {
+        if (args.Length < 1 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        ThreadPool.SetMinThreads(1, 1);
+        ThreadPool.SetMaxThreads(1, 1);
+
+        var sw = new Stopwatch();
+        TaskCompletionSource tcs = null;
+        int count = 0;
+
+        var greenThreadTask = Task.RunAsGreenThread(() =>
+        {
+            while (true)
+            {
+                tcs = new TaskCompletionSource();
+                tcs.Task.Wait();
+                count++;
+            }
+        });
+
+        var resumerTask = Task.Run(() =>
+        {
+            while (true)
+            {
+                tcs.SetResult();
+            }
+        });
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/YieldResume.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/YieldResume.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="YieldResume.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- The spin-waiting on tasks is tuned for thread context switches. Yield/Resume are much faster, updated to skip spin-waiting when on a green thread.
- Added a makeshift way to reuse green threads. For now, reusable green threads don't go away. Set `DOTNET_GreenThreads_DontReuse=1` to not reuse green threads.
- Added some small perf tests. They get built as part of the runtime tests and don't run in the CI, pass "run" as the argument to manually run them.