### PR TITLE
NativeAOT-LLVM: revert change that caused the Ilc exit status to be lost

### DIFF
--- a/src/tests/Common/CLRTest.NativeAot.targets
+++ b/src/tests/Common/CLRTest.NativeAot.targets
@@ -163,6 +163,7 @@ if defined RunNativeAot (
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <RuntimeIdentifier>$(OutputRid)</RuntimeIdentifier>
+    <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
     $(_RootEntryAssemblyLine)
   </PropertyGroup>
 

--- a/src/tests/Common/CLRTest.NativeAot.targets
+++ b/src/tests/Common/CLRTest.NativeAot.targets
@@ -125,7 +125,7 @@ if defined RunNativeAot (
     if errorlevel 1 (
         ECHO END COMPILATION - FAILED
         ECHO FAILED
-        exit /b 1
+        exit 1
     )
 
     set ExePath=$(ExeRunner)native\$(MSBuildProjectName)$(ExeExtension)

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -186,7 +186,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
-    <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
+    <CLRTestMSBuildArgs>/p:MSBuildEnableWorkloadResolver=false</CLRTestMSBuildArgs>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestsCommonProject)' != 'true'">

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -186,7 +186,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
-    <CLRTestMSBuildArgs>/p:MSBuildEnableWorkloadResolver=false</CLRTestMSBuildArgs>
+    <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestsCommonProject)' != 'true'">


### PR DESCRIPTION
This PR removes the `/b` from the `exit` command so the wrapper detects the exit status correctly.  In commit 87777b624b0b8ea295b0fe9cd8505ce262ed75c0 we will remove this file completely.