### PR TITLE
[NativeAOT-LLVM] Fix NAOT runtime libraries VS experience for WASM

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,12 @@
     <BuildingAnOfficialBuildLeg Condition="'$(BuildingAnOfficialBuildLeg)' == '' and '$(OfficialBuildId)' != '' and '$(DotNetBuildFromSource)' != 'true'">true</BuildingAnOfficialBuildLeg>
   </PropertyGroup>
 
+  <!-- Seeding these two properties from Platform allows one to use VS's configuration manager to switch targets -->
+  <PropertyGroup Condition="'$(Platform)' != ''">
+    <TargetOS Condition="'$(Platform)' == 'wasm'">Browser</TargetOS>
+    <TargetArchitecture Condition="'$(Platform)' != 'AnyCPU'">$(Platform)</TargetArchitecture>
+  </PropertyGroup>
+
   <PropertyGroup Label="CalculateTargetOS">
     <_hostOS>Linux</_hostOS>
     <_hostOS Condition="$([MSBuild]::IsOSPlatform('OSX'))">OSX</_hostOS>

--- a/src/coreclr/nativeaot/Directory.Build.props
+++ b/src/coreclr/nativeaot/Directory.Build.props
@@ -17,7 +17,7 @@
 
     <OutputPath Condition="$(MSBuildProjectName.StartsWith('System.Private.'))">$(RuntimeBinDir)/aotsdk/</OutputPath>
     <Configurations>Debug;Release;Checked</Configurations>
-    <Platforms>x64;x86;arm;arm64</Platforms>
+    <Platforms>x64;x86;arm;arm64;wasm</Platforms>
 
     <Platform Condition=" '$(Platform)' == '' ">$(TargetArchitecture)</Platform>
     <Platform Condition=" '$(Platform)' == 'armel' ">arm</Platform>
@@ -80,10 +80,19 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DefineConstants>TARGET_64BIT;TARGET_ARM64;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Platform)' == 'wasm'">
+    <!-- "WASM ABI" here refers to the use of shadow stacks, native-based EH, conservative GC, etc. -->
+    <!-- It does not, in principle, imply TARGET_WASM, or vice-versa, though currently this is the case. -->
+    <!-- In the future we may want to create a Windows/Unix build targeting this ABI, for testing. -->
+    <WasmAbi>true</WasmAbi>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DefineConstants>TARGET_32BIT;TARGET_WASM;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
 
   <PropertyGroup>
     <DefineConstants Condition="'$(TargetsWindows)'=='true'">TARGET_WINDOWS;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(TargetsUnix)'=='true'">TARGET_UNIX;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition="'$(TargetsBrowser)'=='true'">TARGET_UNIX;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Configuration specific properties -->

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -44,10 +44,6 @@
     <FeatureGenericMath>true</FeatureGenericMath>
     <DefineConstants Condition="'$(FeatureGenericMath)' == 'true'">$(DefineConstants);FEATURE_GENERIC_MATH</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetsBrowser)' == 'true'">
-    <DefineConstants >TARGET_UNIX;TARGET_WASM;TARGET_32BIT;FEATURE_64BIT_ALIGNMENT;$(DefineConstants)</DefineConstants>
-    <Platform>llvm</Platform>
-  </PropertyGroup>
 
   <!-- Sources -->
   <ItemGroup>
@@ -182,7 +178,7 @@
     <Compile Include="System\Diagnostics\StackFrame.CoreRT.cs" />
     <Compile Include="System\Diagnostics\StackFrameExtensions.cs" />
     <Compile Include="System\Diagnostics\StackTrace.CoreRT.cs" />
-    <Compile Include="System\Diagnostics\StackTrace.CoreRT.Wasm.cs" Condition="'$(TargetsBrowser)'=='true'"/>
+    <Compile Include="System\Diagnostics\StackTrace.CoreRT.Wasm.cs" Condition="'$(WasmAbi)' == 'true'"/>
     <Compile Include="System\Enum.CoreRT.cs" />
     <Compile Include="System\Environment.CoreRT.cs" />
     <Compile Include="System\GC.cs" />
@@ -228,7 +224,7 @@
     <Compile Include="System\Delegate.cs" />
     <Compile Include="System\RuntimeTypeHandle.cs" />
     <Compile Include="System\Exception.CoreRT.cs" />
-    <Compile Include="System\Exception.CoreRT.LLVM.cs" Condition="'$(Platform)'=='llvm'"/>
+    <Compile Include="System\Exception.CoreRT.LLVM.cs" Condition="'$(WasmAbi)' == 'true'"/>
     <Compile Include="System\RuntimeExceptionHelpers.cs" />
     <Compile Include="System\EETypePtr.cs" />
     <Compile Include="System\Runtime\RuntimeImports.cs" />
