### PR TITLE
NativeAOT-LLVM: Remove GT_PUTARG_TYPE

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3911,8 +3911,10 @@ private:
 
     void impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call);
 
-    bool impCheckImplicitArgumentCoercion(var_types sigType, var_types nodeType) const;
+public:
+    static bool impCheckImplicitArgumentCoercion(var_types sigType, var_types nodeType);
 
+private:
     void impPopReverseCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call, unsigned skipReverseCount);
 
     //---------------- Spilling the importer stack ----------------------------
@@ -4136,10 +4138,7 @@ private:
                            InlineCandidateInfo**  ppInlineCandidateInfo,
                            InlineResult*          inlineResult);
 
-    void impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
-                                GenTree*      curArgVal,
-                                unsigned      argNum,
-                                InlineResult* inlineResult);
+    void impInlineRecordArgInfo(InlineInfo* pInlineInfo, CallArg* arg, unsigned argNum, InlineResult* inlineResult);
 
     void impInlineInitVars(InlineInfo* pInlineInfo);
 
@@ -4457,8 +4456,6 @@ public:
                                        BasicBlock* nonCanonicalBlock,
                                        BasicBlock* canonicalBlock,
                                        flowList*   predEdge);
-
-    GenTree* fgCheckCallArgUpdate(GenTree* parent, GenTree* child, var_types origType);
 
 #if defined(FEATURE_EH_FUNCLETS) && defined(TARGET_ARM)
     // Sometimes we need to defer updating the BBF_FINALLY_TARGET bit. fgNeedToAddFinallyTargetBits signals
@@ -10714,7 +10711,6 @@ public:
             case GT_NULLCHECK:
             case GT_PUTARG_REG:
             case GT_PUTARG_STK:
-            case GT_PUTARG_TYPE:
             case GT_RETURNTRAP:
             case GT_NOP:
             case GT_FIELD:

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2328,12 +2328,6 @@ public:
 
     GenTreeLclVar* gtNewStoreLclVar(unsigned dstLclNum, GenTree* src);
 
-#ifdef TARGET_WASM
-    GenTreePutArgType* gtNewPutArgType(GenTree*             op,
-                                       CorInfoType          corInfoType,
-                                       CORINFO_CLASS_HANDLE clsHnd);
-#endif
-
 #ifdef FEATURE_SIMD
     GenTree* gtNewSIMDVectorZero(var_types simdType, CorInfoType simdBaseJitType, unsigned simdSize);
 #endif

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -991,11 +991,11 @@ inline GenTree* Compiler::gtNewIconEmbFldHndNode(CORINFO_FIELD_HANDLE fldHnd)
 // Arguments:
 //    helper    - Call helper
 //    type      - Type of the node
-//    args      - Call args
+//    args      - Call args (struct args not supported)
 //
 // Return Value:
 //    New CT_HELPER node
-
+//
 inline GenTreeCall* Compiler::gtNewHelperCallNode(
     unsigned helper, var_types type, GenTree* arg1, GenTree* arg2, GenTree* arg3)
 {
@@ -1011,19 +1011,19 @@ inline GenTreeCall* Compiler::gtNewHelperCallNode(
 
     if (arg3 != nullptr)
     {
-        result->gtArgs.PushFront(this, arg3);
+        result->gtArgs.PushFront(this, NewCallArg::Primitive(arg3));
         result->gtFlags |= arg3->gtFlags & GTF_ALL_EFFECT;
     }
 
     if (arg2 != nullptr)
     {
-        result->gtArgs.PushFront(this, arg2);
+        result->gtArgs.PushFront(this, NewCallArg::Primitive(arg2));
         result->gtFlags |= arg2->gtFlags & GTF_ALL_EFFECT;
     }
 
     if (arg1 != nullptr)
     {
-        result->gtArgs.PushFront(this, arg1);
+        result->gtArgs.PushFront(this, NewCallArg::Primitive(arg1));
         result->gtFlags |= arg1->gtFlags & GTF_ALL_EFFECT;
     }
 
@@ -4265,7 +4265,6 @@ void GenTree::VisitOperands(TVisitor visitor)
         case GT_NULLCHECK:
         case GT_PUTARG_REG:
         case GT_PUTARG_STK:
-        case GT_PUTARG_TYPE:
 #if FEATURE_ARG_SPLIT
         case GT_PUTARG_SPLIT:
 #endif // FEATURE_ARG_SPLIT

--- a/src/coreclr/jit/decomposelongs.cpp
+++ b/src/coreclr/jit/decomposelongs.cpp
@@ -1355,10 +1355,11 @@ GenTree* DecomposeLongs::DecomposeShift(LIR::Use& use)
                 unreached();
         }
 
-        GenTreeCall* call = m_compiler->gtNewHelperCallNode(helper, TYP_LONG);
-        call->gtArgs.PushFront(m_compiler, shiftByOp);
-        call->gtArgs.PushFront(m_compiler, hiOp1, WellKnownArg::ShiftHigh);
-        call->gtArgs.PushFront(m_compiler, loOp1, WellKnownArg::ShiftLow);
+        GenTreeCall* call       = m_compiler->gtNewHelperCallNode(helper, TYP_LONG);
+        NewCallArg   loArg      = NewCallArg::Primitive(loOp1).WellKnown(WellKnownArg::ShiftLow);
+        NewCallArg   hiArg      = NewCallArg::Primitive(hiOp1).WellKnown(WellKnownArg::ShiftHigh);
+        NewCallArg   shiftByArg = NewCallArg::Primitive(shiftByOp);
+        call->gtArgs.PushFront(m_compiler, loArg, hiArg, shiftByArg);
         call->gtFlags |= shift->gtFlags & GTF_ALL_EFFECT;
 
         if (shift->IsUnusedValue())

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1216,19 +1216,19 @@ GenTree* Compiler::fgOptimizeDelegateConstructor(GenTreeCall*            call,
             if (ctorData.pArg3 != nullptr)
             {
                 GenTree* arg3 = gtNewIconHandleNode(size_t(ctorData.pArg3), GTF_ICON_FTN_ADDR);
-                lastArg       = call->gtArgs.PushBack(this, arg3);
+                lastArg       = call->gtArgs.PushBack(this, NewCallArg::Primitive(arg3));
             }
 
             if (ctorData.pArg4 != nullptr)
             {
                 GenTree* arg4 = gtNewIconHandleNode(size_t(ctorData.pArg4), GTF_ICON_FTN_ADDR);
-                lastArg       = call->gtArgs.InsertAfter(this, lastArg, arg4);
+                lastArg       = call->gtArgs.InsertAfter(this, lastArg, NewCallArg::Primitive(arg4));
             }
 
             if (ctorData.pArg5 != nullptr)
             {
                 GenTree* arg5 = gtNewIconHandleNode(size_t(ctorData.pArg5), GTF_ICON_FTN_ADDR);
-                lastArg       = call->gtArgs.InsertAfter(this, lastArg, arg5);
+                lastArg       = call->gtArgs.InsertAfter(this, lastArg, NewCallArg::Primitive(arg5));
             }
         }
         else
@@ -4185,42 +4185,4 @@ void Compiler::fgLclFldAssign(unsigned lclNum)
     {
         lvaSetVarDoNotEnregister(lclNum DEBUGARG(DoNotEnregisterReason::LocalField));
     }
-}
-
-//------------------------------------------------------------------------
-// fgCheckCallArgUpdate: check if we are replacing a call argument and add GT_PUTARG_TYPE if necessary.
-//
-// Arguments:
-//    parent   - the parent that could be a call;
-//    child    - the new child node;
-//    origType - the original child type;
-//
-// Returns:
-//   PUT_ARG_TYPE node if it is needed, nullptr otherwise.
-//
-GenTree* Compiler::fgCheckCallArgUpdate(GenTree* parent, GenTree* child, var_types origType)
-{
-    if ((parent == nullptr) || !parent->IsCall())
-    {
-        return nullptr;
-    }
-    const var_types newType = child->TypeGet();
-    if (newType == origType)
-    {
-        return nullptr;
-    }
-    if (varTypeIsStruct(origType) || (genTypeSize(origType) == genTypeSize(newType)))
-    {
-        assert(!varTypeIsStruct(newType));
-        return nullptr;
-    }
-    GenTree* putArgType = gtNewOperNode(GT_PUTARG_TYPE, origType, child);
-#if defined(DEBUG)
-    if (verbose)
-    {
-        printf("For call [%06d] the new argument's type [%06d]", dspTreeID(parent), dspTreeID(child));
-        printf(" does not match the original type size, add a GT_PUTARG_TYPE [%06d]\n", dspTreeID(parent));
-    }
-#endif
-    return putArgType;
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9142,6 +9142,9 @@ void CallArgs::InternalCopyFrom(Compiler* comp, CallArgs* other, CopyNodeFunc co
         carg->m_isTmp           = arg.m_isTmp;
         carg->m_processed       = arg.m_processed;
         carg->AbiInfo           = arg.AbiInfo;
+#ifdef TARGET_WASM
+        carg->m_signatureCorInfoType = arg.m_signatureCorInfoType;
+#endif // TARGET_WASM
         *tail                   = carg;
         tail                    = &carg->m_next;
     }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4236,6 +4236,7 @@ struct NewCallArg
     WellKnownArg WellKnownArg = WellKnownArg::None;
 
 #ifdef TARGET_WASM
+    // Only used to differentiate pointer types (CORINFO_TYPE_PTR) from ints
     CorInfoType SignatureCorInfoType = CORINFO_TYPE_UNDEF;
 #endif
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -29,9 +29,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "layout.h"
 #include "debuginfo.h"
 
-#ifdef TARGET_WASM
 extern var_types JITtype2varType(CorInfoType type);
-#endif // TARGET_WASM
 
 // Debugging GenTree is much easier if we add a magic virtual function to make the debugger able to figure out what type
 // it's got. This is enabled by default in DEBUG. To enable it in RET builds (temporarily!), you need to change the

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4354,11 +4354,7 @@ public:
     // clang-format off
     GenTree*& EarlyNodeRef() { return m_earlyNode; }
     GenTree* GetEarlyNode() { return m_earlyNode; }
-#ifdef TARGET_WASM
-    void SetEarlyNode(GenTree* node, CorInfoType signatureCorInfoType = CORINFO_TYPE_UNDEF) { m_earlyNode = node; m_signatureCorInfoType = signatureCorInfoType; }
-#else
     void SetEarlyNode(GenTree* node) { m_earlyNode = node; }
-#endif
     GenTree*& LateNodeRef() { return m_lateNode; }
     GenTree* GetLateNode() { return m_lateNode; }
     void SetLateNode(GenTree* lateNode) { m_lateNode = lateNode; }
@@ -4372,6 +4368,7 @@ public:
     var_types GetSignatureType() { return m_signatureType; }
 #ifdef TARGET_WASM
     CorInfoType GetSignatureCorInfoType() { return m_signatureCorInfoType; }
+    void SetSignatureCorInfoType(CorInfoType signatureCorInfoType) { m_signatureCorInfoType = signatureCorInfoType; }
     void SetSignatureClassHandle(CORINFO_CLASS_HANDLE signatureClsHnd) { m_signatureClsHnd = signatureClsHnd; }
 #endif
     WellKnownArg GetWellKnownArg() { return m_wellKnownArg; }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4258,20 +4258,23 @@ struct NewCallArg
         return arg;
     }
 
