### PR TITLE
[NativeAOT-LLVM] Implement RPI

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -981,7 +981,6 @@ private:
 
 public:
     unsigned short lvRefCnt(RefCountState state = RCS_NORMAL) const;
-    unsigned short lvRawRefCnt(RefCountState state = RCS_NORMAL) const;
     void incLvRefCnt(unsigned short delta, RefCountState state = RCS_NORMAL);
     void setLvRefCnt(unsigned short newValue, RefCountState state = RCS_NORMAL);
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4566,36 +4566,20 @@ void DEBUG_DESTROY_NODE(GenTree* tree, T... rest)
 //
 // Return Value:
 //    Ref count for the local.
-//
+
 inline unsigned short LclVarDsc::lvRefCnt(RefCountState state) const
 {
-    unsigned short refCount = lvRawRefCnt(state);
 
-    if (lvImplicitlyReferenced && (refCount == 0))
-    {
-        return 1;
-    }
-
-    return refCount;
-}
-
-//------------------------------------------------------------------------------
-// lvRawRefCnt: access the "raw" reference count for this local var
-//
-// Arguments:
-//    state: the requestor's expected ref count state; defaults to RCS_NORMAL
-//
-// Return Value:
-//    "Raw" ref count for the local - will return zero for implicitly referenced
-//    locals that did not appear in IR.
-//
-inline unsigned short LclVarDsc::lvRawRefCnt(RefCountState state) const
-{
 #if defined(DEBUG)
     assert(state != RCS_INVALID);
     Compiler* compiler = JitTls::GetCompiler();
     assert(compiler->lvaRefCountState == state);
 #endif
+
+    if (lvImplicitlyReferenced && (m_lvRefCnt == 0))
+    {
+        return 1;
+    }
 
     return m_lvRefCnt;
 }

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -20,7 +20,7 @@ enum class EEApiId
 {
     GetMangledMethodName,
     GetSymbolMangledName,
-    GetEHDispatchFunctionName,
+    GetEHDispatchFunctionName, // TODO-LLVM: move these to the LLVM helper mechanism.
     GetTypeName,
     AddCodeReloc,
     IsRuntimeImport,
@@ -32,6 +32,7 @@ enum class EEApiId
     GetInstanceFieldAlignment,
     GetAlternativeFunctionName,
     GetExternalMethodAccessor,
+    GetLlvmHelperFuncEntrypoint,
     Count
 };
 
@@ -213,12 +214,12 @@ bool Llvm::needsReturnStackSlot(CorInfoType corInfoType, CORINFO_CLASS_HANDLE cl
     return (corInfoType != CORINFO_TYPE_VOID) && !canStoreArgOnLlvmStack(corInfoType, classHnd);
 }
 
-bool Llvm::callRequiresShadowStackSaveRestore(const GenTreeCall* call) const
+bool Llvm::callRequiresShadowStackSave(const GenTreeCall* call) const
 {
     // In general, if the call is itself not managed (does not have a shadow stack argument) **and** may call
-    // back into managed code, we need to save/restore the shadow stack pointer, so that the RPI frame can pick
-    // it up. Another case where the save/restore is required is when calling into native runtime code that can
-    // trigger a GC (canonical example: allocators), to communicate shadow stack bounds to the roots scan.
+    // back into managed code, we need to save the shadow stack pointer, so that the RPI frame can pick it up.
+    // Another case where the save/restore is required is when calling into native runtime code that can trigger
+    // a GC (canonical example: allocators), to communicate shadow stack bounds to the roots scan.
     // TODO-LLVM-CQ: optimize the GC case by using specialized helpers which would sink the save/restore to the
     // unlikely path of a GC actually happening.
     // TODO-LLVM-CQ: we should skip the managed -> native -> managed transition for runtime imports implemented
@@ -226,14 +227,14 @@ bool Llvm::callRequiresShadowStackSaveRestore(const GenTreeCall* call) const
     //
     if (call->IsHelperCall())
     {
-        return helperCallRequiresShadowStackSaveRestore(_compiler->eeGetHelperNum(call->gtCallMethHnd));
+        return helperCallRequiresShadowStackSave(_compiler->eeGetHelperNum(call->gtCallMethHnd));
     }
 
     // SPGCT calls are assumed to never RPI by contract.
     return !callHasShadowStackArg(call) && !call->IsSuppressGCTransition();
 }
 
