### PR TITLE
 [NativeAOT-LLVM] Fix most warnings for the `HelloWasm` runtime test

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -336,8 +336,10 @@ The .NET Foundation licenses this file to you under the MIT license.
       <EmccArgs>&quot;$(LlvmObject)&quot; -c -o &quot;$(NativeObject)&quot; -s DISABLE_EXCEPTION_CATCHING=0</EmccArgs>
       <EmccArgs Condition="'$(NativeDebugSymbols)' != 'true'">$(EmccArgs) -O2</EmccArgs>
       <EmccArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(EmccArgs) -g3</EmccArgs>
+      <!-- TODO-LLVM: remove when we update to Emscripten with https://github.com/emscripten-core/emscripten/pull/18443 -->
+      <EmccArgs>$(EmccArgs) -s USE_SDL=0</EmccArgs>
     </PropertyGroup>
-    
+
     <Exec Command="&quot;$(EMSDK)/upstream/emscripten/emcc.bat&quot; $(EmccArgs)" Condition="'$(EMSDK)' != '' and '$(OS)' == 'Windows_NT'" />
     <Exec Command="&quot;$(EMSDK)/upstream/emscripten/emcc&quot; $(EmccArgs)" Condition="'$(EMSDK)' != '' and '$(OS)' != 'Windows_NT'" />
 
@@ -346,8 +348,10 @@ The .NET Foundation licenses this file to you under the MIT license.
       <EmccArgs>&quot;$(LlvmClrjitObject)&quot; -c -o &quot;$(NativeClrjitObject)&quot;  -s DISABLE_EXCEPTION_CATCHING=0</EmccArgs>
       <EmccArgs Condition="'$(NativeDebugSymbols)' != 'true'">$(EmccArgs) -O2</EmccArgs>
       <EmccArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(EmccArgs) -g3</EmccArgs>
+      <!-- TODO-LLVM: remove when we update to Emscripten with https://github.com/emscripten-core/emscripten/pull/18443 -->
+      <EmccArgs>$(EmccArgs) -s USE_SDL=0</EmccArgs>
     </PropertyGroup>
-    
+
     <Exec Command="&quot;$(EMSDK)/upstream/emscripten/emcc.bat&quot; $(EmccArgs)" Condition="'$(EMSDK)' != '' and '$(OS)' == 'Windows_NT'" />
     <Exec Command="&quot;$(EMSDK)/upstream/emscripten/emcc&quot; $(EmccArgs)" Condition="'$(EMSDK)' != '' and '$(OS)' != 'Windows_NT'" />
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TentativeInstanceMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TentativeInstanceMethodNode.cs
@@ -35,11 +35,11 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool HasConditionalStaticDependencies => true;
 
-        protected override ISymbolNode GetTarget(NodeFactory factory)
+        public override IMethodNode GetTarget(NodeFactory factory)
         {
             // If the class library doesn't provide this helper, the optimization is disabled.
             MethodDesc helper = factory.InstanceMethodRemovedHelper;
-            return helper == null ? RealBody: factory.MethodEntrypoint(helper);
+            return helper == null ? RealBody : factory.MethodEntrypoint(helper);
         }
 
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TentativeMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TentativeMethodNode.cs
@@ -29,20 +29,11 @@ namespace ILCompiler.DependencyAnalysis
             _methodNode = methodNode;
         }
 
-        protected virtual ISymbolNode GetTarget(NodeFactory factory)
+        public virtual IMethodNode GetTarget(NodeFactory factory)
         {
             // If the class library doesn't provide this helper, the optimization is disabled.
             MethodDesc helper = factory.TypeSystemContext.GetOptionalHelperEntryPoint("ThrowHelpers", "ThrowBodyRemoved");
             return helper == null ? RealBody : factory.MethodEntrypoint(helper);
-        }
-
-        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
-        {
-            if (factory.Target.Architecture == TargetArchitecture.Wasm32)
-            {
-                return new ObjectData(null, new Relocation[] { new Relocation(RelocType.IMAGE_REL_BASED_HIGHLOW, 0, GetTarget(factory)) }, 0, null);
-            }
-            return base.GetData(factory, relocsOnly);
         }
 
         public MethodDesc Method => _methodNode.Method;

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -1269,6 +1269,9 @@ namespace ILCompiler.DependencyAnalysis
 
         private void GetCodeForTentativeMethod(LLVMCodegenCompilation compilation, TentativeMethodNode node, NodeFactory factory)
         {
+            IMethodNode helperMethodNode = node.GetTarget(factory);
+            string helperMangledName = helperMethodNode.GetMangledName(compilation.NameMangler);
+
             LLVMBuilderRef builder = LLVMCodegenCompilation.Module.Context.CreateBuilder();
             MethodDesc method = node.Method;
             string mangledName = node.GetMangledName(factory.NameMangler);
@@ -1276,9 +1279,7 @@ namespace ILCompiler.DependencyAnalysis
 
             LLVMBasicBlockRef block = tentativeStub.AppendBasicBlock("tentativeStub");
             builder.PositionAtEnd(block);
-            MethodDesc helperMethod = factory.TypeSystemContext.GetOptionalHelperEntryPoint("ThrowHelpers", "ThrowBodyRemoved");
-            string helperMangledName = compilation.NodeFactory.MethodEntrypoint(helperMethod).GetMangledName(compilation.NameMangler);
-            LLVMValueRef fn = ILImporter.GetOrCreateLLVMFunction(Module, helperMangledName, helperMethod.Signature, false);
+            LLVMValueRef fn = ILImporter.GetOrCreateLLVMFunction(Module, helperMangledName, helperMethodNode.Method.Signature, false);
             builder.BuildCall(fn, new LLVMValueRef[] { tentativeStub.GetParam(0) }, string.Empty);
             builder.BuildUnreachable();
         }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
@@ -47,6 +47,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             if (CompilationModuleGroup.ContainsMethodBody(method, false))
             {
+                // TODO-LLVM: delete when merging https://github.com/dotnet/runtime/pull/80414 (Jan 10, 2023)
                 // We might be able to optimize the method body away if the owning type was never seen as allocated.
                 if (method.NotCallableWithoutOwningEEType() && CompilationModuleGroup.AllowInstanceMethodOptimization(method))
                     return new TentativeInstanceMethodNode(new LlvmMethodBodyNode(method));

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -194,6 +194,10 @@
     <BuildAsStandalone Condition="'$(BuildAsStandalone)' == ''">true</BuildAsStandalone>
     <OutputType Condition="$(BuildAsStandalone)">Exe</OutputType>
     <TestFramework>GeneratedRunner</TestFramework>
+
+    <!-- Prevent project-specific NuGet props/targets from clashing with the ones we manually import below. -->
+    <ImportProjectExtensionProps>false</ImportProjectExtensionProps>
+    <ImportProjectExtensionTargets>false</ImportProjectExtensionTargets>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)testing\tests.props"  Condition="'$(IsTestsCommonProject)' != 'true'" />

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Reflection;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Collections.Specialized;
 
 #if TARGET_WINDOWS
@@ -1513,7 +1514,7 @@ internal static class Program
         EndTest(Object.ReferenceEquals(retVal, instance));
     }
 
-    private static void NewMethod(Type classForMetaTestsType, ClassForMetaTests instance)
+    private static void NewMethod([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type classForMetaTestsType, ClassForMetaTests instance)
     {
         StartTest("Class get+invoke simple method via reflection");
         var mtd = classForMetaTestsType.GetMethod("ReturnTrueIf1");


### PR DESCRIPTION
Only two, related to the missing `dotnet_browser_entropy` symbol, remain.

Contributes to #2165.