### PR TITLE
[NativeAOT-LLVM] Return complex structs by reference

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -289,9 +289,6 @@ private:
 
 #endif // FEATURE_MULTIREG_RET
 
-#ifdef TARGET_WASM
-                case Compiler::SPK_ByValue:
-#endif // TARGET_WASM
                 case Compiler::SPK_EnclosingType:
                 case Compiler::SPK_PrimitiveType:
                     // No work needs to be done, the call has struct type and should keep it.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -23492,9 +23492,6 @@ void ReturnTypeDesc::InitializeStructReturnType(Compiler*                comp,
                 m_regType[i] = comp->getJitGCType(gcPtrs[i]);
             }
 
-#elif defined(TARGET_WASM)
-            m_regType[0] = TYP_STRUCT;
-
 #else //  TARGET_XXX
 
             // This target needs support here!

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -11460,24 +11460,6 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
                     }
                 }
                 else // The struct was to be returned via a return buffer.
-#if defined(TARGET_WASM)
-                assert(!iciCall->gtArgs.HasRetBuffer());
-
-                if (fgNeedReturnSpillTemp())
-                {
-                    if (!impInlineInfo->retExpr)
-                    {
-                        // The inlinee compiler has figured out the type of the temp already. Use it here.
-                        impInlineInfo->retExpr =
-                            gtNewLclvNode(lvaInlineeReturnSpillTemp, lvaTable[lvaInlineeReturnSpillTemp].lvType);
-                    }
-                }
-                else
-                {
-                    impInlineInfo->retExpr = op2;
-                }
-#endif // defined(TARGET_WASM)
-#if !defined (TARGET_WASM)
                 {
                     assert(iciCall->gtArgs.HasRetBuffer());
                     GenTree* dest = gtCloneExpr(iciCall->gtArgs.GetRetBufferArg()->GetEarlyNode());
@@ -11497,7 +11479,6 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
                         impInlineInfo->retExpr = impAssignStructPtr(dest, op2, retClsHnd, CHECK_SPILL_ALL);
                     }
                 }
-#endif // !defined TARGET_WASM
             }
 
             if (impInlineInfo->retExpr != nullptr)
@@ -11534,7 +11515,7 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
     }
     else if (varTypeIsStruct(info.compRetType))
     {
-#if !defined(FEATURE_MULTIREG_RET) && !defined(TARGET_WASM)
+#if !FEATURE_MULTIREG_RET
         // For both ARM architectures the HFA native types are maintained as structs.
         // Also on System V AMD64 the multireg structs returns are also left as structs.
         noway_assert(info.compRetNativeType != TYP_STRUCT);

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -307,9 +307,7 @@ namespace ILCompiler
 
         internal LLVMTypeRef GetLlvmReturnType(bool isManagedAbi, TypeDesc sigReturnType, out bool isPassedByRef)
         {
-            isPassedByRef = isManagedAbi && IsStruct(sigReturnType) && !CanStoreTypeOnStack(sigReturnType) &&
-                            GetPrimitiveTypeForTrivialWasmStruct(sigReturnType) == null;
-
+            isPassedByRef = IsStruct(sigReturnType) && GetPrimitiveTypeForTrivialWasmStruct(sigReturnType) == null;
             if (isPassedByRef || sigReturnType.IsVoid)
             {
                 return LLVMTypeRef.Void;

--- a/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
+++ b/src/tests/nativeaot/SmokeTests/PInvoke/PInvoke.cs
@@ -347,9 +347,8 @@ namespace PInvokeTests
 #if !CODEGEN_WASM
             // GetFunctionPointerForDelegate NYI on WASM
             TestForwardDelegateWithUnmanagedCallersOnly();
-            // TODO-LLVM: https://github.com/dotnet/runtimelab/issues/2190
-            TestDecimal();
 #endif
+            TestDecimal();
             TestDifferentModopts();
 
             return 100;


### PR DESCRIPTION
Using the return buffer pointer, like other targets. The pointer will always be unmanaged, with us pinning it if necessary.

Contributes to #2214.
Fixes #2190.