-#ifdef TARGET_WASM
-    static NewCallArg Primitive(GenTree* node, var_types type = TYP_UNDEF, CorInfoType corInfoType = CORINFO_TYPE_UNDEF)
-#else
     static NewCallArg Primitive(GenTree* node, var_types type = TYP_UNDEF)
-#endif
     {
         assert(!varTypeIsStruct(node) && !varTypeIsStruct(type));
         NewCallArg arg;
         arg.Node          = node;
         arg.SignatureType = type == TYP_UNDEF ? node->TypeGet() : type;
+        arg.ValidateTypes();
+        return arg;
+    }
+
+    static NewCallArg Primitive(GenTree* node, CorInfoType corInfoType)
+    {
+        assert(corInfoType != CORINFO_TYPE_UNDEF);
+        NewCallArg arg = Primitive(node, JITtype2varType(corInfoType));
 #ifdef TARGET_WASM
         arg.SignatureCorInfoType = corInfoType;
 #endif
-        arg.ValidateTypes();
         return arg;
     }
 

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -96,7 +96,6 @@ GTNODE(ALLOCOBJ         , GenTreeAllocObj    ,0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR) //
 GTNODE(INIT_VAL         , GenTreeOp          ,0,GTK_UNOP) // Initialization value for an initBlk
 
 GTNODE(BOX              , GenTreeBox         ,0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR)   // Marks its first operands (a local) as being a box
-GTNODE(PUTARG_TYPE      , GenTreeOp          ,0,GTK_UNOP|DBK_NOTLIR)            // Saves argument type between importation and morph
 GTNODE(RUNTIMELOOKUP    , GenTreeRuntimeLookup, 0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR) // Runtime handle lookup
 GTNODE(ARR_ADDR         , GenTreeArrAddr     ,0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR)   // Wraps an array address expression
 

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -96,10 +96,6 @@ GTNODE(ALLOCOBJ         , GenTreeAllocObj    ,0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR) //
 GTNODE(INIT_VAL         , GenTreeOp          ,0,GTK_UNOP) // Initialization value for an initBlk
 
 GTNODE(BOX              , GenTreeBox         ,0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR)   // Marks its first operands (a local) as being a box
-<<<<<<< HEAD
-GTNODE(PUTARG_TYPE      , GenTreePutArgType  ,0,GTK_UNOP)            // Saves argument type between importation and morph
-=======
->>>>>>> f8fa9f6d1554e8db291187dd7b2847162703381e
 GTNODE(RUNTIMELOOKUP    , GenTreeRuntimeLookup, 0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR) // Runtime handle lookup
 GTNODE(ARR_ADDR         , GenTreeArrAddr     ,0,GTK_UNOP|GTK_EXOP|DBK_NOTLIR)   // Wraps an array address expression
 

--- a/src/coreclr/jit/gtstructs.h
+++ b/src/coreclr/jit/gtstructs.h
@@ -122,7 +122,6 @@ GTSTRUCT_1(MultiRegOp  , GT_MUL_LONG)
 GTSTRUCT_3(MultiRegOp  , GT_MUL_LONG, GT_PUTARG_REG, GT_BITCAST)
 #elif defined (TARGET_WASM)
 GTSTRUCT_3(MultiRegOp, GT_MUL_LONG, GT_PUTARG_REG, GT_BITCAST)
