### PR TITLE
[NativeAOT-LLVM] Implement delegate constructors and managed helpers

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -86,6 +86,10 @@ struct IndentStack;
 
 class Lowering; // defined in lower.h
 
+#ifdef TARGET_WASM
+class Llvm; // defined in llvm.h
+#endif // TARGET_WASM
+
 // The following are defined in this file, Compiler.h
 
 class Compiler;
@@ -7742,6 +7746,10 @@ public:
     */
 
 public:
+#ifdef TARGET_WASM
+    Llvm* m_llvm;
+#endif // TARGET_WASM
+
 #ifndef TARGET_WASM
     CodeGenInterface* codeGen;
 
@@ -7751,7 +7759,7 @@ public:
 #ifdef DEBUG
     jitstd::list<PreciseIPMapping> genPreciseIPmappings;
 #endif
-#endif // TARGET_WASM
+#endif // !TARGET_WASM
 
     // Managed RetVal - A side hash table meant to record the mapping from a
     // GT_CALL node to its debug info.  This info is used to emit sequence points

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14,6 +14,12 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "hwintrinsic.h"
 #include "simd.h"
 
+#if TARGET_WASM
+#include "llvm.h"
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif // TARGET_WASM
+
 #ifdef _MSC_VER
 #pragma hdrstop
 #endif
