### PR TITLE
[NativeAOT-LLVM] Fix local libraries build

### DIFF
--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.csproj
@@ -3,6 +3,9 @@
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsNETCoreAppRef>false</IsNETCoreAppRef>
+    <!-- NativeAOT-LLVM: retain when merging https://github.com/dotnet/runtime/pull/64000 (Feb 24) -->
+    <!-- NativeAOT-LLVM: take upstream when merging https://github.com/dotnet/runtime/pull/68488 (Apr 25) -->
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.Quic.cs" />


### PR DESCRIPTION
S.N.Quic ref project is special because it sets "IsNETCoreAppRef" to "false", which ends up meaning implicit framework references aren't disabled.

This is a problem because we build with the 6.0 SDK currently, and that doesn't support running source generators from the 7.0 reference pack that is pulled in.

I do not know why CI isn't hitting this. Perhaps a side effect of the locally installed 7.0 SDK?