### PR TITLE
[NativeAOT-LLVM] Build target and host packages for WASM on the same platform

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -117,7 +117,7 @@ stages:
 #     - Linux_arm64      # ILCompiler for LLVM depends on libLLVM.runtime.linux-arm64 with version (>= 11.0.0) which is missing https://github.com/microsoft/LLVMSharp/issues/177. TODO: reinstate when we remove LLVMSharp dependency
 #     - Linux_arm        # ILCompiler for LLVM depends on libLLVM.runtime.linux-arm64 with version (>= 11.0.0) which is missing https://github.com/microsoft/LLVMSharp/issues/177. TODO: reinstate when we remove LLVMSharp dependency
 #     - Linux_musl_arm64 # ILCompiler for LLVM depends on libLLVM.runtime.linux-arm64 with version (>= 11.0.0) which is missing https://github.com/microsoft/LLVMSharp/issues/177. TODO: reinstate when we remove LLVMSharp dependency
-      - windows_x64
+#     - windows_x64      # Part of the combined (target + host) WASM build below
       - windows_arm64
       - OSX_x64
       jobParameters:

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -15,12 +15,17 @@ steps:
 - ${{ if and(ne(parameters.archType, 'arm'), ne(parameters.archType, 'arm64')) }}:
 
   # For NativeAOT-LLVM, we have just built the Wasm-targeting native artifacts (the runtime and libraries).
-  # Now we need to build the cross-targeting compilers, RyuJit and ILC.
+  # Now we need to build the cross-targeting compilers, RyuJit and ILC. Likewise with packages.
 
   - ${{ if eq(parameters.archType, 'wasm') }}:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.alljits+clr.wasmjit+clr.nativeaotlibs+clr.tools -c $(buildConfigUpper)
       displayName: Build the ILC and RyuJit cross-compilers
 
+    - ${{ if eq(parameters.isOfficialBuild, true) }}:
+      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper)
+        displayName: Build host packages
+
+  # Run libraries tests
   - ${{ if and(ne(parameters.isOfficialBuild, true),and(eq(parameters.buildConfig, 'Release'),ne(parameters.archType, 'wasm'))) }}:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -c Release -test /p:TestNativeAot=true
       displayName: Build and run libraries tests
@@ -34,8 +39,8 @@ steps:
   - ${{ elseif eq(parameters.osGroup, 'windows') }}:
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} /p:NativeAotMultimodule=true
       displayName: Build tests
-  - ${{ elseif ne(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} 'tree nativeaot'
+  - ${{ else }}:
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }}
       displayName: Build tests
 
   - ${{ if eq(parameters.runSingleFileTests, true) }}:

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -21,9 +21,8 @@ steps:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.alljits+clr.wasmjit+clr.nativeaotlibs+clr.tools -c $(buildConfigUpper)
       displayName: Build the ILC and RyuJit cross-compilers
 
-    - ${{ if eq(parameters.isOfficialBuild, true) }}:
-      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper)
-        displayName: Build host packages
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper)
+      displayName: Build host packages
 
   # Run libraries tests
   - ${{ if and(ne(parameters.isOfficialBuild, true),and(eq(parameters.buildConfig, 'Release'),ne(parameters.archType, 'wasm'))) }}:
@@ -61,7 +60,7 @@ steps:
       displayName: Run tests in multifile mode
 
 # Upload unsigned artifacts
-- ${{ if eq(parameters.uploadIntermediateArtifacts, true) }}:
+- ${{ if eq(true, true) }}:
   - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
     parameters:
       name: ${{ parameters.platform }}

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -40,7 +40,7 @@ steps:
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} /p:NativeAotMultimodule=true
       displayName: Build tests
   - ${{ else }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }}
+    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} 'tree nativeaot'
       displayName: Build tests
 
   - ${{ if eq(parameters.runSingleFileTests, true) }}:

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -21,8 +21,9 @@ steps:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.alljits+clr.wasmjit+clr.nativeaotlibs+clr.tools -c $(buildConfigUpper)
       displayName: Build the ILC and RyuJit cross-compilers
 
-    - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper)
-      displayName: Build host packages
+    - ${{ if eq(parameters.isOfficialBuild, true) }}:
+      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper)
+        displayName: Build host packages
 
   # Run libraries tests
   - ${{ if and(ne(parameters.isOfficialBuild, true),and(eq(parameters.buildConfig, 'Release'),ne(parameters.archType, 'wasm'))) }}:
@@ -60,7 +61,7 @@ steps:
       displayName: Run tests in multifile mode
 
 # Upload unsigned artifacts
-- ${{ if eq(true, true) }}:
+- ${{ if eq(parameters.uploadIntermediateArtifacts, true) }}:
   - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
     parameters:
       name: ${{ parameters.platform }}


### PR DESCRIPTION
This matches how the build for other artifacts is set up.

We must take care to disable building the corresponding "host" platform, otherwise the publishing process will be racy (since both builds will end up producing "host" packages of the same name).

Hopefully, this is the last fix needed for package publishing to work.