### PR TITLE
[NativeAOT-LLVM] Exception handling: funclets

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5547,7 +5547,6 @@ void Compiler::ResetOptAnnotations()
     fgResetForSsa();
     vnStore               = nullptr;
     m_opAsgnVarDefSsaNums = nullptr;
-    m_blockToEHPreds      = nullptr;
     fgSsaPassesCompleted  = 0;
     fgVNPassesCompleted   = 0;
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -950,6 +950,7 @@ private:
 
 public:
     unsigned short lvRefCnt(RefCountState state = RCS_NORMAL) const;
+    unsigned short lvRawRefCnt(RefCountState state = RCS_NORMAL) const;
     void incLvRefCnt(unsigned short delta, RefCountState state = RCS_NORMAL);
     void setLvRefCnt(unsigned short newValue, RefCountState state = RCS_NORMAL);
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4545,20 +4545,36 @@ inline void DEBUG_DESTROY_NODE(GenTree* tree)
 //
 // Return Value:
 //    Ref count for the local.
-
+//
 inline unsigned short LclVarDsc::lvRefCnt(RefCountState state) const
 {
+    unsigned short refCount = lvRawRefCnt(state);
 
+    if (lvImplicitlyReferenced && (refCount == 0))
+    {
+        return 1;
+    }
+
+    return refCount;
+}
+
+//------------------------------------------------------------------------------
+// lvRawRefCnt: access the "raw" reference count for this local var
+//
+// Arguments:
+//    state: the requestor's expected ref count state; defaults to RCS_NORMAL
+//
+// Return Value:
+//    "Raw" ref count for the local - will return zero for implicitly referenced
+//    locals that did not appear in IR.
+//
+inline unsigned short LclVarDsc::lvRawRefCnt(RefCountState state) const
+{
 #if defined(DEBUG)
     assert(state != RCS_INVALID);
     Compiler* compiler = JitTls::GetCompiler();
     assert(compiler->lvaRefCountState == state);
 #endif
-
-    if (lvImplicitlyReferenced && (m_lvRefCnt == 0))
-    {
-        return 1;
-    }
 
     return m_lvRefCnt;
 }

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -627,15 +627,6 @@ const HelperFuncInfo& Llvm::getHelperFuncInfo(CorInfoHelpFunc helperFunc)
     return info;
 }
 
-// Returns true if the type can be stored on the LLVM stack
-// instead of the shadow stack in this method. This is the case
-// if it is a non-ref primitive or a struct without GC fields.
-//
-bool Llvm::canStoreLocalOnLlvmStack(LclVarDsc* varDsc)
-{
-    return !varDsc->HasGCPtr();
-}
-
 bool Llvm::canStoreArgOnLlvmStack(Compiler* compiler, CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd)
 {
     // structs with no GC pointers can go on LLVM stack.

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -124,7 +124,6 @@ size_t HelperFuncInfo::GetSigArgCount() const
 Llvm::Llvm(Compiler* compiler)
     : _compiler(compiler),
     _info(compiler->info),
-    _function(nullptr),
     _sigInfo(compiler->info.compMethodInfo->args),
     _builder(_llvmContext),
     _prologBuilder(_llvmContext),
@@ -686,10 +685,14 @@ unsigned int Llvm::padNextOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE s
 
 [[noreturn]] void Llvm::failFunctionCompilation()
 {
-    if (_function != nullptr)
+    for (Function* llvmFunc : m_functions)
     {
-        _function->deleteBody();
+        if (llvmFunc != nullptr)
+        {
+            llvmFunc->deleteBody();
+        }
     }
+
     fatal(CORJIT_SKIPPED);
 }
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -177,7 +177,6 @@ private:
     bool callHasShadowStackArg(GenTreeCall* call);
     const HelperFuncInfo& getHelperFuncInfo(CorInfoHelpFunc helperFunc);
 
-    bool canStoreLocalOnLlvmStack(LclVarDsc* varDsc);
     static bool canStoreArgOnLlvmStack(Compiler* compiler, CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
 
     unsigned int padOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned int atOffset);
@@ -253,6 +252,8 @@ private:
     GenTree* createShadowStackStoreNode(var_types storeType, GenTree* addr, GenTree* data);
     GenTree* insertShadowStackAddr(GenTree* insertBefore, ssize_t offset);
 
+    bool isShadowFrameLocal(LclVarDsc* varDsc) const;
+
     // ================================================================================================================
     // |                                                   Codegen                                                    |
     // ================================================================================================================
@@ -325,12 +326,15 @@ private:
     DebugMetadata getOrCreateDebugMetadata(const char* documentFileName);
     llvm::DILocation* createDebugFunctionAndDiLocation(struct DebugMetadata debugMetadata, unsigned int lineNo);
 
+    Function* getRootLlvmFunction();
+    Function* getCurrentLlvmFunction();
+
     llvm::BasicBlock* createInlineLlvmBlock();
     llvm::BasicBlock* getFirstLlvmBlockForBlock(BasicBlock* block);
     llvm::BasicBlock* getLastLlvmBlockForBlock(BasicBlock* block);
     void setLastLlvmBlockForBlock(BasicBlock* block, llvm::BasicBlock* llvmBlock);
 
-    bool isLlvmFrameLocal(LclVarDsc* varDsc);
+    Value* getLocalAddr(unsigned lclNum);
     unsigned int getTotalLocalOffset();
 };
 

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -16,6 +16,12 @@ void Llvm::Compile()
         failFunctionCompilation();
     }
 