-GTSTRUCT_N(PutArgType, GT_PUTARG_TYPE)
 #endif
 /*****************************************************************************/
 #undef  GTSTRUCT_0

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -860,6 +860,19 @@ void Compiler::impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call)
         {
             // Morph trees that aren't already OBJs or MKREFANY to be OBJs
             assert(ti.IsType(TI_STRUCT));
+
+            // The argument and parameter types can be different for legitimate
+            // reasons, but we expect them to be compatible in those cases. One
+            // example where this happens is when inlining shared code into a
+            // non-generic function, in which case we might see the __Canon in
+            // the parameter type but exact types in the signature type.
+            //
+            // TODO-ARGS: Remove this quirk; we should be able to use the
+            // signature type that is different in the rare case above. It will
+            // cause positive diffs, but that is probably an indication that we
+            // have downstream phases that should be using
+            // `ClassLayout::AreCompatible` instead.
+            //
             classHnd = ti.GetClassHandleForValueClass();
 
             bool forceNormalization = false;
@@ -921,23 +934,23 @@ void Compiler::impPopCallArgs(CORINFO_SIG_INFO* sig, GenTreeCall* call)
             }
         }
 
-        const var_types nodeArgType = argNode->TypeGet();
-        if (!varTypeIsStruct(jitSigType) && genTypeSize(nodeArgType) != genTypeSize(jitSigType))
+        NewCallArg arg;
+        if (varTypeIsStruct(jitSigType))
         {
-            assert(!varTypeIsStruct(nodeArgType));
-            // Some ABI require precise size information for call arguments less than target pointer size,
-            // for example arm64 OSX. Create a special node to keep this information until morph
-            // consumes it into `CallArgs`.
-            argNode = gtNewOperNode(GT_PUTARG_TYPE, jitSigType, argNode);
+            arg = NewCallArg::Struct(argNode, jitSigType, classHnd);
+        }
+        else
+        {
+            arg = NewCallArg::Primitive(argNode, jitSigType);
         }
 
         if (lastArg == nullptr)
         {
-            lastArg = call->gtArgs.PushFront(this, argNode);
+            lastArg = call->gtArgs.PushFront(this, arg);
         }
         else
         {
-            lastArg = call->gtArgs.InsertAfterUnchecked(this, lastArg, argNode);
+            lastArg = call->gtArgs.InsertAfterUnchecked(this, lastArg, arg);
         }
 
         call->gtFlags |= argNode->gtFlags & GTF_GLOB_EFFECT;
@@ -988,7 +1001,7 @@ static bool TypeIs(var_types type1, var_types type2, T... rest)
 //   - it can't check long -> native int case on 64-bit platforms,
 //      so the behavior is different depending on the target bitness.
 //
-bool Compiler::impCheckImplicitArgumentCoercion(var_types sigType, var_types nodeType) const
+bool Compiler::impCheckImplicitArgumentCoercion(var_types sigType, var_types nodeType)
 {
     if (sigType == nodeType)
     {
@@ -1239,6 +1252,8 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
             WellKnownArg wellKnownArgType =
                 srcCall->ShouldHaveRetBufArg() ? WellKnownArg::RetBuffer : WellKnownArg::None;
 
+            NewCallArg newArg = NewCallArg::Primitive(destAddr).WellKnown(wellKnownArgType);
+
 #if !defined(TARGET_ARM)
             // Unmanaged instance methods on Windows or Unix X86 need the retbuf arg after the first (this) parameter
             if ((TargetOS::IsWindows || compUnixX86Abi()) && srcCall->IsUnmanaged())
@@ -1253,18 +1268,18 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
                     if (srcCall->gtArgs.Args().begin() == srcCall->gtArgs.Args().end())
                     {
                         // Empty arg list
-                        srcCall->gtArgs.PushFront(this, destAddr, wellKnownArgType);
+                        srcCall->gtArgs.PushFront(this, newArg);
                     }
                     else if (srcCall->GetUnmanagedCallConv() == CorInfoCallConvExtension::Thiscall)
                     {
                         // For thiscall, the "this" parameter is not included in the argument list reversal,
                         // so we need to put the return buffer as the last parameter.
-                        srcCall->gtArgs.PushBack(this, destAddr, wellKnownArgType);
+                        srcCall->gtArgs.PushBack(this, newArg);
                     }
                     else if (srcCall->gtArgs.Args().begin()->GetNext() == nullptr)
                     {
                         // Only 1 arg, so insert at beginning
-                        srcCall->gtArgs.PushFront(this, destAddr, wellKnownArgType);
+                        srcCall->gtArgs.PushFront(this, newArg);
                     }
                     else
                     {
@@ -1281,17 +1296,17 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
                         }
 
                         assert(secondLastArg && "Expected to find second last arg");
-                        srcCall->gtArgs.InsertAfter(this, secondLastArg, destAddr, wellKnownArgType);
+                        srcCall->gtArgs.InsertAfter(this, secondLastArg, newArg);
                     }
 
 #else
                     if (srcCall->gtArgs.Args().begin() == srcCall->gtArgs.Args().end())
                     {
-                        srcCall->gtArgs.PushFront(this, destAddr, wellKnownArgType);
+                        srcCall->gtArgs.PushFront(this, newArg);
                     }
                     else
                     {
-                        srcCall->gtArgs.InsertAfter(this, &*srcCall->gtArgs.Args().begin(), destAddr, wellKnownArgType);
+                        srcCall->gtArgs.InsertAfter(this, &*srcCall->gtArgs.Args().begin(), newArg);
                     }
 #endif
                 }
@@ -1301,10 +1316,10 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
                     // The argument list has already been reversed.
                     // Insert the return buffer as the last node so it will be pushed on to the stack last
                     // as required by the native ABI.
-                    srcCall->gtArgs.PushBack(this, destAddr, wellKnownArgType);
+                    srcCall->gtArgs.PushBack(this, newArg);
 #else
                     // insert the return value buffer into the argument list as first byref parameter
-                    srcCall->gtArgs.PushFront(this, destAddr, wellKnownArgType);
+                    srcCall->gtArgs.PushFront(this, newArg);
 #endif
                 }
             }
@@ -1312,7 +1327,7 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
 #endif // !defined(TARGET_ARM)
             {
                 // insert the return value buffer into the argument list as first byref parameter after 'this'
-                srcCall->gtArgs.InsertAfterThisOrFirst(this, destAddr, wellKnownArgType);
+                srcCall->gtArgs.InsertAfterThisOrFirst(this, newArg);
             }
 
             // now returns void, not a struct
