### PR TITLE
[NativeAOT-LLVM] Implement more things

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -20,6 +20,7 @@ enum class EEApiId
 {
     GetMangledMethodName,
     GetSymbolMangledName,
+    GetSignatureForMethodSymbol,
     GetEHDispatchFunctionName, // TODO-LLVM: move these to the LLVM helper mechanism.
     GetTypeName,
     AddCodeReloc,
@@ -763,6 +764,11 @@ const char* Llvm::GetMangledMethodName(CORINFO_METHOD_HANDLE methodHandle)
 const char* Llvm::GetMangledSymbolName(void* symbol)
 {
     return CallEEApi<EEApiId::GetSymbolMangledName, const char*>(m_pEECorInfo, symbol);
+}
+
+bool Llvm::GetSignatureForMethodSymbol(CORINFO_GENERIC_HANDLE symbolHandle, CORINFO_SIG_INFO* pSig)
+{
+    return CallEEApi<EEApiId::GetSignatureForMethodSymbol, int>(m_pEECorInfo, symbolHandle, pSig) != 0;
 }
 
 const char* Llvm::GetEHDispatchFunctionName(CORINFO_EH_CLAUSE_FLAGS handlerType)

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -509,7 +509,7 @@ bool Llvm::helperCallHasManagedCallingConvention(CorInfoHelpAnyFunc helperFunc) 
         { FUNC(CORINFO_HELP_PROF_FCN_TAILCALL) },
         { FUNC(CORINFO_HELP_BBT_FCN_ENTER) },
 
-        // TODO-LLVM: this is not a real "helper"; investigate what needs to be done to enable it.
+        // Not used in NativeAOT.
         { FUNC(CORINFO_HELP_PINVOKE_CALLI) },
 
         // NYI in NativeAOT.

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -311,7 +311,7 @@ private:
     void failUnsupportedCalls(GenTreeCall* callNode);
     CallArg* lowerCallReturn(GenTreeCall* callNode);
 
-    void normalizeStructUse(GenTree* node, ClassLayout* layout);
+    GenTree* normalizeStructUse(LIR::Use& use, ClassLayout* layout);
 
     unsigned representAsLclVar(LIR::Use& use);
     GenTree* createStoreNode(var_types nodeType, GenTree* addr, GenTree* data);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -233,6 +233,7 @@ private:
     //
     const char* GetMangledMethodName(CORINFO_METHOD_HANDLE methodHandle);
     const char* GetMangledSymbolName(void* symbol);
+    bool GetSignatureForMethodSymbol(CORINFO_GENERIC_HANDLE symbolHandle, CORINFO_SIG_INFO* pSig);
     const char* GetEHDispatchFunctionName(CORINFO_EH_CLAUSE_FLAGS handlerType);
     const char* GetTypeName(CORINFO_CLASS_HANDLE typeHandle);
     void AddCodeReloc(void* handle);
@@ -400,6 +401,7 @@ private:
 
     FunctionType* getFunctionType();
     llvm::FunctionCallee consumeCallTarget(GenTreeCall* call);
+    FunctionType* createFunctionTypeForSignature(CORINFO_SIG_INFO* pSig);
     FunctionType* createFunctionTypeForCall(GenTreeCall* call);
     FunctionType* createFunctionTypeForHelper(CorInfoHelpAnyFunc helperFunc);
     void annotateHelperFunction(CorInfoHelpAnyFunc helperFunc, Function* llvmFunc);
@@ -408,8 +410,8 @@ private:
                                            std::function<void(Function*)> annotateFunction = [](Function*) { });
     Function* getOrCreateExternalLlvmFunctionAccessor(StringRef name);
 
