### PR TITLE
[NativeAOT-LLVM] Make adding new Jit-EE APIs a little easier

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -23,7 +23,6 @@ enum class EEApiId
 {
     GetMangledMethodName,
     GetSymbolMangledName,
-    GetSymbolMangledNameFromHelperTarget, // TODO-LLVM: unused, delete.
     GetTypeName,
     AddCodeReloc,
     IsRuntimeImport,

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -34,7 +34,6 @@ enum class EEApiId
     GetArgTypeIncludingParameterized,
     GetParameterType,
     GetTypeDescriptor,
-    GetCompilerHelpersMethodHandle,
     GetInstanceFieldAlignment,
     Count
 };
@@ -746,11 +745,6 @@ CorInfoTypeWithMod Llvm::GetParameterType(CORINFO_CLASS_HANDLE typeHandle, CORIN
 TypeDescriptor Llvm::GetTypeDescriptor(CORINFO_CLASS_HANDLE typeHandle)
 {
     return CallEEApi<EEApiId::GetTypeDescriptor, TypeDescriptor>(typeHandle);
-}
-
-CORINFO_METHOD_HANDLE Llvm::GetCompilerHelpersMethodHandle(const char* helperClassTypeName, const char* helperMethodName)
-{
-    return CallEEApi<EEApiId::GetCompilerHelpersMethodHandle, CORINFO_METHOD_HANDLE>(helperClassTypeName, helperMethodName);
 }
 
 uint32_t Llvm::GetInstanceFieldAlignment(CORINFO_CLASS_HANDLE fieldTypeHandle)

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -190,7 +190,7 @@ private:
     const char* GetMangledMethodName(CORINFO_METHOD_HANDLE methodHandle);
     const char* GetMangledSymbolName(void* symbol);
     const char* GetTypeName(CORINFO_CLASS_HANDLE typeHandle);
-    const char* AddCodeReloc(void* handle);
+    void AddCodeReloc(void* handle);
     bool IsRuntimeImport(CORINFO_METHOD_HANDLE methodHandle);
     const char* GetDocumentFileName();
     uint32_t FirstSequencePointLineNumber();

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -200,7 +200,6 @@ private:
     CorInfoTypeWithMod GetArgTypeIncludingParameterized(CORINFO_SIG_INFO* sigInfo, CORINFO_ARG_LIST_HANDLE arg, CORINFO_CLASS_HANDLE* pTypeHandle);
     CorInfoTypeWithMod GetParameterType(CORINFO_CLASS_HANDLE typeHandle, CORINFO_CLASS_HANDLE* pInnerParameterTypeHandle);
     TypeDescriptor GetTypeDescriptor(CORINFO_CLASS_HANDLE typeHandle);
-    CORINFO_METHOD_HANDLE GetCompilerHelpersMethodHandle(const char* helperClassTypeName, const char* helperMethodName);
     uint32_t GetInstanceFieldAlignment(CORINFO_CLASS_HANDLE fieldTypeHandle);
 
     // ================================================================================================================

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -291,11 +291,5 @@ namespace ILCompiler
         {
             return ILImporter.PadOffset(type, (int)atOffset);
         }
-
-        public override MethodDesc GetCompilerHelpersMethodDesc(string className, string helperMethodName)
-        {
-            MetadataType helperType = TypeSystemContext.SystemModule.GetKnownType("Internal.Runtime.CompilerHelpers", className);
-            return helperType.GetKnownMethod(helperMethodName, null);
-        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -255,11 +255,6 @@ namespace ILCompiler
         {
             throw new NotImplementedException();
         }
-
-        public virtual MethodDesc GetCompilerHelpersMethodDesc(string className, string methodName)
-        {
-            throw new NotImplementedException();
-        }
     }
 
     [Flags]

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -358,14 +358,6 @@ namespace Internal.JitInterface
             return typeDescriptor;
         }
 
-        [UnmanagedCallersOnly]
-        public static CORINFO_METHOD_STRUCT_* getCompilerHelpersMethodHandle(IntPtr thisHandle, byte* className, byte* methodName)
-        {
-            var _this = GetThis(thisHandle);
-
-            return _this.ObjectToHandle(_this._compilation.GetCompilerHelpersMethodDesc(Marshal.PtrToStringUTF8((IntPtr)className), Marshal.PtrToStringUTF8((IntPtr)methodName)));
-        }
-
         // Must be kept in sync with the unmanaged version in "jit/llvm.cpp".
         //
         enum EEApiId
@@ -383,7 +375,6 @@ namespace Internal.JitInterface
             GetArgTypeIncludingParameterized,
             GetParameterType,
             GetTypeDescriptor,
-            GetCompilerHelpersMethodHandle,
             GetInstanceFieldAlignment,
             Count
         }