@@ -1375,13 +1390,14 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
     }
     else if (src->gtOper == GT_RET_EXPR)
     {
+        noway_assert(src->AsRetExpr()->gtInlineCandidate->OperIs(GT_CALL));
         GenTreeCall* call = src->AsRetExpr()->gtInlineCandidate->AsCall();
-        noway_assert(call->gtOper == GT_CALL);
 
         if (call->ShouldHaveRetBufArg())
         {
             // insert the return value buffer into the argument list as first byref parameter after 'this'
-            call->gtArgs.InsertAfterThisOrFirst(this, destAddr, WellKnownArg::RetBuffer);
+            call->gtArgs.InsertAfterThisOrFirst(this,
+                                                NewCallArg::Primitive(destAddr).WellKnown(WellKnownArg::RetBuffer));
 
             // now returns void, not a struct
             src->gtType  = TYP_VOID;
@@ -2373,7 +2389,10 @@ GenTree* Compiler::impRuntimeLookupToTree(CORINFO_RESOLVED_TOKEN* pResolvedToken
 
         // ((sizeCheck fails || nullCheck fails))) ? (helperCall : handle).
         // Add checks and the handle as call arguments, indirect call transformer will handle this.
-        helperCall->gtArgs.PushFront(this, nullCheck, sizeCheck, handleForResult);
+        NewCallArg nullCheckArg       = NewCallArg::Primitive(nullCheck);
+        NewCallArg sizeCheckArg       = NewCallArg::Primitive(sizeCheck);
+        NewCallArg handleForResultArg = NewCallArg::Primitive(handleForResult);
+        helperCall->gtArgs.PushFront(this, nullCheckArg, sizeCheckArg, handleForResultArg);
         result = helperCall;
         addExpRuntimeLookupCandidate(helperCall);
     }
@@ -8449,7 +8468,7 @@ void Compiler::impInsertHelperCall(CORINFO_HELPER_DESC* helperInfo)
             default:
                 NO_WAY("Illegal helper arg type");
         }
-        callout->gtArgs.PushFront(this, currentArg);
+        callout->gtArgs.PushFront(this, NewCallArg::Primitive(currentArg));
     }
 
     impAppendTree(callout, (unsigned)CHECK_SPILL_NONE, impCurStmtDI);
@@ -8730,8 +8749,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     bool bIntrinsicImported = false;
 
     CORINFO_SIG_INFO calliSig;
-    GenTree*         extraArg     = nullptr;
-    WellKnownArg     extraArgKind = WellKnownArg::None;
+    NewCallArg       extraArg;
 
     /*-------------------------------------------------------------------------
      * First create the call node
@@ -9036,7 +9054,8 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 GenTree* fptr = impImportLdvirtftn(thisPtr, pResolvedToken, callInfo);
                 assert(fptr != nullptr);
 
-                call->AsCall()->gtArgs.PushFront(this, thisPtrCopy, WellKnownArg::ThisPointer);
+                call->AsCall()
+                    ->gtArgs.PushFront(this, NewCallArg::Primitive(thisPtrCopy).WellKnown(WellKnownArg::ThisPointer));
 
                 // Now make an indirect call through the function pointer
 
@@ -9363,9 +9382,9 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
         varCookie = info.compCompHnd->getVarArgsHandle(sig, &pVarCookie);
         assert((!varCookie) != (!pVarCookie));
-        assert(extraArg == nullptr);
-        extraArg     = gtNewIconEmbHndNode(varCookie, pVarCookie, GTF_ICON_VARG_HDL, sig);
-        extraArgKind = WellKnownArg::VarArgsCookie;
+        GenTree* cookieNode = gtNewIconEmbHndNode(varCookie, pVarCookie, GTF_ICON_VARG_HDL, sig);
+        assert(extraArg.Node == nullptr);
+        extraArg = NewCallArg::Primitive(cookieNode).WellKnown(WellKnownArg::VarArgsCookie);
     }
 
     //-------------------------------------------------------------------------
@@ -9487,9 +9506,8 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
             }
         }
 
-        assert(extraArg == nullptr);
-        extraArg     = instParam;
-        extraArgKind = WellKnownArg::InstParam;
+        assert(extraArg.Node == nullptr);
+        extraArg = NewCallArg::Primitive(instParam).WellKnown(WellKnownArg::InstParam);
     }
 
     if ((opcode == CEE_NEWOBJ) && ((clsFlags & CORINFO_FLG_DELEGATE) != 0))
@@ -9511,18 +9529,18 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     // The main group of arguments
 
     impPopCallArgs(sig, call->AsCall());
-    if (extraArg != nullptr)
+    if (extraArg.Node != nullptr)
     {
         if (Target::g_tgtArgOrder == Target::ARG_ORDER_R2L)
         {
-            call->AsCall()->gtArgs.PushFront(this, extraArg, extraArgKind);
+            call->AsCall()->gtArgs.PushFront(this, extraArg);
         }
         else
         {
-            call->AsCall()->gtArgs.PushBack(this, extraArg, extraArgKind);
+            call->AsCall()->gtArgs.PushBack(this, extraArg);
         }
 
-        call->gtFlags |= extraArg->gtFlags & GTF_GLOB_EFFECT;
+        call->gtFlags |= extraArg.Node->gtFlags & GTF_GLOB_EFFECT;
     }
 
     //-------------------------------------------------------------------------
@@ -9549,7 +9567,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
         // Store the "this" value in the call
         call->gtFlags |= obj->gtFlags & GTF_GLOB_EFFECT;
-        call->AsCall()->gtArgs.PushFront(this, obj, WellKnownArg::ThisPointer);
+        call->AsCall()->gtArgs.PushFront(this, NewCallArg::Primitive(obj).WellKnown(WellKnownArg::ThisPointer));
 
         // Is this a virtual or interface call?
         if (call->AsCall()->IsVirtual())
@@ -16065,6 +16083,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             }
 
             case CEE_REFANYVAL:
+            {
 
                 // get the class handle and make a ICON node out of it
 
@@ -16083,11 +16102,16 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 op1 = impNormStructVal(op1, impGetRefAnyClass(), (unsigned)CHECK_SPILL_ALL);
 
                 // Call helper GETREFANY(classHandle, op1);
-                op1 = gtNewHelperCallNode(CORINFO_HELP_GETREFANY, TYP_BYREF, op2, op1);
+                GenTreeCall* helperCall   = gtNewHelperCallNode(CORINFO_HELP_GETREFANY, TYP_BYREF);
+                NewCallArg   clsHandleArg = NewCallArg::Primitive(op2);
+                NewCallArg   typedRefArg  = NewCallArg::Struct(op1, TYP_STRUCT, impGetRefAnyClass());
+                helperCall->gtArgs.PushFront(this, clsHandleArg, typedRefArg);
+                helperCall->gtFlags |= (op1->gtFlags | op2->gtFlags) & GTF_ALL_EFFECT;
+                op1 = helperCall;
 
                 impPushOnStack(op1, tiRetVal);
                 break;
-
+            }
             case CEE_REFANYTYPE:
 
                 op1 = impPopStack().val;
@@ -19103,7 +19127,7 @@ void Compiler::impMakeDiscretionaryInlineObservations(InlineInfo* pInlineInfo, I
 
         CORINFO_CLASS_HANDLE sigClass;
         CorInfoType          corType = strip(info.compCompHnd->getArgType(&sig, sigArg, &sigClass));
-        GenTree*             argNode = argUse == nullptr ? nullptr : argUse->GetEarlyNode()->gtSkipPutArgType();
+        GenTree*             argNode = argUse == nullptr ? nullptr : argUse->GetEarlyNode();
 
         if (corType == CORINFO_TYPE_CLASS)
         {
@@ -19527,7 +19551,7 @@ void Compiler::impCheckCanInline(GenTreeCall*           call,
 //
 // Arguments:
 //   pInlineInfo - inline info for the inline candidate
-//   curArgVal - tree for the caller actual argument value
+//   arg - the caller argument
 //   argNum - logical index of this argument
 //   inlineResult - result of ongoing inline evaluation
 //
@@ -19539,15 +19563,15 @@ void Compiler::impCheckCanInline(GenTreeCall*           call,
 //   pass the argument into the inlinee.
 
 void Compiler::impInlineRecordArgInfo(InlineInfo*   pInlineInfo,
-                                      GenTree*      curArgVal,
+                                      CallArg*      arg,
                                       unsigned      argNum,
                                       InlineResult* inlineResult)
 {
     InlArgInfo* inlCurArgInfo = &pInlineInfo->inlArgInfo[argNum];
 
-    inlCurArgInfo->argNode = curArgVal; // Save the original tree, with PUT_ARG and RET_EXPR.
+    inlCurArgInfo->arg = arg;
+    GenTree* curArgVal = arg->GetNode();
 
-    curArgVal = curArgVal->gtSkipPutArgType();
     curArgVal = curArgVal->gtRetExprVal();
 
     if (curArgVal->gtOper == GT_MKREFANY)
@@ -19725,8 +19749,8 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
                 break;
         }
 
-        GenTree* actualArg = gtFoldExpr(arg.GetEarlyNode());
-        impInlineRecordArgInfo(pInlineInfo, actualArg, ilArgCnt, inlineResult);
+        arg.SetEarlyNode(gtFoldExpr(arg.GetEarlyNode()));
+        impInlineRecordArgInfo(pInlineInfo, &arg, ilArgCnt, inlineResult);
 
         if (inlineResult->IsFailure())
         {
@@ -19795,6 +19819,8 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
     CORINFO_ARG_LIST_HANDLE argLst;
     argLst = methInfo->args.args;
 
+    // TODO-ARGS: We can presumably just use type info stored in CallArgs
+    // instead of reiterating the signature.
     unsigned i;
     for (i = (thisArg ? 1 : 0); i < ilArgCnt; i++, argLst = info.compCompHnd->getArgNext(argLst))
     {
@@ -19820,114 +19846,105 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
         lclVarInfo[i].lclTypeInfo    = sigType;
         lclVarInfo[i].lclHasLdlocaOp = false;
 
-        /* Does the tree type match the signature type? */
+        // Does the tree type match the signature type?
 