-    llvm::GlobalVariable* getOrCreateExternalSymbol(StringRef symbolName);
-    llvm::GlobalVariable* getOrCreateSymbol(CORINFO_GENERIC_HANDLE symbolHandle);
+    llvm::GlobalVariable* getOrCreateDataSymbol(StringRef symbolName);
+    llvm::GlobalValue* getOrCreateSymbol(CORINFO_GENERIC_HANDLE symbolHandle);
 
     Instruction* getCast(Value* source, Type* targetType);
     Value* castIfNecessary(Value* source, Type* targetType, llvm::IRBuilder<>* builder = nullptr);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -379,6 +379,7 @@ private:
     void buildBinaryOperation(GenTree* node);
     void buildShift(GenTreeOp* node);
     void buildIntrinsic(GenTreeIntrinsic* intrinsicNode);
+    void buildMemoryBarrier(GenTree* node);
     void buildReturn(GenTree* node);
     void buildJTrue(GenTree* node);
     void buildSwitch(GenTreeUnOp* switchNode);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2698,13 +2698,7 @@ llvm::CallBase* Llvm::emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Val
 
 FunctionType* Llvm::getFunctionType()
 {
-    // TODO-LLVM: delete this when these signatures implemented
-    if (_sigInfo.hasExplicitThis())
-        failFunctionCompilation();
-
     std::vector<llvm::Type*> argVec(_llvmArgCount);
-    llvm::Type*              retLlvmType;
-
     for (unsigned i = 0; i < _compiler->lvaCount; i++)
     {
         LclVarDsc* varDsc = _compiler->lvaGetDesc(i);
@@ -2715,11 +2709,11 @@ FunctionType* Llvm::getFunctionType()
         }
     }
 
-    retLlvmType = _retAddressLclNum == BAD_VAR_NUM
+    llvm::Type* retLlvmType = _retAddressLclNum == BAD_VAR_NUM
         ? getLlvmTypeForCorInfoType(_sigInfo.retType, _sigInfo.retTypeClass)
         : Type::getVoidTy(_llvmContext);
 
-    return FunctionType::get(retLlvmType, ArrayRef<Type*>(argVec), false);
+    return FunctionType::get(retLlvmType, argVec, /* isVarArg */ false);
 }
 
 llvm::FunctionCallee Llvm::consumeCallTarget(GenTreeCall* call)

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1230,8 +1230,8 @@ void Llvm::visitNode(GenTree* node)
             // TODO-LLVM-CQ: enable these as intrinsics.
             unreached();
         case GT_MEMORYBARRIER:
-            // TODO-LLVM: atomics.
-            failFunctionCompilation();
+            buildMemoryBarrier(node);
+            break;
         case GT_EQ:
         case GT_NE:
         case GT_LE:
@@ -2311,6 +2311,12 @@ void Llvm::buildIntrinsic(GenTreeIntrinsic* intrinsicNode)
     }
 
     mapGenTreeToValue(intrinsicNode, intrinsicValue);
+}
+
+void Llvm::buildMemoryBarrier(GenTree* node)
+{
+    assert(node->OperIs(GT_MEMORYBARRIER));
+    _builder.CreateFence(llvm::AtomicOrdering::AcquireRelease);
 }
 
 void Llvm::buildReturn(GenTree* node)

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1920,12 +1920,6 @@ void Llvm::buildIntegralConst(GenTreeIntConCommon* node)
     Value* constValue;
     if (node->IsCnsIntOrI() && node->IsIconHandle()) // TODO-LLVM: change to simply "IsIconHandle" once upstream does.
     {
-        if (node->IsIconHandle(GTF_ICON_FTN_ADDR))
-        {
-            // TODO-LLVM: we need to reference the proper function symbol here.
-            failFunctionCompilation();
-        }
-
         constValue = getOrCreateSymbol(CORINFO_GENERIC_HANDLE(node->AsIntCon()->IconValue()));
     }
     else
@@ -2767,6 +2761,42 @@ llvm::FunctionCallee Llvm::consumeCallTarget(GenTreeCall* call)
     return callee;
 }
 
