### PR TITLE
NativeAOT-LLVM: Remove nmake from wasm build

### DIFF
--- a/eng/native/gen-buildsys.cmd
+++ b/eng/native/gen-buildsys.cmd
@@ -31,18 +31,14 @@ set __UseEmcmake=0
 if /i "%__Ninja%" == "1" (
     set __CmakeGenerator=Ninja
 ) else (
-    if /i NOT "%__Arch%" == "wasm" (
-        if /i "%__VSVersion%" == "vs2022" (set __CmakeGenerator=%__CmakeGenerator% 17 2022)
-        if /i "%__VSVersion%" == "vs2019" (set __CmakeGenerator=%__CmakeGenerator% 16 2019)
-        if /i "%__VSVersion%" == "vs2017" (set __CmakeGenerator=%__CmakeGenerator% 15 2017)
+    if /i "%__VSVersion%" == "vs2022" (set __CmakeGenerator=%__CmakeGenerator% 17 2022)
+    if /i "%__VSVersion%" == "vs2019" (set __CmakeGenerator=%__CmakeGenerator% 16 2019)
+    if /i "%__VSVersion%" == "vs2017" (set __CmakeGenerator=%__CmakeGenerator% 15 2017)
 
-        if /i "%__Arch%" == "x64" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
-        if /i "%__Arch%" == "arm" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM)
-        if /i "%__Arch%" == "arm64" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM64)
-        if /i "%__Arch%" == "x86" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A Win32)
-    ) else (
-        set __CmakeGenerator=NMake Makefiles
-    )
+    if /i "%__Arch%" == "x64" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)
+    if /i "%__Arch%" == "arm" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM)
+    if /i "%__Arch%" == "arm64" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A ARM64)
+    if /i "%__Arch%" == "x86" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A Win32)
 )
 
 if /i "%__Arch%" == "wasm" (

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -199,7 +199,6 @@ if %__BuildArchArm64%==1 (
 if %__BuildArchWasm%==1 (
     set __TargetOS=browser
     set __BuildArch=wasm
-    set __Ninja=0
 )
 
 set /A __TotalSpecifiedBuildType=__BuildTypeDebug + __BuildTypeChecked + __BuildTypeRelease
@@ -251,9 +250,8 @@ set "__IntermediatesDir=%__RootBinDir%\obj\coreclr\%__TargetOS%.%__BuildArch%.%_
 set "__LogsDir=%__RootBinDir%\log\!__BuildType!"
 set "__MsbuildDebugLogsDir=%__LogsDir%\MsbuildDebugLogs"
 set "__ArtifactsIntermediatesDir=%__RepoRootDir%\artifacts\obj\coreclr\"
-REM wasm is using Nmake: dont append ide - TODO-LLVM: change wasm to Ninja
 if "%__Ninja%"=="0" (
-  if NOT "%__BuildArch%"=="wasm" (set "__IntermediatesDir=%__IntermediatesDir%\ide")
+  set "__IntermediatesDir=%__IntermediatesDir%\ide"
 )
 set "__PackagesBinDir=%__BinDir%\.nuget"
 set "__CrossComponentBinDir=%__BinDir%"
@@ -632,10 +630,7 @@ if %__BuildNative% EQU 1 (
         set __CmakeBuildToolArgs=
     ) else (
         REM We pass the /m flag directly to MSBuild so that we can get both MSBuild and CL parallelism, which is fastest for our builds.
-        REM wasm uses nmake which does not support /m
-        if not "%__BuildArch%" == "wasm" (
-            set __CmakeBuildToolArgs=/nologo /m !__Logging!
-        )
+        set __CmakeBuildToolArgs=/nologo /m !__Logging!
     )
 
     "%CMakePath%" --build %__IntermediatesDir% --target %__CMakeTarget% --config %__BuildType% -- !__CmakeBuildToolArgs!


### PR DESCRIPTION
For some historical reason nmake was used for the wasm side of the build, this PR removes that and uses the default of Ninja on Windows, removing one small annoyance when merging.

cc @dotnet/nativeaot-llvm 