### PR TITLE
NativeAOT-LLVM: Fix publishing of additional wasm files

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -97,11 +97,11 @@
     <Delete Files="$(PublishDir)\$(TargetName)$(NativeBinaryExt)" />
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)" DestinationFolder="$(PublishDir)" />
 
-    <Delete Files="$(PublishDir)\$(TargetName).js" Condition="'$(Platform)'=='wasm'"/>
-    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).js" DestinationFolder="$(PublishDir)" Condition="'$(Platform)'=='wasm'"/>
+    <Delete Files="$(PublishDir)\$(TargetName).js" Condition="'$(TargetArchitecture)'=='wasm'"/>
+    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).js" DestinationFolder="$(PublishDir)" Condition="'$(TargetArchitecture)'=='wasm'"/>
 
-    <Delete Files="$(PublishDir)\$(TargetName).wasm" Condition="'$(Platform)'=='wasm'"/>
-    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).wasm" DestinationFolder="$(PublishDir)" Condition="'$(Platform)'=='wasm'"/>
+    <Delete Files="$(PublishDir)\$(TargetName).wasm" Condition="'$(TargetArchitecture)'=='wasm'"/>
+    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).wasm" DestinationFolder="$(PublishDir)" Condition="'$(TargetArchitecture)'=='wasm'"/>
 
   </Target>
 


### PR DESCRIPTION
This PR addresses the comment at https://github.com/dotnet/runtimelab/issues/2121#issuecomment-1362271101 where the js and wasm files do not get copied to the publish folder.

It changes condition of the additional copies to use TargetArchitecure=wasm.  (Platform is AnyCPU now)

cc @dotnet/nativeaot-llvm 