### PR TITLE
NativeAOT-LLVM: Change image for NetCore1ESPool-Internal pool to windows.vs2019.amd64

### DIFF
--- a/eng/common/templates/jobs/jobs.yml
+++ b/eng/common/templates/jobs/jobs.yml
@@ -84,7 +84,7 @@ jobs:
           - Source_Build_Complete
         pool:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          demands: ImageOverride -equals windows.vs2019.amd64
 
         runAsPublic: ${{ parameters.runAsPublic }}
         publishUsingPipelines: ${{ parameters.enablePublishUsingPipelines }}

--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -95,7 +95,7 @@ stages:
       condition: eq( ${{ parameters.enableNugetValidation }}, 'true')
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
 
       steps:
         - template: setup-maestro-vars.yml
@@ -126,7 +126,7 @@ stages:
       condition: and( eq( ${{ parameters.enableSigningValidation }}, 'true'), ne( variables['PostBuildSign'], 'true'))
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - template: setup-maestro-vars.yml
           parameters:
@@ -180,7 +180,7 @@ stages:
       condition: eq( ${{ parameters.enableSourceLinkValidation }}, 'true')
       pool:
         name: NetCore1ESPool-Internal
-        demands: ImageOverride -equals Build.Server.Amd64.VS2019
+        demands: ImageOverride -equals windows.vs2019.amd64
       steps:
         - template: setup-maestro-vars.yml
           parameters:
@@ -231,7 +231,7 @@ stages:
     timeoutInMinutes: 120
     pool:
       name: NetCore1ESPool-Internal
-      demands: ImageOverride -equals Build.Server.Amd64.VS2019
+      demands: ImageOverride -equals windows.vs2019.amd64
     steps:
       - template: setup-maestro-vars.yml
         parameters:


### PR DESCRIPTION
This PR changes the image to correct the publish failure reported at https://github.com/dotnet/runtimelab/issues/2120#issuecomment-1359899066

There are other occurences of the image `Build.Server.Amd64.VS2019` in our current branch in the files

source-index-stage1.yml
execute-sdl.yml
onelocbuild.yml
http.yml
ssl.yml

I didn't recognize them as being pertinent to the publish so haven't changed them here.

cc @dotnet/nativeaot-llvm 