### PR TITLE
 [NativeAOT-LLVM] Simplify LLVM object writer

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1036,7 +1036,6 @@ namespace ILCompiler.DependencyAnalysis
                     }
 #endif
 
-
                     ObjectNodeSection section = node.Section;
                     if (objectWriter.ShouldShareSymbol(node))
                     {

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -2343,7 +2343,7 @@ namespace Internal.IL
             {
                 node = _compilation.NodeFactory.NecessaryTypeSymbol(target);
             }
-            LLVMValueRef eeTypePointer = LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler, false);
+            LLVMValueRef eeTypePointer = LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler);
             _dependencies.Add(node, "LLVM Type ptr");
 
             return eeTypePointer;
@@ -4372,7 +4372,7 @@ namespace Internal.IL
 
                     ISymbolNode node = _compilation.ComputeConstantLookup(helperId, typeDesc);
                     _dependencies.Add(node, "LLVM Type ptr");
-                    LLVMValueRef eeTypePointer = LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler, false);
+                    LLVMValueRef eeTypePointer = LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler);
 
                     PushLoadExpression(StackValueKind.ByRef, "ldtoken", eeTypePointer, GetWellKnownType(WellKnownType.IntPtr));
                 }
@@ -4931,7 +4931,7 @@ namespace Internal.IL
             if (builder.Handle == IntPtr.Zero)
                 builder = _builder;
 
-            LLVMValueRef addressOfAddress = LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler, false);
+            LLVMValueRef addressOfAddress = LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler);
             //return addressOfAddress;
             return builder.BuildLoad(addressOfAddress, "LoadAddressOfSymbolNode");
         }
@@ -4990,7 +4990,7 @@ namespace Internal.IL
 
                 ISymbolNode node = _compilation.ComputeConstantLookup(helperId, type);
                 _dependencies.Add(node, "LLVM Type ptr");
-                eeType = LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler, false);
+                eeType = LLVMObjectWriter.GetSymbolValuePointer(Module, node, _compilation.NameMangler);
                 eeTypeEntry = new LoadExpressionEntry(StackValueKind.ValueType, "eeType", eeType, GetWellKnownType(WellKnownType.IntPtr).MakePointerType());
             }
             var toBoxValue = _stack.Pop();

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -90,7 +90,6 @@ namespace ILCompiler
 
             LLVMObjectWriter.EmitObject(outputFile, nodes, NodeFactory, this, dumper);
 
-
             Console.WriteLine($"RyuJIT compilation results, total methods {totalMethodCount} RyuJit Methods {ryuJitMethodCount} {((decimal)ryuJitMethodCount * 100 / totalMethodCount):n4}%");
         }
 


### PR DESCRIPTION
The writer seems to have been written as an amalgam of its native version and (presumably) the C++ codegen version, inheriting some dead code and unnecessary complexity. This change removes some of that.

It also adds a few comments and reorders members of the class in a more logical fashion.

I would recommend reviewing the change commit-by-commit (possibly skipping the last one altogether).