### PR TITLE
[Green-Threads] Add a set of benchmarks with deeper stacks

### DIFF
--- a/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitDeep.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitDeep.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static async Task Recurse(int depth, bool rcvFirst, Socket socket, byte[] buffer)
+    {
+        if (depth > 0)
+        {
+            await Recurse(depth - 1, rcvFirst, socket, buffer);
+            return;
+        }
+
+        if (rcvFirst)
+            await socket.ReceiveAsync(buffer);
+        await socket.SendAsync(buffer);
+        if (!rcvFirst)
+            await socket.ReceiveAsync(buffer);
+    }
+
+    public static int Main(string[] args)
+    {
+        if (args.Length < 2 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        int recurseDepth = int.Parse(args[1]);
+
+        ThreadPool.SetMinThreads(2, 1);
+        ThreadPool.SetMaxThreads(2, 1);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        Task.Run(async () =>
+        {
+            var buffer = new byte[1];
+            var listener = new TcpListener(IPAddress.Loopback, 55555);
+            listener.Start();
+            var socket = await listener.AcceptSocketAsync();
+            listener.Stop();
+
+            while (true)
+            {
+                await Recurse(recurseDepth, true, socket, buffer);
+            }
+        });
+
+        Thread.Sleep(100);
+
+        Task.Run(async () =>
+        {
+            var buffer = new byte[1];
+            var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, 55555);
+            var socket = client.Client;
+
+            while (true)
+            {
+                await Recurse(recurseDepth, false, socket, buffer);
+                ++count;
+            }
+        });
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitDeep.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitDeep.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SocketAwaitDeep.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitGTDeep.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitGTDeep.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    public static async Task Recurse(int depth, bool rcvFirst, Socket socket, byte[] buffer)
+    {
+        if (depth > 0)
+        {
+            await Recurse(depth - 1, rcvFirst, socket, buffer);
+            return;
+        }
+
+        if (rcvFirst)
+            await socket.ReceiveAsync(buffer);
+        await socket.SendAsync(buffer);
+        if (!rcvFirst)
+            await socket.ReceiveAsync(buffer);
+    }
+
+    public static int Main(string[] args)
+    {
+        if (args.Length < 2 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        int recurseDepth = int.Parse(args[1]);
+
+        ThreadPool.SetMinThreads(2, 1);
+        ThreadPool.SetMaxThreads(2, 1);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        Task.RunAsGreenThread(async () =>
+        {
+            var buffer = new byte[1];
+            var listener = new TcpListener(IPAddress.Loopback, 55555);
+            listener.Start();
+            var socket = await listener.AcceptSocketAsync();
+            listener.Stop();
+
+            while (true)
+            {
+                await Recurse(recurseDepth, true, socket, buffer);
+            }
+        });
+
+        Thread.Sleep(100);
+
+        Task.RunAsGreenThread(async () =>
+        {
+            var buffer = new byte[1];
+            var client = new TcpClient();
+            await client.ConnectAsync(IPAddress.Loopback, 55555);
+            var socket = client.Client;
+
+            while (true)
+            {
+                await Recurse(recurseDepth, false, socket, buffer);
+                ++count;
+            }
+        });
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitGTDeep.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketAwaitGTDeep.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SocketAwaitGTDeep.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketWaitDeep.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketWaitDeep.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Recurse(int depth, bool rcvFirst, Socket socket, byte[] buffer)
+    {
+        if (depth > 0)
+        {
+            Recurse(depth - 1, rcvFirst, socket, buffer);
+            return;
+        }
+
+        if (rcvFirst)
+            socket.Receive(buffer);
+        socket.Send(buffer);
+        if (!rcvFirst)
+            socket.Receive(buffer);
+    }
+
+    public static int Main(string[] args)
+    {
+        if (args.Length < 2 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        int recurseDepth = int.Parse(args[1]);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        var serverThread = new Thread(() =>
+        {
+            var buffer = new byte[1];
+            var listener = new TcpListener(IPAddress.Loopback, 55555);
+            listener.Start();
+            var socket = listener.AcceptSocket();
+            listener.Stop();
+
+            while (true)
+            {
+                Recurse(recurseDepth, true, socket, buffer);
+            }
+        });
+        serverThread.IsBackground = true;
+        serverThread.Start();
+
+        Thread.Sleep(100);
+
+        var clientThread = new Thread(() =>
+        {
+            var buffer = new byte[1];
+            var client = new TcpClient();
+            client.Connect(IPAddress.Loopback, 55555);
+            var socket = client.Client;
+
+            while (true)
+            {
+                Recurse(recurseDepth, false, socket, buffer);
+                ++count;
+            }
+        });
+        clientThread.IsBackground = true;
+        clientThread.Start();
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketWaitDeep.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketWaitDeep.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SocketWaitDeep.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketWaitGTDeep.cs
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketWaitGTDeep.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class Test_greenthread_perf_YieldResume
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Recurse(int depth, bool rcvFirst, Socket socket, byte[] buffer)
+    {
+        if (depth > 0)
+        {
+            Recurse(depth - 1, rcvFirst, socket, buffer);
+            return;
+        }
+
+        if (rcvFirst)
+            socket.Receive(buffer);
+        socket.Send(buffer);
+        if (!rcvFirst)
+            socket.Receive(buffer);
+    }
+
+    public static int Main(string[] args)
+    {
+        if (args.Length < 2 || args[0] != "run")
+        {
+            Console.WriteLine("Pass argument 'run' to run benchmark.");
+            return 100;
+        }
+
+        int recurseDepth = int.Parse(args[1]);
+
+        ThreadPool.SetMinThreads(2, 1);
+        ThreadPool.SetMaxThreads(2, 1);
+
+        var sw = new Stopwatch();
+        int count = 0;
+
+        Task.RunAsGreenThread(() =>
+        {
+            var buffer = new byte[1];
+            var listener = new TcpListener(IPAddress.Loopback, 55555);
+            listener.Start();
+            var socket = listener.AcceptSocket();
+            listener.Stop();
+
+            while (true)
+            {
+                Recurse(recurseDepth, true, socket, buffer);
+            }
+        });
+
+        Thread.Sleep(100);
+
+        Task.RunAsGreenThread(() =>
+        {
+            var buffer = new byte[1];
+            var client = new TcpClient();
+            client.Connect(IPAddress.Loopback, 55555);
+            var socket = client.Client;
+
+            while (true)
+            {
+                Recurse(recurseDepth, false, socket, buffer);
+                ++count;
+            }
+        });
+
+        for (int i = 0; i < 8; i++)
+        {
+            int initialCount = count;
+            sw.Restart();
+            Thread.Sleep(500);
+            int finalCount = count;
+            sw.Stop();
+            Console.WriteLine($"{sw.Elapsed.TotalNanoseconds / (finalCount - initialCount),15:0.000} ns");
+        }
+
+        return 100;
+    }
+}

--- a/src/tests/baseservices/threading/greenthreads/perf/SocketWaitGTDeep.csproj
+++ b/src/tests/baseservices/threading/greenthreads/perf/SocketWaitGTDeep.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SocketWaitGTDeep.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
These microbenchmarks test the performance of setup/teardown of stack frames which are performing async activity.