+FunctionType* Llvm::createFunctionTypeForSignature(CORINFO_SIG_INFO* pSig)
+{
+    assert(!pSig->isVarArg()); // We do not support varargs.
+    bool isManagedCallConv = pSig->getCallConv() == CORINFO_CALLCONV_DEFAULT;
+
+    std::vector<Type*> llvmParamTypes{};
+    if (isManagedCallConv)
+    {
+        llvmParamTypes.push_back(getPtrLlvmType()); // The shadow stack.
+    }
+
+    bool hasReturnSlot = isManagedCallConv && needsReturnStackSlot(pSig->retType, pSig->retTypeClass);
+    if (hasReturnSlot)
+    {
+        llvmParamTypes.push_back(getPtrLlvmType());
+    }
+
+    CORINFO_ARG_LIST_HANDLE sigArgs = pSig->args;
+    for (unsigned i = 0; i < pSig->numArgs; i++, sigArgs = m_info->compCompHnd->getArgNext(sigArgs))
+    {
+        CORINFO_CLASS_HANDLE sigArgClass;
+        CorInfoType sigArgType = strip(m_info->compCompHnd->getArgType(pSig, sigArgs, &sigArgClass));
+
+        // TODO-LLVM-ABI: this will need to be changed once we support the correct ABI for structs.
+        if (!isManagedCallConv || canStoreArgOnLlvmStack(sigArgType, sigArgClass))
+        {
+            llvmParamTypes.push_back(getLlvmTypeForCorInfoType(sigArgType, sigArgClass));
+        }
+    }
+
+    Type* retLlvmType = hasReturnSlot ? Type::getVoidTy(_llvmContext)
+                                      : getLlvmTypeForCorInfoType(pSig->retType, pSig->retTypeClass);
+
+    return FunctionType::get(retLlvmType, llvmParamTypes, /* isVarArg */ false);
+}
+
 FunctionType* Llvm::createFunctionTypeForCall(GenTreeCall* call)
 {
     llvm::Type* retLlvmType = getLlvmTypeForCorInfoType(call->gtCorInfoType, call->gtRetClsHnd);
@@ -2836,7 +2866,7 @@ void Llvm::annotateHelperFunction(CorInfoHelpAnyFunc helperFunc, Function* llvmF
     {
         llvmFunc->setDoesNotReturn();
     }
-    if (Compiler::s_helperCallProperties.NonNullReturn(jitHelperFunc))
+    if (Compiler::s_helperCallProperties.NonNullReturn(jitHelperFunc) && llvmFunc->getReturnType()->isPointerTy())
     {
         llvmFunc->addRetAttr(llvm::Attribute::NonNull);
     }
@@ -2867,7 +2897,7 @@ Function* Llvm::getOrCreateExternalLlvmFunctionAccessor(StringRef name)
     return accessorFuncRef;
 }
 
-llvm::GlobalVariable* Llvm::getOrCreateExternalSymbol(StringRef symbolName)
+llvm::GlobalVariable* Llvm::getOrCreateDataSymbol(StringRef symbolName)
 {
     llvm::GlobalVariable* symbol = _module->getGlobalVariable(symbolName);
     if (symbol == nullptr)
@@ -2879,11 +2909,23 @@ llvm::GlobalVariable* Llvm::getOrCreateExternalSymbol(StringRef symbolName)
     return symbol;
 }
 
-llvm::GlobalVariable* Llvm::getOrCreateSymbol(CORINFO_GENERIC_HANDLE symbolHandle)
+llvm::GlobalValue* Llvm::getOrCreateSymbol(CORINFO_GENERIC_HANDLE symbolHandle)
 {
-    const char* symbolName = GetMangledSymbolName(symbolHandle);
+    StringRef symbolName = GetMangledSymbolName(symbolHandle);
     AddCodeReloc(symbolHandle);
-    llvm::GlobalVariable* symbol = getOrCreateExternalSymbol(symbolName);
+
+    CORINFO_SIG_INFO sig;
+    llvm::GlobalValue* symbol;
+    if (GetSignatureForMethodSymbol(symbolHandle, &sig)) // Is this a data symbol or a function symbol?
+    {
+        symbol = getOrCreateKnownLlvmFunction(symbolName, [this, &sig]() {
+            return createFunctionTypeForSignature(&sig);
+        });
+    }
+    else
+    {
+        symbol = getOrCreateDataSymbol(symbolName);
+    }
 
     return symbol;
 }

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -187,7 +187,7 @@ void Llvm::populateLlvmArgNums()
 
     unsigned firstSigArgLclNum = 0;
     assert(_sigInfo.hasThis() == (m_info->compThisArg != BAD_VAR_NUM));
-    if (_sigInfo.hasThis())
+    if (_sigInfo.hasThis() && !_sigInfo.hasExplicitThis())
     {
         // "this" is never an LLVM parameter as it is always a GC reference.
         assert(varTypeIsGC(_compiler->lvaGetDesc(m_info->compThisArg)));

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -635,6 +635,8 @@ bool Llvm::ConvertShadowStackLocalNode(GenTreeLclVarCommon* node)
 
 void Llvm::lowerCall(GenTreeCall* callNode)
 {
+    // TODO-LLVM-CQ: enable fast shadow tail calls. Requires correct ABI handling.
+    assert(!callNode->IsTailCall());
     failUnsupportedCalls(callNode);
 
     if (callNode->IsHelperCall(_compiler, CORINFO_HELP_RETHROW))
@@ -1208,12 +1210,6 @@ void Llvm::failUnsupportedCalls(GenTreeCall* callNode)
     if (callNode->IsHelperCall())
     {
         return;
-    }
-
-    // we can't do these yet
-    if (callNode->IsTailCall())
-    {
-        failFunctionCompilation();
     }
 
     CORINFO_SIG_INFO* calleeSigInfo = callNode->callSig;

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -224,9 +224,6 @@ Type* Llvm::getLlvmTypeForVarType(var_types type)
         case TYP_REF:
         case TYP_BYREF:
             return getPtrLlvmType();
-        case TYP_BLK:
-        case TYP_STRUCT:
-            failFunctionCompilation();
         default:
             unreached();
     }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -17,12 +17,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #include "allocacheck.h" // for alloca
 
-#if TARGET_WASM
-#include "llvm.h"
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif // TARGET_WASM
-
 // Convert the given node into a call to the specified helper passing
 // the given argument list.
 //
@@ -6097,8 +6091,6 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result, 
 //    caller({ double, double, double, double, double, double }) // 48 byte stack
 //    callee(int, int) -- 2 int registers
 //
-// LLVM Wasm:
-//    Fast tail calls cannot be made if the return type is going to be lowered into the shadow stack
 
 bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
 {
@@ -6309,14 +6301,6 @@ bool Compiler::fgCanFastTailCall(GenTreeCall* callee, const char** failReason)
         reportFastTailCallDecision("Callee has a byref parameter");
         return false;
     }
-
-#if TARGET_WASM
-    if (m_llvm->needsReturnStackSlot(callee))
-    {
-        reportFastTailCallDecision("Callee has a return type that must be passed on the LLVM shadow stack");
-        return false;
-    }
-#endif // TARGET_WASM
 
     reportFastTailCallDecision(nullptr);
     return true;

--- a/src/coreclr/jit/targetwasm.h
+++ b/src/coreclr/jit/targetwasm.h
@@ -15,8 +15,8 @@
 
   #define FEATURE_FIXED_OUT_ARGS   0       // Not relevant to LLVM/WASM
   #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
-  #define FEATURE_FASTTAILCALL     1       // Tail calls made as epilog+jmp
-  #define FEATURE_TAILCALL_OPT     1       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.
+  #define FEATURE_FASTTAILCALL     0       // Tail calls made as epilog+jmp
+  #define FEATURE_TAILCALL_OPT     0       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.
   #define FEATURE_SET_FLAGS        0       // Set to true to force the JIT to mark the trees with GTF_SET_FLAGS when the flags need to be set
 
   #define FEATURE_MULTIREG_ARGS_OR_RET  0  // Support for passing and/or returning single values in more than one register

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -395,13 +395,13 @@ void Thread::Destroy()
 }
 
 #ifdef HOST_WASM
-extern RtuObjectRef * t_pShadowStackTop;
-extern RtuObjectRef * t_pShadowStackBottom;
+extern RtuObjectRef* GetShadowStackBottom();
+extern RtuObjectRef* GetShadowStackTop();
 
 void GcScanWasmShadowStack(void * pfnEnumCallback, void * pvCallbackData)
 {
     // Wasm does not permit iteration of stack frames so is uses a shadow stack instead
-    RedhawkGCInterface::EnumGcRefsInRegionConservatively(t_pShadowStackBottom, t_pShadowStackTop, pfnEnumCallback, pvCallbackData);
+    RedhawkGCInterface::EnumGcRefsInRegionConservatively(GetShadowStackBottom(), GetShadowStackTop(), pfnEnumCallback, pvCallbackData);
 }
 #endif
 

--- a/src/coreclr/nativeaot/Runtime/wasm/PInvoke.cpp
+++ b/src/coreclr/nativeaot/Runtime/wasm/PInvoke.cpp
@@ -6,8 +6,8 @@
 #include "CommonTypes.h"
 #include "CommonMacros.h"
 
-extern "C" void* t_pShadowStackBottom = nullptr;
-extern "C" void* t_pShadowStackTop;
+extern "C" thread_local void* t_pShadowStackBottom = nullptr;
+extern "C" thread_local void* t_pShadowStackTop = nullptr;
 
 COOP_PINVOKE_HELPER(void*, RhpGetOrInitShadowStackTop, ())
 {
@@ -29,4 +29,14 @@ COOP_PINVOKE_HELPER(void*, RhpGetShadowStackTop, ())
 COOP_PINVOKE_HELPER(void, RhpSetShadowStackTop, (void* pShadowStack))
 {
     t_pShadowStackTop = pShadowStack;
+}
+
+void* GetShadowStackBottom()
+{
+    return t_pShadowStackBottom;
+}
+
+void* GetShadowStackTop()
+{
+    return t_pShadowStackTop;
 }

--- a/src/coreclr/tools/Common/TypeSystem/IL/ILImporter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/ILImporter.cs
@@ -949,17 +949,5 @@ namespace Internal.IL
         {
             ImportStoreElement(GetWellKnownType(wellKnownType));
         }
-
-        // TODO-LLVM: investigate ICU and EnumCalendarInfo
-        public static MethodIL ReplaceStubbedWasmMethods(MethodDesc method, MethodIL methodIL)
-        {
-            if ((method.OwningType as EcmaType)?.Name == "CalendarData" && method.Name == "EnumCalendarInfo")
-            {
-                // just return false 
-                return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.ldc_i4_0, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
-            }
-
-            return methodIL;
-        }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -85,10 +85,7 @@ namespace Internal.IL
 
             if (_compilation.TargetArchIsWasm())
             {
-                methodIL = ReplaceStubbedWasmMethods(method, methodIL);
-
-                // TODO-LLVM: delete when all IL->LLVM module is gone
-                // ThrowNullReferenceException is added at various places in the IL->LLVM compilation, just add it
+                // ThrowNullReferenceException is needed by the explicit null checks we generate with LLVM.
                 MetadataType helperType = _compilation.TypeSystemContext.SystemModule.GetKnownType("Internal.Runtime.CompilerHelpers", "ThrowHelpers");
                 MethodDesc helperMethod = helperType.GetKnownMethod("ThrowNullReferenceException", null);
                 _dependencies.Add(_factory.MethodEntrypoint(helperMethod), "Wasm EH");

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -111,8 +111,6 @@ namespace Internal.IL
             _compilation = compilation;
             _method = method;
 
-            methodIL = ReplaceStubbedWasmMethods(method, methodIL);
-
             _canonMethodIL = methodIL;
             // Get the runtime determined method IL so that this works right in shared code
             // and tokens in shared code resolve to runtime determined types.

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter.cs
@@ -4406,9 +4406,10 @@ namespace Internal.IL
 
         void ThrowOrRethrow(StackEntry exceptionObject)
         {
-            if (RhpThrowEx.Handle.Equals(IntPtr.Zero))
+            LLVMValueRef throwFunc = Module.GetNamedFunction("RhpThrowEx");
+            if (throwFunc.Handle.Equals(IntPtr.Zero))
             {
-                RhpThrowEx = Module.AddFunction("RhpThrowEx", LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) }, false));
+                throwFunc = Module.AddFunction("RhpThrowEx", LLVMTypeRef.CreateFunction(LLVMTypeRef.Void, new LLVMTypeRef[] { LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) }, false));
             }
 
             _builder.BuildStore(GetShadowStack(), ShadowStackTop);