-        GenTree* inlArgNode = inlArgInfo[i].argNode;
+        GenTree* inlArgNode = inlArgInfo[i].arg->GetNode();
 
-        if ((sigType != inlArgNode->gtType) || inlArgNode->OperIs(GT_PUTARG_TYPE))
+        if (sigType == inlArgNode->gtType)
         {
-            assert(impCheckImplicitArgumentCoercion(sigType, inlArgNode->gtType));
-            assert(!varTypeIsStruct(inlArgNode->gtType) && !varTypeIsStruct(sigType));
+            continue;
+        }
 
-            /* In valid IL, this can only happen for short integer types or byrefs <-> [native] ints,
-               but in bad IL cases with caller-callee signature mismatches we can see other types.
-               Intentionally reject cases with mismatches so the jit is more flexible when
-               encountering bad IL. */
+        assert(impCheckImplicitArgumentCoercion(sigType, inlArgNode->gtType));
+        assert(!varTypeIsStruct(inlArgNode->gtType) && !varTypeIsStruct(sigType));
 
-            bool isPlausibleTypeMatch = (genActualType(sigType) == genActualType(inlArgNode->gtType)) ||
-                                        (genActualTypeIsIntOrI(sigType) && inlArgNode->gtType == TYP_BYREF) ||
-                                        (sigType == TYP_BYREF && genActualTypeIsIntOrI(inlArgNode->gtType));
+        // In valid IL, this can only happen for short integer types or byrefs <-> [native] ints,
+        // but in bad IL cases with caller-callee signature mismatches we can see other types.
+        // Intentionally reject cases with mismatches so the jit is more flexible when
+        // encountering bad IL.
 
-            if (!isPlausibleTypeMatch)
+        bool isPlausibleTypeMatch = (genActualType(sigType) == genActualType(inlArgNode->gtType)) ||
+                                    (genActualTypeIsIntOrI(sigType) && inlArgNode->gtType == TYP_BYREF) ||
+                                    (sigType == TYP_BYREF && genActualTypeIsIntOrI(inlArgNode->gtType));
+
+        if (!isPlausibleTypeMatch)
+        {
+            inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_TYPES_INCOMPATIBLE);
+            return;
+        }
+
+        // The same size but different type of the arguments.
+        GenTree** pInlArgNode = &inlArgInfo[i].arg->EarlyNodeRef();
+
+        // Is it a narrowing or widening cast?
+        // Widening casts are ok since the value computed is already
+        // normalized to an int (on the IL stack)
+        if (genTypeSize(inlArgNode->gtType) >= genTypeSize(sigType))
+        {
+            if (sigType == TYP_BYREF)
             {
-                inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_TYPES_INCOMPATIBLE);
-                return;
+                lclVarInfo[i].lclVerTypeInfo = typeInfo(varType2tiType(TYP_I_IMPL));
             }
+            else if (inlArgNode->gtType == TYP_BYREF)
+            {
+                assert(varTypeIsIntOrI(sigType));
 
-            GenTree** pInlArgNode;
-            if (inlArgNode->OperIs(GT_PUTARG_TYPE))
-            {
-                // There was a widening or narrowing cast.
-                GenTreeUnOp* putArgType = inlArgNode->AsUnOp();
-                pInlArgNode             = &putArgType->gtOp1;
-                inlArgNode              = putArgType->gtOp1;
-            }
-            else
-            {
-                // The same size but different type of the arguments.
-                pInlArgNode = &inlArgInfo[i].argNode;
-            }
-
-            /* Is it a narrowing or widening cast?
-             * Widening casts are ok since the value computed is already
-             * normalized to an int (on the IL stack) */
-            if (genTypeSize(inlArgNode->gtType) >= genTypeSize(sigType))
-            {
-                if (sigType == TYP_BYREF)
+                /* If possible bash the BYREF to an int */
+                if (inlArgNode->IsLocalAddrExpr() != nullptr)
                 {
+                    inlArgNode->gtType           = TYP_I_IMPL;
                     lclVarInfo[i].lclVerTypeInfo = typeInfo(varType2tiType(TYP_I_IMPL));
                 }
-                else if (inlArgNode->gtType == TYP_BYREF)
+                else
                 {
-                    assert(varTypeIsIntOrI(sigType));
-
-                    /* If possible bash the BYREF to an int */
-                    if (inlArgNode->IsLocalAddrExpr() != nullptr)
-                    {
-                        inlArgNode->gtType           = TYP_I_IMPL;
-                        lclVarInfo[i].lclVerTypeInfo = typeInfo(varType2tiType(TYP_I_IMPL));
-                    }
-                    else
-                    {
-                        /* Arguments 'int <- byref' cannot be changed */
-                        inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_INT);
-                        return;
-                    }
+                    // Arguments 'int <- byref' cannot be changed
+                    inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_INT);
+                    return;
                 }
