### PR TITLE
NativeAOT-LLVM Set buildConfig from debugOnPrReleaseOnRolling as per runtime

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -162,6 +162,7 @@ extends:
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
             jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+            buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
             jobParameters:
               liveRuntimeBuildConfig: Release
               liveLibrariesBuildConfig: Release


### PR DESCRIPTION
Might fix #2242 

In `runtime.yml` the buildConfig for the `installer/jobs/build-job.yml` is from `buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}`

This PR adds that line to `runtimelab.yml`

cc @dotnet/nativeaot-llvm 