+    if ((_info.compFlags & CORINFO_FLG_SYNCH) != 0)
+    {
+        // TODO-LLVM-EH: enable.
+        failFunctionCompilation();
+    }
+
     if (initializeFunctions())
     {
         return;

--- a/src/coreclr/jit/register.h
+++ b/src/coreclr/jit/register.h
@@ -112,9 +112,10 @@ REGDEF(STK,    16+XMMBASE,  0x0000,       "STK"  )
 // (in particular, fixing the assumption that "this" is always enregistered), we will
 // pretend we have one register (both integer and FP, for simplicity).
 //
-REGDEF(R0,  0, 0x01, "R0")
-REGDEF(F0,  1, 0x02, "F0")
-REGDEF(STK, 2, 0x00, "SS")
+REGDEF(R0,   0, 0x01, "R0")
+REGDEF(F0,   1, 0x02, "F0")
+REGDEF(LLVM, 2, 0x04, "LLVM")
+REGDEF(STK,  3, 0x00, "SS")
 
 #else
   #error Unsupported or unset target architecture


### PR DESCRIPTION
This change implements various pieces needed for funclet-based EH.
1\) Place locals live in funclets on the shadow stack. Allow a given local to be both live on the shadow stack and in an LLVM register.
2\) Generate funclets in codegen.

Currently, all functions with EH get skipped for RyuJit, so to test the support added here that needs to be manually undone.

<details>
<summary>Example C# and generated LLVM IR</summary>

