### PR TITLE
NativeAOT-LLVM: Remove Installer build-job job

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -157,22 +157,6 @@ extends:
                 isOfficialBuild: true
                 librariesBinArtifactName: libraries_bin_official_allconfigurations
 
-      # Installer official builds need to build installers and need the libraries all configurations build
-      - ${{ if eq(variables.isOfficialBuild, true) }}:
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
-            buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
-            jobParameters:
-              liveRuntimeBuildConfig: Release
-              liveLibrariesBuildConfig: Release
-              isOfficialBuild: ${{ variables.isOfficialBuild }}
-              useOfficialAllConfigurations: true
-              dependsOnGlobalBuild: true
-            platforms:
-            - Linux_x64
-            - windows_x64
-
     - ${{ if eq(variables.isOfficialBuild, true) }}:
       - template: /eng/pipelines/official/stages/publish.yml
         parameters:


### PR DESCRIPTION
This PR removes the `/eng/pipelines/installer/jobs/build-job.yml` which is failing.  It wasn't present before the last merge and I only included it because I started afresh with the `runtimelab.yml` from upstream.

cc @dotnet/nativeaot-llvm 