### PR TITLE
[NativeAOT-LLVM] Return GC primitives (and structs wrapping them) by value

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -14,12 +14,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "hwintrinsic.h"
 #include "simd.h"
 
-#if TARGET_WASM
-#include "llvm.h"
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif // TARGET_WASM
-
 #ifdef _MSC_VER
 #pragma hdrstop
 #endif
@@ -2063,14 +2057,6 @@ bool GenTreeCall::HasSideEffects(Compiler* compiler, bool ignoreExceptions, bool
     {
         return true;
     }
-
-#ifdef TARGET_WASM
-    // This call may have an implicit side effect of writing to the return slot pointer.
-    if (TypeIs(TYP_VOID) && compiler->m_llvm->needsReturnStackSlot(this))
-    {
-        return true;
-    }
-#endif // TARGET_WASM
 
     CorInfoHelpFunc       helper           = compiler->eeGetHelperNum(gtCallMethHnd);
     HelperCallProperties& helperProperties = compiler->s_helperCallProperties;

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -188,7 +188,6 @@ private:
 public:
     Llvm(Compiler* compiler);
 
-    bool needsReturnStackSlot(const GenTreeCall* callee);
     var_types GetArgTypeForStructWasm(CORINFO_CLASS_HANDLE structHnd, structPassingKind* pPassKind, unsigned size);
     var_types GetReturnTypeForStructWasm(CORINFO_CLASS_HANDLE structHnd, structPassingKind* pPassKind, unsigned size);
 
@@ -204,7 +203,8 @@ private:
 
     GCInfo* getGCInfo();
 
-    bool needsReturnStackSlot(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
+    bool needsReturnStackSlot(const GenTreeCall* callee);
+    bool needsReturnStackSlot(CorInfoType sigRetType, CORINFO_CLASS_HANDLE sigRetClass);
 
     bool callRequiresShadowStackSave(const GenTreeCall* call) const;
     bool helperCallRequiresShadowStackSave(CorInfoHelpAnyFunc helperFunc) const;

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1106,14 +1106,22 @@ void Llvm::insertNullCheckForCall(GenTreeCall* callNode)
 {
     assert(callNode->NeedsNullCheck() && callNode->gtArgs.HasThisPointer());
 
-    LIR::Use thisArgUse(CurrentRange(), &callNode->gtArgs.GetThisArg()->EarlyNodeRef(), callNode);
-    unsigned thisArgLclNum = representAsLclVar(thisArgUse);
+    CallArg* thisArg = callNode->gtArgs.GetThisArg();
+    if (_compiler->fgAddrCouldBeNull(thisArg->GetNode()))
+    {
+        LIR::Use thisArgUse(CurrentRange(), &thisArg->EarlyNodeRef(), callNode);
+        unsigned thisArgLclNum = representAsLclVar(thisArgUse);
 
-    GenTree* thisArgNode = _compiler->gtNewLclvNode(thisArgLclNum, _compiler->lvaGetDesc(thisArgLclNum)->TypeGet());
-    GenTree* thisArgNullCheck = _compiler->gtNewNullCheck(thisArgNode, CurrentBlock());
-    CurrentRange().InsertBefore(callNode, thisArgNode, thisArgNullCheck);
+        GenTree* thisArgNode = _compiler->gtNewLclvNode(thisArgLclNum, _compiler->lvaGetDesc(thisArgLclNum)->TypeGet());
+        GenTree* thisArgNullCheck = _compiler->gtNewNullCheck(thisArgNode, CurrentBlock());
+        CurrentRange().InsertBefore(callNode, thisArgNode, thisArgNullCheck);
 
-    lowerIndir(thisArgNullCheck->AsIndir());
+        lowerIndir(thisArgNullCheck->AsIndir());
+    }
+    else
+    {
+        callNode->gtFlags &= ~GTF_CALL_NULLCHECK;
+    }
 }
 
 void Llvm::lowerUnmanagedCall(GenTreeCall* callNode)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -376,16 +376,14 @@ namespace ILCompiler.DependencyAnalysis
             var thunkFunc = _module.GetNamedFunction(thunkSymbolName);
             if (thunkFunc.Handle == IntPtr.Zero)
             {
-                thunkFunc = _module.AddFunction(thunkSymbolName,
-                    LLVMTypeRef.CreateFunction(LLVMTypeRef.Void,
-                        new[] { _ptrType /* shadow stack, not used */, _ptrType /* return spill slot */, _ptrType /* MethodTable* */ }));
+                LLVMTypeRef thunkFuncType = LLVMTypeRef.CreateFunction(_ptrType, new[] { _ptrType /* shadow stack, not used */, _ptrType /* MethodTable* */ });
+                thunkFunc = _module.AddFunction(thunkSymbolName, thunkFuncType);
                 using LLVMBuilderRef builder = LLVMBuilderRef.Create(_module.Context);
                 builder.PositionAtEnd(thunkFunc.AppendBasicBlock("Thunk"));
 
                 LLVMValueRef allocatorFunc = GetOrCreateSymbol(new ExternSymbolNode(unmanagedSymbolName));
-                LLVMValueRef allocatedObj = CreateCall(builder, allocatorFunc, new[] { thunkFunc.Params[2] });
-                builder.BuildStore(allocatedObj, thunkFunc.Params[1]);
-                builder.BuildRetVoid();
+                LLVMValueRef allocatedObj = CreateCall(builder, allocatorFunc, new[] { thunkFunc.Params[1] });
+                builder.BuildRet(allocatedObj);
             }
 
             return thunkSymbolName;
@@ -945,11 +943,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private LLVMValueRef OutputCodeForGetThreadStaticBase(LLVMBuilderRef builder, LLVMValueRef pModuleDataSlot)
         {
-            // Unfortunately, the helper to get the thread static base returns the pointer indirectly, so we have to
-            // allocate some space on the shadow stack for it (note: the base is an unpinned object). TODO-LLVM-ABI:
-            // simplify once we stop returning GC primitives by reference.
             LLVMValueRef shadowStack = builder.InsertBlock.Parent.GetParam(0);
-            LLVMValueRef calleeShadowStack = CreateAddOffset(builder, shadowStack, _nodeFactory.Target.PointerSize, "calleeShadowStack");
 
             // First arg: address of the TypeManager slot that provides the helper with information about
             // module index and the type manager instance (which is used for initialization on first access).
@@ -961,10 +955,10 @@ namespace ILCompiler.DependencyAnalysis
 
             IMethodNode getBaseHelperNode = (IMethodNode)_nodeFactory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType);
             LLVMValueRef getBaseHelperFunc = GetOrCreateLLVMFunction(getBaseHelperNode);
-            LLVMValueRef[] getBaseHelperArgs = new[] { calleeShadowStack, shadowStack, pModuleData, typeTlsIndex };
-            CreateCall(builder, getBaseHelperFunc, getBaseHelperArgs);
+            LLVMValueRef[] getBaseHelperArgs = new[] { shadowStack, pModuleData, typeTlsIndex };
+            LLVMValueRef getBaseHelperCall = CreateCall(builder, getBaseHelperFunc, getBaseHelperArgs);
 
-            return builder.BuildLoad2(_ptrType, shadowStack, "threadStaticBase");
+            return getBaseHelperCall;
         }
 
         private LLVMValueRef GetOrCreateSymbol(ISymbolNode symbolRef)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -307,7 +307,9 @@ namespace ILCompiler
 
         internal LLVMTypeRef GetLlvmReturnType(bool isManagedAbi, TypeDesc sigReturnType, out bool isPassedByRef)
         {
-            isPassedByRef = isManagedAbi && !CanStoreTypeOnStack(sigReturnType);
+            isPassedByRef = isManagedAbi && IsStruct(sigReturnType) && !CanStoreTypeOnStack(sigReturnType) &&
+                            GetPrimitiveTypeForTrivialWasmStruct(sigReturnType) == null;
+
             if (isPassedByRef || sigReturnType.IsVoid)
             {
                 return LLVMTypeRef.Void;


### PR DESCRIPTION
Contributes to #2214.

Saves about 1% on code size in fully optimized code.