@@ -4417,12 +4418,12 @@ namespace Internal.IL
             ExceptionRegion currentExceptionRegion = GetCurrentTryRegion();
             if (currentExceptionRegion == null)
             {
-                _builder.BuildCall(RhpThrowEx, args, "");
+                _builder.BuildCall(throwFunc, args, "");
                 _builder.BuildUnreachable();
             }
             else
             {
-                _builder.BuildInvoke(RhpThrowEx, args, GetOrCreateUnreachableBlock(), GetOrCreateLandingPad(currentExceptionRegion), "");
+                _builder.BuildInvoke(throwFunc, args, GetOrCreateUnreachableBlock(), GetOrCreateLandingPad(currentExceptionRegion), "");
             }
 
             for (int i = 0; i < _handlerRegionsForOffsetLookup.Length; i++)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter_Statics.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter_Statics.cs
@@ -365,8 +365,6 @@ namespace Internal.IL
                 if (s_shadowStackTop.Handle.Equals(IntPtr.Zero))
                 {
                     s_shadowStackTop = LLVMCodegenCompilation.Module.AddGlobal(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0), "t_pShadowStackTop");
-                    s_shadowStackTop.Linkage = LLVMLinkage.LLVMExternalLinkage;
-                    s_shadowStackTop.Initializer = LLVMValueRef.CreateConstPointerNull(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
                     s_shadowStackTop.ThreadLocalMode = LLVMThreadLocalMode.LLVMLocalDynamicTLSModel;
                 }
                 return s_shadowStackTop;

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter_Statics.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/ILToLLVMImporter_Statics.cs
@@ -104,7 +104,6 @@ namespace Internal.IL
         static LLVMValueRef DoNothingFunction = default(LLVMValueRef);
         static LLVMValueRef CxaBeginCatchFunction = default(LLVMValueRef);
         static LLVMValueRef CxaEndCatchFunction = default(LLVMValueRef);
-        static LLVMValueRef RhpThrowEx = default(LLVMValueRef);
         static LLVMValueRef RhpCallCatchFunclet = default(LLVMValueRef);
         static LLVMValueRef LlvmCatchFunclet = default(LLVMValueRef);
         static LLVMValueRef LlvmFilterFunclet = default(LLVMValueRef);


### PR DESCRIPTION
Please refer to the commit list for details.

List of things still not implemented in RyuJit:
1) MD arrays - will be fixed in #2199.
2) `TYP_STRUCT` `LCL_FLD` - will be fixed in #2199.
3) Correct ABI for structs - will be fixed after the IL backend is phased out.
4) Some calls without signatures - also depends on #2199.
5) Volatile operations and memory ordering - not critical for IL backend deletion.

The Debug logs have some nice numbers:
```
RyuJIT compilation results, total methods 16168 RyuJit Methods 16168 100.0000%
```