### PR TITLE
[NativeAOT-LLVM] Pass structs by reference in accordance with the WASM C ABI

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4946,6 +4946,11 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     fgResetForSsa();
     DoPhase(this, PHASE_BUILD_SSA, &Compiler::fgSsaBuild);
 
+    // The common phase checks and dumps are no longer relevant past this point.
+    //
+    activePhaseChecks = PhaseChecks::CHECK_NONE;
+    activePhaseDumps  = PhaseDumps::DUMP_NONE;
+
     auto buildLlvmPhase = [this]() {
         m_llvm->Compile();
     };

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4342,6 +4342,9 @@ struct CallArgABIInformation
 #ifdef TARGET_LOONGARCH64
         , StructFloatFieldType()
 #endif
+#ifdef TARGET_WASM
+        , IsPointer(false)
+#endif
         , ArgType(TYP_UNDEF)
         , IsBackFilled(false)
         , IsStruct(false)
@@ -4385,6 +4388,10 @@ public:
     // e.g  `struct {int a; float b;}` passed by an integer register and a float register.
     var_types StructFloatFieldType[2];
 #endif
+#ifdef TARGET_WASM
+    // Whether the ABI type of this argument is an unmanaged pointer.
+    bool IsPointer : 1;
+#endif // TARGET_WASM
     // The type used to pass this argument. This is generally the original
     // argument type, but when a struct is passed as a scalar type, this is
     // that type. Note that if a struct is passed by reference, this will still
@@ -4653,7 +4660,6 @@ public:
     var_types GetSignatureType() { return m_signatureType; }
 #ifdef TARGET_WASM
     CorInfoType GetSignatureCorInfoType() { return m_signatureCorInfoType; }
-    void SetSignatureCorInfoType(CorInfoType signatureCorInfoType) { m_signatureCorInfoType = signatureCorInfoType; }
 #endif
     WellKnownArg GetWellKnownArg() { return m_wellKnownArg; }
     bool IsTemp() { return m_isTmp; }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1493,6 +1493,10 @@ void Compiler::lvaInitVarDsc(LclVarDsc*              varDsc,
     varDsc->lvIsSplit   = 0;
 #endif // TARGET_LOONGARCH64
 
+#ifdef TARGET_WASM
+    varDsc->lvCorInfoType = corInfoType;
+#endif // TARGET_WASM
+
     // Set the lvType (before this point it is TYP_UNDEF).
 
     if (GlobalJitOptions::compFeatureHfa)
@@ -2906,7 +2910,7 @@ bool Compiler::lvaIsImplicitByRefLocal(unsigned lclNum) const
     {
         assert(varDsc->lvIsParam);
 
-        assert(varTypeIsStruct(varDsc) || (varDsc->TypeGet() == TYP_BYREF));
+        assert(varTypeIsStruct(varDsc) || (varDsc->TypeGet() == TYP_BYREF) || (varDsc->TypeGet() == TYP_I_IMPL));
         return true;
     }
 #endif // FEATURE_IMPLICIT_BYREFS

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -22,15 +22,13 @@ enum class EEApiId
     GetSymbolMangledName,
     GetSignatureForMethodSymbol,
     GetEHDispatchFunctionName, // TODO-LLVM: move these to the LLVM helper mechanism.
-    GetTypeName,
     AddCodeReloc,
     IsRuntimeImport,
     GetDocumentFileName,
     GetOffsetLineNumber,
-    StructIsWrappedPrimitive,
+    GetPrimitiveTypeForTrivialWasmStruct,
     PadOffset,
     GetTypeDescriptor,
-    GetInstanceFieldAlignment,
     GetAlternativeFunctionName,
     GetExternalMethodAccessor,
     GetLlvmHelperFuncEntrypoint,
@@ -770,11 +768,6 @@ const char* Llvm::GetEHDispatchFunctionName(CORINFO_EH_CLAUSE_FLAGS handlerType)
     return CallEEApi<EEApiId::GetEHDispatchFunctionName, const char*>(m_pEECorInfo, handlerType);
 }
 
-const char* Llvm::GetTypeName(CORINFO_CLASS_HANDLE typeHandle)
-{
-    return CallEEApi<EEApiId::GetTypeName, const char*>(m_pEECorInfo, typeHandle);
-}
-
 void Llvm::AddCodeReloc(void* handle)
 {
     CallEEApi<EEApiId::AddCodeReloc, void>(m_pEECorInfo, handle);
@@ -795,11 +788,9 @@ uint32_t Llvm::GetOffsetLineNumber(unsigned ilOffset)
     return CallEEApi<EEApiId::GetOffsetLineNumber, uint32_t>(m_pEECorInfo, ilOffset);
 }
 
-bool Llvm::StructIsWrappedPrimitive(CORINFO_CLASS_HANDLE typeHandle, CorInfoType corInfoType)
+CorInfoType Llvm::GetPrimitiveTypeForTrivialWasmStruct(CORINFO_CLASS_HANDLE structHandle)
 {
-    // Maintains compatiblity with the IL->LLVM generation.
-    // TODO-LLVM, when IL generation is no more, see if we can remove this unwrapping.
-    return CallEEApi<EEApiId::StructIsWrappedPrimitive, uint32_t>(m_pEECorInfo, typeHandle, corInfoType) != 0;
+    return CallEEApi<EEApiId::GetPrimitiveTypeForTrivialWasmStruct, CorInfoType>(m_pEECorInfo, structHandle);
 }
 
 uint32_t Llvm::PadOffset(CORINFO_CLASS_HANDLE typeHandle, unsigned atOffset)
@@ -810,11 +801,6 @@ uint32_t Llvm::PadOffset(CORINFO_CLASS_HANDLE typeHandle, unsigned atOffset)
 TypeDescriptor Llvm::GetTypeDescriptor(CORINFO_CLASS_HANDLE typeHandle)
 {
     return CallEEApi<EEApiId::GetTypeDescriptor, TypeDescriptor>(m_pEECorInfo, typeHandle);
-}
-
-uint32_t Llvm::GetInstanceFieldAlignment(CORINFO_CLASS_HANDLE fieldTypeHandle)
-{
-    return CallEEApi<EEApiId::GetInstanceFieldAlignment, uint32_t>(m_pEECorInfo, fieldTypeHandle);
 }
 
 const char* Llvm::GetAlternativeFunctionName()

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -204,8 +204,6 @@ private:
 
     GCInfo* getGCInfo();
 
