### PR TITLE
[NativeAOT-LLVM] Implement basic debug info support for types and variables

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -220,6 +220,7 @@ set( JIT_WASM64_SOURCES
   llvmtypes.cpp
   llvmlower.cpp
   llvmcodegen.cpp
+  llvmdebuginfo.cpp
 )
 set( JIT_WASM32_SOURCES
   targetwasm.cpp
@@ -227,6 +228,7 @@ set( JIT_WASM32_SOURCES
   llvmtypes.cpp
   llvmlower.cpp
   llvmcodegen.cpp
+  llvmdebuginfo.cpp
 )
 
 set( JIT_ARM_SOURCES

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4941,10 +4941,16 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     };
     DoPhase(this, PHASE_LOWER_LLVM, lowerPhase);
 
-    lvaMarkLocalVars();  // For SSA.
-
-    fgResetForSsa();
-    DoPhase(this, PHASE_BUILD_SSA, &Compiler::fgSsaBuild);
+    fgSsaDomTree = nullptr;
+    if (opts.OptimizationEnabled())
+    {
+        auto lateSsaPhase = [this]() {
+            lvaMarkLocalVars();
+            fgResetForSsa();
+            fgSsaBuild();
+        };
+        DoPhase(this, PHASE_BUILD_SSA, lateSsaPhase);
+    }
 
     auto buildLlvmPhase = [this]() {
         m_llvm->Compile();

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4164,11 +4164,7 @@ unsigned Compiler::GetSsaNumForLocalVarDef(GenTree* lcl)
 
 inline bool Compiler::PreciseRefCountsRequired()
 {
-#if defined(TARGET_WASM)
-    return opts.OptimizationEnabled() || compRationalIRForm;
-#else
     return opts.OptimizationEnabled();
-#endif
 }
 
 template <typename TVisitor>

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1559,7 +1559,9 @@ unsigned Compiler::compMapILvarNum(unsigned ILvarNum)
     {
         // Parameter
         varNum = compMapILargNum(ILvarNum);
+#ifndef TARGET_WASM // Shadow parameters will not be marked "lvIsParam" by LLVM debug info generation time.
         noway_assert(lvaTable[varNum].lvIsParam);
+#endif // !TARGET_WASM
     }
     else if (ILvarNum < info.compILlocalsCount)
     {

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -997,9 +997,9 @@ void Compiler::fgExtendDbgLifetimes()
                     LIR::Range initRange = LIR::EmptyRange();
                     initRange.InsertBefore(nullptr, zero, store);
 
-#if !defined(TARGET_64BIT) && !defined(TARGET_WASM32) && !defined(TARGET_WASM64)
+#if !defined(TARGET_64BIT) && !defined(TARGET_WASM32)
                     DecomposeLongs::DecomposeRange(this, initRange);
-#endif // !defined(TARGET_64BIT)
+#endif // !defined(TARGET_64BIT) && !defined(TARGET_WASM32)
 #ifndef TARGET_WASM
                     m_pLowering->LowerRange(block, initRange);
 #endif // !TARGET_WASM
@@ -2184,10 +2184,6 @@ bool Compiler::fgTryRemoveNonLocal(GenTree* node, LIR::Range* blockRange)
 //
 bool Compiler::fgTryRemoveDeadStoreLIR(GenTree* store, GenTreeLclVarCommon* lclNode, BasicBlock* block)
 {
-    // TODO-LLVM: we should not need this for correctness, investigate removing.
-    if (!PreciseRefCountsRequired())
-        return false;
-
     assert(!opts.MinOpts());
 
     // We cannot remove stores to (tracked) TYP_STRUCT locals with GC pointers marked as "explicit init",

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -372,6 +372,7 @@ private:
     bool initializeFunctions();
     void generateProlog();
     void initializeLocals();
+    void generateBlocks();
     void generateBlock(BasicBlock* block);
     void generateEHDispatch();
     Value* generateEHDispatchTable(Function* llvmFunc, unsigned innerEHIndex, unsigned outerEHIndex);

--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // ================================================================================================================
-// |                            DWARD debug info generation for the LLVM backend                                  |
+// |                            DWARF debug info generation for the LLVM backend                                  |
 // ================================================================================================================
 
 #include "llvm.h"

--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -1,0 +1,444 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ================================================================================================================
+// |                            DWARD debug info generation for the LLVM backend                                  |
+// ================================================================================================================
+
+#include "llvm.h"
+
+using namespace llvm::dwarf;
+
+using llvm::Metadata;
+using llvm::DINode;
+using llvm::DINodeArray;
+using llvm::DIFile;
+using llvm::DIType;
+using llvm::DISubroutineType;
+using llvm::DILocation;
+
+enum CorInfoLlvmDebugTypeKind
+{
+    CORINFO_LLVM_DEBUG_TYPE_UNDEF,
+    CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE,
+    CORINFO_LLVM_DEBUG_TYPE_COMPOSITE,
+    CORINFO_LLVM_DEBUG_TYPE_ENUM,
+    CORINFO_LLVM_DEBUG_TYPE_ARRAY,
+    CORINFO_LLVM_DEBUG_TYPE_POINTER,
+    CORINFO_LLVM_DEBUG_TYPE_FUNCTION,
+    CORINFO_LLVM_DEBUG_TYPE_COUNT
+};
+
+struct CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO
+{
+    const char* Name;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+    unsigned Offset;
+};
+
+struct CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO
+{
+    const char* Name;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+    const char* BaseSymbolName;
+    unsigned StaticOffset;
+    int IsStaticDataInObject;
+};
+
+struct CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO
+{
+    const char* Name;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE BaseClass;
+    unsigned Size;
+
+    unsigned InstanceFieldCount;
+    CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* InstanceFields;
+
+    unsigned StaticFieldCount;
+    CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO* StaticFields;
+};
+
+struct CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO
+{
+    const char* Name;
+    unsigned long long Value;
+};
+
+struct CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO
+{
+    const char* Name;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+    unsigned long long ElementCount;
+    CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* Elements;
+};
+
+struct CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO
+{
+    const char* Name;
+    unsigned Rank;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+    int IsMultiDimensional;
+};
+
+struct CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO
+{
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+    int IsReference;
+};
+
+struct CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO
+{
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE TypeOfThisPointer;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE ReturnType;
+    unsigned NumberOfArguments;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE* ArgumentTypes;
+};
+
+struct CORINFO_LLVM_TYPE_DEBUG_INFO
+{
+    CorInfoLlvmDebugTypeKind Kind;
+
+    union
+    {
+        CorInfoType PrimitiveType;
+        CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO CompositeInfo;
+        CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO EnumInfo;
+        CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO ArrayInfo;
+        CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO PointerInfo;
+        CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO FunctionInfo;
+    };
+};
+
+struct CORINFO_LLVM_VARIABLE_DEBUG_INFO
+{
+    const char* Name;
+    unsigned VarNumber;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+};
+
+struct CORINFO_LLVM_METHOD_DEBUG_INFO
+{
+    const char* Name;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE OwnerType;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+    unsigned VariableCount;
+    CORINFO_LLVM_VARIABLE_DEBUG_INFO* Variables;
+};
+
+void Llvm::initializeDebugInfo()
+{
+    if (!_compiler->opts.compDbgInfo)
+    {
+        return;
+    }
+
+    CORINFO_LLVM_METHOD_DEBUG_INFO info;
+    GetDebugInfoForCurrentMethod(&info);
+
+    initializeDebugInfoBuilder();
+
+    DIFile* debugFile = getUnknownDebugFile();
+    DIType* ownerDebugType = getOrCreateDebugType(info.OwnerType);
+    DISubroutineType* debugFuncType = llvm::cast<DISubroutineType>(getOrCreateDebugType(info.Type));
+    StringRef linkageName = getRootLlvmFunction()->getName();
+    llvm::DISubprogram::DISPFlags flags = llvm::DISubprogram::SPFlagDefinition | llvm::DISubprogram::SPFlagLocalToUnit;
+
+    m_diFunction = m_diBuilder->createMethod(ownerDebugType, info.Name, linkageName, debugFile, 0, debugFuncType, 0, 0,
+                                             nullptr, DINode::FlagZero, flags);
+
+    for (size_t i = 0; i < info.VariableCount; i++)
+    {
+        CORINFO_LLVM_VARIABLE_DEBUG_INFO* pVariableInfo = &info.Variables[i];
+        DIType* debugType = getOrCreateDebugType(pVariableInfo->Type);
+        unsigned num = pVariableInfo->VarNumber;
+
+        llvm::DILocalVariable* debugVariable;
+        if (num < m_info->compILargsCount)
+        {
+            bool isThis = (m_info->compThisArg != BAD_VAR_NUM) && (num == 0);
+            DINode::DIFlags flags = isThis ? (DINode::FlagObjectPointer | DINode::FlagArtificial) : DINode::FlagZero;
+
+            debugVariable = m_diBuilder->createParameterVariable(m_diFunction, pVariableInfo->Name, num + 1, debugFile,
+                                                                 0, debugType, flags);
+        }
+        else
+        {
+            debugVariable = m_diBuilder->createAutoVariable(m_diFunction, pVariableInfo->Name, debugFile, 0, debugType);
+        }
+
+        unsigned lclNum = _compiler->compMapILvarNum(num);
+        m_debugVariablesMap.Set(lclNum, debugVariable);
+    }
+
+    // TODO-LLVM-EH: debugging in funclets.
+    getRootLlvmFunction()->setSubprogram(m_diFunction);
+}
+
+void Llvm::initializeDebugInfoBuilder()
+{
+    m_diBuilder = new (_compiler->getAllocator(CMK_DebugInfo)) llvm::DIBuilder(*_module, true, s_debugCompileUnit);
+
+    if (s_debugCompileUnit == nullptr)
+    {
+        m_diBuilder->createCompileUnit(DW_LANG_C_plus_plus, getUnknownDebugFile(), "ILC", false, "", 1, "",
+                                       llvm::DICompileUnit::FullDebug, 0, false);
+    }
+}
+
+DILocation* Llvm::createDebugLocation(unsigned lineNo)
+{
+    assert(m_diFunction != nullptr);
+    return DILocation::get(_llvmContext, lineNo, 0, m_diFunction);
+}
+
+DILocation* Llvm::getArtificialDebugLocation()
+{
+    if (m_diFunction == nullptr)
+    {
+        return nullptr;
+    }
+
+    // Line number "0" is used to represent non-user code in DWARF.
+    return createDebugLocation(0);
+}
+
+DIFile* Llvm::getUnknownDebugFile()
+{
+    return m_diBuilder->createFile("<unknown>", "");
+}
+
+DIType* Llvm::getOrCreateDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle)
+{
+    DIType* debugType;
+    if (!s_debugTypesMap.Lookup(debugTypeHandle, &debugType))
+    {
+        debugType = createDebugType(debugTypeHandle);
+        s_debugTypesMap.Set(debugTypeHandle, debugType, decltype(s_debugTypesMap)::Overwrite);
+    }
+
+    return debugType;
+}
+
+DIType* Llvm::createDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle)
+{
+    CORINFO_LLVM_TYPE_DEBUG_INFO info;
+    GetDebugInfoForDebugType(debugTypeHandle, &info);
+
+    switch (info.Kind)
+    {
+        case CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE:
+            return createDebugTypeForPrimitive(info.PrimitiveType);
+        case CORINFO_LLVM_DEBUG_TYPE_COMPOSITE:
+            return createDebugTypeForCompositeType(debugTypeHandle, &info.CompositeInfo);
+        case CORINFO_LLVM_DEBUG_TYPE_ENUM:
+            return createDebugTypeForEnumType(&info.EnumInfo);
+        case CORINFO_LLVM_DEBUG_TYPE_ARRAY:
+            return createDebugTypeForArrayType(&info.ArrayInfo);
+        case CORINFO_LLVM_DEBUG_TYPE_POINTER:
+            return createDebugTypeForPointerType(&info.PointerInfo);
+        case CORINFO_LLVM_DEBUG_TYPE_FUNCTION:
+            return createDebugTypeForFunctionType(&info.FunctionInfo);
+        default:
+            unreached();
+    }
+}
+
+DIType* Llvm::createDebugTypeForPrimitive(CorInfoType type)
+{
+    switch (type)
+    {
+        case CORINFO_TYPE_VOID:
+            return nullptr;
+        case CORINFO_TYPE_BOOL:
+            return m_diBuilder->createBasicType("bool", 8, DW_ATE_boolean);
+        case CORINFO_TYPE_CHAR:
+            return m_diBuilder->createBasicType("char16_t", 16, DW_ATE_UTF);
+        case CORINFO_TYPE_BYTE:
+            return m_diBuilder->createBasicType("sbyte", 8, DW_ATE_signed);
+        case CORINFO_TYPE_UBYTE:
+            return m_diBuilder->createBasicType("byte", 8, DW_ATE_unsigned);
+        case CORINFO_TYPE_SHORT:
+            return m_diBuilder->createBasicType("short", 16, DW_ATE_signed);
+        case CORINFO_TYPE_USHORT:
+            return m_diBuilder->createBasicType("ushort", 16, DW_ATE_unsigned);
+        case CORINFO_TYPE_INT:
+            return m_diBuilder->createBasicType("int", 32, DW_ATE_signed);
+        case CORINFO_TYPE_UINT:
+            return m_diBuilder->createBasicType("uint", 32, DW_ATE_unsigned);
+        case CORINFO_TYPE_LONG:
+            return m_diBuilder->createBasicType("long", 64, DW_ATE_signed);
+        case CORINFO_TYPE_ULONG:
+            return m_diBuilder->createBasicType("ulong", 64, DW_ATE_unsigned);
+        case CORINFO_TYPE_NATIVEINT:
+            return m_diBuilder->createBasicType("nint", TARGET_POINTER_BITS, DW_ATE_signed);
+        case CORINFO_TYPE_NATIVEUINT:
+            return m_diBuilder->createBasicType("nuint", TARGET_POINTER_BITS, DW_ATE_unsigned);
+        case CORINFO_TYPE_FLOAT:
+            return m_diBuilder->createBasicType("float", 4, DW_ATE_float);
+        case CORINFO_TYPE_DOUBLE:
+            return m_diBuilder->createBasicType("double", 8, DW_ATE_float);
+        default:
+            unreached();
+    }
+}
+
+DIType* Llvm::createDebugTypeForCompositeType(
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle, CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO* pInfo)
+{
+    // Forward-declare our structure to handle recursion.
+    StringRef name = pInfo->Name;
+    DIFile* debugFile = getUnknownDebugFile();
+    llvm::TempDIType declType = llvm::TempDIType(
+        m_diBuilder->createReplaceableCompositeType(DW_TAG_structure_type, name, nullptr, debugFile, 0));
+    s_debugTypesMap.Set(debugTypeHandle, declType.get());
+
+    unsigned index = 0;
+    std::vector<Metadata*> debugElements((pInfo->BaseClass != NO_DEBUG_TYPE) + pInfo->InstanceFieldCount);
+    if (pInfo->BaseClass != NO_DEBUG_TYPE)
+    {
+        DIType* baseDebugType = getOrCreateDebugType(pInfo->BaseClass);
+        debugElements[index++] = m_diBuilder->createInheritance(declType.get(), baseDebugType, 0, 0, DINode::FlagZero);
+    }
+
+    for (size_t i = 0; i < pInfo->InstanceFieldCount; i++)
+    {
+        CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* pFieldInfo = &pInfo->InstanceFields[i];
+        DIType* fieldDebugType = getOrCreateDebugType(pFieldInfo->Type);
+        debugElements[index++] = createDebugMember(pFieldInfo->Name, fieldDebugType, pFieldInfo->Offset);
+    }
+
+    DIType* debugType = createClassDebugType(name, pInfo->Size, debugElements);
+    m_diBuilder->replaceTemporary(std::move(declType), debugType);
+
+    // TODO-LLVM-DI: static fields.
+    return debugType;
+}
+
+DIType* Llvm::createDebugTypeForEnumType(CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO* pInfo)
+{
+    std::vector<Metadata*> elements(pInfo->ElementCount);
+    for (size_t i = 0; i < pInfo->ElementCount; i++)
+    {
+        CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* pElementInfo = &pInfo->Elements[i];
+        llvm::DIEnumerator* element = m_diBuilder->createEnumerator(pElementInfo->Name, pElementInfo->Value);
+
+        elements[i] = element;
+    }
+
+    DINodeArray elementsArray = m_diBuilder->getOrCreateArray(elements);
+    DIType* underlyingDebugType = getOrCreateDebugType(pInfo->ElementType);
+    DIType* enumDebugType =
+        m_diBuilder->createEnumerationType(nullptr, pInfo->Name, getUnknownDebugFile(), 0,
+                                           underlyingDebugType->getSizeInBits(), underlyingDebugType->getAlignInBits(),
+                                           elementsArray, underlyingDebugType);
+
+    return enumDebugType;
+}
+
+DIType* Llvm::createDebugTypeForArrayType(CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO* pInfo)
+{
+    // Array layout: [void* m_pEEType, int32 Length, [int32 padding on 64 bit], <bounds>, Data].
+    // Where <bounds> (for an MD array) is an array of [LowerBound..., Length...].
+    unsigned rank = pInfo->Rank;
+    bool isMDArray = pInfo->IsMultiDimensional != 0;
+    std::vector<Metadata*> members = std::vector<Metadata*>();
+
+    DIType* lengthDebugType = createDebugTypeForPrimitive(CORINFO_TYPE_INT);
+    DIDerivedType* lengthDebugField = createDebugMember("Length", lengthDebugType, OFFSETOF__CORINFO_Array__length);
+    members.push_back(lengthDebugField);
+
+    if (isMDArray)
+    {
+        unsigned lowerBoundsOffset = _compiler->eeGetMDArrayLowerBoundOffset(rank, 0);
+        DIType* boundsDebugType = createFixedArrayDebugType(lengthDebugType, rank);
+        DIDerivedType* lowerBoundsDebugField = createDebugMember("LowerBounds", boundsDebugType, lowerBoundsOffset);
+        members.push_back(lowerBoundsDebugField);
+
+        unsigned lengthsOffset = _compiler->eeGetMDArrayLengthOffset(rank, 0);
+        DIDerivedType* lengthsDebugField = createDebugMember("Lengths", boundsDebugType, lengthsOffset);
+        members.push_back(lengthsDebugField);
+    }
+
+    unsigned dataOffset = isMDArray ? _compiler->eeGetMDArrayDataOffset(rank) : _compiler->eeGetArrayDataOffset();
+    DIType* elementDebugType = getOrCreateDebugType(pInfo->ElementType);
+    DIType* dataDebugType = createFixedArrayDebugType(elementDebugType, 0);
+    DIDerivedType* dataDebugField = createDebugMember("Data", dataDebugType, dataOffset);
+    members.push_back(dataDebugField);
+
+    DIType* debugType = createClassDebugType(pInfo->Name, dataOffset, members);
+    return debugType;
+}
+
+DIType* Llvm::createDebugTypeForPointerType(CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO* pInfo)
+{
+    DIType* debugPointeeType = getOrCreateDebugType(pInfo->ElementType);
+    DIType* debugPointerType;
+    if (pInfo->IsReference != 0)
+    {
+        // Reference to a reference is not valid C++; our target debuggers cannot handle it. Emit reference to
+        // a pointer instead.
+        if (debugPointeeType->getTag() == DW_TAG_reference_type)
+        {
+            debugPointeeType = createPointerDebugType(llvm::cast<DIDerivedType>(debugPointeeType)->getBaseType());
+        }
+
+        debugPointerType =
+            m_diBuilder->createReferenceType(DW_TAG_reference_type, debugPointeeType, TARGET_POINTER_BITS);
+    }
+    else
+    {
+        debugPointerType = createPointerDebugType(debugPointeeType);
+    }
+
+    return debugPointerType;
+}
+
+DISubroutineType* Llvm::createDebugTypeForFunctionType(CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO* pInfo)
+{
+    std::vector<Metadata*> debugParameters = std::vector<Metadata*>();
+    debugParameters.push_back(getOrCreateDebugType(pInfo->ReturnType));
+
+    if (pInfo->TypeOfThisPointer != NO_DEBUG_TYPE)
+    {
+        debugParameters.push_back(getOrCreateDebugType(pInfo->TypeOfThisPointer));
+    }
+
+    for (size_t i = 0; i < pInfo->NumberOfArguments; i++)
+    {
+        debugParameters.push_back(getOrCreateDebugType(pInfo->ArgumentTypes[i]));
+    }
+
+    llvm::DITypeRefArray debugParametersArray = m_diBuilder->getOrCreateTypeArray(debugParameters);
+    return m_diBuilder->createSubroutineType(debugParametersArray);
+}
+
+DIType* Llvm::createFixedArrayDebugType(DIType* elementDebugType, unsigned size)
+{
+    unsigned sizeInBits = elementDebugType->getSizeInBits() * size;
+    llvm::DISubrange* boundsRange = m_diBuilder->getOrCreateSubrange(0, size);
+    DINodeArray boundsArray = m_diBuilder->getOrCreateArray(boundsRange);
+    DIType* debugType =
+        m_diBuilder->createArrayType(sizeInBits, elementDebugType->getAlignInBits(), elementDebugType, boundsArray);
+
+    return debugType;
+}
+
+DIType* Llvm::createClassDebugType(StringRef name, unsigned size, ArrayRef<Metadata*> elements)
+{
+    DINodeArray fieldsArray = m_diBuilder->getOrCreateArray(elements);
+    DIType* debugType = m_diBuilder->createClassType(nullptr, name, getUnknownDebugFile(), 0, size * BITS_PER_BYTE,
+                                                     0, 0, DINode::FlagZero, nullptr, fieldsArray);
+    return debugType;
+}
+
+DIDerivedType* Llvm::createDebugMember(StringRef name, llvm::DIType* debugType, unsigned offset)
+{
+    return m_diBuilder->createMemberType(nullptr, name, getUnknownDebugFile(), 0, debugType->getSizeInBits(),
+                                         debugType->getAlignInBits(), offset * BITS_PER_SIZE_T, DINode::FlagZero,
+                                         debugType);
+}
+
+DIDerivedType* Llvm::createPointerDebugType(DIType* pointeeDebugType)
+{
+    return m_diBuilder->createPointerType(pointeeDebugType, TARGET_POINTER_BITS);
+}

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1151,7 +1151,7 @@ CallArg* Llvm::lowerCallReturn(GenTreeCall* callNode)
         GenTree* returnValueAddress = insertShadowStackAddr(callNode, getCurrentShadowFrameSize(), _shadowStackLclNum);
 
         // create temp for the return address
-        unsigned   returnTempNum    = _compiler->lvaGrabTemp(false DEBUGARG("return value address"));
+        unsigned   returnTempNum    = _compiler->lvaGrabTemp(true DEBUGARG("return value address"));
         LclVarDsc* returnAddrVarDsc = _compiler->lvaGetDesc(returnTempNum);
         returnAddrVarDsc->lvType    = TYP_I_IMPL;
 

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 // ================================================================================================================
 // |                                     "Type system" for the LLVM backend                                       |
 // ================================================================================================================

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -592,8 +592,17 @@ void SsaBuilder::InsertPhiToRationalIRForm(BasicBlock* block, unsigned lclNum)
     GenTree*  phi      = new (m_pCompiler, GT_PHI) GenTreePhi(type);
     GenTree*  storeLcl = m_pCompiler->gtNewStoreLclVar(lclNum, phi);
 
+    GenTree* insertionPoint = nullptr;
+    for (GenTree* node : LIR::AsRange(block))
+    {
+        if (!node->OperIs(GT_PHI))
+        {
+            insertionPoint = node;
+            break;
+        }
+    }
     LIR::AsRange(block).InsertAtBeginning(phi);
-    LIR::AsRange(block).InsertAfter(phi, storeLcl);
+    LIR::AsRange(block).InsertBefore(insertionPoint, storeLcl);
 
     JITDUMP("Added PHI definition for V%02u at start of " FMT_BB ".\n", lclNum, block->bbNum);
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/ILCompiler.RyuJit.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/ILCompiler.RyuJit.csproj
@@ -100,5 +100,6 @@
 
   <ItemGroup>
     <Compile Include="JitInterface\CorInfoImpl.Llvm.cs" />
+    <Compile Include="JitInterface\CorInfoImpl.Llvm.DebugInfo.cs" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.DebugInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.DebugInfo.cs
@@ -1,0 +1,514 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+using ILCompiler;
+using ILCompiler.DependencyAnalysis;
+
+using Internal.IL;
+using Internal.TypeSystem;
+using Internal.TypeSystem.TypesDebugInfo;
+
+namespace Internal.JitInterface
+{
+    sealed unsafe partial class CorInfoImpl : ITypesDebugInfoWriter
+    {
+        // We want to reuse the code inside UserDefinedTypeDescriptor for our debug info writing. That code assumes a  "push"
+        // model, where something (object writer) is emitting types as it goes along. This is in contrast to the "pull" model
+        // that the Jit/EE interface has, with the Jit asking us questions about debug shapes of types. To work around this,
+        // we "push" the info on the shapes of types to the "_debugTypesShapes" array, to be queried when giving answers:
+        //
+        //  [Jit] getDebugShape(type) -> [EE] UDT.GetIndexForType -> [UDT] (emit required shapes with EE.Get<Type>Index) ->|
+        //                                                                                                                 |
+        //  [Jit] emitDebugType(shape) <- [EE] _definedTypesData[index] <- (note the shape may have already been emitted) <-
+        //
+        // An additional complication in this scheme is the fact we have no efficient way to go from a debug shape index to
+        // the type it represents, and so have to use the index as the type representative across the Jit/EE interface, to
+        // support cases where the shape needs to reference types.
+        //
+        private UserDefinedTypeDescriptor _debugTypesDescriptor;
+        private ArrayBuilder<DebugTypeShape> _debugTypesShapes;
+        private ArrayBuilder<MemberFunctionIdTypeDescriptor> _debugFunctions;
+        private Dictionary<string, uint> _incompleteTypesMap;
+
+        private UserDefinedTypeDescriptor DebugTypesDescriptor => _debugTypesDescriptor ??= InitializeLlvmDebugInfo();
+
+        private UserDefinedTypeDescriptor InitializeLlvmDebugInfo()
+        {
+            // Make zero an illegal shape index.
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_COUNT, null));
+            _incompleteTypesMap = new();
+
+            return new(this, _compilation.NodeFactory);
+        }
+
+        public uint GetEnumTypeIndex(EnumTypeDescriptor enumTypeDescriptor, EnumRecordTypeDescriptor[] typeRecords)
+        {
+            uint index = (uint)_debugTypesShapes.Count;
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ENUM, (enumTypeDescriptor, typeRecords)));
+            return index;
+        }
+
+        public uint GetClassTypeIndex(ClassTypeDescriptor classTypeDescriptor)
+        {
+            // Multiple type forwards may be requested for the same underlying type. Return the same index for all of of them to support later
+            // updating the shape entry with the complete type.
+            ref uint index = ref CollectionsMarshal.GetValueRefOrAddDefault(_incompleteTypesMap, classTypeDescriptor.Name, out bool exists);
+            if (exists)
+            {
+                return index;
+            }
+
+            index = (uint)_debugTypesShapes.Count;
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_UNDEF, null));
+            return index;
+        }
+
+        public uint GetCompleteClassTypeIndex(ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptor classFieldsTypeDescriptor, DataFieldDescriptor[] fields, StaticDataFieldDescriptor[] statics)
+        {
+            uint index = (uint)_debugTypesShapes.Count;
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_COMPOSITE, (classTypeDescriptor, classFieldsTypeDescriptor, fields, statics)));
+
+            if (_incompleteTypesMap.TryGetValue(classTypeDescriptor.Name, out uint incompleteTypeIndex))
+            {
+                _debugTypesShapes[(int)incompleteTypeIndex] = new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_UNDEF, index);
+            }
+            return index;
+        }
+
+        public uint GetArrayTypeIndex(ClassTypeDescriptor classDescriptor, ArrayTypeDescriptor arrayTypeDescriprtor)
+        {
+            uint index = (uint)_debugTypesShapes.Count;
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ARRAY, (classDescriptor, arrayTypeDescriprtor)));
+            return index;
+        }
+
+        public uint GetPointerTypeIndex(PointerTypeDescriptor pointerDescriptor)
+        {
+            uint index = (uint)_debugTypesShapes.Count;
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_POINTER, pointerDescriptor));
+            return index;
+        }
+
+        public uint GetMemberFunctionTypeIndex(MemberFunctionTypeDescriptor memberDescriptor, uint[] argumentTypes)
+        {
+            uint index = (uint)_debugTypesShapes.Count;
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FUNCTION, (memberDescriptor, argumentTypes)));
+            return index;
+        }
+
+        public uint GetMemberFunctionId(MemberFunctionIdTypeDescriptor memberIdDescriptor)
+        {
+            // Note that function descriptors reside in a namespace distinct from "types".
+            uint index = (uint)_debugFunctions.Count;
+            _debugFunctions.Add(memberIdDescriptor);
+            return index;
+        }
+
+        public uint GetPrimitiveTypeIndex(TypeDesc type)
+        {
+            uint index = (uint)_debugTypesShapes.Count;
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE, type));
+            return index;
+        }
+
+        public string GetMangledName(TypeDesc type)
+        {
+            return _compilation.NodeFactory.NameMangler.GetMangledTypeName(type);
+        }
+
+        struct DebugTypeShape
+        {
+            public CorInfoLlvmDebugTypeKind Kind;
+            public object Data;
+
+            public DebugTypeShape(CorInfoLlvmDebugTypeKind kind, object data) => (Kind, Data) = (kind, data);
+        }
+
+        enum CORINFO_LLVM_DEBUG_TYPE_HANDLE { }
+
+        enum CorInfoLlvmDebugTypeKind
+        {
+            CORINFO_LLVM_DEBUG_TYPE_UNDEF,
+            CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE,
+            CORINFO_LLVM_DEBUG_TYPE_COMPOSITE,
+            CORINFO_LLVM_DEBUG_TYPE_ENUM,
+            CORINFO_LLVM_DEBUG_TYPE_ARRAY,
+            CORINFO_LLVM_DEBUG_TYPE_POINTER,
+            CORINFO_LLVM_DEBUG_TYPE_FUNCTION,
+            CORINFO_LLVM_DEBUG_TYPE_COUNT
+        }
+
+        struct CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO
+        {
+            public byte* Name;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+            public uint Offset;
+        }
+
+        struct CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO
+        {
+            public byte* Name;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+            public byte* BaseSymbolName;
+            public uint StaticOffset;
+            public int IsStaticDataInObject;
+        }
+
+        struct CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO
+        {
+            public byte* Name;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE BaseClass;
+            public uint Size;
+
+            public uint InstanceFieldCount;
+            public CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* InstanceFields;
+
+            public uint StaticFieldCount;
+            public CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO* StaticFields;
+        }
+
+        struct CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO
+        {
+            public byte* Name;
+            public ulong Value;
+        }
+
+        struct CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO
+        {
+            public byte* Name;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+            public ulong ElementCount;
+            public CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* Elements;
+        }
+
+        struct CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO
+        {
+            public byte* Name;
+            public uint Rank;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+            public int IsMultiDimensional;
+        }
+
+        struct CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO
+        {
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+            public int IsReference;
+        }
+
+        struct CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO
+        {
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE TypeOfThisPointer;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE ReturnType;
+            public uint NumberOfArguments;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE* ArgumentTypes;
+        }
+
+        struct CORINFO_LLVM_TYPE_DEBUG_INFO
+        {
+            public CorInfoLlvmDebugTypeKind Kind;
+            public CORINFO_LLVM_TYPE_DEBUG_INFO_UNION Union;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        struct CORINFO_LLVM_TYPE_DEBUG_INFO_UNION
+        {
+            [FieldOffset(0)]
+            public CorInfoType PrimitiveType;
+            [FieldOffset(0)]
+            public CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO CompositeInfo;
+            [FieldOffset(0)]
+            public CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO EnumInfo;
+            [FieldOffset(0)]
+            public CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO ArrayInfo;
+            [FieldOffset(0)]
+            public CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO PointerInfo;
+            [FieldOffset(0)]
+            public CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO FunctionInfo;
+        }
+
+        CORINFO_LLVM_DEBUG_TYPE_HANDLE GetDebugTypeForType(CORINFO_CLASS_STRUCT_* typeHandle)
+        {
+            TypeDesc type = HandleToObject(typeHandle);
+            uint index = DebugTypesDescriptor.GetVariableTypeIndex(type);
+
+            return IndexToDebugTypeHandle(index);
+        }
+
+        void GetDebugInfoForDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle, CORINFO_LLVM_TYPE_DEBUG_INFO* pInfo)
+        {
+            int index = (int)DebugTypeHandleToIndex(debugTypeHandle);
+            DebugTypeShape shape = _debugTypesShapes[index];
+
+            pInfo->Kind = shape.Kind;
+            switch (shape.Kind)
+            {
+                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE:
+                    GetDebugInfoForPrimitiveType(shape.Data, &pInfo->Union.PrimitiveType);
+                    break;
+                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_COMPOSITE:
+                    GetDebugInfoForCompositeType(shape.Data, &pInfo->Union.CompositeInfo);
+                    break;
+                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ENUM:
+                    GetDebugInfoForEnumType(shape.Data, &pInfo->Union.EnumInfo);
+                    break;
+                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ARRAY:
+                    GetDebugInfoForArrayType(shape.Data, &pInfo->Union.ArrayInfo);
+                    break;
+                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_POINTER:
+                    GetDebugInfoForPointerType(shape.Data, &pInfo->Union.PointerInfo);
+                    break;
+                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FUNCTION:
+                    GetDebugInfoForFunctionType(shape.Data, &pInfo->Union.FunctionInfo);
+                    break;
+                default:
+                    throw new UnreachableException();
+            }
+        }
+
+        private void GetDebugInfoForPrimitiveType(object data, CorInfoType* pType)
+        {
+            TypeDesc type = (TypeDesc)data;
+            Debug.Assert(type.IsPrimitive);
+
+            *pType = asCorInfoType(type);
+        }
+
+        private void GetDebugInfoForCompositeType(object data, CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO* pInfo)
+        {
+            var (descriptor, _, fields, statics) = ((ClassTypeDescriptor, ClassFieldsTypeDescriptor, DataFieldDescriptor[], StaticDataFieldDescriptor[]))data;
+
+            pInfo->Name = ToPinnedUtf8String(descriptor.Name);
+            pInfo->BaseClass = IndexToDebugTypeHandle(descriptor.BaseClassId);
+            pInfo->Size = checked((uint)descriptor.InstanceSize);
+
+            int instanceFieldCount = fields.Length - statics.Length;
+            var instanceFieldsInfo = instanceFieldCount != 0 ? new CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO[instanceFieldCount] : null;
+            int staticFieldCount = statics.Length;
+            var staticFieldsInfo = staticFieldCount != 0 ? new CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO[staticFieldCount] : null;
+
+            for (int i = 0, s = 0, j = 0; j < fields.Length; j++)
+            {
+                DataFieldDescriptor field = fields[j];
+                byte* pName = ToPinnedUtf8String(field.Name);
+
+                if (field.Offset == 0xFFFFFFFF) // Static field.
+                {
+                    StaticDataFieldDescriptor staticField = statics[s];
+                    ref CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO fieldInfo = ref staticFieldsInfo[s++];
+                    fieldInfo.Name = pName;
+                    fieldInfo.Type = IndexToDebugTypeHandle(field.FieldTypeIndex);
+                    fieldInfo.BaseSymbolName = ToPinnedUtf8String(staticField.StaticDataName);
+                    fieldInfo.StaticOffset = checked((uint)staticField.StaticOffset);
+                    fieldInfo.IsStaticDataInObject = staticField.IsStaticDataInObject;
+                }
+                else
+                {
+                    ref CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO fieldInfo = ref instanceFieldsInfo[i++];
+                    fieldInfo.Name = pName;
+                    fieldInfo.Type = IndexToDebugTypeHandle(field.FieldTypeIndex);
+                    fieldInfo.Offset = checked((uint)field.Offset);
+                }
+            }
+
+            pInfo->InstanceFieldCount = (uint)instanceFieldCount;
+            pInfo->InstanceFields = instanceFieldsInfo != null ? (CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO*)GetPin(instanceFieldsInfo) : null;
+            pInfo->StaticFieldCount = (uint)staticFieldCount;
+            pInfo->StaticFields = staticFieldsInfo != null ? (CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO*)GetPin(staticFieldsInfo) : null;
+        }
+
+        private void GetDebugInfoForEnumType(object data, CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO* pInfo)
+        {
+            var (descriptor, elements) = ((EnumTypeDescriptor, EnumRecordTypeDescriptor[]))data;
+
+            pInfo->ElementType = IndexToDebugTypeHandle(descriptor.ElementType);
+            pInfo->Name = ToPinnedUtf8String(descriptor.Name);
+            pInfo->ElementCount = descriptor.ElementCount;
+
+            CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO[] elementsInfo = new CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO[elements.Length];
+            for (int i = 0; i < elementsInfo.Length; i++)
+            {
+                EnumRecordTypeDescriptor element = elements[i];
+                ref CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO elementInfo = ref elementsInfo[i];
+                elementInfo.Name = ToPinnedUtf8String(element.Name);
+                elementInfo.Value = element.Value;
+            }
+
+            pInfo->Elements = (CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO*)GetPin(elementsInfo);
+        }
+
+        private void GetDebugInfoForArrayType(object data, CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO* pInfo)
+        {
+            var (classDescriptor, arrayDescriptor) = ((ClassTypeDescriptor, ArrayTypeDescriptor))data;
+
+            pInfo->Name = ToPinnedUtf8String(classDescriptor.Name);
+            pInfo->Rank = arrayDescriptor.Rank;
+            pInfo->ElementType = IndexToDebugTypeHandle(arrayDescriptor.ElementType);
+            pInfo->IsMultiDimensional = arrayDescriptor.IsMultiDimensional;
+        }
+
+        private void GetDebugInfoForPointerType(object data, CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO* pInfo)
+        {
+            var descriptor = (PointerTypeDescriptor)data;
+
+            pInfo->ElementType = IndexToDebugTypeHandle(descriptor.ElementType);
+            pInfo->IsReference = descriptor.IsReference;
+        }
+
+        private void GetDebugInfoForFunctionType(object data, CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO* pInfo)
+        {
+            var (descriptor, argumentTypes) = ((MemberFunctionTypeDescriptor, uint[]))data;
+
+            uint voidTypeIndex = DebugTypesDescriptor.GetTypeIndex(_compilation.TypeSystemContext.GetWellKnownType(WellKnownType.Void), needsCompleteType: true);
+            if (descriptor.TypeIndexOfThisPointer == voidTypeIndex)
+            {
+                pInfo->TypeOfThisPointer = 0;
+            }
+            else
+            {
+                pInfo->TypeOfThisPointer = IndexToDebugTypeHandle(descriptor.TypeIndexOfThisPointer);
+            }
+
+            pInfo->ReturnType = IndexToDebugTypeHandle(descriptor.ReturnType);
+            pInfo->NumberOfArguments = descriptor.NumberOfArguments;
+            pInfo->ArgumentTypes = (CORINFO_LLVM_DEBUG_TYPE_HANDLE*)GetPin(argumentTypes);
+        }
+
+        struct CORINFO_LLVM_VARIABLE_DEBUG_INFO
+        {
+            public byte* Name;
+            public uint VarNumber;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+        }
+
+        struct CORINFO_LLVM_METHOD_DEBUG_INFO
+        {
+            public byte* Name;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE OwnerType;
+            public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+            public uint VariableCount;
+            public CORINFO_LLVM_VARIABLE_DEBUG_INFO* Variables;
+        }
+
+        private void GetDebugInfoForMethod(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)
+        {
+            MethodDesc method = _methodCodeNode.Method;
+            int methodIndex = (int)DebugTypesDescriptor.GetMethodFunctionIdTypeIndex(method);
+            MemberFunctionIdTypeDescriptor descriptor = _debugFunctions[methodIndex];
+
+            pInfo->Name = ToPinnedUtf8String(descriptor.Name);
+            pInfo->OwnerType = IndexToDebugTypeHandle(descriptor.ParentClass);
+            pInfo->Type = IndexToDebugTypeHandle(descriptor.MemberFunction);
+
+            bool isStateMachineMoveNextMethod = _debugInfo.IsStateMachineMoveNextMethod;
+            MethodSignature sig = method.Signature;
+            int offset = sig.IsStatic ? 0 : 1;
+            int parameterCount = sig.Length + offset;
+            uint variableCount = 0;
+
+            int i = 0;
+            string[] parameterNames = new string[parameterCount];
+            foreach (var paramName in _debugInfo.GetParameterNames())
+            {
+                string assignedName;
+                if (!sig.IsStatic && i == 0)
+                {
+                    assignedName = isStateMachineMoveNextMethod ? "locals" : "this";
+                }
+                else
+                {
+                    assignedName = paramName;
+                }
+
+                if (assignedName != null)
+                {
+                    parameterNames[i] = assignedName;
+                    variableCount++;
+                }
+                i++;
+            }
+
+            MethodIL methodIL = (MethodIL)HandleToObject(_methodScope);
+            LocalVariableDefinition[] locals = methodIL.GetLocals();
+
+            string[] localNames = new string[locals.Length];
+            foreach (var local in _debugInfo.GetLocalVariables())
+            {
+                if (!local.CompilerGenerated && local.Slot < localNames.Length && localNames[local.Slot] != local.Name)
+                {
+                    localNames[local.Slot] = local.Name;
+                    variableCount++;
+                }
+            }
+
+            i = 0;
+            CORINFO_LLVM_VARIABLE_DEBUG_INFO[] variables = new CORINFO_LLVM_VARIABLE_DEBUG_INFO[variableCount];
+            for (int num = 0; num < parameterNames.Length + locals.Length; num++)
+            {
+                string name;
+                uint typeIndex;
+                if (num < parameterCount)
+                {
+                    // This is a parameter
+                    if (!sig.IsStatic && num == 0)
+                    {
+                        // We emit special types for async state machines (see also "ObjectWriter.EmitDebugVar").
+                        typeIndex = isStateMachineMoveNextMethod
+                            ? DebugTypesDescriptor.GetStateMachineThisVariableTypeIndex(method.OwningType)
+                            : DebugTypesDescriptor.GetThisTypeIndex(method.OwningType);
+                    }
+                    else
+                    {
+                        typeIndex = DebugTypesDescriptor.GetVariableTypeIndex(method.Signature[num - offset]);
+                    }
+
+                    name = parameterNames[num];
+                }
+                else
+                {
+                    // This is a local
+                    int localNumber = num - parameterCount;
+                    typeIndex = DebugTypesDescriptor.GetVariableTypeIndex(locals[localNumber].Type);
+                    name = localNames[localNumber];
+                }
+
+                if (name != null)
+                {
+                    ref CORINFO_LLVM_VARIABLE_DEBUG_INFO info = ref variables[i++];
+                    info.Name = ToPinnedUtf8String(name);
+                    info.VarNumber = (uint)num;
+                    info.Type = IndexToDebugTypeHandle(typeIndex);
+                }
+            }
+            Debug.Assert(i == variableCount);
+
+            pInfo->VariableCount = variableCount;
+            pInfo->Variables = (CORINFO_LLVM_VARIABLE_DEBUG_INFO*)GetPin(variables);
+        }
+
+        private CORINFO_LLVM_DEBUG_TYPE_HANDLE IndexToDebugTypeHandle(uint index)
+        {
+            // Replace incomplete type references with complete ones so that the Jit never sees them.
+            DebugTypeShape shape = _debugTypesShapes[(int)index];
+            if (shape.Kind == CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_UNDEF)
+            {
+                Debug.Assert(shape.Data is not null);
+                index = (uint)shape.Data;
+            }
+
+            return (CORINFO_LLVM_DEBUG_TYPE_HANDLE)index;
+        }
+
+        private static uint DebugTypeHandleToIndex(CORINFO_LLVM_DEBUG_TYPE_HANDLE handle) => (uint)handle;
+
+        private byte* ToPinnedUtf8String(string name) => (byte*)GetPin(StringToUTF8(name));
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -8,7 +8,7 @@
 
 
   <!-- BEGIN: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true' and '$(IlcInnerLoop)' != 'true'">
     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
     <PublishTrimmed>true</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <Target Name="PublishCompiler"
