### PR TITLE
Fix package publishing

### DIFF
--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -10,7 +10,7 @@ variables:
   value: 1000
 
 - name: isOfficialBuild
-  value: ${{ and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.DefinitionName'], 'dotnet-runtime-official')) }}
+  value: ${{ and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}
 - name: isRollingBuild
   value: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
 - name: isExtraPlatformsBuild


### PR DESCRIPTION
The condition to detect official builds changed in dotnet/runtime, and it is not detecting official runtimelab build correctly anymore. Revert to the original condition.