-    static CorInfoType toCorInfoType(var_types varType);
-
     bool needsReturnStackSlot(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
 
     bool callRequiresShadowStackSave(const GenTreeCall* call) const;
@@ -218,10 +216,17 @@ private:
     static const HelperFuncInfo& getHelperFuncInfo(CorInfoHelpAnyFunc helperFunc);
 
     bool canStoreArgOnLlvmStack(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
+    bool getLlvmArgTypeForArg(bool                 isManagedAbi,
+                              CorInfoType          argSigType,
+                              CORINFO_CLASS_HANDLE argSigClass,
+                              CorInfoType*         pArgType = nullptr,
+                              bool*                pIsByRef = nullptr);
 
     unsigned padOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned atOffset);
     unsigned padNextOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned atOffset);
 
+    static CorInfoType toCorInfoType(var_types varType);
+    static CorInfoType getLlvmArgTypeForCallArg(CallArg* arg);
     TargetAbiType getAbiTypeForType(var_types type);
 
     CORINFO_GENERIC_HANDLE getSymbolHandleForHelperFunc(CorInfoHelpAnyFunc helperFunc);
@@ -364,7 +369,6 @@ private:
     void buildCnsDouble(GenTreeDblCon* node);
     void buildIntegralConst(GenTreeIntConCommon* node);
     void buildCall(GenTreeCall* node);
-    Value* buildFieldList(GenTreeFieldList* fieldList, Type* llvmType);
     void buildInd(GenTreeIndir* indNode);
     void buildBlk(GenTreeBlk* blkNode);
     void buildStoreInd(GenTreeStoreInd* storeIndOp);
@@ -395,7 +399,7 @@ private:
     Value* emitHelperCall(CorInfoHelpAnyFunc helperFunc, ArrayRef<Value*> sigArgs = { });
     llvm::CallBase* emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Value*> args);
 
-    FunctionType* getFunctionType();
+    FunctionType* createFunctionType();
     llvm::FunctionCallee consumeCallTarget(GenTreeCall* call);
     FunctionType* createFunctionTypeForSignature(CORINFO_SIG_INFO* pSig);
     FunctionType* createFunctionTypeForCall(GenTreeCall* call);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -233,15 +233,13 @@ private:
     const char* GetMangledSymbolName(void* symbol);
     bool GetSignatureForMethodSymbol(CORINFO_GENERIC_HANDLE symbolHandle, CORINFO_SIG_INFO* pSig);
     const char* GetEHDispatchFunctionName(CORINFO_EH_CLAUSE_FLAGS handlerType);
-    const char* GetTypeName(CORINFO_CLASS_HANDLE typeHandle);
     void AddCodeReloc(void* handle);
     bool IsRuntimeImport(CORINFO_METHOD_HANDLE methodHandle) const;
     const char* GetDocumentFileName();
     uint32_t GetOffsetLineNumber(unsigned ilOffset);
-    bool StructIsWrappedPrimitive(CORINFO_CLASS_HANDLE typeHandle, CorInfoType corInfoType);
+    CorInfoType GetPrimitiveTypeForTrivialWasmStruct(CORINFO_CLASS_HANDLE structHandle);
     uint32_t PadOffset(CORINFO_CLASS_HANDLE typeHandle, unsigned atOffset);
     TypeDescriptor GetTypeDescriptor(CORINFO_CLASS_HANDLE typeHandle);
-    uint32_t GetInstanceFieldAlignment(CORINFO_CLASS_HANDLE fieldTypeHandle);
     const char* GetAlternativeFunctionName();
     CORINFO_GENERIC_HANDLE GetExternalMethodAccessor(
         CORINFO_METHOD_HANDLE methodHandle, const TargetAbiType* callSiteSig, int sigLength);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -80,7 +80,7 @@ void Llvm::Compile()
 bool Llvm::initializeFunctions()
 {
     const char* mangledName = GetMangledMethodName(m_info->compMethodHnd);
-    Function* rootLlvmFunction = getOrCreateKnownLlvmFunction(mangledName, [=]() { return getFunctionType(); });
+    Function* rootLlvmFunction = getOrCreateKnownLlvmFunction(mangledName, [=]() { return createFunctionType(); });
     if (!rootLlvmFunction->isDeclaration())
     {
         BADCODE("Duplicate definition");
@@ -1929,24 +1929,10 @@ void Llvm::buildIntegralConst(GenTreeIntConCommon* node)
 void Llvm::buildCall(GenTreeCall* call)
 {
     std::vector<Value*> argVec = std::vector<Value*>();
-
-    GenTree* argNode = nullptr;
-    for (CallArg& callArg: call->gtArgs.Args())
+    for (CallArg& arg : call->gtArgs.Args())
     {
-        argNode = callArg.GetNode();
-
-        Type*    argLlvmType = getLlvmTypeForCorInfoType(callArg.GetSignatureCorInfoType(), callArg.GetSignatureClassHandle());
-        Value*   argValue;
-
-        if (argNode->OperIs(GT_FIELD_LIST))
-        {
-            assert(callArg.GetSignatureType() == TYP_STRUCT);
-            argValue = buildFieldList(argNode->AsFieldList(), argLlvmType);
-        }
-        else
-        {
-            argValue = consumeValue(argNode, argLlvmType);
-        }
+        Type* argLlvmType = getLlvmTypeForCorInfoType(getLlvmArgTypeForCallArg(&arg), arg.GetSignatureClassHandle());
+        Value* argValue = consumeValue(arg.GetNode(), argLlvmType);
 
         argVec.push_back(argValue);
     }
@@ -1974,27 +1960,6 @@ void Llvm::buildCall(GenTreeCall* call)
     }
 
     mapGenTreeToValue(call, callValue);
-}
-
-Value* Llvm::buildFieldList(GenTreeFieldList* fieldList, Type* llvmType)
-{
-    assert(fieldList->TypeIs(TYP_STRUCT));
-
-    if (llvmType->isStructTy() || fieldList->Uses().begin()->GetNext() != nullptr)
-    {
-        Value* alloca = _builder.CreateAlloca(llvmType);
-
-        for (GenTreeFieldList::Use& use : fieldList->Uses())
-        {
-            Value* fieldAddr = gepOrAddr(alloca, use.GetOffset());
-            Type*  fieldType = getLlvmTypeForVarType(use.GetType());
-            _builder.CreateStore(consumeValue(use.GetNode(), fieldType), fieldAddr);
-        }
-
-        return _builder.CreateLoad(llvmType, alloca);
-    }
-
-    return consumeValue(fieldList->Uses().begin()->GetNode(), llvmType);
 }
 
 void Llvm::buildInd(GenTreeIndir* indNode)
@@ -2675,7 +2640,7 @@ llvm::CallBase* Llvm::emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Val
     return callInst;
 }
 
