### PR TITLE
[NativeAOT-LLVM] Implement a few more opcodes

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -288,6 +288,7 @@ private:
     void buildLocalField(GenTreeLclFld* lclFld);
     void buildLocalVarAddr(GenTreeLclVarCommon* lclVar);
     void buildAdd(GenTreeOp* node);
+    void buildSub(GenTreeOp* node);
     void buildDivMod(GenTree* node);
     void buildCast(GenTreeCast* cast);
     void buildLclHeap(GenTreeUnOp* lclHeap);
@@ -319,6 +320,7 @@ private:
     void emitDoNothingCall();
     void emitJumpToThrowHelper(Value* jumpCondValue, SpecialCodeKind throwKind);
     void emitNullCheckForIndir(GenTreeIndir* indir, Value* addrValue);
+    Value* emitOverflowLlvmIntrinsic(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value);
     Value* emitHelperCall(CorInfoHelpFunc helperFunc, ArrayRef<Value*> sigArgs = { });
     Value* emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Value*> args);
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -308,7 +308,8 @@ private:
     void buildShift(GenTreeOp* node);
     void buildReturn(GenTree* node);
     void buildCatchArg(GenTree* node);
-    void buildJTrue(GenTree* node, Value* opValue);
+    void buildJTrue(GenTree* node);
+    void buildSwitch(GenTreeUnOp* switchNode);
     void buildNullCheck(GenTreeIndir* nullCheckNode);
     void buildBoundsCheck(GenTreeBoundsChk* boundsCheck);
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -322,7 +322,7 @@ private:
     void emitDoNothingCall();
     void emitJumpToThrowHelper(Value* jumpCondValue, SpecialCodeKind throwKind);
     void emitNullCheckForIndir(GenTreeIndir* indir, Value* addrValue);
-    Value* emitOverflowLlvmIntrinsic(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value);
+    Value* emitCheckedArithmeticOperation(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value);
     Value* emitHelperCall(CorInfoHelpFunc helperFunc, ArrayRef<Value*> sigArgs = { });
     Value* emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Value*> args);
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -290,6 +290,7 @@ private:
     void buildAdd(GenTreeOp* node);
     void buildSub(GenTreeOp* node);
     void buildDivMod(GenTree* node);
+    void buildRotate(GenTreeOp* node);
     void buildCast(GenTreeCast* cast);
     void buildLclHeap(GenTreeUnOp* lclHeap);
     void buildCmp(GenTreeOp* node);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -218,6 +218,9 @@ private:
     unsigned getElementSize(CORINFO_CLASS_HANDLE fieldClassHandle, CorInfoType corInfoType);
     void addPaddingFields(unsigned paddingSize, std::vector<Type*>& llvmFields);
 
+    Type* getPtrLlvmType();
+    Type* getIntPtrLlvmType();
+
     // ================================================================================================================
     // |                                                   Lowering                                                   |
     // ================================================================================================================

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -469,7 +469,7 @@ void Llvm::fillPhis()
     //    directly.
     // 2. IR doesn't insert inputs for different outgoing edges from the same block. For conditional branches,
     //    we simply don't generate the degenerate case. For switches, we compensate for this here, by inserting
-    //    "duplicate" entries into PHIs in case the count of incodimg LLVM edges did not match the count of IR
+    //    "duplicate" entries into PHIs in case the count of incoming LLVM edges did not match the count of IR
     //    entries. This is simpler to do here than in SSA builder because SSA builder uses successor iterators
     //    which explicitly filter out duplicates; creating those that do not would be an intrusive change. This
     //    can (should) be reconsidered this once/if we are integrated directly into upstream.
@@ -955,7 +955,7 @@ void Llvm::buildAdd(GenTreeOp* node)
         {
             llvm::Intrinsic::ID intrinsicId =
                 node->IsUnsigned() ? llvm::Intrinsic::uadd_with_overflow : llvm::Intrinsic::sadd_with_overflow;
-            addValue = emitOverflowLlvmIntrinsic(intrinsicId, op1Value, op2Value);
+            addValue = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value);
         }
         else
         {
@@ -1000,7 +1000,7 @@ void Llvm::buildSub(GenTreeOp* node)
         {
             llvm::Intrinsic::ID intrinsicId =
                 node->IsUnsigned() ? llvm::Intrinsic::usub_with_overflow: llvm::Intrinsic::ssub_with_overflow;
-            subValue = emitOverflowLlvmIntrinsic(intrinsicId, op1Value, op2Value);
+            subValue = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value);
         }
         else
         {
@@ -1681,7 +1681,7 @@ void Llvm::buildBinaryOperation(GenTree* node)
             {
                 llvm::Intrinsic::ID intrinsicId =
                     node->IsUnsigned() ? llvm::Intrinsic::umul_with_overflow : llvm::Intrinsic::smul_with_overflow;
-                result = emitOverflowLlvmIntrinsic(intrinsicId, op1Value, op2Value);
+                result = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value);
             }
             else
             {
@@ -1994,7 +1994,7 @@ void Llvm::emitNullCheckForIndir(GenTreeIndir* indir, Value* addrValue)
     }
 }
 
-Value* Llvm::emitOverflowLlvmIntrinsic(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value)
+Value* Llvm::emitCheckedArithmeticOperation(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value)
 {
     assert(op1Value->getType()->isIntegerTy() && op2Value->getType()->isIntegerTy());
 

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -312,7 +312,7 @@ void Llvm::addPaddingFields(unsigned paddingSize, std::vector<Type*>& llvmFields
 
 Type* Llvm::getPtrLlvmType()
 {
-    return Type::getInt8PtrTy(_llvmContext);
+    return llvm::PointerType::getUnqual(_llvmContext);
 }
 
 Type* Llvm::getIntPtrLlvmType()

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -309,3 +309,17 @@ void Llvm::addPaddingFields(unsigned paddingSize, std::vector<Type*>& llvmFields
         llvmFields.push_back(Type::getInt8Ty(_llvmContext));
     }
 }
+
+Type* Llvm::getPtrLlvmType()
+{
+    return Type::getInt8PtrTy(_llvmContext);
+}
+
+Type* Llvm::getIntPtrLlvmType()
+{
+#ifdef TARGET_64BIT
+    return Type::getInt64Ty(_llvmContext);
+#else
+    return Type::getInt32Ty(_llvmContext);
+#endif
+}


### PR DESCRIPTION
Namely, `SUB`, `MUL`, `ROL`, `ROR` and `SWITCH`, as well as checked `ADD`/`SUB`/`MUL`.

Mostly trivial, but switches did require some adjustments to the PHI code as LLVM is different from IR in how it handles duplicate predecessor edges.