### PR TITLE
Disable Build and run libraries tests for official builds

### DIFF
--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -21,7 +21,7 @@ steps:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.alljits+clr.wasmjit+clr.nativeaotlibs+clr.tools -c $(buildConfigUpper)
       displayName: Build the ILC and RyuJit cross-compilers
 
-  - ${{ if and(eq(parameters.buildConfig, 'Release'),ne(parameters.archType, 'wasm')) }}:
+  - ${{ if and(ne(parameters.isOfficialBuild, true),and(eq(parameters.buildConfig, 'Release'),ne(parameters.archType, 'wasm'))) }}:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -c Release -test /p:TestNativeAot=true
       displayName: Build and run libraries tests
 


### PR DESCRIPTION
These tests are just a sanity check that non-wasm config is not broken. We do not need to run this sanity check for official builds.