### PR TITLE
[NativeAOT-LLVM] Implement support for lazy virtual tables

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -382,9 +382,8 @@ namespace ILCompiler
 
             // Can we do a fixed lookup? Start by checking if we can get to the dictionary.
             // Context source having a vtable with fixed slots is a prerequisite.
-            // TODO-LLVM: Is this going to prevent CT_INDIRECT being implemented for LLVM clrjit?
-            if (!TargetArchIsWasm() && (contextSource == GenericContextSource.MethodParameter
-                || HasFixedSlotVTable(contextMethod.OwningType)))
+            if (contextSource == GenericContextSource.MethodParameter
+                || HasFixedSlotVTable(contextMethod.OwningType))
             {
                 DictionaryLayoutNode dictionaryLayout;
                 if (contextSource == GenericContextSource.MethodParameter)

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -223,7 +223,7 @@ namespace ILCompiler
                 syntax.DefineOption("completetypemetadata", ref _completeTypesMetadata, "Generate complete metadata for types");
                 syntax.DefineOption("reflectiondata", ref _reflectionData, $"Reflection data to generate (one of: {string.Join(", ", validReflectionDataOptions)})");
                 syntax.DefineOption("scanreflection", ref _scanReflection, "Scan IL for reflection patterns");
-                syntax.DefineOption("scan", ref _useScanner, "Use IL scanner to generate optimized code (implied by -O).  For LLVM this has no effect because the scanner is always on");
+                syntax.DefineOption("scan", ref _useScanner, "Use IL scanner to generate optimized code (implied by -O)");
                 syntax.DefineOption("noscan", ref _noScanner, "Do not use IL scanner to generate optimized code");
                 syntax.DefineOption("ildump", ref _ilDump, "Dump IL assembly listing for compiler-generated IL");
                 syntax.DefineOption("stacktracedata", ref _emitStackTraceData, "Emit data to support generating stack trace strings at runtime");
@@ -875,8 +875,7 @@ namespace ILCompiler
             // We also don't do this for multifile because scanner doesn't simulate inlining (this would be
             // fixable by using a CompilationGroup for the scanner that has a bigger worldview, but
             // let's cross that bridge when we get there).
-            // For LLVM the scanner is always on to enable precomputed vtable slots
-            bool useScanner = _useScanner || _isLlvmCodegen ||
+            bool useScanner = _useScanner ||
                 (_optimizationMode != OptimizationMode.None && !_multiFile);
 
             useScanner &= !_noScanner;


### PR DESCRIPTION
We can now compile things with scanner disabled.

Two motivating reasons:
1) Reducing differences with other targets.
2) Allows users to work around scanner-specific bugs.