-bool Llvm::helperCallRequiresShadowStackSaveRestore(CorInfoHelpFunc helperFunc) const
+bool Llvm::helperCallRequiresShadowStackSave(CorInfoHelpAnyFunc helperFunc) const
 {
     // Save/restore is needed if the helper doesn't have a shadow stack argument, unless we know it won't call
     // back into managed code. TODO-LLVM-CQ: mark (make, if required) more helpers "HFIF_NO_RPI_OR_GC".
@@ -246,7 +247,7 @@ bool Llvm::callHasShadowStackArg(const GenTreeCall* call) const
     return callHasManagedCallingConvention(call);
 }
 
-bool Llvm::helperCallHasShadowStackArg(CorInfoHelpFunc helperFunc) const
+bool Llvm::helperCallHasShadowStackArg(CorInfoHelpAnyFunc helperFunc) const
 {
     return helperCallHasManagedCallingConvention(helperFunc);
 }
@@ -267,7 +268,7 @@ bool Llvm::callHasManagedCallingConvention(const GenTreeCall* call) const
     return !call->IsUnmanaged();
 }
 
-bool Llvm::helperCallHasManagedCallingConvention(CorInfoHelpFunc helperFunc) const
+bool Llvm::helperCallHasManagedCallingConvention(CorInfoHelpAnyFunc helperFunc) const
 {
     return getHelperFuncInfo(helperFunc).HasFlags(HFIF_SS_ARG);
 }
@@ -289,7 +290,7 @@ bool Llvm::helperCallHasManagedCallingConvention(CorInfoHelpFunc helperFunc) con
 // Return Value:
 //    Reference to the info structure for "helperFunc".
 //
-/* static */ const HelperFuncInfo& Llvm::getHelperFuncInfo(CorInfoHelpFunc helperFunc)
+/* static */ const HelperFuncInfo& Llvm::getHelperFuncInfo(CorInfoHelpAnyFunc helperFunc)
 {
     // Note on Runtime[Type|Method|Field]Handle: it should faithfully be represented as CORINFO_TYPE_VALUECLASS.
     // However, that is currently both not necessary due to the unwrapping performed for LLVM types and not what
@@ -610,14 +611,18 @@ bool Llvm::helperCallHasManagedCallingConvention(CorInfoHelpFunc helperFunc) con
         { FUNC(CORINFO_HELP_CLASSPROFILE64) },
         { FUNC(CORINFO_HELP_PARTIAL_COMPILATION_PATCHPOINT) },
         { FUNC(CORINFO_HELP_VALIDATE_INDIRECT_CALL) },
-        { FUNC(CORINFO_HELP_DISPATCH_INDIRECT_CALL) }
+        { FUNC(CORINFO_HELP_DISPATCH_INDIRECT_CALL) },
+        { FUNC(CORINFO_HELP_COUNT) },
+
+        { FUNC(CORINFO_HELP_LLVM_GET_OR_INIT_SHADOW_STACK_TOP) CORINFO_TYPE_PTR, { }, HFIF_NO_RPI_OR_GC },
+        { FUNC(CORINFO_HELP_LLVM_SET_SHADOW_STACK_TOP) CORINFO_TYPE_VOID, { CORINFO_TYPE_PTR }, HFIF_NO_RPI_OR_GC },
     };
     // clang-format on
 
     // Make sure our array is up-to-date.
-    static_assert_no_msg(ArrLen(s_infos) == CORINFO_HELP_COUNT);
+    static_assert_no_msg(ArrLen(s_infos) == CORINFO_HELP_ANY_COUNT);
 
-    assert(helperFunc < CORINFO_HELP_COUNT);
+    assert(helperFunc < CORINFO_HELP_ANY_COUNT);
     const HelperFuncInfo& info = s_infos[helperFunc];
 
     // We don't fill out the info for some helpers because we don't expect to encounter them.
@@ -701,6 +706,34 @@ TargetAbiType Llvm::getAbiTypeForType(var_types type)
         default:
             unreached();
     }