@@ -407,7 +398,6 @@ namespace Internal.JitInterface
             callbacks[(int)EEApiId.GetArgTypeIncludingParameterized] = (delegate* unmanaged<IntPtr, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_STRUCT_*, CORINFO_CLASS_STRUCT_**, CorInfoTypeWithMod>)&getArgTypeIncludingParameterized;
             callbacks[(int)EEApiId.GetParameterType] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CORINFO_CLASS_STRUCT_**, CorInfoTypeWithMod>)&getParameterType;
             callbacks[(int)EEApiId.GetTypeDescriptor] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor>)&getTypeDescriptor;
-            callbacks[(int)EEApiId.GetCompilerHelpersMethodHandle] = (delegate* unmanaged<IntPtr, byte*, byte*, CORINFO_METHOD_STRUCT_*>)&getCompilerHelpersMethodHandle;
             callbacks[(int)EEApiId.GetInstanceFieldAlignment] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint>)&getInstanceFieldAlignment;
             callbacks[(int)EEApiId.Count] = (void*)0x1234;
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -132,21 +132,6 @@ namespace Internal.JitInterface
             return (byte*)_this.GetPin(sb.UnderlyingArray);
         }
 
-        [UnmanagedCallersOnly]
-        public static byte* getSymbolMangledNameFromHelperTarget(IntPtr thisHandle, void* handle)
-        {
-            var _this = GetThis(thisHandle);
-
-            var node = (ReadyToRunHelperNode)_this.HandleToObject((IntPtr)handle);
-            var method = node.Target as MethodDesc;
-
-            // Abstract methods must require a lookup so no point passing the abstract name back
-            if (method.IsAbstract || method.IsVirtual) return null;
-
-            Utf8StringBuilder sb = new Utf8StringBuilder();
-            return (byte*)_this.GetPin(AppendNullByte(_this._compilation.NameMangler.GetMangledMethodName(method).UnderlyingArray));
-        }
-
         // IL backend does not use the mangled name.  The unmangled name is easier to read.
         [UnmanagedCallersOnly]
         public static byte* getTypeName(IntPtr thisHandle, CORINFO_CLASS_STRUCT_* structHnd)
@@ -387,7 +372,6 @@ namespace Internal.JitInterface
         {
             GetMangledMethodName,
             GetSymbolMangledName,
-            GetSymbolMangledNameFromHelperTarget,
             GetTypeName,
             AddCodeReloc,
             IsRuntimeImport,
@@ -412,7 +396,6 @@ namespace Internal.JitInterface
             void** callbacks = stackalloc void*[(int)EEApiId.Count + 1];
             callbacks[(int)EEApiId.GetMangledMethodName] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*>)&getMangledMethodName;
             callbacks[(int)EEApiId.GetSymbolMangledName] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*>)&getSymbolMangledName;
-            callbacks[(int)EEApiId.GetSymbolMangledNameFromHelperTarget] = (delegate* unmanaged<IntPtr, void*, byte*>)&getSymbolMangledNameFromHelperTarget;
             callbacks[(int)EEApiId.GetTypeName] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, byte*>)&getTypeName;
             callbacks[(int)EEApiId.AddCodeReloc] = (delegate* unmanaged<IntPtr, void*, void>)&addCodeReloc;
             callbacks[(int)EEApiId.IsRuntimeImport] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, uint>)&isRuntimeImport;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using ILCompiler;
@@ -379,47 +381,64 @@ namespace Internal.JitInterface
             return _this.ObjectToHandle(_this._compilation.GetCompilerHelpersMethodDesc(Marshal.PtrToStringUTF8((IntPtr)className), Marshal.PtrToStringUTF8((IntPtr)methodName)));
         }
 
+        // Must be kept in sync with the unmanaged version in "jit/llvm.cpp".
+        //
+        enum EEApiId
+        {
+            GetMangledMethodName,
+            GetSymbolMangledName,
+            GetSymbolMangledNameFromHelperTarget,
+            GetTypeName,
+            AddCodeReloc,
+            IsRuntimeImport,
+            GetDocumentFileName,
+            FirstSequencePointLineNumber,
+            GetOffsetLineNumber,
+            StructIsWrappedPrimitive,
+            PadOffset,
+            GetArgTypeIncludingParameterized,
+            GetParameterType,
+            GetTypeDescriptor,
+            GetCompilerHelpersMethodHandle,
+            GetInstanceFieldAlignment,
+            Count
+        }
+
         [DllImport(JitLibrary)]