-          Condition="'$(BuildingInsideVisualStudio)' != 'true'"
+          Condition="'$(BuildingInsideVisualStudio)' != 'true' and '$(IlcInnerLoop)' != 'true'"
           AfterTargets="Build"
           DependsOnTargets="Publish;StompSingleFileHostPath" />
 

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -27,6 +27,8 @@
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\Reflection\Reflection.csproj" />
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\Reflection\Reflection_FromUsage.csproj" />
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\ComWrappers\ComWrappers.csproj" />
+
+      <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\HelloWasm\WasmDebugging.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.cs
@@ -1,0 +1,169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// This is a manual test. It is meant to be compiled and then stepped through with the debugger,
+// verifiying the assertions provided in comments. Note as well that at this time, Debugger.Break
+// does not work right (an upstream issue), so breakpoints have to be set manually.
+//
+using System;
+using System.Diagnostics;
+
+unsafe class Program
+{
+    public static int Main()
+    {
+        SimpleStruct simpleStruct = new() { IntField = 1, FloatField = 2.0f };
+        SimpleClass simpleClass = new() { IntField = 1, FloatField = 2.0f };
+
+        TestBasicTypesDisplay(true, false, 'a', 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, 1.0f, 2.0);
+        TestEnumDisplay(DayOfWeek.Monday);
+        TestByRefDisplay(ref simpleStruct, ref simpleClass);
+        TestPointerDisplay(&simpleStruct);
+        TestStringDisplay("Basic string");
+        TestBasicArrayDisplay(new int[] { 1, 2, 3 }, new double[] { 1, 2, 3 });
+        TestComplexArrayDisplay(new[] { simpleClass }, new[] { simpleStruct });
+        TestBasicMultiDimensionalArrayDisplay(new int[,] { { 1, 2, 3 }, { 4, 5, 6 } });
+        TestSimpleStructDisplay(simpleStruct);
+        TestSimpleClassDisplay(simpleClass);
+        TestDerivedClassDisplay(new() { IntField = 1, FloatField = 2.0f, LongField = 3 });
+        TestRecursiveClassDisplay(new() { Value = 1, Next = new() { Value = 2 } });
+
+        simpleStruct.TestStructInstanceMethod();
+        simpleClass.TestClassInstanceMethod();
+        TestVariables(5, simpleStruct, simpleClass);
+
+        // TODO-LLVM-DI: debugging and EH.
+        return 100;
+    }
+
+    private static void TestBasicTypesDisplay(
+        bool boolTrue, bool boolFalse,
+        char charA,
+        byte i1, sbyte iM1, ushort i2, short iM2, uint i3, int iM3, ulong i4, long iM4, nuint i5, nint iM5,
+        float f1, double d2)
+    {
+        Debugger.Break(); // All of the parameters should be inspectable and have their designated values.
+    }
+
+    private static void TestEnumDisplay(DayOfWeek dayOfWeek)
+    {
+        Debugger.Break(); // The "dayOfWeek" parameter should be inspectable and equal to "DayOfWeek.Monday".
+    }
+
+    private static void TestByRefDisplay(ref SimpleStruct p1, ref SimpleClass p2)
+    {
+        Debugger.Break(); // Both "p1" and "p2" parameters should be inspectable and equal to "{ 1, 2.0 }".
+    }
+
+    private static void TestPointerDisplay(SimpleStruct* s)
+    {
+        Debugger.Break(); // The "*s" value should be inspectable and equal to "{ 1, 2.0 }".
+    }
+
+    private static void TestStringDisplay(string s)
+    {
+        Debugger.Break(); // The "s" parameter should be inspectable and equal to "Basic string".
+    }
+
+    private static void TestBasicArrayDisplay(int[] p1, double[] p2)
+    {
+        Debugger.Break(); // Both "p1" and "p2" parameters should be inspectable and equal to "{ 1, 2, 3 }".
+    }
+
+    private static void TestComplexArrayDisplay(SimpleClass[] p1, SimpleStruct[] p2)
+    {
+        Debugger.Break(); // Both "p1" and "p2" parameters should be inspectable and equal to "{ { 1, 2.0 } }".
+    }
+
+    private static void TestBasicMultiDimensionalArrayDisplay(int[,] s)
+    {
+        Debugger.Break(); // The "s" parameter should be inspectable and equal to "{ { 1, 2, 3 }, { 4, 5, 6 }".
+    }
+
+    private static void TestSimpleStructDisplay(SimpleStruct s)
+    {
+        Debugger.Break(); // The "s" parameter should be inspectable and equal to "{ 1, 2.0 }".
+    }
+
+    private static void TestSimpleClassDisplay(SimpleClass s)
+    {
+        Debugger.Break(); // The "s" parameter should be inspectable and equal to "{ 1, 2.0 }".
+    }
+
+    private static void TestDerivedClassDisplay(DerivedClass s)
+    {
+        Debugger.Break(); // The "s" parameter should be inspectable and equal to "{ 1, 2.0, 3 }".
+    }
+
+    private static void TestRecursiveClassDisplay(RecursiveClass s)
+    {
+        Debugger.Break(); // The "s" parameter should be inspectable and equal to "{ 1, Next = { 2 } }".
+    }
+
+    private static void TestVariables(int p1, SimpleStruct p2, SimpleClass p3)
+    {
+        int unusedBasicLocal = 1;
+        Debugger.Break(); // "unusedBasicLocal" should be equal to "1".
+
+        SimpleClass unusedClassLocal = new() { IntField = 1, FloatField = 2.0f };
+        Debugger.Break(); // "unusedClassLocal" should be equal to "{ 1, 2.0 }".
+
+        int index;
+        Debugger.Break(); // "index" should be to "0".
+        for (index = 0; index < 10; index++) { }
+        Debugger.Break(); // "index" should be to "10".
+
+        SimpleClass classLocal = new() { IntField = 1 };
+        Debugger.Break(); // "classLocal.IntField" should be equal to "1".
+        classLocal.IntField = 2;
+        Debugger.Break(); // "classLocal.IntField" should be equal to "2".
+
+        SimpleStruct structLocal = new() { IntField = 1 };
+        Debugger.Break(); // "structLocal.IntField" should be equal to "1".
+        structLocal.IntField = 2;
+        Debugger.Break(); // "structLocal.IntField" should be equal to "2".
+
+        p2.IntField = p1;
+        p3.IntField = p1;
+        Debugger.Break(); // "p2.IntField" and "p3.IntField" should be equal to "p1".
+
+        structLocal = p2;
+        Debugger.Break(); // "structLocal" should be equal to "p2".
+        classLocal = p3;
+        Debugger.Break(); // "classLocal" should be equal to "p3".        
+    }
+}
+
+struct SimpleStruct
+{
+    public int IntField;
+    public float FloatField;
+
+    public void TestStructInstanceMethod()
+    {
+        Debugger.Break(); // "this" should be equal to "{ 1, 2.0 }".
+    }
+}
+
+class SimpleClass
+{
+    public int IntField;
+    public float FloatField;
+
+    public void TestClassInstanceMethod()
+    {
+        Debugger.Break(); // "this" should be equal to "{ 1, 2.0 }".
+    }
+}
+
+class DerivedClass : SimpleClass
+{
+    public long LongField;
+}
+
+class RecursiveClass
+{
+    public int Value;
+    public RecursiveClass Next;
+}

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="WasmDebugging.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This implements basic debug info emission for variables and complex types. We can now inspect parameters, locals and instance fields. This is sufficient for low-level runtime debugging. See also the newly added (unfortunately, manual) test for supported scenarios.

Not implemented are static fields, debugging in funclets, dynamic type discovery, pretty printing of arrays/strings, calling methods from the debugger, etc. Additionally, compiler-generated helpers such as "get static base" are stepped into and show raw WASM, so step-in experience is subpar.

That said, this is still approximately a lot better than not being able to inspect anything at all \:).

The implementation is somewhat complex, due to the desire to reuse code intended for the non-LLVM object writer (`UserDefinedTypeDescriptor`). At the end of the day, though, it is just converting EE data structures into Jit/EE data structures into the DWARF-like metadata LLVM uses.

Notably, this disables SSA for debug code as the toolchain cannot handle `dbg.value`-based variables, everything has be spilled to be accessible in the debugger.