-FunctionType* Llvm::getFunctionType()
+FunctionType* Llvm::createFunctionType()
 {
     std::vector<llvm::Type*> argVec(_llvmArgCount);
     for (unsigned i = 0; i < _compiler->lvaCount; i++)
@@ -2771,13 +2736,13 @@ FunctionType* Llvm::createFunctionTypeForSignature(CORINFO_SIG_INFO* pSig)
     CORINFO_ARG_LIST_HANDLE sigArgs = pSig->args;
     for (unsigned i = 0; i < pSig->numArgs; i++, sigArgs = m_info->compCompHnd->getArgNext(sigArgs))
     {
-        CORINFO_CLASS_HANDLE sigArgClass;
-        CorInfoType sigArgType = strip(m_info->compCompHnd->getArgType(pSig, sigArgs, &sigArgClass));
+        CORINFO_CLASS_HANDLE argSigClass;
+        CorInfoType argSigType = strip(m_info->compCompHnd->getArgType(pSig, sigArgs, &argSigClass));
 
-        // TODO-LLVM-ABI: this will need to be changed once we support the correct ABI for structs.
-        if (!isManagedCallConv || canStoreArgOnLlvmStack(sigArgType, sigArgClass))
+        CorInfoType argType;
+        if (getLlvmArgTypeForArg(isManagedCallConv, argSigType, argSigClass, &argType))
         {
-            llvmParamTypes.push_back(getLlvmTypeForCorInfoType(sigArgType, sigArgClass));
+            llvmParamTypes.push_back(getLlvmTypeForCorInfoType(argType, argSigClass));
         }
     }
 
@@ -2792,10 +2757,9 @@ FunctionType* Llvm::createFunctionTypeForCall(GenTreeCall* call)
     llvm::Type* retLlvmType = getLlvmTypeForCorInfoType(call->gtCorInfoType, call->gtRetClsHnd);
 
     std::vector<llvm::Type*> argVec = std::vector<llvm::Type*>();
-
-    for (CallArg& callArg: call->gtArgs.Args())
+    for (CallArg& arg : call->gtArgs.Args())
     {
-        argVec.push_back(getLlvmTypeForCorInfoType(callArg.GetSignatureCorInfoType(), callArg.GetSignatureClassHandle()));
+        argVec.push_back(getLlvmTypeForCorInfoType(getLlvmArgTypeForCallArg(&arg), arg.GetSignatureClassHandle()));
     }
 
     return FunctionType::get(retLlvmType, argVec, /* isVarArg */ false);
@@ -2803,8 +2767,7 @@ FunctionType* Llvm::createFunctionTypeForCall(GenTreeCall* call)
 
 FunctionType* Llvm::createFunctionTypeForHelper(CorInfoHelpAnyFunc helperFunc)
 {
-    INDEBUG(bool isManagedHelper = helperCallHasManagedCallingConvention(helperFunc));
-
+    const bool isManagedHelper = helperCallHasManagedCallingConvention(helperFunc);
     const HelperFuncInfo& helperInfo = getHelperFuncInfo(helperFunc);
     std::vector<Type*> argVec = std::vector<Type*>();
 
@@ -2816,11 +2779,15 @@ FunctionType* Llvm::createFunctionTypeForHelper(CorInfoHelpAnyFunc helperFunc)
     size_t sigArgCount = helperInfo.GetSigArgCount();
     for (size_t i = 0; i < sigArgCount; i++)
     {
-        CorInfoType argType = helperInfo.GetSigArgType(i);
-        CORINFO_CLASS_HANDLE argClass = helperInfo.GetSigArgClass(_compiler, i);
-        assert(!isManagedHelper || canStoreArgOnLlvmStack(argType, argClass));
+        CorInfoType argSigType =  helperInfo.GetSigArgType(i);
+        CORINFO_CLASS_HANDLE argSigClass = helperInfo.GetSigArgClass(_compiler, i);
 
-        argVec.push_back(getLlvmTypeForCorInfoType(argType, argClass));
+        CorInfoType argType;
+        bool isArgPassedByRef;
+        bool isLlvmArg = getLlvmArgTypeForArg(isManagedHelper, argSigType, argSigClass, &argType, &isArgPassedByRef);
+        assert(isLlvmArg && !isArgPassedByRef);
+
+        argVec.push_back(getLlvmTypeForCorInfoType(argType, argSigClass));
     }
 
     CorInfoType sigRetType = helperInfo.GetSigReturnType();

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1260,13 +1260,13 @@ GenTree* Llvm::normalizeStructUse(LIR::Use& use, ClassLayout* layout)
     }
     else
     {
+        // TODO-LLVM: use GenTree::GetLayout here once enough of upstream is merged and delete the
+        // "useHandle == NO_CLASS_HANDLE" check below.
         CORINFO_CLASS_HANDLE useHandle = _compiler->gtGetStructHandleIfPresent(node);
 
         // Note both can be blocks ("NO_CLASS_HANDLE"), in which case we don't need to do anything.
-        // TODO-LLVM-CQ: base this check on the actual LLVM types not being equivalent, as layout ->
-        // LLVM type correspondence is reductive. Additionally (but orthogonally), we should map
-        // canonically equivalent types to the same LLVM type.
-        if (useHandle != layout->GetClassHandle())
+        if ((useHandle != layout->GetClassHandle()) &&
+            ((useHandle == NO_CLASS_HANDLE) || (getLlvmTypeForStruct(useHandle) != getLlvmTypeForStruct(layout))))
         {
             switch (node->OperGet())
             {

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -164,12 +164,13 @@ void Llvm::populateLlvmArgNums()
     }
 
     unsigned nextLlvmArgNum = 0;
+    bool isManagedAbi = !_compiler->opts.IsReversePInvoke();
 
     _shadowStackLclNum = _compiler->lvaGrabTempWithImplicitUse(true DEBUGARG("shadowstack"));
     LclVarDsc* shadowStackVarDsc = _compiler->lvaGetDesc(_shadowStackLclNum);
     shadowStackVarDsc->lvType = TYP_I_IMPL;
     shadowStackVarDsc->lvCorInfoType = CORINFO_TYPE_PTR;
-    if (!_compiler->opts.IsReversePInvoke())
+    if (isManagedAbi)
     {
         shadowStackVarDsc->lvLlvmArgNum = nextLlvmArgNum++;
         shadowStackVarDsc->lvIsParam = true;
@@ -185,44 +186,34 @@ void Llvm::populateLlvmArgNums()
         retAddressVarDsc->lvIsParam = true;
     }
 
-    unsigned firstSigArgLclNum = 0;
-    assert(_sigInfo.hasThis() == (m_info->compThisArg != BAD_VAR_NUM));
-    if (_sigInfo.hasThis() && !_sigInfo.hasExplicitThis())
+    if (m_info->compThisArg != BAD_VAR_NUM)
     {
-        // "this" is never an LLVM parameter as it is always a GC reference.
-        assert(varTypeIsGC(_compiler->lvaGetDesc(m_info->compThisArg)));
-        firstSigArgLclNum++;
+        LclVarDsc* thisVarDsc = _compiler->lvaGetDesc(m_info->compThisArg);
+        thisVarDsc->lvCorInfoType = toCorInfoType(thisVarDsc->TypeGet());
     }
 
-    assert(_sigInfo.hasTypeArg() == (m_info->compTypeCtxtArg != BAD_VAR_NUM));
-    if (_sigInfo.hasTypeArg())
+    if (m_info->compTypeCtxtArg != BAD_VAR_NUM)
     {
-        // Type context is an unmanaged pointer and thus LLVM parameter.
-        LclVarDsc* typeCtxtVarDsc = _compiler->lvaGetDesc(m_info->compTypeCtxtArg);
-        assert(typeCtxtVarDsc->lvIsParam);
-
-        typeCtxtVarDsc->lvLlvmArgNum = nextLlvmArgNum++;
-        typeCtxtVarDsc->lvCorInfoType = CORINFO_TYPE_PTR;
-        firstSigArgLclNum++;
+        _compiler->lvaGetDesc(m_info->compTypeCtxtArg)->lvCorInfoType = CORINFO_TYPE_PTR;
     }
 
-    CORINFO_ARG_LIST_HANDLE sigArgs = _sigInfo.args;
-    for (unsigned i = 0; i < _sigInfo.numArgs; i++, sigArgs = m_info->compCompHnd->getArgNext(sigArgs))
+    for (unsigned lclNum = 0; lclNum < m_info->compArgsCount; lclNum++)
     {
-        CORINFO_CLASS_HANDLE classHnd;
-        CorInfoType          corInfoType = strip(m_info->compCompHnd->getArgType(&_sigInfo, sigArgs, &classHnd));
-        if (canStoreArgOnLlvmStack(corInfoType, classHnd))
+        LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
+
+        if (_compiler->lvaIsImplicitByRefLocal(lclNum))
         {
-            LclVarDsc* varDsc = _compiler->lvaGetDesc(firstSigArgLclNum + i);
-
-            varDsc->lvLlvmArgNum = nextLlvmArgNum++;
-            varDsc->lvCorInfoType = corInfoType;
-            varDsc->lvClassHnd = classHnd;
+            // Implicit byrefs in our calling convention always point to the stack.
+            assert(varDsc->TypeGet() == TYP_BYREF);
+            varDsc->lvType = TYP_I_IMPL;
+            varDsc->lvCorInfoType = CORINFO_TYPE_PTR;
         }
-        else
+
+        CorInfoType argSigType = varDsc->lvCorInfoType;
+        CORINFO_CLASS_HANDLE argSigClass = (varDsc->TypeGet() == TYP_STRUCT) ? varDsc->GetStructHnd() : NO_CLASS_HANDLE;
+        if (getLlvmArgTypeForArg(isManagedAbi, argSigType, argSigClass))
         {
-            // No shadow parameters in RPI methods.
-            assert(!_compiler->opts.IsReversePInvoke());
+            varDsc->lvLlvmArgNum = nextLlvmArgNum++;
         }
     }
 
@@ -903,6 +894,11 @@ void Llvm::lowerVirtualStubCallAfterArgs(
     stubCall->gtArgs.PushFront(_compiler, NewCallArg::Primitive(shadowStackForStub, CORINFO_TYPE_PTR),
                                NewCallArg::Primitive(thisForStub, CORINFO_TYPE_CLASS),
                                NewCallArg::Primitive(cellArgNode, CORINFO_TYPE_PTR));
+    for (CallArg& arg : stubCall->gtArgs.Args())
+    {
+        arg.AbiInfo.IsPointer = arg.GetSignatureCorInfoType() == CORINFO_TYPE_PTR;
+        arg.AbiInfo.ArgType = arg.GetSignatureType();
+    }
     stubCall->gtCorInfoType = CORINFO_TYPE_PTR;
     stubCall->gtFlags |= GTF_CALL_UNMANAGED;
     stubCall->gtCallMoreFlags |= GTF_CALL_M_SUPPRESS_GC_TRANSITION;
@@ -958,21 +954,7 @@ void Llvm::lowerUnmanagedCall(GenTreeCall* callNode)
 
         for (CallArg& arg : callNode->gtArgs.Args())
         {
-            var_types argType = arg.GetSignatureType();
-            if (argType == TYP_STRUCT)
-            {
-                CorInfoType simpleArgType = GetPrimitiveTypeForTrivialWasmStruct(arg.GetSignatureClassHandle());
-
-                if (simpleArgType == CORINFO_TYPE_UNDEF)
-                {
-                    // TODO-LLVM-ABI: implement by-ref passing of structs.
-                    NYI("Unmanaged ABI for structs");
-                }
-
-                argType = JITtype2varType(simpleArgType);
-            }
-
-            sig.Push(getAbiTypeForType(argType));
+            sig.Push(getAbiTypeForType(JITtype2varType(getLlvmArgTypeForCallArg(&arg))));
         }
 
         // WASM requires the callee and caller signature to match. At the LLVM level, "callee type" is the function
@@ -1002,7 +984,7 @@ void Llvm::lowerUnmanagedCall(GenTreeCall* callNode)
         lowerLocal(frameAddr);
         lowerCall(helperCall);
 
-        // Insert CORINFO_HELP_JIT_PINVOKE_END. // No need to explicitly lower the call/local address as the
+        // Insert CORINFO_HELP_JIT_PINVOKE_END. No need to explicitly lower the call/local address as the
         // normal lowering loop will pick them up.
         frameAddr = _compiler->gtNewLclVarAddrNode(_compiler->lvaInlinedPInvokeFrameVar);
         helperCall = _compiler->gtNewHelperCallNode(CORINFO_HELP_JIT_PINVOKE_END, TYP_VOID, frameAddr);
@@ -1036,7 +1018,20 @@ unsigned Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
     // it doesn't apply to runtime imports, or helpers implemented as FCalls, etc).
     const bool isManagedCall = callHasManagedCallingConvention(callNode);
     unsigned shadowFrameSize = getCurrentShadowFrameSize();
-    unsigned shadowStackUseOffset = 0;
+    int sigArgIdx = 0;
+
+    // Insert the shadow stack at the front
+    if (callHasShadowStackArg(callNode))
+    {
+        GenTree* calleeShadowStack = insertShadowStackAddr(callNode, shadowFrameSize, _shadowStackLclNum);
+        callNode->gtArgs.PushFront(_compiler, NewCallArg::Primitive(calleeShadowStack, CORINFO_TYPE_PTR));
+        sigArgIdx--;
+    }
+
+    if (lowerCallReturn(callNode) != nullptr)
+    {
+        sigArgIdx--;
+    }
 
     const HelperFuncInfo* helperInfo = nullptr;
     if (callNode->IsHelperCall())
@@ -1044,32 +1039,15 @@ unsigned Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
         helperInfo = &getHelperFuncInfo(_compiler->eeGetHelperNum(callNode->gtCallMethHnd));
     }
 
-    // Get the first arg before we start pushing non IR args to the list.
-    CallArg* callArg = callNode->gtArgs.Args().begin().GetArg();
+    unsigned shadowStackUseOffset = 0;
     CallArg* lastLlvmStackArg = nullptr;
-
-    // Insert the shadow stack at the front
-    if (callHasShadowStackArg(callNode))
-    {
-        GenTree* calleeShadowStack = insertShadowStackAddr(callNode, shadowFrameSize, _shadowStackLclNum);
-
-        lastLlvmStackArg = callNode->gtArgs.PushFront(_compiler, NewCallArg::Primitive(calleeShadowStack, CORINFO_TYPE_PTR));
-    }
-
-    CallArg* returnSlot = lowerCallReturn(callNode);
-
-    if (returnSlot != nullptr)
-    {
-        lastLlvmStackArg = returnSlot;
-    }
-
-    unsigned sigArgIdx = 0;
+    CallArg* callArg = callNode->gtArgs.Args().begin().GetArg();
     while (callArg != nullptr)
     {
         GenTree* argNode = callArg->GetNode();
         CorInfoType argSigType;
         CORINFO_CLASS_HANDLE argSigClass;
-        if (helperInfo == nullptr)
+        if ((helperInfo == nullptr) || (sigArgIdx < 0))
         {
             if (callArg->GetWellKnownArg() == WellKnownArg::ThisPointer)
             {
@@ -1097,11 +1075,13 @@ unsigned Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
             argSigClass = helperInfo->GetSigArgClass(_compiler, sigArgIdx);
         }
 
-        if (isManagedCall && !canStoreArgOnLlvmStack(argSigType, argSigClass))
+        CorInfoType argType;
+        if (!getLlvmArgTypeForArg(isManagedCall, argSigType, argSigClass, &argType))
         {
-            if (argSigType == CORINFO_TYPE_VALUECLASS)
+            assert(!callArg->AbiInfo.PassedByRef);
+            if (argType == CORINFO_TYPE_VALUECLASS)
             {
-                shadowStackUseOffset = padOffset(argSigType, argSigClass, shadowStackUseOffset);
+                shadowStackUseOffset = padOffset(argType, argSigClass, shadowStackUseOffset);
             }
 
             if (argNode->OperIs(GT_FIELD_LIST))
@@ -1128,9 +1108,9 @@ unsigned Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
                 CurrentRange().InsertBefore(callNode, storeNode);
             }
 
-            if (argSigType == CORINFO_TYPE_VALUECLASS)
+            if (argType == CORINFO_TYPE_VALUECLASS)
             {
-                shadowStackUseOffset = padNextOffset(argSigType, argSigClass, shadowStackUseOffset);
+                shadowStackUseOffset = padNextOffset(argType, argSigClass, shadowStackUseOffset);
             }
             else
             {
@@ -1147,7 +1127,8 @@ unsigned Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
                 argNode = normalizeStructUse(argNodeUse, _compiler->typGetObjLayout(argSigClass));
             }
 
-            callArg->SetSignatureCorInfoType(argSigType);
+            callArg->AbiInfo.IsPointer = argType == CORINFO_TYPE_PTR;
+            callArg->AbiInfo.ArgType = JITtype2varType(argType);
             lastLlvmStackArg = callArg;
         }
 
@@ -1173,11 +1154,11 @@ CallArg* Llvm::lowerCallReturn(GenTreeCall* callNode)
         GenTree* returnValueAddress = insertShadowStackAddr(callNode, getCurrentShadowFrameSize(), _shadowStackLclNum);
 
         // create temp for the return address
-        unsigned   returnTempNum    = _compiler->lvaGrabTemp(false DEBUGARG("return value address"));
+        unsigned returnTempNum = _compiler->lvaGrabTemp(false DEBUGARG("return value address"));
         LclVarDsc* returnAddrVarDsc = _compiler->lvaGetDesc(returnTempNum);
-        returnAddrVarDsc->lvType    = TYP_I_IMPL;
+        returnAddrVarDsc->lvType = TYP_I_IMPL;
 
-        GenTree* addrStore     = _compiler->gtNewStoreLclVar(returnTempNum, returnValueAddress);
+        GenTree* addrStore = _compiler->gtNewStoreLclVar(returnTempNum, returnValueAddress);
         GenTree* returnAddrLcl = _compiler->gtNewLclvNode(returnTempNum, TYP_I_IMPL);
 
         GenTree* returnAddrLclAfterCall = _compiler->gtNewLclvNode(returnTempNum, TYP_I_IMPL);

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -97,104 +97,60 @@ Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
 {
     if (_llvmStructs->find(structHandle) == _llvmStructs->end())
     {
-        Type* llvmType;
-        unsigned fieldAlignment;
+        Type* llvmStructType;
 
-        // LLVM thinks certain sizes of struct have a different calling convention than Clang does.
-        // Treating them as ints fixes that and is more efficient in general
-
-        unsigned structSize = m_info->compCompHnd->getClassSize(structHandle);
-        switch (structSize)
+        // We treat trivial structs like their underlying types for compatibility with the native ABI.
+        CorInfoType primitiveType = GetPrimitiveTypeForTrivialWasmStruct(structHandle);
+        if (primitiveType != CORINFO_TYPE_UNDEF)
         {
-            case 1:
-                llvmType = Type::getInt8Ty(_llvmContext);
-                break;
-            case 2:
-                fieldAlignment = GetInstanceFieldAlignment(structHandle);
-                if (fieldAlignment == 2)
-                {
-                    llvmType = Type::getInt16Ty(_llvmContext);
-                    break;
-                }
-            case 4:
-                fieldAlignment = GetInstanceFieldAlignment(structHandle);
-                if (fieldAlignment == 4)
-                {
-                    if (StructIsWrappedPrimitive(structHandle, CORINFO_TYPE_FLOAT))
-                    {
-                        llvmType = Type::getFloatTy(_llvmContext);
-                    }
-                    else
-                    {
-                        llvmType = Type::getInt32Ty(_llvmContext);
-                    }
-                    break;
-                }
-            case 8:
-                fieldAlignment = GetInstanceFieldAlignment(structHandle);
-                if (fieldAlignment == 8)
-                {
-                    if (StructIsWrappedPrimitive(structHandle, CORINFO_TYPE_DOUBLE))
-                    {
-                        llvmType = Type::getDoubleTy(_llvmContext);
-                    }
-                    else
-                    {
-                        llvmType = Type::getInt64Ty(_llvmContext);
-                    }
-                    break;
-                }
-
-            default:
-                // Forward-declare the struct in case there's a reference to it in the fields.
-                // This must be a named struct or LLVM hits a stack overflow
-                const char* name = GetTypeName(structHandle);
-                llvm::StructType* llvmStructType = llvm::StructType::create(_llvmContext, name);
-                llvmType = llvmStructType;
-                StructDesc* structDesc = getStructDesc(structHandle);
-                unsigned    fieldCnt   = structDesc->getFieldCount();
-
-
-                unsigned lastOffset = 0;
-                unsigned totalSize = 0;
-                std::vector<Type*> llvmFields = std::vector<Type*>();
-                unsigned prevElementSize = 0;
-
-
-                for (unsigned fieldIx = 0; fieldIx < fieldCnt; fieldIx++)
-                {
-                    FieldDesc* fieldDesc = structDesc->getFieldDesc(fieldIx);
-
-                    // Pad to this field if necessary
-                    unsigned paddingSize = fieldDesc->getFieldOffset() - lastOffset - prevElementSize;
-                    if (paddingSize > 0)
-                    {
-                        addPaddingFields(paddingSize, llvmFields);
-                        totalSize += paddingSize;
-                    }
-
-                    CorInfoType fieldCorType = fieldDesc->getCorType();
-
-                    unsigned fieldSize = getElementSize(fieldDesc->getClassHandle(), fieldCorType);
-
-                    llvmFields.push_back(getLlvmTypeForCorInfoType(fieldCorType, fieldDesc->getClassHandle()));
-
-                    totalSize += fieldSize;
-                    lastOffset = fieldDesc->getFieldOffset();
-                    prevElementSize = fieldSize;
-                }
-
-                // If explicit layout is greater than the sum of fields, add padding
-                if (totalSize < structSize)
-                {
-                    addPaddingFields(structSize - totalSize, llvmFields);
-                }
-
-                llvmStructType->setBody(llvmFields, true);
-                break;
+            llvmStructType = getLlvmTypeForCorInfoType(primitiveType, NO_CLASS_HANDLE);
         }
-        _llvmStructs->insert({ structHandle, llvmType });
+        else
+        {
+            StructDesc* structDesc = getStructDesc(structHandle);
+            unsigned fieldCount = structDesc->getFieldCount();
+
+            unsigned lastOffset = 0;
+            unsigned totalSize = 0;
+            std::vector<Type*> llvmFields = std::vector<Type*>();
+            unsigned prevElementSize = 0;
+
+            for (unsigned fieldIx = 0; fieldIx < fieldCount; fieldIx++)
+            {
+                FieldDesc* fieldDesc = structDesc->getFieldDesc(fieldIx);
+
+                // Pad to this field if necessary
+                unsigned paddingSize = fieldDesc->getFieldOffset() - lastOffset - prevElementSize;
+                if (paddingSize > 0)
+                {
+                    addPaddingFields(paddingSize, llvmFields);
+                    totalSize += paddingSize;
+                }
+
+                CorInfoType fieldCorType = fieldDesc->getCorType();
+
+                unsigned fieldSize = getElementSize(fieldDesc->getClassHandle(), fieldCorType);
+
+                llvmFields.push_back(getLlvmTypeForCorInfoType(fieldCorType, fieldDesc->getClassHandle()));
+
+                totalSize += fieldSize;
+                lastOffset = fieldDesc->getFieldOffset();
+                prevElementSize = fieldSize;
+            }
+
+            // If explicit layout is greater than the sum of fields, add padding
+            unsigned structSize = m_info->compCompHnd->getClassSize(structHandle);
+            if (totalSize < structSize)
+            {
+                addPaddingFields(structSize - totalSize, llvmFields);
+            }
+
+            llvmStructType = llvm::StructType::get(_llvmContext, llvmFields, /* isPacked */ true);
+        }
+
+        _llvmStructs->insert({structHandle, llvmStructType});
     }
+
     return _llvmStructs->at(structHandle);
 }
 

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -198,7 +198,7 @@ Type* Llvm::getLlvmTypeForLclVar(LclVarDsc* varDsc)
     }
     if (varDsc->lvCorInfoType != CORINFO_TYPE_UNDEF)
     {
-        return getLlvmTypeForCorInfoType(varDsc->lvCorInfoType, varDsc->lvClassHnd);
+        return getLlvmTypeForCorInfoType(varDsc->lvCorInfoType, NO_CLASS_HANDLE);
     }
 
     return getLlvmTypeForVarType(varDsc->TypeGet());
@@ -209,7 +209,7 @@ Type* Llvm::getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HAN
     switch (corInfoType)
     {
         case CORINFO_TYPE_PTR:
-            return Type::getInt8Ty(_llvmContext)->getPointerTo();
+            return getPtrLlvmType();
 
         case CORINFO_TYPE_VALUECLASS:
             return getLlvmTypeForStruct(classHnd);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -3495,7 +3495,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
 #endif
 
 #if defined(TARGET_X86) || defined(TARGET_WASM)
-        if (isStructArg)
+        if (isStructArg && !arg.AbiInfo.PassedByRef)
         {
             GenTreeLclVar* lcl = nullptr;
 

--- a/src/coreclr/jit/targetwasm.h
+++ b/src/coreclr/jit/targetwasm.h
@@ -19,6 +19,7 @@
   #define FEATURE_TAILCALL_OPT     0       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.
   #define FEATURE_SET_FLAGS        0       // Set to true to force the JIT to mark the trees with GTF_SET_FLAGS when the flags need to be set
 
+  #define FEATURE_IMPLICIT_BYREFS       1  // Support for struct parameters passed via pointers to shadow copies
   #define FEATURE_MULTIREG_ARGS_OR_RET  0  // Support for passing and/or returning single values in more than one register
   #define FEATURE_MULTIREG_ARGS         0  // Support for passing a single argument in more than one register
   #define FEATURE_MULTIREG_RET          0  // Support for returning a single value in more than one register

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -48,7 +48,7 @@ namespace ILCompiler
             ConfigurableWasmImportPolicy configurableWasmImportPolicy,
             MethodImportationErrorProvider errorProvider,
             RyuJitCompilationOptions baseOptions)
-            : base(dependencyGraph, nodeFactory, GetCompilationRoots(roots, nodeFactory), ilProvider, debugInformationProvider, logger, devirtualizationManager, inliningPolicy, instructionSetSupport,
+            : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, logger, devirtualizationManager, inliningPolicy, instructionSetSupport,
                 null /* ProfileDataManager */, errorProvider, baseOptions, 1)
         {
             NodeFactory = nodeFactory;
@@ -56,12 +56,6 @@ namespace ILCompiler
             DataLayout = options.DataLayout;
             ModuleName = options.ModuleName;
             ConfigurableWasmImportPolicy = configurableWasmImportPolicy;
-        }
-
-        private static IEnumerable<ICompilationRootProvider> GetCompilationRoots(IEnumerable<ICompilationRootProvider> existingRoots, NodeFactory factory)
-        {
-            foreach (var existingRoot in existingRoots)
-                yield return existingRoot;
         }
 
         protected override void CompileInternal(string outputFile, ObjectDumper dumper)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -237,7 +237,7 @@ namespace ILCompiler
             return base.GetMethodIL(method);
         }
 
-        public virtual bool StructIsWrappedPrimitive(TypeDesc method, TypeDesc primitiveTypeDesc) => throw new NotImplementedException();
+        public virtual TypeDesc GetPrimitiveTypeForTrivialWasmStruct(TypeDesc type) => throw new NotImplementedException();
         public virtual int PadOffset(TypeDesc type, int atOffset) => throw new NotImplementedException();
         public virtual string GetRuntimeExportManagedEntrypointName(MethodDesc method) => throw new NotImplementedException();
         public virtual ISymbolNode GetExternalMethodAccessor(MethodDesc method, ReadOnlySpan<TargetAbiType> signature) => throw new NotImplementedException();

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
@@ -202,10 +202,10 @@ namespace PInvokeTests
         static extern void StructTest_ByRef(ref SequentialStruct ss);
 
         [DllImport("PInvokeNative", CallingConvention = CallingConvention.StdCall, EntryPoint = "StructTest_ByRef")]
-        static extern bool ClassTest([In, Out] SequentialClass ss);
+        static extern void ClassTest([In, Out] SequentialClass ss);
 
         [DllImport("PInvokeNative", CallingConvention = CallingConvention.StdCall, EntryPoint = "StructTest_ByRef")]
-        static extern bool AsAnyTest([In, Out, MarshalAs(40 /* UnmanagedType.AsAny */)] object o);
+        static extern void AsAnyTest([In, Out, MarshalAs(40 /* UnmanagedType.AsAny */)] object o);
 
         [DllImport("PInvokeNative", CallingConvention = CallingConvention.StdCall)]
         static extern void StructTest_ByOut(out SequentialStruct ss);

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
@@ -330,11 +330,8 @@ namespace PInvokeTests
             TestString();
             TestStringBuilder();
             TestLastError();
-#if !CODEGEN_WASM
-            // TODO-LLVM: https://github.com/dotnet/runtimelab/issues/2190
             TestHandleRef();
             TestSafeHandle();
-#endif
             TestStringArray();
             TestSizeParamIndex();
 #if !CODEGEN_WASM
@@ -342,12 +339,9 @@ namespace PInvokeTests
             TestDelegate();
 #endif
             TestStruct();
-#if !CODEGEN_WASM
-            // TODO-LLVM: https://github.com/dotnet/runtimelab/issues/2190
             TestLayoutClassPtr();
             TestLayoutClass();
             TestAsAny();
-#endif
             TestMarshalStructAPIs();
             TestWithoutPreserveSig();
 #if !CODEGEN_WASM
@@ -355,24 +349,8 @@ namespace PInvokeTests
             TestForwardDelegateWithUnmanagedCallersOnly();
             // TODO-LLVM: https://github.com/dotnet/runtimelab/issues/2190
             TestDecimal();
-
-            // TODO-LLVM: Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code.
-            //at abort(E:\GitHub\runtimelab\artifacts\tests\coreclr\Browser.wasm.Debug\nativeaot\SmokeTests\PInvoke\PInvoke\native\PInvoke.js:942:11)
-            //at _abort(E:\GitHub\runtimelab\artifacts\tests\coreclr\Browser.wasm.Debug\nativeaot\SmokeTests\PInvoke\PInvoke\native\PInvoke.js:5178:7)
-            //at RaiseFailFastException(< anonymous >:wasm - function[464]:0x34d82)
-            //at PalRaiseFailFastException(_EXCEPTION_RECORD32*, _CONTEXT*, unsigned int) (< anonymous >:wasm - function[285]:0x20a8b)
-            //at Thread::ReversePInvokeAttachOrTrapThread(ReversePInvokeFrame *)(< anonymous >:wasm - function[314]:0x21efc)
-            //at RhpReversePInvokeAttachOrTrapThread2(< anonymous >:wasm - function[323]:0x2291a)
-            //at RhpReversePInvoke(< anonymous >:wasm - function[324]:0x22b54)
-            //at UnmanagedMethod(< anonymous >:wasm - function[2413]:0x189dd2)
-            //at PInvoke_PInvokeTests_Program__TestDifferentModopts(< anonymous >:wasm - function[2412]:0x189884)
-            //at PInvoke_PInvokeTests_Program__Main(< anonymous >:wasm - function[9321]:0x67560a)
-            //at PInvoke__Module___MainMethodWrapper(< anonymous >:wasm - function[9320]:0x6754e7)
-            //at StartupCodeMain(< anonymous >:wasm - function[2332]:0x182278)
-            //at __managed__Main(< anonymous >:wasm - function[4429]:0x1c80a9)
-            //at main(< anonymous >:wasm - function[19533]:0x134d3ff)
-            TestDifferentModopts();
 #endif
+            TestDifferentModopts();
 
             return 100;
         }
@@ -859,20 +837,15 @@ namespace PInvokeTests
             ss.f3 = "Hello";
             ss.f4 = "Hola";
 
-#if !CODEGEN_WASM
-            // TODO-LLVM: https://github.com/dotnet/runtimelab/issues/2190
             ThrowIfNotEquals(true, StructTest(ss), "Struct marshalling scenario1 failed.");
 
             StructTest_ByRef(ref ss);
             ThrowIfNotEquals(true,  ss.f1 == 2 && ss.f2 == 11.0 && ss.f3.Equals("Ifmmp") && ss.f4.Equals("Ipmb"), "Struct marshalling scenario2 failed.");
-#endif
 
             SequentialStruct ss2 = new SequentialStruct();
             StructTest_ByOut(out ss2);
             ThrowIfNotEquals(true, ss2.f0 == 1 && ss2.f1 == 1.0 &&  ss2.f2 == 1.0 && ss2.f3.Equals("0123456") && ss2.f4.Equals("789"), "Struct marshalling scenario3 failed.");
 
-#if !CODEGEN_WASM
-            // TODO-LLVM: https://github.com/dotnet/runtimelab/issues/2190
             NesterOfSequentialStruct.SequentialStruct ss3 = new NesterOfSequentialStruct.SequentialStruct();
             ss3.f1 = 10.0f;
             ss3.f2 = 123;
@@ -885,12 +858,10 @@ namespace PInvokeTests
             es.f3 = "Hello";
             ThrowIfNotEquals(true, StructTest_Explicit(es), "Struct marshalling scenario4 failed.");
 
-            // TODO-LLVM: https://github.com/dotnet/runtimelab/issues/2190
             NestedStruct ns = new NestedStruct();
             ns.f1 = 100;
             ns.f2 = es;
             ThrowIfNotEquals(true, StructTest_Nested(ns), "Struct marshalling scenario5 failed.");
-#endif
 
             SequentialStruct[] ssa = null;
             ThrowIfNotEquals(true, IsNULL(ssa), "Non-blittable array null check failed");

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvokeNative.cpp
@@ -318,9 +318,9 @@ DLL_EXPORT bool __stdcall ReleaseMemory(void *mem)
    return true;
 }
 
-DLL_EXPORT bool __stdcall SafeHandleTest(HANDLE sh, long shValue)
+DLL_EXPORT bool __stdcall SafeHandleTest(HANDLE sh, long long shValue)
 {
-    return (long)((size_t)(sh)) == shValue;
+    return (long long)((size_t)(sh)) == shValue;
 }
 
 DLL_EXPORT long __stdcall SafeHandleOutTest(HANDLE **sh)


### PR DESCRIPTION
And switch from generating named struct types to unnamed; we no longer need the former with opaque pointers.

Closes #2151.
Contributes to #2190.

We still need to implement the return counterpart to this code, that will come in a separate change.