### PR TITLE
 [NativeAOT-LLVM] Pass OfficialBuildId when building packages

### DIFF
--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -22,7 +22,7 @@ steps:
       displayName: Build the ILC and RyuJit cross-compilers
 
     - ${{ if eq(parameters.isOfficialBuild, true) }}:
-      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper)
+      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) /p:OfficialBuildId=$(Build.BuildNumber)
         displayName: Build host packages
 
   # Run libraries tests

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -18,11 +18,11 @@ steps:
   # Now we need to build the cross-targeting compilers, RyuJit and ILC. Likewise with packages.
 
   - ${{ if eq(parameters.archType, 'wasm') }}:
-    - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.alljits+clr.wasmjit+clr.nativeaotlibs+clr.tools -c $(buildConfigUpper)
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.alljits+clr.wasmjit+clr.nativeaotlibs+clr.tools -c $(buildConfigUpper) $(_officialBuildParameter)
       displayName: Build the ILC and RyuJit cross-compilers
 
     - ${{ if eq(parameters.isOfficialBuild, true) }}:
-      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) /p:OfficialBuildId=$(Build.BuildNumber)
+      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) $(_officialBuildParameter)
         displayName: Build host packages
 
   # Run libraries tests


### PR DESCRIPTION
Should fix the missing build numbers for packages.

@dotnet/nativeaot-llvm 