@@ -2039,6 +2045,14 @@ bool GenTreeCall::HasSideEffects(Compiler* compiler, bool ignoreExceptions, bool
     {
         return true;
     }
+
+#ifdef TARGET_WASM
+    // This call may have an implicit side effect of writing to the return slot pointer.
+    if (TypeIs(TYP_VOID) && compiler->m_llvm->needsReturnStackSlot(this))
+    {
+        return true;
+    }
+#endif // TARGET_WASM
 
     CorInfoHelpFunc       helper           = compiler->eeGetHelperNum(gtCallMethHnd);
     HelperCallProperties& helperProperties = compiler->s_helperCallProperties;

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -989,19 +989,7 @@ void Llvm::failUnsupportedCalls(GenTreeCall* callNode)
 {
     if (callNode->IsHelperCall())
     {
-        switch (_compiler->eeGetHelperNum(callNode->gtCallMethHnd))
-        {
-            // Needs VM work to generate the right helper.
-            case CORINFO_HELP_READYTORUN_DELEGATE_CTOR:
-                if (callNode->gtArgs.CountArgs() != 3)
-                {
-                    return;
-                }
-                failFunctionCompilation();
-
-            default:
-                return;
-        }
+        return;
     }
 
     if (callNode->IsVirtualStub())

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -172,7 +172,7 @@ void Llvm::populateLlvmArgNums()
     shadowStackVarDsc->lvCorInfoType = CORINFO_TYPE_PTR;
     shadowStackVarDsc->lvIsParam = true;
 
-    if (needsReturnStackSlot(_compiler, _sigInfo.retType, _sigInfo.retTypeClass))
+    if (needsReturnStackSlot(_sigInfo.retType, _sigInfo.retTypeClass))
     {
         _retAddressLclNum = _compiler->lvaGrabTemp(true DEBUGARG("returnslot"));
         LclVarDsc* retAddressVarDsc  = _compiler->lvaGetDesc(_retAddressLclNum);
@@ -183,19 +183,19 @@ void Llvm::populateLlvmArgNums()
     }
 
     unsigned firstSigArgLclNum = 0;
-    assert(_sigInfo.hasThis() == (_info.compThisArg != BAD_VAR_NUM));
+    assert(_sigInfo.hasThis() == (m_info->compThisArg != BAD_VAR_NUM));
     if (_sigInfo.hasThis())
     {
         // "this" is never an LLVM parameter as it is always a GC reference.
-        assert(varTypeIsGC(_compiler->lvaGetDesc(_info.compThisArg)));
+        assert(varTypeIsGC(_compiler->lvaGetDesc(m_info->compThisArg)));
         firstSigArgLclNum++;
     }
 
-    assert(_sigInfo.hasTypeArg() == (_info.compTypeCtxtArg != BAD_VAR_NUM));
+    assert(_sigInfo.hasTypeArg() == (m_info->compTypeCtxtArg != BAD_VAR_NUM));
     if (_sigInfo.hasTypeArg())
     {
         // Type context is an unmanaged pointer and thus LLVM parameter.
-        LclVarDsc* typeCtxtVarDsc = _compiler->lvaGetDesc(_info.compTypeCtxtArg);
+        LclVarDsc* typeCtxtVarDsc = _compiler->lvaGetDesc(m_info->compTypeCtxtArg);
         assert(typeCtxtVarDsc->lvIsParam);
 
         typeCtxtVarDsc->lvLlvmArgNum = nextLlvmArgNum++;
@@ -204,11 +204,11 @@ void Llvm::populateLlvmArgNums()
     }
 
     CORINFO_ARG_LIST_HANDLE sigArgs = _sigInfo.args;
-    for (unsigned int i = 0; i < _sigInfo.numArgs; i++, sigArgs = _info.compCompHnd->getArgNext(sigArgs))
+    for (unsigned int i = 0; i < _sigInfo.numArgs; i++, sigArgs = m_info->compCompHnd->getArgNext(sigArgs))
     {
         CORINFO_CLASS_HANDLE classHnd;
-        CorInfoType          corInfoType = strip(_info.compCompHnd->getArgType(&_sigInfo, sigArgs, &classHnd));
-        if (canStoreArgOnLlvmStack(_compiler, corInfoType, classHnd))
+        CorInfoType          corInfoType = strip(m_info->compCompHnd->getArgType(&_sigInfo, sigArgs, &classHnd));
+        if (canStoreArgOnLlvmStack(corInfoType, classHnd))
         {
             LclVarDsc* varDsc = _compiler->lvaGetDesc(firstSigArgLclNum + i);
 
@@ -793,7 +793,7 @@ void Llvm::lowerReturn(GenTreeUnOp* retNode)
         {
             // TODO-LLVM: change to "SetOper" once enough of upstream is merged.
             lclVarNode->ChangeOper(GT_LCL_FLD);
-            lclVarNode->ChangeType(_info.compRetType);
+            lclVarNode->ChangeType(m_info->compRetType);
         }
     }
 }
@@ -819,17 +819,21 @@ void Llvm::lowerReturn(GenTreeUnOp* retNode)
 //
 void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
 {
-    // rewrite the args, adding shadow stack, and moving gc tracked args to the shadow stack
+    // Rewrite the args, adding shadow stack, and moving gc tracked args to the shadow stack.
+    // This transformation only applies to calls that have a managed calling convention (e. g.
+    // it doesn't apply to runtime imports, or helpers implemented as FCalls, etc).
+    const bool isManagedCall = callHasManagedCallingConvention(callNode);
     unsigned shadowStackUseOffset = 0;
 
     CORINFO_SIG_INFO* sigInfo = nullptr;
     CORINFO_ARG_LIST_HANDLE sigArgs = nullptr;
     const HelperFuncInfo* helperInfo = nullptr;
     unsigned sigArgCount = 0;
+    unsigned callArgCount = callNode->gtArgs.CountArgs();
     if (callNode->IsHelperCall())
     {
         helperInfo = &getHelperFuncInfo(_compiler->eeGetHelperNum(callNode->gtCallMethHnd));
-        sigArgCount = helperInfo->GetSigArgCount();
+        sigArgCount = helperInfo->GetSigArgCount(&callArgCount);
     }
     else
     {
@@ -841,7 +845,7 @@ void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
     callNode->gtArgs.MoveLateToEarly();
 
     // Relies on the fact all arguments not in the signature come before those that are.
-    unsigned firstSigArgIx    = callNode->gtArgs.CountArgs() - sigArgCount;
+    unsigned firstSigArgIx    = callArgCount - sigArgCount;
     unsigned argIx            = 0;
     CallArg* lastLlvmStackArg = nullptr;
 
@@ -877,15 +881,12 @@ void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
         CorInfoType          corInfoType;
         bool                 isSigArg    = argIx >= firstSigArgIx;
 
-        // We currently do not place any args for helpers on the shadow stack. This is a potential GC
-        // hole and not correct ABI-wise for managed helpers. TODO-LLVM: investigate and fix issues.
-        bool argOnShadowStack = false;
         if (sigInfo != nullptr)
         {
             // Is this an in-signature argument?
             if (isSigArg)
             {
-                corInfoType = strip(_info.compCompHnd->getArgType(sigInfo, sigArgs, &clsHnd));
+                corInfoType = strip(m_info->compCompHnd->getArgType(sigInfo, sigArgs, &clsHnd));
                 sigArgs     = _compiler->info.compCompHnd->getArgNext(sigArgs);
             }
             else // Not-in-sig arguments. We need to handle these specially.
@@ -905,8 +906,6 @@ void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
                     corInfoType = toCorInfoType(genActualType(argNode));
                 }
             }
-
-            argOnShadowStack = !canStoreArgOnLlvmStack(_compiler, corInfoType, clsHnd);
         }
         else
         {
@@ -922,7 +921,7 @@ void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
             clsHnd = helperInfo->GetSigArgClass(_compiler, argIx);
         }
 
-        if (argOnShadowStack)
+        if (isManagedCall && !canStoreArgOnLlvmStack(corInfoType, clsHnd))
         {
             if (corInfoType == CORINFO_TYPE_VALUECLASS)
             {
@@ -994,12 +993,10 @@ void Llvm::failUnsupportedCalls(GenTreeCall* callNode)
         {
             // Needs VM work to generate the right helper.
             case CORINFO_HELP_READYTORUN_DELEGATE_CTOR:
-            // These helpers are implemented purely in managed code, and have "object"
-            // parameters/return values which need to be passed on the shadow stack.
-            // Our lowering code currently does not handle such helpers.
-            case CORINFO_HELP_GVMLOOKUP_FOR_SLOT:
-            case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE:
-            case CORINFO_HELP_NEW_MDARR:
+                if (callNode->gtArgs.CountArgs() != 3)
+                {
+                    return;
+                }
                 failFunctionCompilation();
 
             default:
@@ -1036,14 +1033,6 @@ void Llvm::failUnsupportedCalls(GenTreeCall* callNode)
     {
         failFunctionCompilation();
     }
-
-    for (CallArg& callArg : callNode->gtArgs.Args())
-    {
-        if (callArg.GetWellKnownArg() == WellKnownArg::VirtualStubCell)
-        {
-            failFunctionCompilation();
-        }
-    }
 }
 
 // If the return type must be GC tracked, removes the return type
@@ -1055,7 +1044,7 @@ CallArg* Llvm::lowerCallReturn(GenTreeCall* callNode)
 {
     CallArg* returnSlot = nullptr;
 
-    if (needsReturnStackSlot(_compiler, callNode))
+    if (needsReturnStackSlot(callNode))
     {
         // replace the "CALL ref" with a "CALL void" that takes a return address as the first argument
         GenTree* returnValueAddress = insertShadowStackAddr(callNode, getCurrentShadowFrameSize(), _shadowStackLclNum);

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -9,7 +9,7 @@ StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
     if (_structDescMap->find(structHandle) == _structDescMap->end())
     {
         TypeDescriptor structTypeDescriptor = GetTypeDescriptor(structHandle);
-        unsigned structSize                 = _info.compCompHnd->getClassSize(structHandle); // TODO-LLVM: add to TypeDescriptor?
+        unsigned structSize                 = m_info->compCompHnd->getClassSize(structHandle); // TODO-LLVM: add to TypeDescriptor?
 
         std::vector<CORINFO_FIELD_HANDLE> sparseFields = std::vector<CORINFO_FIELD_HANDLE>(structSize);
         std::vector<unsigned> sparseFieldSizes = std::vector<unsigned>(structSize);
@@ -21,12 +21,12 @@ StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
         for (unsigned i = 0; i < structTypeDescriptor.getFieldCount(); i++)
         {
             CORINFO_FIELD_HANDLE fieldHandle = structTypeDescriptor.getField(i);
-            unsigned             fldOffset   = _info.compCompHnd->getFieldOffset(fieldHandle);
+            unsigned             fldOffset   = m_info->compCompHnd->getFieldOffset(fieldHandle);
 
             assert(fldOffset < structSize);
 
             CORINFO_CLASS_HANDLE fieldClass;
-            CorInfoType corInfoType = _info.compCompHnd->getFieldType(fieldHandle, &fieldClass);
+            CorInfoType corInfoType = m_info->compCompHnd->getFieldType(fieldHandle, &fieldClass);
 
             unsigned fieldSize = getElementSize(fieldClass, corInfoType);
 
@@ -73,7 +73,7 @@ StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
             CORINFO_FIELD_HANDLE fieldHandle = sparseFields[fldOffset];
             CORINFO_CLASS_HANDLE fieldClassHandle = NO_CLASS_HANDLE;
 
-            const CorInfoType corInfoType = _info.compCompHnd->getFieldType(fieldHandle, &fieldClassHandle);
+            const CorInfoType corInfoType = m_info->compCompHnd->getFieldType(fieldHandle, &fieldClassHandle);
             fields[fieldIx] = FieldDesc(fldOffset, corInfoType, fieldClassHandle);
             fieldIx++;
         }
@@ -103,7 +103,7 @@ Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
         // LLVM thinks certain sizes of struct have a different calling convention than Clang does.
         // Treating them as ints fixes that and is more efficient in general
 
-        unsigned structSize = _info.compCompHnd->getClassSize(structHandle);
+        unsigned structSize = m_info->compCompHnd->getClassSize(structHandle);
         switch (structSize)
         {
             case 1:
@@ -270,7 +270,7 @@ unsigned Llvm::getElementSize(CORINFO_CLASS_HANDLE classHandle, CorInfoType corI
 {
     if (classHandle != NO_CLASS_HANDLE)
     {
-        return _info.compCompHnd->getClassSize(classHandle);
+        return m_info->compCompHnd->getClassSize(classHandle);
     }
 
     return genTypeSize(JITtype2varType(corInfoType));

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -18,14 +18,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "allocacheck.h" // for alloca
 
 #if TARGET_WASM
-#undef min
-#undef max
-
 #include "llvm.h"
-
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 #define min(a, b) (((a) < (b)) ? (a) : (b))
-
 #endif // TARGET_WASM
 
 // Convert the given node into a call to the specified helper passing
@@ -6478,7 +6473,7 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
     }
 
 #if TARGET_WASM
-    if (Llvm::needsReturnStackSlot(this, callee))
+    if (m_llvm->needsReturnStackSlot(callee))
     {
         reportFastTailCallDecision("Callee has a return type that must be passed on the LLVM shadow stack");
         return false;

--- a/src/coreclr/nativeaot/Runtime/CommonMacros.h
+++ b/src/coreclr/nativeaot/Runtime/CommonMacros.h
@@ -162,7 +162,7 @@ inline bool IS_ALIGNED(T* val, uintptr_t alignment);
 
 #define DATA_ALIGNMENT  4
 #ifndef OS_PAGE_SIZE
-#define OS_PAGE_SIZE    0x4
+#define OS_PAGE_SIZE    0x8
 #endif
 
 #else

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchCellNode.cs
@@ -93,23 +93,35 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             IEETypeNode interfaceType = factory.NecessaryTypeSymbol(_targetMethod.OwningType);
-            if (interfaceType.RepresentsIndirectionCell)
+            if (factory.Target.SupportsRelativePointers)
             {
-                objData.EmitReloc(interfaceType, RelocType.IMAGE_REL_BASED_RELPTR32,
-                    (int)InterfaceDispatchCellCachePointerFlags.CachePointerIsIndirectedInterfaceRelativePointer);
+                if (interfaceType.RepresentsIndirectionCell)
+                {
+                    objData.EmitReloc(interfaceType, RelocType.IMAGE_REL_BASED_RELPTR32,
+                        (int)InterfaceDispatchCellCachePointerFlags.CachePointerIsIndirectedInterfaceRelativePointer);
+                }
+                else
+                {
+                    objData.EmitReloc(interfaceType, RelocType.IMAGE_REL_BASED_RELPTR32,
+                        (int)InterfaceDispatchCellCachePointerFlags.CachePointerIsInterfaceRelativePointer);
+                }
+
+                if (objData.TargetPointerSize == 8)
+                {
+                    // IMAGE_REL_BASED_RELPTR is a 32-bit relocation. However, the cell needs a full pointer
+                    // width there since a pointer to the cache will be written into the cell. Emit additional
+                    // 32 bits on targets whose pointer size is 64 bit.
+                    objData.EmitInt(0);
+                }
             }
             else
             {
-                objData.EmitReloc(interfaceType, RelocType.IMAGE_REL_BASED_RELPTR32,
-                    (int)InterfaceDispatchCellCachePointerFlags.CachePointerIsInterfaceRelativePointer);
-            }
-
-            if (objData.TargetPointerSize == 8)
-            {
-                // IMAGE_REL_BASED_RELPTR is a 32-bit relocation. However, the cell needs a full pointer 
-                // width there since a pointer to the cache will be written into the cell. Emit additional
-                // 32 bits on targets whose pointer size is 64 bit. 
-                objData.EmitInt(0);
+                // There are no free bits in the cache flags, but we could support the indirection cell case
+                // by repurposing "CachePointerIsIndirectedInterfaceRelativePointer" to mean "relative indirect
+                // if the target supports it, simple indirect otherwise".
+                Debug.Assert(!interfaceType.RepresentsIndirectionCell);
+                objData.EmitPointerReloc(interfaceType,
+                    (int)InterfaceDispatchCellCachePointerFlags.CachePointerIsInterfacePointerOrMetadataToken);
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmReadyToRunHelperNode.cs
@@ -78,9 +78,10 @@ namespace ILCompiler.DependencyAnalysis
                         }
                         else
                         {
-                            //closed delegate, Wasm needs the constructor
-                            encoder.Builder.EmitReloc(target.Constructor, RelocType.IMAGE_REL_BASED_REL32);
+                            Debug.Assert(target.Constructor.Method.Signature.Length == 2);
                         }
+
+                        encoder.Builder.EmitReloc(target.Constructor, RelocType.IMAGE_REL_BASED_REL32);
                     }
                     break;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -435,9 +435,13 @@ namespace Internal.IL
                                 {
                                     _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.TypeHandle, delTargetMethod.OwningType), reason);
                                 }
-                            }
 
-                            _dependencies.Add(info.Constructor, "LLVM delegate ctor");
+                                _dependencies.Add(GetGenericLookupHelper(ReadyToRunHelperId.DelegateCtor, info), "LLVM delegate ctor");
+                            }
+                            else
+                            {
+                                _dependencies.Add(_factory.ReadyToRunHelper(ReadyToRunHelperId.DelegateCtor, info), "LLVM delegate ctor");
+                            }
                             return;
                         }
                     }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMSharpInterop.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMSharpInterop.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using LLVMSharp.Interop;
@@ -32,6 +33,12 @@ namespace Internal.IL
         {
             using var marshaledName = new MarshaledString(name);
             return LLVM.GetNamedGlobalAlias(module, marshaledName, (nuint)marshaledName.Length);
+        }
+
+        public static LLVMTypeRef GetValueType(this LLVMValueRef value)
+        {
+            Debug.Assert(value.IsAGlobalValue.Handle != IntPtr.Zero);
+            return LLVM.GlobalGetValueType(value);
         }
 
         internal struct MarshaledString : IDisposable


### PR DESCRIPTION
Two core changes:

1) Implement lowering support for helpers that take arguments on the shadow stack; implement the distinction of "managed" (shadow) vs "unmanaged" calling conventions. In the former, the caller uses the shadow stack to pass GC values, in the latter they are passed directly as pointer values. FCalls as well as runtime imports use the "unmanaged" calling convention, and must therefore ensure they report any live references properly, or forbid the GC from occurring.
   - This also lays the groundwork for supporting true native calls, i. e. PInvokes.
2) Implement `CORINFO_HELP_READYTORUN_DELEGATE_CTOR`:
   - Object writer code emission support
   - ILImporter rewrite to use it in the same manner RyuJit does (modulo `.constrained; ldftn` handling).