### PR TITLE
[NativeAOT-LLVM] Debug info refactoring

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -8,11 +8,10 @@
 #include "llvm/Bitcode/BitcodeWriter.h"
 #pragma warning (error: 4459)
 
-LLVMContext      _llvmContext;
-Module*          _module            = nullptr;
-llvm::DIBuilder* _diBuilder         = nullptr;
-char*            _outputFileName;
-Function*        _doNothingFunction;
+LLVMContext _llvmContext;
+Module*     _module = nullptr;
+char*       _outputFileName;
+Function*   _doNothingFunction;
 
 std::unordered_map<CORINFO_CLASS_HANDLE, Type*>* _llvmStructs = new std::unordered_map<CORINFO_CLASS_HANDLE, Type*>();
 std::unordered_map<CORINFO_CLASS_HANDLE, StructDesc*>* _structDescMap = new std::unordered_map<CORINFO_CLASS_HANDLE, StructDesc*>();
@@ -105,18 +104,16 @@ Llvm::Llvm(Compiler* compiler)
     _builder(_llvmContext),
     _blkToLlvmBlksMap(compiler->getAllocator(CMK_Codegen)),
     _sdsuMap(compiler->getAllocator(CMK_Codegen)),
-    _localsMap(compiler->getAllocator(CMK_Codegen)),
-    _debugMetadataMap(compiler->getAllocator(CMK_Codegen))
+    _localsMap(compiler->getAllocator(CMK_Codegen))
 {
 }
 
 void Llvm::llvmShutdown()
 {
-    if (_diBuilder != nullptr)
+    if (_module->getNamedMetadata("llvm.dbg.cu") != nullptr)
     {
         _module->addModuleFlag(llvm::Module::Warning, "Dwarf Version", 4);
         _module->addModuleFlag(llvm::Module::Warning, "Debug Info Version", 3);
-        _diBuilder->finalize();
     }
 
     std::error_code ec;
@@ -696,6 +693,7 @@ const char* Llvm::GetDocumentFileName()
 
 uint32_t Llvm::FirstSequencePointLineNumber()
 {
+    // TODO-LLVM: unused, delete.
     return CallEEApi<EEApiId::FirstSequencePointLineNumber, uint32_t>();
 }
 

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -27,7 +27,6 @@ enum class EEApiId
     AddCodeReloc,
     IsRuntimeImport,
     GetDocumentFileName,
-    FirstSequencePointLineNumber,
     GetOffsetLineNumber,
     StructIsWrappedPrimitive,
     PadOffset,
@@ -689,12 +688,6 @@ bool Llvm::IsRuntimeImport(CORINFO_METHOD_HANDLE methodHandle)
 const char* Llvm::GetDocumentFileName()
 {
     return CallEEApi<EEApiId::GetDocumentFileName, const char*>();
-}
-
-uint32_t Llvm::FirstSequencePointLineNumber()
-{
-    // TODO-LLVM: unused, delete.
-    return CallEEApi<EEApiId::FirstSequencePointLineNumber, uint32_t>();
 }
 
 uint32_t Llvm::GetOffsetLineNumber(unsigned ilOffset)

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -201,7 +201,6 @@ private:
     void AddCodeReloc(void* handle);
     bool IsRuntimeImport(CORINFO_METHOD_HANDLE methodHandle);
     const char* GetDocumentFileName();
-    uint32_t FirstSequencePointLineNumber();
     uint32_t GetOffsetLineNumber(unsigned ilOffset);
     bool StructIsWrappedPrimitive(CORINFO_CLASS_HANDLE typeHandle, CorInfoType corInfoType);
     uint32_t PadOffset(CORINFO_CLASS_HANDLE typeHandle, unsigned atOffset);

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -203,17 +203,12 @@ namespace Internal.JitInterface
             var curSequencePoint = _this.GetSequencePoint(0);
             string fullPath = curSequencePoint.Document;
 
-            if (fullPath == null) return null;
+            if (string.IsNullOrEmpty(fullPath))
+            {
+                return null;
+            }
 
             return (byte*)_this.GetPin(StringToUTF8(fullPath));
-        }
-
-        [UnmanagedCallersOnly]
-        public static uint firstSequencePointLineNumber(IntPtr thisHandle)
-        {
-            var _this = GetThis(thisHandle);
-
-            return (uint)_this.GetSequencePoint(0).LineNumber;
         }
 
         [UnmanagedCallersOnly]
@@ -335,7 +330,6 @@ namespace Internal.JitInterface
             AddCodeReloc,
             IsRuntimeImport,
             GetDocumentFileName,
-            FirstSequencePointLineNumber,
             GetOffsetLineNumber,
             StructIsWrappedPrimitive,
             PadOffset,
@@ -357,7 +351,6 @@ namespace Internal.JitInterface
             callbacks[(int)EEApiId.AddCodeReloc] = (delegate* unmanaged<IntPtr, void*, void>)&addCodeReloc;
             callbacks[(int)EEApiId.IsRuntimeImport] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, uint>)&isRuntimeImport;
             callbacks[(int)EEApiId.GetDocumentFileName] = (delegate* unmanaged<IntPtr, byte*>)&getDocumentFileName;
-            callbacks[(int)EEApiId.FirstSequencePointLineNumber] = (delegate* unmanaged<IntPtr, uint>)&firstSequencePointLineNumber;
             callbacks[(int)EEApiId.GetOffsetLineNumber] = (delegate* unmanaged<IntPtr, uint, uint>)&getOffsetLineNumber;
             callbacks[(int)EEApiId.StructIsWrappedPrimitive] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType, uint>)&structIsWrappedPrimitive;
             callbacks[(int)EEApiId.PadOffset] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint, uint>)&padOffset;


### PR DESCRIPTION
Two changes:
1) Initialize the DI structures eagerly instead of lazily.
2) Insert a zero-offset ILOffset node so that we don't have problems with missing DI locations for calls.