### PR TITLE
NativeAOT-LLVM: Trunc llvm values when building GT_STORE_IND to a smaller int type

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1248,10 +1248,9 @@ void Llvm::buildBlk(GenTreeBlk* blkNode)
 }
 
 // TODO-LLVM: delete when https://github.com/dotnet/runtime/pull/70518 from upstream is merged.
-// TODO-LLVM: Other combinations of a small int and larger int types are presumably possible, these are just the ones hit
 bool storeIndRequiresTrunc(var_types storeType, var_types dataType)
 {
-    return (storeType == TYP_BYTE || storeType == TYP_SHORT) && dataType == TYP_LONG;
+    return varTypeIsSmall(storeType) && dataType == TYP_LONG;
 }
 
 void Llvm::buildStoreInd(GenTreeStoreInd* storeIndOp)

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1247,7 +1247,7 @@ void Llvm::buildBlk(GenTreeBlk* blkNode)
     mapGenTreeToValue(blkNode, blkValue);
 }
 
-// TODO-LLVM: delete when enough merged to not see these IR sequences any more (Nov 2022?).
+// TODO-LLVM: delete when https://github.com/dotnet/runtime/pull/70518 from upstream is merged.
 // TODO-LLVM: Other combinations of a small int and larger int types are presumably possible, these are just the ones hit
 bool storeIndRequiresTrunc(var_types storeType, var_types dataType)
 {


### PR DESCRIPTION
This PR uses an LLVM `trunc` when storing a large int into a small int. E.g. for this IR

```c#
------------ BB01 [000..095) (return), preds={} succs={}
N001 (  1,  1) [000009] ------------         t9 =    LCL_VAR   byref  V00 arg0         u:1 $80
N003 (  1,  1) [000010] ------------        t10 =    LCL_VAR   long   V01 arg1         u:1 $c0
                                                  /--*  t9     byref
                                                  +--*  t10    long
               [000066] -A-XG-------              *  STOREIND  byte
```

Fixes https://github.com/dotnet/runtimelab/issues/2114

cc @dotnet/nativeaot-llvm 