### PR TITLE
[NativeAOT-LLVM] Implement `ldvirtftn` support

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -556,9 +556,9 @@ bool Llvm::helperCallHasManagedCallingConvention(CorInfoHelpAnyFunc helperFunc) 
         { FUNC(CORINFO_HELP_READYTORUN_ISINSTANCEOF) },
         { FUNC(CORINFO_HELP_READYTORUN_CHKCAST) },
 
-        // Emitted by the compiler as intrinsics. (see "ILCompiler.LLVM\CodeGen\LLVMObjectWriter.cs", "GetCodeForReadyToRunGenericHelper").
+        // Emitted by the compiler as intrinsics. (see "ILCompiler.LLVM\CodeGen\LLVMObjectWriter.cs", "GetCodeForReadyToRunGenericHelper" and others).
         { FUNC(CORINFO_HELP_READYTORUN_STATIC_BASE) CORINFO_TYPE_PTR, { }, HFIF_SS_ARG },
-        { FUNC(CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR) }, // Not used in NativeAOT.
+        { FUNC(CORINFO_HELP_READYTORUN_VIRTUAL_FUNC_PTR) CORINFO_TYPE_PTR, { CORINFO_TYPE_CLASS } },
         { FUNC(CORINFO_HELP_READYTORUN_GENERIC_HANDLE) CORINFO_TYPE_PTR, { CORINFO_TYPE_PTR }, HFIF_SS_ARG },
         { FUNC(CORINFO_HELP_READYTORUN_DELEGATE_CTOR) CORINFO_TYPE_VOID, { CORINFO_TYPE_CLASS, CORINFO_TYPE_CLASS, CORINFO_TYPE_PTR }, HFIF_SS_ARG | HFIF_VAR_ARG },
         { FUNC(CORINFO_HELP_READYTORUN_GENERIC_STATIC_BASE) CORINFO_TYPE_PTR, { CORINFO_TYPE_PTR }, HFIF_SS_ARG },

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -280,6 +280,8 @@ internal unsafe static class Program
 
         TestConstrainedStructCalls();
 
+        TestLdvirtftn();
+
         TestValueTypeElementIndexing();
 
         TestArrayItfDispatch();
@@ -1378,6 +1380,24 @@ internal unsafe static class Program
         StartTest("Array interface dispatch test");
         EndTest(arrayItfDispatchTest.Count == 37,
             "Failed.  asm.js (WASM=1) known to fail due to alignment problem, although this problem sometimes means we don't even get this far and fails with an invalid function pointer.");
+    }
+
+    class ClassForLdvirtftnTest : ICloneable
+    {
+        public override string ToString() => "ClassForLdvirtftnTest";
+
+        public object Clone() => "ClassForLdvirtftnTestClone";
+    }
+
+    private static void TestLdvirtftn()
+    {
+        ClassForLdvirtftnTest obj = new();
+
+        StartTest("Testing ldvirtftn (vtable)");
+        EndTest(ILHelpers.ILHelpersTest.TestLdvirtftnVTable(obj));
+
+        StartTest("Testing ldvirtftn (interface)");
+        EndTest(ILHelpers.ILHelpersTest.TestLdvirtftnInterface(obj));
     }
 
     private static void TestValueTypeElementIndexing()

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/ILHelpers.il
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/ILHelpers.il
@@ -5,6 +5,8 @@
 
 .assembly ILHelpers { }
 
+.typedef [mscorlib]System.ICloneable as ICloneable
+
 .class public ILHelpers.ILHelpersTest
 {
   // RVA static field
@@ -136,6 +138,44 @@
   {
     ldtoken method int32 ILHelpers.ILHelpersTest::TestLdTokenMethod(int32)
     call class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Reflection.MethodBase::GetMethodFromHandle(valuetype [mscorlib]System.RuntimeMethodHandle)
+    ret
+  }
+
+  .method public static bool TestLdvirtftnVTable(object obj)
+  {
+    ldarg obj
+    ldarg obj
+    call void* .this::GetToStringFunctionPointer(object)
+    calli instance string()
+    ldarg obj
+    callvirt instance string object::ToString()
+    call bool string::Equals(string, string)
+    ret
+  }
+
+  .method private static void* GetToStringFunctionPointer(object obj) noinlining
+  {
+    ldarg obj
+    ldvirtftn instance string object::ToString()
+    ret
+  }
+
+  .method public static bool TestLdvirtftnInterface(class ICloneable obj)
+  {
+    ldarg obj
+    ldarg obj
+    call void* .this::GetCloneFunctionPointer(class ICloneable)
+    calli instance object()
+    ldarg obj
+    callvirt instance object ICloneable::Clone()
+    ceq
+    ret
+  }
+
+  .method private static void* GetCloneFunctionPointer(class ICloneable obj) noinlining
+  {
+    ldarg obj
+    ldvirtftn instance object ICloneable::Clone()
     ret
   }
 }


### PR DESCRIPTION
Emit the necessary helper in the object writer.