-                else if (genTypeSize(sigType) < TARGET_POINTER_SIZE)
-                {
-                    // Narrowing cast.
-                    if (inlArgNode->OperIs(GT_LCL_VAR))
-                    {
-                        const unsigned lclNum = inlArgNode->AsLclVarCommon()->GetLclNum();
-                        if (!lvaTable[lclNum].lvNormalizeOnLoad() && sigType == lvaGetRealType(lclNum))
-                        {
-                            // We don't need to insert a cast here as the variable
-                            // was assigned a normalized value of the right type.
-                            continue;
-                        }
-                    }
-
-                    inlArgNode = gtNewCastNode(TYP_INT, inlArgNode, false, sigType);
-
-                    inlArgInfo[i].argIsLclVar = false;
-                    // Try to fold the node in case we have constant arguments.
-                    if (inlArgInfo[i].argIsInvariant)
-                    {
-                        inlArgNode = gtFoldExprConst(inlArgNode);
-                        assert(inlArgNode->OperIsConst());
-                    }
-                    *pInlArgNode = inlArgNode;
-                }
-#ifdef TARGET_64BIT
-                else if (genTypeSize(genActualType(inlArgNode->gtType)) < genTypeSize(sigType))
-                {
-                    // This should only happen for int -> native int widening
-                    inlArgNode = gtNewCastNode(genActualType(sigType), inlArgNode, false, sigType);
-
-                    inlArgInfo[i].argIsLclVar = false;
-
-                    /* Try to fold the node in case we have constant arguments */
-
-                    if (inlArgInfo[i].argIsInvariant)
-                    {
-                        inlArgNode = gtFoldExprConst(inlArgNode);
-                        assert(inlArgNode->OperIsConst());
-                    }
-                    *pInlArgNode = inlArgNode;
-                }
-#endif // TARGET_64BIT
             }
+            else if (genTypeSize(sigType) < TARGET_POINTER_SIZE)
+            {
+                // Narrowing cast.
+                if (inlArgNode->OperIs(GT_LCL_VAR))
+                {
+                    const unsigned lclNum = inlArgNode->AsLclVarCommon()->GetLclNum();
+                    if (!lvaTable[lclNum].lvNormalizeOnLoad() && sigType == lvaGetRealType(lclNum))
+                    {
+                        // We don't need to insert a cast here as the variable
+                        // was assigned a normalized value of the right type.
+                        continue;
+                    }
+                }
+
+                inlArgNode = gtNewCastNode(TYP_INT, inlArgNode, false, sigType);
+
+                inlArgInfo[i].argIsLclVar = false;
+                // Try to fold the node in case we have constant arguments.
+                if (inlArgInfo[i].argIsInvariant)
+                {
+                    inlArgNode = gtFoldExprConst(inlArgNode);
+                    assert(inlArgNode->OperIsConst());
+                }
+                *pInlArgNode = inlArgNode;
+            }
+#ifdef TARGET_64BIT
+            else if (genTypeSize(genActualType(inlArgNode->gtType)) < genTypeSize(sigType))
+            {
+                // This should only happen for int -> native int widening
+                inlArgNode = gtNewCastNode(genActualType(sigType), inlArgNode, false, sigType);
+
+                inlArgInfo[i].argIsLclVar = false;
+
+                /* Try to fold the node in case we have constant arguments */
+
+                if (inlArgInfo[i].argIsInvariant)
+                {
+                    inlArgNode = gtFoldExprConst(inlArgNode);
+                    assert(inlArgNode->OperIsConst());
+                }
+                *pInlArgNode = inlArgNode;
+            }
+#endif // TARGET_64BIT
         }
     }
 