@@ -450,16 +446,16 @@
     <Compile Include="$(AotCommonPath)\Internal\Runtime\TransitionBlock.cs">
       <Link>Common\TransitionBlock.cs</Link>
     </Compile>
-    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.wasm.cs" Condition="'$(Platform)'=='llvm'">
+    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.wasm.cs" Condition="'$(WasmAbi)' == 'true'">
       <Link>Runtime.Base\src\System\Runtime\ExceptionHandling.wasm.cs</Link>
     </Compile>
-    <Compile Include="$(RuntimeBasePath)System\Runtime\StackFrameIterator.wasm.cs" Condition="'$(Platform)'=='llvm'">
+    <Compile Include="$(RuntimeBasePath)System\Runtime\StackFrameIterator.wasm.cs" Condition="'$(WasmAbi)' == 'true'">
       <Link>Runtime.Base\src\System\Runtime\StackFrameIterator.wasm.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(InPlaceRuntime)' == 'true'">
-    <Compile Include="$(IntermediatesDir)\nativeaot\Runtime\Full\AsmOffsets.cs" Condition="'$(Platform)'!='llvm'"/>
-    <Compile Include="$(IntermediatesDir.Replace('\ide', ''))\nativeaot\Runtime\Portable\AsmOffsetsPortable.cs" Condition="'$(Platform)'=='llvm'"/> <!-- its never in \ide\ -->
+    <Compile Include="$(IntermediatesDir)\nativeaot\Runtime\Full\AsmOffsets.cs" Condition="'$(WasmAbi)' != 'true'"/>
+    <Compile Include="$(IntermediatesDir.Replace('\ide', ''))\nativeaot\Runtime\Portable\AsmOffsetsPortable.cs" Condition="'$(WasmAbi)' == 'true'"/> <!-- its never in \ide\ -->
   </ItemGroup>
 
   <Import Project="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System.Private.CoreLib.Shared.projitems" Label="Shared" />

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -14,9 +14,6 @@
   <PropertyGroup>
     <NativeFormatCommonPath>$(CompilerCommonPath)\Internal\NativeFormat</NativeFormatCommonPath>
   </PropertyGroup>
-  <PropertyGroup>
-    <DefineConstants Condition="'$(TargetsBrowser)' == 'true'">TARGET_UNIX;TARGET_WASM;TARGET_32BIT;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(NativeFormatCommonPath)\NativeFormat.cs" />
     <Compile Include="$(NativeFormatCommonPath)\NativeFormatReader.cs" />

--- a/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
@@ -13,9 +13,8 @@
   <PropertyGroup Condition="'$(Platform)' == 'armel'">
     <DefineConstants>FEATURE_64BIT_ALIGNMENT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetsBrowser)' == 'true'">
-    <DefineConstants>TARGET_WASM;TARGET_32BIT;FEATURE_64BIT_ALIGNMENT;$(DefineConstants)</DefineConstants>
-    <Platform>llvm</Platform>
+  <PropertyGroup Condition="'$(Platform)' == 'wasm'">
+    <DefineConstants>FEATURE_64BIT_ALIGNMENT;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <!-- For now, link Runtime.Base into Test.CoreLib until there is proper multifile build -->
   <PropertyGroup>
@@ -77,8 +76,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(InPlaceRuntime)' == 'true'">
-    <Compile Include="$(IntermediatesDir)\nativeaot\Runtime\Full\AsmOffsets.cs" Condition="'$(Platform)'!='llvm'"/>
-    <Compile Include="$(IntermediatesDir.Replace('\ide', ''))\nativeaot\Runtime\Portable\AsmOffsetsPortable.cs" Condition="'$(Platform)'=='llvm'"/> <!-- its never in \ide\ -->
+    <Compile Include="$(IntermediatesDir)\nativeaot\Runtime\Full\AsmOffsets.cs" Condition="'$(WasmAbi)' != 'true'"/>
+    <Compile Include="$(IntermediatesDir.Replace('\ide', ''))\nativeaot\Runtime\Portable\AsmOffsetsPortable.cs" Condition="'$(WasmAbi)' == 'true'"/> <!-- its never in \ide\ -->
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CompilerCommonPath)\Internal\NativeFormat\NativeFormatReader.Primitives.cs">


### PR DESCRIPTION
It was not possible to simply open VS and start editing code for the WASM version of SPCL because some key MSBuild properties weren't set properly. This change fixes that: one can now simply define a new config in VS named "wasm" and things "just work".