### PR TITLE
[NativeAOT-LLVM] Remove unnecessary symbol indirections

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -357,9 +357,8 @@ private:
     FunctionType* createFunctionTypeForCall(GenTreeCall* call);
     FunctionType* createFunctionTypeForHelper(CorInfoHelpFunc helperFunc);
 
-    llvm::GlobalVariable* getOrCreateExternalSymbol(const char* symbolName, Type* symbolType = nullptr);
-    llvm::GlobalVariable* getOrCreateSymbol(CORINFO_GENERIC_HANDLE symbolHandle, Type* symbolType = nullptr);
-    Value* emitSymbolRef(CORINFO_GENERIC_HANDLE symbolHandle);
+    llvm::GlobalVariable* getOrCreateExternalSymbol(const char* symbolName);
+    llvm::GlobalVariable* getOrCreateSymbol(CORINFO_GENERIC_HANDLE symbolHandle);
     CORINFO_GENERIC_HANDLE getSymbolHandleForClassToken(mdToken token);
 
     Instruction* getCast(Value* source, Type* targetType);

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/StackFrameIterator.wasm.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/StackFrameIterator.wasm.cs
@@ -178,7 +178,7 @@ namespace System.Runtime
             else
             {
                 pClause->Filter = null;
-                pClause->ClauseType = *(MethodTable**)pCurrent[0];
+                pClause->ClauseType = (MethodTable*)pCurrent[0];
             }
 
             pClause->Handler = pCurrent[1];

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMSharpInterop.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMSharpInterop.cs
@@ -6,17 +6,17 @@ using LLVMSharp.Interop;
 namespace Internal.IL
 {
     //TODO-LLVM: delete this file when IL->LLVM module has gone
-    internal class LLVMSharpInterop
+    internal static unsafe class LLVMSharpInterop
     {
         ///
         /// Wrapper while waiting for https://github.com/microsoft/LLVMSharp/pull/144
         /// 
-        internal static unsafe void DISetSubProgram(LLVMValueRef function, LLVMMetadataRef diFunction)
+        internal static void DISetSubProgram(LLVMValueRef function, LLVMMetadataRef diFunction)
         {
             LLVM.SetSubprogram(function, diFunction);
         }
 
-        internal static unsafe LLVMAttributeRef CreateAttribute(LLVMContextRef context, string name, string value)
+        internal static LLVMAttributeRef CreateAttribute(LLVMContextRef context, string name, string value)
         {
             ReadOnlySpan<char> nameSpan = name.AsSpan();
             ReadOnlySpan<char> valueSpan = value.AsSpan();
@@ -28,7 +28,13 @@ namespace Internal.IL
                 marshaledValue.Value, (uint)marshaledValue.Length);
         }
 
-        internal unsafe struct MarshaledString : IDisposable
+        public static LLVMValueRef GetNamedAlias(this LLVMModuleRef module, ReadOnlySpan<char> name)
+        {
+            using var marshaledName = new MarshaledString(name);
+            return LLVM.GetNamedGlobalAlias(module, marshaledName, (nuint)marshaledName.Length);
+        }
+
+        internal struct MarshaledString : IDisposable
         {
             public MarshaledString(ReadOnlySpan<char> input)
             {

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -86,7 +86,7 @@ namespace ILCompiler
             CorInfoImpl.Shutdown(); // writes the LLVM bitcode
             CorInfoImpl.FreeUnmanagedResources();
 
-            LLVMObjectWriter.EmitObject(outputFile, nodes, NodeFactory, this, dumper);
+            LLVMObjectWriter.EmitObject(outputFile, nodes, this, dumper);
 
             Console.WriteLine($"RyuJIT compilation results, total methods {totalMethodCount} RyuJit Methods {ryuJitMethodCount} {((decimal)ryuJitMethodCount * 100 / totalMethodCount):n4}%");
         }
@@ -278,11 +278,6 @@ namespace ILCompiler
         public TypeDesc GetWellKnownType(WellKnownType wellKnownType)
         {
             return TypeSystemContext.GetWellKnownType(wellKnownType);
-        }
-
-        public override void AddOrReturnGlobalSymbol(ISymbolNode symbolNode, NameMangler nameMangler)
-        {
-            LLVMObjectWriter.AddOrReturnGlobalSymbol(Module, symbolNode, nameMangler);
         }
 
         public override bool StructIsWrappedPrimitive(TypeDesc method, TypeDesc primitiveTypeDesc)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -239,11 +239,6 @@ namespace ILCompiler
             return base.GetMethodIL(method);
         }
 
-        public virtual void AddOrReturnGlobalSymbol(ISymbolNode symbolNode, NameMangler nameMangler)
-        {
-            throw new NotImplementedException("only called from clrjit for LLVM, what is a better way to do this?");
-        }
-
         public virtual bool StructIsWrappedPrimitive(TypeDesc method, TypeDesc primitiveTypeDesc)
         {
             throw new NotImplementedException();

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -65,14 +65,12 @@ namespace Internal.JitInterface
                         {
                             var nonGcStaticSymbolForGCStaticBase = _this._compilation.NodeFactory.TypeNonGCStaticsSymbol(target);
                             _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0, nonGcStaticSymbolForGCStaticBase));
-                            _this.AddOrReturnGlobalSymbol(nonGcStaticSymbolForGCStaticBase, _this._compilation.NameMangler);
                         }
 
                         break;
                     case ReadyToRunHelperId.GetNonGCStaticBase:
                         var nonGcStaticSymbol = _this._compilation.NodeFactory.TypeNonGCStaticsSymbol(target);
                         _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0, nonGcStaticSymbol));