+}
+
+CORINFO_GENERIC_HANDLE Llvm::getSymbolHandleForHelperFunc(CorInfoHelpAnyFunc helperFunc)
+{
+    if (helperFunc < CORINFO_HELP_COUNT)
+    {
+        void* pIndirection = nullptr;
+        void* handle = _compiler->compGetHelperFtn(static_cast<CorInfoHelpFunc>(helperFunc), &pIndirection);
+        assert(pIndirection == nullptr);
+
+        return CORINFO_GENERIC_HANDLE(handle);
+    }
+
+    assert(helperFunc < CORINFO_HELP_ANY_COUNT);
+    return GetLlvmHelperFuncEntrypoint(static_cast<CorInfoHelpLlvmFunc>(helperFunc));
+}
+
+CORINFO_GENERIC_HANDLE Llvm::getSymbolHandleForClassToken(mdToken token)
+{
+    // The importer call here relies on RyuJit not inlining EH (which it currently does not).
+    CORINFO_RESOLVED_TOKEN resolvedToken;
+    _compiler->impResolveToken((BYTE*)&token, &resolvedToken, CORINFO_TOKENKIND_Class);
+
+    void* pIndirection = nullptr;
+    CORINFO_CLASS_HANDLE typeSymbolHandle = m_info->compCompHnd->embedClassHandle(resolvedToken.hClass, &pIndirection);
+    assert(pIndirection == nullptr);
+
+    return CORINFO_GENERIC_HANDLE(typeSymbolHandle);
 }
 
 [[noreturn]] void Llvm::failFunctionCompilation()