-        private extern static void registerLlvmCallbacks(IntPtr thisHandle, byte* outputFileName, byte* triple, byte* dataLayout,
-            delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*> getMangedMethodNamePtr,
-            delegate* unmanaged<IntPtr, void*, byte*> getSymbolMangledName,
-            delegate* unmanaged<IntPtr, void*, byte*> getSymbolMangledNameFromHelperTarget,
-            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, byte*> getTypeName,
-            delegate* unmanaged<IntPtr, void*, void> addCodeReloc,
-            delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, uint> isRuntimeImport,
-            delegate* unmanaged<IntPtr, byte*> getDocumentFileName,
-            delegate* unmanaged<IntPtr, uint> firstSequencePointLineNumber,
-            delegate* unmanaged<IntPtr, uint, uint> getOffsetLineNumber,
-            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType, uint> structIsWrappedPrimitive,
-            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint, uint> padOffset,
-            delegate* unmanaged<IntPtr, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_STRUCT_*, CORINFO_CLASS_STRUCT_**, CorInfoTypeWithMod> getArgTypeIncludingParameterized,
-            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CORINFO_CLASS_STRUCT_**, CorInfoTypeWithMod> getParameterType,
-            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor> getTypeDescriptor,
-            delegate* unmanaged<IntPtr, byte*, byte*, CORINFO_METHOD_STRUCT_*> getCompilerHelpersMethodHandle,
-            delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint> getInstanceFieldAlignment
-            );
+        private extern static void registerLlvmCallbacks(IntPtr thisHandle, byte* outputFileName, byte* triple, byte* dataLayout, void** callbacks);
 
         public void RegisterLlvmCallbacks(IntPtr corInfoPtr, string outputFileName, string triple, string dataLayout)
         {
+            void** callbacks = stackalloc void*[(int)EEApiId.Count + 1];
+            callbacks[(int)EEApiId.GetMangledMethodName] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*>)&getMangledMethodName;
+            callbacks[(int)EEApiId.GetSymbolMangledName] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, byte*>)&getSymbolMangledName;
+            callbacks[(int)EEApiId.GetSymbolMangledNameFromHelperTarget] = (delegate* unmanaged<IntPtr, void*, byte*>)&getSymbolMangledNameFromHelperTarget;
+            callbacks[(int)EEApiId.GetTypeName] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, byte*>)&getTypeName;
+            callbacks[(int)EEApiId.AddCodeReloc] = (delegate* unmanaged<IntPtr, void*, void>)&addCodeReloc;
+            callbacks[(int)EEApiId.IsRuntimeImport] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, uint>)&isRuntimeImport;
+            callbacks[(int)EEApiId.GetDocumentFileName] = (delegate* unmanaged<IntPtr, byte*>)&getDocumentFileName;
+            callbacks[(int)EEApiId.FirstSequencePointLineNumber] = (delegate* unmanaged<IntPtr, uint>)&firstSequencePointLineNumber;
+            callbacks[(int)EEApiId.GetOffsetLineNumber] = (delegate* unmanaged<IntPtr, uint, uint>)&getOffsetLineNumber;
+            callbacks[(int)EEApiId.StructIsWrappedPrimitive] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType, uint>)&structIsWrappedPrimitive;
+            callbacks[(int)EEApiId.PadOffset] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint, uint>)&padOffset;
+            callbacks[(int)EEApiId.GetArgTypeIncludingParameterized] = (delegate* unmanaged<IntPtr, CORINFO_SIG_INFO*, CORINFO_ARG_LIST_STRUCT_*, CORINFO_CLASS_STRUCT_**, CorInfoTypeWithMod>)&getArgTypeIncludingParameterized;
+            callbacks[(int)EEApiId.GetParameterType] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CORINFO_CLASS_STRUCT_**, CorInfoTypeWithMod>)&getParameterType;
+            callbacks[(int)EEApiId.GetTypeDescriptor] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor>)&getTypeDescriptor;
+            callbacks[(int)EEApiId.GetCompilerHelpersMethodHandle] = (delegate* unmanaged<IntPtr, byte*, byte*, CORINFO_METHOD_STRUCT_*>)&getCompilerHelpersMethodHandle;
+            callbacks[(int)EEApiId.GetInstanceFieldAlignment] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint>)&getInstanceFieldAlignment;
+            callbacks[(int)EEApiId.Count] = (void*)0x1234;
+
+#if DEBUG
+            for (int i = 0; i < (int)EEApiId.Count; i++)
+            {
+                Debug.Assert(callbacks[i] != null);
+            }
+#endif
+
             registerLlvmCallbacks(corInfoPtr, (byte*)GetPin(StringToUTF8(outputFileName)),
                 (byte*)GetPin(StringToUTF8(triple)),
                 (byte*)GetPin(StringToUTF8(dataLayout)),
-                &getMangledMethodName,
-                &getSymbolMangledName,
-                &getSymbolMangledNameFromHelperTarget,
-                &getTypeName,
-                &addCodeReloc,
-                &isRuntimeImport,
-                &getDocumentFileName,
-                &firstSequencePointLineNumber,
-                &getOffsetLineNumber,
-                &structIsWrappedPrimitive,
-                &padOffset,
-                &getArgTypeIncludingParameterized,
-                &getParameterType,
-                &getTypeDescriptor,
-                &getCompilerHelpersMethodHandle,
-                &getInstanceFieldAlignment
+                callbacks
             );
         }
 


### PR DESCRIPTION
Passing an array of callbacks lets the native side repeat itself less.

We also delete two unused APIs.

Extracted from the ongoing EH work.