@@ -20151,7 +20168,7 @@ GenTree* Compiler::impInlineFetchArg(unsigned lclNum, InlArgInfo* inlArgInfo, In
     const var_types      lclTyp           = lclInfo.lclTypeInfo;
     GenTree*             op1              = nullptr;
 
-    GenTree* argNode = argInfo.argNode->gtSkipPutArgType()->gtRetExprVal();
+    GenTree* argNode = argInfo.arg->GetNode()->gtRetExprVal();
 
     if (argInfo.argIsInvariant && !argCanBeModified)
     {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9091,6 +9091,9 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 assert((sig->callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_VARARG &&
                        (sig->callConv & CORINFO_CALLCONV_MASK) != CORINFO_CALLCONV_NATIVEVARARG);
 
+#if TARGET_WASM
+                call->AsCall()->callSig = new (this, CMK_Generic) CORINFO_SIG_INFO(*sig);
+#endif
                 goto DONE;
             }
 
@@ -9183,6 +9186,11 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
     // static bit and hasThis are negations of one another
     assert(((mflags & CORINFO_FLG_STATIC) != 0) == ((sig->callConv & CORINFO_CALLCONV_HASTHIS) == 0));
     assert(call != nullptr);
+
+#if TARGET_WASM
+    assert(call->AsCall()->callSig == nullptr);
+    call->AsCall()->callSig = new (this, CMK_Generic) CORINFO_SIG_INFO(*sig);
+#endif
 
     /*-------------------------------------------------------------------------
      * Check special-cases etc
@@ -9681,12 +9689,13 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
 DONE:
 
-#if defined(DEBUG)
+// The LLVM codegen always wants callSig and sets it higher up
+#if defined(DEBUG) && !defined(TARGET_WASM)
     // In debug we want to be able to register callsites with the EE.
     assert(call->AsCall()->callSig == nullptr);
     call->AsCall()->callSig  = new (this, CMK_Generic) CORINFO_SIG_INFO;
     *call->AsCall()->callSig = *sig;
-#endif // defined(DEBUG)
+#endif // defined(DEBUG) && !defined(TARGET_WASM)
 
     // Final importer checks for calls flagged as tail calls.
     //

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -603,7 +603,7 @@ struct LateDevirtualizationInfo
 
 struct InlArgInfo
 {
-    GenTree* argNode;                     // caller node for this argument
+    CallArg* arg;                         // the caller argument
     GenTree* argBashTmpNode;              // tmp node created, if it may be replaced with actual arg
     unsigned argTmpNum;                   // the argument tmp number
     unsigned argIsUsed : 1;               // is this arg used at all?

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1992,7 +1992,7 @@ void Llvm::buildCall(GenTreeCall* call)
 
         if (lastArg->OperIs(GT_FIELD_LIST))
         {
-            assert(callArg.GetSignatureType() == var_types::TYP_STRUCT);
+            assert(callArg.GetSignatureType() == TYP_STRUCT);
             argValue = buildFieldList(lastArg->AsFieldList(), argLlvmType);
         }
         else
@@ -2765,7 +2765,6 @@ FunctionType* Llvm::createFunctionTypeForCall(GenTreeCall* call)
 
     for (CallArg& callArg: call->gtArgs.Args())
     {
-        GenTree* putArg = callArg.GetNode();
         argVec.push_back(getLlvmTypeForCorInfoType(callArg.GetSignatureCorInfoType(), callArg.GetSignatureClassHandle()));
     }
 

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1982,22 +1982,22 @@ void Llvm::buildCall(GenTreeCall* call)
 
     std::vector<Value*> argVec = std::vector<Value*>();
 
-    GenTree* lastArg = nullptr;
+    GenTree* argNode = nullptr;
     for (CallArg& callArg: call->gtArgs.Args())
     {
-        lastArg = callArg.GetNode();
+        argNode = callArg.GetNode();
 
         Type*    argLlvmType = getLlvmTypeForCorInfoType(callArg.GetSignatureCorInfoType(), callArg.GetSignatureClassHandle());
         Value*   argValue;
 
-        if (lastArg->OperIs(GT_FIELD_LIST))
+        if (argNode->OperIs(GT_FIELD_LIST))
         {
             assert(callArg.GetSignatureType() == TYP_STRUCT);
-            argValue = buildFieldList(lastArg->AsFieldList(), argLlvmType);
+            argValue = buildFieldList(argNode->AsFieldList(), argLlvmType);
         }
         else
         {
-            argValue = consumeValue(lastArg, argLlvmType);
+            argValue = consumeValue(argNode, argLlvmType);
         }
 
         argVec.push_back(argValue);

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -892,8 +892,8 @@ void Llvm::lowerVirtualStubCallAfterArgs(
     // been set up and thus needs a larger shadow stack offset. This is done to not create a new safe point across
     // which GC arguments to the main call would be live; the stub itself may call into managed code and trigger a GC.
     unsigned shadowStackOffsetForStub = getCurrentShadowFrameSize() + shadowArgsSize;
-    GenTree* thisForStub              = _compiler->gtNewLclvNode(thisArgLclNum, TYP_REF);
     GenTree* shadowStackForStub       = insertShadowStackAddr(callNode, shadowStackOffsetForStub, _shadowStackLclNum);
+    GenTree* thisForStub              = _compiler->gtNewLclvNode(thisArgLclNum, TYP_REF);
 
     // This call could be indirect (in case this is shared code and the cell address needed
     // to be resolved dynamically). Use the available address node directly in that case.

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -686,7 +686,7 @@ void Llvm::lowerRethrow(GenTreeCall* callNode)
     assert(callNode->gtArgs.IsEmpty());
 
     GenTree* excObjAddr = insertShadowStackAddr(callNode, getCatchArgOffset(), _shadowStackLclNum);
-    callNode->gtArgs.PushFront(_compiler, NewCallArg::Primitive(excObjAddr, TYP_UNDEF, CORINFO_TYPE_PTR));
+    callNode->gtArgs.PushFront(_compiler, NewCallArg::Primitive(excObjAddr, CORINFO_TYPE_PTR));
 }
 
 void Llvm::lowerCatchArg(GenTree* catchArgNode)
@@ -918,9 +918,9 @@ void Llvm::lowerVirtualStubCallAfterArgs(
 
     GenTree* thisForStub  = _compiler->gtNewLclvNode(thisArgLclNum, TYP_REF);
     GenTreeCall* stubCall = _compiler->gtNewIndCallNode(stubAddr, TYP_I_IMPL);
-    stubCall->gtArgs.PushFront(_compiler, NewCallArg::Primitive(shadowStackForStub, TYP_I_IMPL, CORINFO_TYPE_PTR),
-                               NewCallArg::Primitive(thisForStub, TYP_REF, CORINFO_TYPE_PTR),
-                               NewCallArg::Primitive(cellArgNode, TYP_I_IMPL, CORINFO_TYPE_PTR));
+    stubCall->gtArgs.PushFront(_compiler, NewCallArg::Primitive(shadowStackForStub, CORINFO_TYPE_PTR),
+                               NewCallArg::Primitive(thisForStub, CORINFO_TYPE_CLASS),
+                               NewCallArg::Primitive(cellArgNode, CORINFO_TYPE_PTR));
     stubCall->gtCorInfoType = CORINFO_TYPE_PTR;
     stubCall->gtFlags |= GTF_CALL_UNMANAGED;
     stubCall->gtCallMoreFlags |= GTF_CALL_M_SUPPRESS_GC_TRANSITION;
@@ -1007,7 +1007,7 @@ unsigned Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
     {
         GenTree* calleeShadowStack = insertShadowStackAddr(callNode, shadowFrameSize, _shadowStackLclNum);
 
-        lastLlvmStackArg = callNode->gtArgs.PushFront(_compiler, NewCallArg::Primitive(calleeShadowStack, TYP_I_IMPL, CORINFO_TYPE_PTR));
+        lastLlvmStackArg = callNode->gtArgs.PushFront(_compiler, NewCallArg::Primitive(calleeShadowStack, CORINFO_TYPE_PTR));
     }
 
     CallArg* returnSlot = lowerCallReturn(callNode);
@@ -1200,7 +1200,7 @@ CallArg* Llvm::lowerCallReturn(GenTreeCall* callNode)
 
         // if we are lowering a return, then we will at least have a shadow stack CallArg
         returnSlot = callNode->gtArgs.InsertAfter(_compiler, callNode->gtArgs.GetArgByIndex(0),
-                                                  NewCallArg::Primitive(returnAddrLcl, TYP_I_IMPL, CORINFO_TYPE_PTR));
+                                                  NewCallArg::Primitive(returnAddrLcl, CORINFO_TYPE_PTR));
 
         callNode->gtReturnType = TYP_VOID;
         callNode->gtCorInfoType = CORINFO_TYPE_VOID;

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -924,7 +924,7 @@ void Llvm::lowerVirtualStubCallAfterArgs(
     stubCall->gtCorInfoType = CORINFO_TYPE_PTR;
     stubCall->gtFlags |= GTF_CALL_UNMANAGED;
     stubCall->gtCallMoreFlags |= GTF_CALL_M_SUPPRESS_GC_TRANSITION;
-    CurrentRange().InsertBefore(callNode, thisForStub, stubCall);
+    CurrentRange().InsertBefore(callNode, stubCall);
 
     // Finally, retarget our call. It is no longer VSD.
     callNode->gtCallType = CT_INDIRECT;

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -892,7 +892,7 @@ void Llvm::lowerVirtualStubCallAfterArgs(
     // been set up and thus needs a larger shadow stack offset. This is done to not create a new safe point across
     // which GC arguments to the main call would be live; the stub itself may call into managed code and trigger a GC.
     unsigned shadowStackOffsetForStub = getCurrentShadowFrameSize() + shadowArgsSize;
-    GenTree* shadowStack = insertShadowStackAddr(callNode, shadowStackOffsetForStub, _shadowStackLclNum);
+    GenTree* shadowStackForStub       = insertShadowStackAddr(callNode, shadowStackOffsetForStub, _shadowStackLclNum);
 
     // This call could be indirect (in case this is shared code and the cell address needed
     // to be resolved dynamically). Use the available address node directly in that case.
@@ -918,7 +918,7 @@ void Llvm::lowerVirtualStubCallAfterArgs(
 
     GenTree* thisForStub  = _compiler->gtNewLclvNode(thisArgLclNum, TYP_REF);
     GenTreeCall* stubCall = _compiler->gtNewIndCallNode(stubAddr, TYP_I_IMPL);
-    stubCall->gtArgs.PushFront(_compiler, NewCallArg::Primitive(shadowStack, TYP_I_IMPL, CORINFO_TYPE_PTR),
+    stubCall->gtArgs.PushFront(_compiler, NewCallArg::Primitive(shadowStackForStub, TYP_I_IMPL, CORINFO_TYPE_PTR),
                                NewCallArg::Primitive(thisForStub, TYP_REF, CORINFO_TYPE_PTR),
                                NewCallArg::Primitive(cellArgNode, TYP_I_IMPL, CORINFO_TYPE_PTR));
     stubCall->gtCorInfoType = CORINFO_TYPE_PTR;

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1114,7 +1114,8 @@ unsigned Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
                 callArg->SetSignatureClassHandle(clsHnd);
             }
 
-            callArg->SetEarlyNode(argNode, corInfoType);
+            callArg->SetEarlyNode(argNode);
+            callArg->SetSignatureCorInfoType(corInfoType);
             lastLlvmStackArg = callArg;
         }
 

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -892,8 +892,9 @@ void Llvm::lowerVirtualStubCallAfterArgs(
     // been set up and thus needs a larger shadow stack offset. This is done to not create a new safe point across
     // which GC arguments to the main call would be live; the stub itself may call into managed code and trigger a GC.
     unsigned shadowStackOffsetForStub = getCurrentShadowFrameSize() + shadowArgsSize;
-    GenTree* shadowStackForStub       = insertShadowStackAddr(callNode, shadowStackOffsetForStub, _shadowStackLclNum);
-    GenTree* thisForStub              = _compiler->gtNewLclvNode(thisArgLclNum, TYP_REF);
+    GenTree* shadowStackForStub = insertShadowStackAddr(callNode, shadowStackOffsetForStub, _shadowStackLclNum);
+    GenTree* thisForStub = _compiler->gtNewLclvNode(thisArgLclNum, TYP_REF);
+    CurrentRange().InsertBefore(callNode, thisForStub);
 
     // This call could be indirect (in case this is shared code and the cell address needed
     // to be resolved dynamically). Use the available address node directly in that case.

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1108,9 +1108,15 @@ unsigned Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
         }
         else // Arg on LLVM stack.
         {
-            if (!argNode->OperIs(GT_FIELD_LIST) && argNode->TypeIs(TYP_STRUCT))
+            if (argNode->TypeIs(TYP_STRUCT))
             {
-                normalizeStructUse(argNode, _compiler->typGetObjLayout(clsHnd));
+                if (!argNode->OperIs(GT_FIELD_LIST) && argNode->TypeIs(TYP_STRUCT))
+                {
+                    normalizeStructUse(argNode, _compiler->typGetObjLayout(clsHnd));
+                }
+
+                // TODO-LLVM: delete (together with 'SetSignatureClassHandle') when merging
+                // https://github.com/dotnet/runtime/pull/69969 (May 31).
                 callArg->SetSignatureClassHandle(clsHnd);
             }
 

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -892,6 +892,7 @@ void Llvm::lowerVirtualStubCallAfterArgs(
     // been set up and thus needs a larger shadow stack offset. This is done to not create a new safe point across
     // which GC arguments to the main call would be live; the stub itself may call into managed code and trigger a GC.
     unsigned shadowStackOffsetForStub = getCurrentShadowFrameSize() + shadowArgsSize;
+    GenTree* thisForStub              = _compiler->gtNewLclvNode(thisArgLclNum, TYP_REF);
     GenTree* shadowStackForStub       = insertShadowStackAddr(callNode, shadowStackOffsetForStub, _shadowStackLclNum);
 
     // This call could be indirect (in case this is shared code and the cell address needed
@@ -916,7 +917,6 @@ void Llvm::lowerVirtualStubCallAfterArgs(
     stubAddr->gtFlags |= GTF_IND_NONFAULTING;
     CurrentRange().InsertBefore(callNode, stubAddr);
 
-    GenTree* thisForStub  = _compiler->gtNewLclvNode(thisArgLclNum, TYP_REF);
     GenTreeCall* stubCall = _compiler->gtNewIndCallNode(stubAddr, TYP_I_IMPL);
     stubCall->gtArgs.PushFront(_compiler, NewCallArg::Primitive(shadowStackForStub, CORINFO_TYPE_PTR),
                                NewCallArg::Primitive(thisForStub, CORINFO_TYPE_CLASS),

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2338,7 +2338,9 @@ void Lowering::LowerCFGCall(GenTreeCall* call)
             // morph, sequence and lower, to avoid redoing that for the actual target.
             GenTree*     targetPlaceholder = comp->gtNewZeroConNode(callTarget->TypeGet());
             GenTreeCall* validate          = comp->gtNewHelperCallNode(CORINFO_HELP_VALIDATE_INDIRECT_CALL, TYP_VOID);
-            validate->gtArgs.PushFront(comp, targetPlaceholder, WellKnownArg::ValidateIndirectCallTarget);
+            NewCallArg   newArg =
+                NewCallArg::Primitive(targetPlaceholder).WellKnown(WellKnownArg::ValidateIndirectCallTarget);
+            validate->gtArgs.PushFront(comp, newArg);
 
             comp->fgMorphTree(validate);
 
@@ -2385,7 +2387,10 @@ void Lowering::LowerCFGCall(GenTreeCall* call)
 #ifdef REG_DISPATCH_INDIRECT_CALL_ADDR
             // Now insert the call target as an extra argument.
             //
-            CallArg* targetArg = call->gtArgs.PushBack(comp, nullptr, WellKnownArg::DispatchIndirectCallTarget);
+            NewCallArg callTargetNewArg =
+                NewCallArg::Primitive(callTarget).WellKnown(WellKnownArg::DispatchIndirectCallTarget);
+            CallArg* targetArg = call->gtArgs.PushBack(comp, callTargetNewArg);
+            targetArg->SetEarlyNode(nullptr);
             targetArg->SetLateNode(callTarget);
             call->gtArgs.PushLateBack(targetArg);
 
@@ -4343,10 +4348,13 @@ void Lowering::InsertPInvokeMethodProlog()
     //     TCB = CORINFO_HELP_INIT_PINVOKE_FRAME(&symFrameStart, secretArg);
     GenTreeCall* call = comp->gtNewHelperCallNode(CORINFO_HELP_INIT_PINVOKE_FRAME, TYP_I_IMPL);
 
-    call->gtArgs.PushBack(comp, frameAddr, WellKnownArg::PInvokeFrame);
+    NewCallArg frameAddrArg = NewCallArg::Primitive(frameAddr).WellKnown(WellKnownArg::PInvokeFrame);
+    call->gtArgs.PushBack(comp, frameAddrArg);
 // for x86/arm32 don't pass the secretArg.
 #if !defined(TARGET_X86) && !defined(TARGET_ARM)
-    call->gtArgs.PushBack(comp, PhysReg(REG_SECRET_STUB_PARAM), WellKnownArg::SecretStubParam);
+    NewCallArg stubParamArg =
+        NewCallArg::Primitive(PhysReg(REG_SECRET_STUB_PARAM)).WellKnown(WellKnownArg::SecretStubParam);
+    call->gtArgs.PushBack(comp, stubParamArg);
 #endif
 
     // some sanity checks on the frame list root vardsc

--- a/src/coreclr/jit/rationalize.cpp
+++ b/src/coreclr/jit/rationalize.cpp
@@ -211,13 +211,13 @@ void Rationalizer::RewriteNodeAsCall(GenTree**             use,
 
     if (arg2 != nullptr)
     {
-        call->gtArgs.PushFront(comp, arg2);
+        call->gtArgs.PushFront(comp, NewCallArg::Primitive(arg2));
         call->gtFlags |= arg2->gtFlags & GTF_ALL_EFFECT;
     }
 
     if (arg1 != nullptr)
     {
-        call->gtArgs.PushFront(comp, arg1);
+        call->gtArgs.PushFront(comp, NewCallArg::Primitive(arg1));
         call->gtFlags |= arg1->gtFlags & GTF_ALL_EFFECT;
     }
 
@@ -308,8 +308,8 @@ void Rationalizer::SanityCheck()
 
             for (GenTree* const tree : stmt->TreeList())
             {
-                // QMARK and PUT_ARG_TYPE nodes should have been removed before this phase.
-                assert(!tree->OperIs(GT_QMARK, GT_PUTARG_TYPE));
+                // QMARK nodes should have been removed before this phase.
+                assert(!tree->OperIs(GT_QMARK));
 
                 if (tree->OperGet() == GT_ASG)
                 {


### PR DESCRIPTION
This PR merges PR 68748 from runtime, removing the `GT_PUTARG_TYPE` node.  It adds a `CorInfoType` field to `NewCallArg` to track pointer types.