@@ -794,6 +827,11 @@ CORINFO_GENERIC_HANDLE Llvm::GetExternalMethodAccessor(
 {
     return CallEEApi<EEApiId::GetExternalMethodAccessor, CORINFO_GENERIC_HANDLE>(m_pEECorInfo, methodHandle, sig,
                                                                                sigLength);
+}
+
+CORINFO_GENERIC_HANDLE Llvm::GetLlvmHelperFuncEntrypoint(CorInfoHelpLlvmFunc helperFunc)
+{
+    return CallEEApi<EEApiId::GetLlvmHelperFuncEntrypoint, CORINFO_GENERIC_HANDLE>(m_pEECorInfo, helperFunc);
 }
 
 extern "C" DLLEXPORT void registerLlvmCallbacks(void** jitImports, void** jitExports)

--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -220,6 +220,7 @@ if (CLR_CMAKE_TARGET_ARCH_WASM)
   list(APPEND COMMON_RUNTIME_SOURCES
     ${ARCH_SOURCES_DIR}/StubDispatch.cpp
     ${ARCH_SOURCES_DIR}/ExceptionHandling.cpp
+    ${ARCH_SOURCES_DIR}/PInvoke.cpp
 )
 endif (CLR_CMAKE_TARGET_ARCH_WASM)
 

--- a/src/coreclr/nativeaot/Runtime/wasm/PInvoke.cpp
+++ b/src/coreclr/nativeaot/Runtime/wasm/PInvoke.cpp
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <stdlib.h>
+
+#include "CommonTypes.h"
+#include "CommonMacros.h"
+
+extern "C" void* t_pShadowStackBottom = nullptr;
+extern "C" void* t_pShadowStackTop;
+
+COOP_PINVOKE_HELPER(void*, RhpGetOrInitShadowStackTop, ())
+{
+    void* pShadowStack = t_pShadowStackTop;
+    if (pShadowStack == nullptr)
+    {
+        pShadowStack = malloc(1000000); // ~1MB.
+        t_pShadowStackBottom = pShadowStack;
+    }
+
+    return pShadowStack;
+}
+
+COOP_PINVOKE_HELPER(void*, RhpGetShadowStackTop, ())
+{
+    return t_pShadowStackTop;
+}
+
+COOP_PINVOKE_HELPER(void, RhpSetShadowStackTop, (void* pShadowStack))
+{
+    t_pShadowStackTop = pShadowStack;
+}

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter_Statics.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter_Statics.cs
@@ -47,17 +47,7 @@ namespace Internal.IL
             ILImporter ilImporter = null;
             try
             {
-                string mangledName;
-
-                // TODO: Better detection of the StartupCodeMain method
-                if (methodCodeNodeNeedingCode.Method.Signature.IsStatic && methodCodeNodeNeedingCode.Method.Name == "StartupCodeMain")
-                {
-                    mangledName = "StartupCodeMain";
-                }
-                else
-                {
-                    mangledName = compilation.NameMangler.GetMangledMethodName(methodCodeNodeNeedingCode.Method).ToString();
-                }
+                string mangledName = compilation.NameMangler.GetMangledMethodName(methodCodeNodeNeedingCode.Method).ToString();
 
                 ilImporter = new ILImporter(compilation, method, methodIL, mangledName);
 
@@ -220,18 +210,13 @@ namespace Internal.IL
             return llvmFunction;
         }
 
-        internal static void GenerateRuntimeExportThunk(LLVMCodegenCompilation compilation, MethodDesc compiledMethod, LLVMValueRef llvmFunction)
+        internal static void GenerateRuntimeExportThunk(LLVMCodegenCompilation compilation, MethodDesc method, LLVMValueRef llvmFunction)
         {
-            if ((compiledMethod.IsRuntimeExport || compiledMethod.IsUnmanagedCallersOnly) && compiledMethod is EcmaMethod)  // TODO: Reverse delegate invokes probably need something here, but what would be the export name?
+            if (method.IsRuntimeExport || method.IsUnmanagedCallersOnly)
             {
-                EcmaMethod ecmaMethod = ((EcmaMethod)compiledMethod);
-                string exportName = ecmaMethod.IsRuntimeExport ? ecmaMethod.GetRuntimeExportName() : ecmaMethod.GetUnmanagedCallersOnlyExportName();
-                if (exportName == null)
-                {
-                    exportName = ecmaMethod.Name;
-                }
-
-                EmitNativeToManagedThunk(compilation, compiledMethod, exportName, llvmFunction);
+                IMethodNode methodNode = compilation.NodeFactory.MethodEntrypoint(method);
+                string name = compilation.NodeFactory.GetSymbolAlternateName(methodNode) ?? method.Name;
+                EmitNativeToManagedThunk(compilation, method, name, llvmFunction);
             }
         }
 
@@ -251,28 +236,17 @@ namespace Internal.IL
             LLVMTypeRef thunkSig = LLVMTypeRef.CreateFunction(GetLLVMTypeForTypeDesc(method.Signature.ReturnType), llvmParams, false);
             LLVMValueRef thunkFunc = GetOrCreateLLVMFunction(LLVMCodegenCompilation.Module, nativeName, thunkSig);
 
-            LLVMBasicBlockRef shadowStackSetupBlock = thunkFunc.AppendBasicBlock("ShadowStackSetupBlock");
-            LLVMBasicBlockRef allocateShadowStackBlock = thunkFunc.AppendBasicBlock("allocateShadowStackBlock");
-            LLVMBasicBlockRef managedCallBlock = thunkFunc.AppendBasicBlock("ManagedCallBlock");
+            using LLVMBuilderRef builder = Context.CreateBuilder();
+            LLVMBasicBlockRef block = thunkFunc.AppendBasicBlock("ManagedCallBlock");
+            builder.PositionAtEnd(block);
 
-            LLVMBuilderRef builder = Context.CreateBuilder();
-            builder.PositionAtEnd(shadowStackSetupBlock);
+            // Get the shadow stack. If we are wrapping a runtime export, the caller is (by definition) managed, so we must have set up the shadow
+            // stack already and can bypass the init check.
+            string getShadowStackFuncName = method.IsRuntimeExport ? "RhpGetShadowStackTop" : "RhpGetOrInitShadowStackTop";
+            LLVMTypeRef getShadowStackFuncSig = LLVMTypeRef.CreateFunction(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), Array.Empty<LLVMTypeRef>());
+            LLVMValueRef getShadowStackFunc = GetOrCreateLLVMFunction(LLVMCodegenCompilation.Module, getShadowStackFuncName, getShadowStackFuncSig);
+            LLVMValueRef shadowStack = builder.BuildCall(getShadowStackFunc, Array.Empty<LLVMValueRef>());
 