-                        _this.AddOrReturnGlobalSymbol(nonGcStaticSymbol, _this._compilation.NameMangler);
                         break;
                     case ReadyToRunHelperId.GetThreadStaticBase:
                         _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0,
@@ -80,22 +78,12 @@ namespace Internal.JitInterface
                         _this._codeRelocs.Add(new Relocation(RelocType.IMAGE_REL_BASED_REL32, 0,
                             _this._compilation.NodeFactory.TypeNonGCStaticsSymbol(target)));
                         var nonGcStaticSymbolForGCStaticBase2 = _this._compilation.NodeFactory.TypeNonGCStaticsSymbol(target);
-                        _this.AddOrReturnGlobalSymbol(nonGcStaticSymbolForGCStaticBase2, _this._compilation.NameMangler);
                         break;
                     default:
                         throw new NotImplementedException();
                 }
 
                 return;
-            }
-
-            if (node is FrozenStringNode frozenStringNode)
-            {
-                _this.AddOrReturnGlobalSymbol(frozenStringNode, _this._compilation.NameMangler);
-            }
-            else if (node is EETypeNode eeTypeNode)
-            {
-                _this.AddOrReturnGlobalSymbol(eeTypeNode, _this._compilation.NameMangler);
             }
         }
 
@@ -131,10 +119,6 @@ namespace Internal.JitInterface
             var node = (ISymbolNode)_this.HandleToObject((IntPtr)handle);
             Utf8StringBuilder sb = new Utf8StringBuilder();
             node.AppendMangledName(_this._compilation.NameMangler, sb);
-            if (node is FrozenStringNode || node is EETypeNode)
-            {
-                sb.Append("___SYMBOL");
-            }
 
             sb.Append("\0");
             return (byte*)_this.GetPin(sb.UnderlyingArray);
@@ -393,11 +377,6 @@ namespace Internal.JitInterface
                 (byte*)GetPin(StringToUTF8(dataLayout)),
                 callbacks
             );
-        }
-
-        void AddOrReturnGlobalSymbol(ISymbolNode symbolNode, NameMangler nameMangler)
-        {
-            _compilation.AddOrReturnGlobalSymbol(symbolNode, nameMangler);
         }
 
         public static void FreeUnmanagedResources()

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/ILHelpers.il
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/ILHelpers.il
@@ -135,7 +135,7 @@
   .method public static object LdMethodToken()
   {
     ldtoken method int32 ILHelpers.ILHelpersTest::TestLdTokenMethod(int32)
-    call class [mscorlib]System.Reflection.MethodBase [System.Private.CoreLib]System.Reflection.MethodBase::GetMethodFromHandle(valuetype [mscorlib]System.RuntimeMethodHandle)
+    call class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Reflection.MethodBase::GetMethodFromHandle(valuetype [mscorlib]System.RuntimeMethodHandle)
     ret
   }
 }


### PR DESCRIPTION
Up until this change, we used a scheme where each `ISymbolNode` was referenced via a load from a `__SYMBOL` shadow symbol containing its address. With this change, we use LLVM's global alias feature instead and reference things directly, removing the unnecessary indirection.

Happily, that means removing more code from the object writer.