### PR TITLE
NativeAOT-LLVM : Fix assert when GT_FIELD_LIST has > 1 member and is emitted as an LLVM primitive

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1206,7 +1206,7 @@ Value* Llvm::buildFieldList(GenTreeFieldList* fieldList, Type* llvmType)
 {
     assert(fieldList->TypeIs(TYP_STRUCT));
 
-    if (llvmType->isStructTy() || fieldList->Uses().begin() != fieldList->Uses().end())
+    if (llvmType->isStructTy() || fieldList->Uses().begin()->GetNext() != nullptr)
     {
         Value* alloca = _builder.CreateAlloca(llvmType);
         Value* allocaAsBytePtr = _builder.CreatePointerCast(alloca, Type::getInt8PtrTy(_llvmContext));
@@ -1221,9 +1221,6 @@ Value* Llvm::buildFieldList(GenTreeFieldList* fieldList, Type* llvmType)
 
         return _builder.CreateLoad(alloca);
     }
-
-    // single primitive type wrapped in struct
-    assert(fieldList->Uses().begin()->GetNext() == nullptr);
 
     return consumeValue(fieldList->Uses().begin()->GetNode(), llvmType);
 }

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -563,7 +563,7 @@ void Llvm::visitNode(GenTree* node)
             break;
         case GT_FIELD_LIST:
         case GT_INIT_VAL:
-            // These ('contained') nodes aways generate code as part of their parent.
+            // These ('contained') nodes always generate code as part of their parent.
             break;
         default:
             failFunctionCompilation();
@@ -1206,7 +1206,7 @@ Value* Llvm::buildFieldList(GenTreeFieldList* fieldList, Type* llvmType)
 {
     assert(fieldList->TypeIs(TYP_STRUCT));
 
-    if (llvmType->isStructTy())
+    if (llvmType->isStructTy() || fieldList->Uses().begin() != fieldList->Uses().end())
     {
         Value* alloca = _builder.CreateAlloca(llvmType);
         Value* allocaAsBytePtr = _builder.CreatePointerCast(alloca, Type::getInt8PtrTy(_llvmContext));

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -391,6 +391,8 @@ internal static class Program
 
         TestDoublePrint();
 
+        TestGenStructContains();
+
         // This test should remain last to get other results before stopping the debugger
         PrintLine("Debugger.Break() test: Ok if debugger is open and breaks.");
         System.Diagnostics.Debugger.Break();
@@ -3796,6 +3798,17 @@ internal static class Program
         StartTest("Test Double ToString");
 
         EndTest(1d.ToString() == "1");
+    }
+
+    static void TestGenStructContains()
+    {
+        StartTest("Test Double ToString");
+
+        var col = new List<ValueTuple<char, char>>() { new ValueTuple<char, char>('a', 'b') };
+
+        var contains = col.Contains(new ValueTuple<char,char>('a', 'b'));
+
+        EndTest(contains);
     }
 
     static ushort ReadUInt16()


### PR DESCRIPTION
This PR extends the condition when we build out GT_FIELD_LIST to include cases like 
```
struct { char, char }
````
This is emitted as an LLVM `i32` but needs to be alloc'ed, and built out as field stores.

Fixes #2112 which contains a log of an example that failed.

cc @SingleAccretion 