-            // Allocate shadow stack if it's null
-            LLVMValueRef shadowStackPtr = builder.BuildAlloca(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "ShadowStackPtr");
-            LLVMValueRef savedShadowStack = builder.BuildLoad(ShadowStackTop, "SavedShadowStack");
-            builder.BuildStore(savedShadowStack, shadowStackPtr);
-            LLVMValueRef shadowStackNull = builder.BuildICmp(LLVMIntPredicate.LLVMIntEQ, savedShadowStack, LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)), "ShadowStackNull");
-            builder.BuildCondBr(shadowStackNull, allocateShadowStackBlock, managedCallBlock);
-
-            builder.PositionAtEnd(allocateShadowStackBlock);
-
-            LLVMValueRef newShadowStack = builder.BuildArrayMalloc(LLVMTypeRef.Int8, BuildConstInt32(1000000), "NewShadowStack");
-            builder.BuildStore(newShadowStack, shadowStackPtr);
-            builder.BuildStore(newShadowStack, ShadowStackTop);
-            builder.BuildBr(managedCallBlock);
-
-            builder.PositionAtEnd(managedCallBlock);
             LLVMTypeRef reversePInvokeFrameType = LLVMTypeRef.CreateStruct(new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) }, false);
             LLVMValueRef reversePInvokeFrame = default(LLVMValueRef);
             LLVMTypeRef reversePInvokeFunctionType = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(reversePInvokeFrameType, 0) }, false);
@@ -283,7 +257,6 @@ namespace Internal.IL
                 builder.BuildCall(RhpReversePInvoke, new LLVMValueRef[] { reversePInvokeFrame }, "");
             }
 
-            LLVMValueRef shadowStack = builder.BuildLoad(shadowStackPtr, "ShadowStack");
             int curOffset = 0;
             curOffset = PadNextOffset(method.Signature.ReturnType, curOffset);
             ImportCallMemset(shadowStack, 0, curOffset, builder); // clear any uncovered object references for GC.Collect
@@ -323,6 +296,11 @@ namespace Internal.IL
             {
                 LLVMValueRef RhpReversePInvokeReturn = GetOrCreateLLVMFunction(LLVMCodegenCompilation.Module, "RhpReversePInvokeReturn", reversePInvokeFunctionType);
                 builder.BuildCall(RhpReversePInvokeReturn, new LLVMValueRef[] { reversePInvokeFrame }, "");
+
+                // Restore the shadow stack. Note: only needed for UCO methods as otherwise the caller is guaranteed to never use the stale value.
+                LLVMTypeRef setShadowStackFuncSig = LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) });
+                LLVMValueRef setShadowStackFunc = GetOrCreateLLVMFunction(LLVMCodegenCompilation.Module, "RhpSetShadowStackTop", setShadowStackFuncSig);
+                builder.BuildCall(setShadowStackFunc, new[] { shadowStack });
             }
 
             if (!method.Signature.ReturnType.IsVoid)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
@@ -15,12 +15,10 @@ namespace ILCompiler
     public sealed class LLVMCodegenCompilationBuilder : RyuJitCompilationBuilder
     {
         LLVMCodegenConfigProvider _config = new LLVMCodegenConfigProvider();
-        private bool _nativeLib;
 
-        public LLVMCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group, bool nativeLib)
+        public LLVMCodegenCompilationBuilder(CompilerTypeSystemContext context, CompilationModuleGroup group)
             : base(context, group, new LLVMNodeMangler())
         {
-            _nativeLib = nativeLib;
         }
 
         public override CompilationBuilder UseBackendOptions(IEnumerable<string> options)
@@ -37,7 +35,7 @@ namespace ILCompiler
             LLVMCodegenNodeFactory factory = new LLVMCodegenNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider, GetPreinitializationManager());
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
 
-            return new LLVMCodegenCompilation(graph, factory, _compilationRoots, GetILProvider(), _debugInformationProvider, _logger, _config, _inliningPolicy, _devirtualizationManager, _instructionSetSupport, _nativeLib, _wasmImportPolicy, _methodImportationErrorProvider);
+            return new LLVMCodegenCompilation(graph, factory, _compilationRoots, GetILProvider(), _debugInformationProvider, _logger, _config, _inliningPolicy, _devirtualizationManager, _instructionSetSupport, _wasmImportPolicy, _methodImportationErrorProvider);
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -730,7 +730,7 @@ namespace ILCompiler
             CompilationBuilder builder;
             if (_isLlvmCodegen)
             {
-                builder = new LLVMCodegenCompilationBuilder(typeSystemContext, compilationGroup, _nativeLib);
+                builder = new LLVMCodegenCompilationBuilder(typeSystemContext, compilationGroup);
             }
             else
             {


### PR DESCRIPTION
Interesting parts:

1) Introduce the "LLVM-specific helper" mechanism. Use it to hide the shadow stack top variable.
2) Delete the bespoke RPI generation for managed main/startup methods by supporting non-ECMA UCO methods in ILC's LLVM generation.