```cs
[MethodImpl(MethodImplOptions.NoInlining)]
private static int Problem(int state)
{
    [MethodImpl(MethodImplOptions.NoInlining)]
    void Call() { }

    try
    {
        state = 1;
        Call();
    }
    catch when (_floatStatic is 0)
    {
        try
        {
            Console.WriteLine("H0");
            state++;
        }
        catch
        {
            Console.WriteLine("H00");
            state = 3;
        }
    }
    catch (NullReferenceException e)
    {
        state = 4;
        Console.WriteLine("H1");
    }
    catch (Exception e)
    {
        state = 5;
        Console.WriteLine("H2");
    }
    finally
    {
        state++;
        Console.WriteLine("F0");
    }

    return state;
}
```
```llvm
===================================================================================================================
LLVM IR for RyuJitReproduction.Program:Problem(int):int after codegen:
-------------------------------------------------------------------------------------------------------------------

define i32 @RyuJitReproduction_RyuJitReproduction_Program__Problem(i8* %0, i32 %1) personality { i8*, i32 } (i32, i8*, i8*, ...)* @__gxx_personality_v0 {
Prolog:
  br label %BB01

BB01:                                             ; preds = %Prolog
  %2 = bitcast i8* %0 to i32*
  store i32 %1, i32* %2, align 4
  %3 = getelementptr i8, i8* %0, i32 4
  %4 = bitcast i8* %3 to i32*
  store i32 0, i32* %4, align 4
  %5 = getelementptr i8, i8* %0, i32 8
  %6 = bitcast i8* %5 to i8**
  store i8* null, i8** %6, align 4
  %7 = getelementptr i8, i8* %0, i32 12
  %8 = bitcast i8* %7 to i8**
  store i8* null, i8** %8, align 4
  %9 = getelementptr i8, i8* %0, i32 16
  %10 = bitcast i8* %9 to i8**
  store i8* null, i8** %10, align 4
  %11 = getelementptr i8, i8* %0, i32 20
  %12 = bitcast i8* %11 to i8**
  store i8* null, i8** %12, align 4
  %13 = getelementptr i8, i8* %0, i32 24
  %14 = bitcast i8* %13 to i8**
  store i8* null, i8** %14, align 4
  br label %BB02

BB02:                                             ; preds = %BB01
  br label %BB03.1

BB27:                                             ; preds = %BB19, %BB21, %BB23, %BB25
  %15 = bitcast i8* %0 to i32*
  %16 = load i32, i32* %15, align 4
  ret i32 %16

BB25:                                             ; preds = %BB24
  br label %BB27

BB23:                                             ; preds = %BB22
  br label %BB27

BB21:                                             ; preds = %BB20
  br label %BB27

BB19:                                             ; preds = %BB18
  br label %BB27

BB17:                                             ; preds = %BB16
  br label %BB28

BB28:                                             ; preds = %BB17
  %17 = getelementptr i8, i8* %0, i32 4
  %18 = bitcast i8* %17 to i32*
  %19 = load i32, i32* %18, align 4
  ret i32 %19

BB03.1:                                           ; preds = %BB02
  %20 = bitcast i8* %0 to i32*
  store i32 1, i32* %20, align 4
  %21 = getelementptr i8, i8* %0, i32 28
  invoke void @RyuJitReproduction_RyuJitReproduction_Program___Problem_g__Call_27_0(i8* %21)
          to label %BB03.2 unwind label %BBT1

BB03.2:                                           ; preds = %BB03.1
  br label %BB24

BBT1:                                             ; preds = %BB03.1
  %22 = landingpad { i8*, i32 }
          catch i8* null
  resume { i8*, i32 } %22

BB15:                                             ; No predecessors!
  br label %BB22

BB22:                                             ; preds = %BB15
  call void @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F6_Finally"(i8* %0)
  br label %BB23

BB14:                                             ; No predecessors!
  br label %BB20

BB20:                                             ; preds = %BB14
  call void @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F6_Finally"(i8* %0)
  br label %BB21

BB13:                                             ; No predecessors!
  br label %BB18

BB18:                                             ; preds = %BB13
  call void @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F6_Finally"(i8* %0)
  br label %BB19

BB12:                                             ; No predecessors!
  br label %BB16

BB16:                                             ; preds = %BB12
  call void @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F6_Finally"(i8* %0)
  br label %BB17

BB24:                                             ; preds = %BB03.2
  call void @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F6_Finally"(i8* %0)
  br label %BB25
}

define internal i32 @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F1_Catch"(i8* %0) {
BB07:
  %1 = getelementptr i8, i8* %0, i32 24
  %2 = bitcast i8* %1 to i8**
  store i8* null, i8** %2, align 4
  %3 = load i32*, i32** @__Str_H00___SYMBOL, align 4
  %4 = getelementptr i8, i8* %0, i32 28
  %5 = getelementptr i8, i8* %0, i32 28
  %6 = bitcast i8* %5 to i8**
  %7 = bitcast i32* %3 to i8*
  store i8* %7, i8** %6, align 4
  call void @System_Console_System_Console__WriteLine_12(i8* %4)
  %8 = getelementptr i8, i8* %0, i32 4
  %9 = bitcast i8* %8 to i32*
  store i32 3, i32* %9, align 4
  ret i32 0
}

define internal i32 @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F2_Filter"(i8* %0) {
BB04.1:
  %1 = getelementptr i8, i8* %0, i32 16
  %2 = bitcast i8* %1 to i8**
  store i8* null, i8** %2, align 4
  %3 = getelementptr i8, i8* %0, i32 28
  %4 = call i8* @__GetNonGCStaticBase_RyuJitReproduction_RyuJitReproduction_Program(i8* %3)
  %5 = getelementptr i8, i8* %4, i32 80
  %6 = bitcast i8* %5 to float*
  %7 = icmp eq float* %6, null
  br i1 %7, label %BB04.2, label %BB04.3

BB04.2:                                           ; preds = %BB04.1
  %8 = getelementptr i8, i8* %0, i32 28
  call void @S_P_CoreLib_Internal_Runtime_CompilerHelpers_ThrowHelpers__ThrowNullReferenceException(i8* %8)
  unreachable

BB04.3:                                           ; preds = %BB04.1
  %9 = load float, float* %6, align 4
  %10 = fcmp oeq float %9, 0.000000e+00
  %11 = zext i1 %10 to i32
  ret i32 %11
}

define internal i32 @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F3_FilteredCatch"(i8* %0) personality { i8*, i32 } (i32, i8*, i8*, ...)* @__gxx_personality_v0 {
BB05:
  %1 = getelementptr i8, i8* %0, i32 20
  %2 = bitcast i8* %1 to i8**
  store i8* null, i8** %2, align 4
  br label %BB06.1

BB06.1:                                           ; preds = %BB05
  %3 = load i32*, i32** @__Str_H0___SYMBOL, align 4
  %4 = getelementptr i8, i8* %0, i32 28
  %5 = getelementptr i8, i8* %0, i32 28
  %6 = bitcast i8* %5 to i8**
  %7 = bitcast i32* %3 to i8*
  store i8* %7, i8** %6, align 4
  invoke void @System_Console_System_Console__WriteLine_12(i8* %4)
          to label %BB06.2 unwind label %BBT0

BB06.2:                                           ; preds = %BB06.1
  %8 = bitcast i8* %0 to i32*
  %9 = load i32, i32* %8, align 4
  %10 = add i32 %9, 1
  %11 = bitcast i8* %0 to i32*
  store i32 %10, i32* %11, align 4
  br label %BB09

BBT0:                                             ; preds = %BB06.1
  %12 = landingpad { i8*, i32 }
          catch i8* null
  resume { i8*, i32 } %12

BB09:                                             ; preds = %BB06.2
  ret i32 0

BB08:                                             ; No predecessors!
  ret i32 0
}

define internal i32 @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F4_Catch"(i8* %0) {
BB10:
  %1 = getelementptr i8, i8* %0, i32 12
  %2 = bitcast i8* %1 to i8**
  store i8* null, i8** %2, align 4
  %3 = bitcast i8* %0 to i32*
  store i32 4, i32* %3, align 4
  %4 = load i32*, i32** @__Str_H1___SYMBOL, align 4
  %5 = getelementptr i8, i8* %0, i32 28
  %6 = getelementptr i8, i8* %0, i32 28
  %7 = bitcast i8* %6 to i8**
  %8 = bitcast i32* %4 to i8*
  store i8* %8, i8** %7, align 4
  call void @System_Console_System_Console__WriteLine_12(i8* %5)
  ret i32 0
}

define internal i32 @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F5_Catch"(i8* %0) {
BB11:
  %1 = getelementptr i8, i8* %0, i32 8
  %2 = bitcast i8* %1 to i8**
  store i8* null, i8** %2, align 4
  %3 = bitcast i8* %0 to i32*
  store i32 5, i32* %3, align 4
  %4 = load i32*, i32** @__Str_H2___SYMBOL, align 4
  %5 = getelementptr i8, i8* %0, i32 28
  %6 = getelementptr i8, i8* %0, i32 28
  %7 = bitcast i8* %6 to i8**
  %8 = bitcast i32* %4 to i8*
  store i8* %8, i8** %7, align 4
  call void @System_Console_System_Console__WriteLine_12(i8* %5)
  ret i32 0
}

define internal void @"RyuJitReproduction_RyuJitReproduction_Program__Problem$F6_Finally"(i8* %0) {
BB26:
  %1 = bitcast i8* %0 to i32*
  %2 = load i32, i32* %1, align 4
  %3 = add i32 %2, 1
  %4 = bitcast i8* %0 to i32*
  store i32 %3, i32* %4, align 4
  %5 = load i32*, i32** @__Str_F0___SYMBOL, align 4
  %6 = getelementptr i8, i8* %0, i32 28
  %7 = getelementptr i8, i8* %0, i32 28
  %8 = bitcast i8* %7 to i8**
  %9 = bitcast i32* %5 to i8*
  store i8* %9, i8** %8, align 4
  call void @System_Console_System_Console__WriteLine_12(i8* %6)
  ret void
}
```
</details>