### PR TITLE
NativeAOT-LLVM: Reinstate SingleEntry.targets

### DIFF
--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -61,17 +61,19 @@ Install and activate Emscripten. See [Install Emscripten](https://emscripten.org
 For WebAssembly, it is always a cross-architecture scenario as the compiler runs on Windows/Linux/MacOS and the runtime is for WebAssembly.  WebAssembly is not integrated into the main ILCompiler so first remove (if you added it from above)
 
 ```xml
-<PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" />
+<PackageReference Include="Microsoft.DotNet.ILCompiler" Version="8.0.0-*" />
 ```
 
 Then, the required package reference is
 ```xml
-<PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM; runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="7.0.0-*" />
+<PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM; runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-*" />
 ```
 and the publish command (there is no Release build currently)
 ```bash
 > dotnet publish -r browser-wasm -c Debug /p:TargetArchitecture=wasm /p:PlatformTarget=AnyCPU /p:MSBuildEnableWorkloadResolver=false --self-contained
 ```
+
+Publishing using `PublishAot=true` is not currently supported for WebAssembly.
 
 Note that the wasm-tools workload is identified as a dependency even though its not used, and this confuses the toolchain, hence `/p:MSBuildEnableWorkloadResolver=false`
 

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -95,8 +95,8 @@ Working on the Jit itself, one possible workflow is taking advantage of the gene
 It is also possible to publish an ordinary console project for Wasm using packages produced by the build: `build nativeaot.packages && build nativeaot.packages -a wasm -os Browser`, assuming all the binaries mentioned above have been built (note that the order is important - the build always produces an architecture-independent package that has a dependency on an architecture-dependent one, and we want that architecture-dependent package to be built for Wasm). Add the `path-to-repo/artifacts/packages/[Debug|Release]/Shipping` directory to your project's `NuGet.Config`, and the following two references to the project file itself:
 ```xml
 <ItemGroup>
-  <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="7.0.0-dev" />
-  <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="7.0.0-dev" />
+  <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-dev" />
+  <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-dev" />
 </ItemGroup>
 ```
 You should now be able to publish the project for Wasm: `dotnet publish --self-contained -r browser-wasm /p:MSBuildEnableWorkloadResolver=false`. This produces `YourApp.html` and `YourApp.js` files under `bin\<Config>\<TFM>\browser-wasm\native`. The former can be opened in the browser, the latter - run via NodeJS.

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.LLVM.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.LLVM.targets
@@ -1,4 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="$(MSBuildThisFileDirectory)\Microsoft.DotNet.ILCompiler.SingleEntry.targets" />
 
 </Project>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -53,23 +53,42 @@
     </KnownILCompilerPack>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetArchitecture)' == 'wasm'">
+    <NeedNativePublishSupportForLLVM>true</NeedNativePublishSupportForLLVM>
+  </PropertyGroup>
+
   <!-- Generate a warning if the non-SDK path is used  -->
-  <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true' and '$(ILCompilerTargetsPath)' != ''  and '$(NeedNativePublishSupportForSDK6)' != 'true'" 
+  <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true' and '$(ILCompilerTargetsPath)' != ''  and '$(NeedNativePublishSupportForLLVM)' != 'true'" 
       BeforeTargets="ImportRuntimeIlcPackageTarget">
     <Warning Text="Delete explicit 'Microsoft.DotNet.ILCompiler' package reference in your project file. Explicit 'Microsoft.DotNet.ILCompiler' package reference can run into version errors." />
   </Target>
 
   <!-- Locate the runtime package according to the current target runtime -->
-  <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' and ('$(PublishAot)' == 'true' or '$(NeedNativePublishSupportForSDK6)' == 'true') and $(IlcCalledViaPackage) == 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
-    <Error Condition="'@(ResolvedILCompilerPack)' == '' and '$(NeedNativePublishSupportForSDK6)' != 'true'" Text="The ResolvedILCompilerPack ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
+  <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' and ('$(PublishAot)' == 'true' or '$(NeedNativePublishSupportForLLVM)' == 'true') and $(IlcCalledViaPackage) == 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
+    <Error Condition="'@(ResolvedILCompilerPack)' == '' and '$(NeedNativePublishSupportForLLVM)' != 'true'" Text="The ResolvedILCompilerPack ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
 
-    <PropertyGroup Condition="'$(NeedNativePublishSupportForSDK6)' != 'true'">
+    <PropertyGroup Condition="'$(NeedNativePublishSupportForLLVM)' != 'true'">
       <IlcHostPackagePath Condition="'@(ResolvedILCompilerPack)' == '$(IlcHostPackageName)'">@(ResolvedILCompilerPack->'%(PackageDirectory)')</IlcHostPackagePath>
       <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == '$(RuntimeIlcPackageName)'">@(ResolvedTargetILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
       <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == ''">@(ResolvedILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(NeedNativePublishSupportForSDK6)' == 'true'">
+    <ResolvePackageDependencies
+      ProjectPath="$(MSBuildProjectFullPath)"
+      ProjectAssetsFile="$(ProjectAssetsFile)"
+      ProjectLanguage="$(Language)"
+      TargetFramework="$(TargetFramework)"
+      ContinueOnError="ErrorAndContinue"
+      Condition="'$(NeedNativePublishSupportForLLVM)' == 'true'">
+
+      <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />
+      <Output TaskParameter="PackageDependencies" ItemName="PackageDependencies" />
+      <Output TaskParameter="TargetDefinitions" ItemName="TargetDefinitions" />
+      <Output TaskParameter="FileDefinitions" ItemName="FileDefinitions" />
+      <Output TaskParameter="FileDependencies" ItemName="FileDependencies" />
+    </ResolvePackageDependencies>
+
+    <PropertyGroup Condition="'$(NeedNativePublishSupportForLLVM)' == 'true'">
       <RuntimePackagePath Condition="'%(PackageDefinitions.Name)' == '$(RuntimeIlcPackageName)'">%(PackageDefinitions.ResolvedPath)</RuntimePackagePath>
       <IlcHostPackagePath Condition="'%(PackageDefinitions.Name)' == '$(IlcHostPackageName)'">%(PackageDefinitions.ResolvedPath)</IlcHostPackagePath>
     </PropertyGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -53,42 +53,24 @@
     </KnownILCompilerPack>
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetArchitecture)' == 'wasm'">
-    <NeedNativePublishSupportForLLVM>true</NeedNativePublishSupportForLLVM>
-  </PropertyGroup>
-
   <!-- Generate a warning if the non-SDK path is used  -->
-  <Target Name="GenerateILCompilerExplicitPackageReferenceWarning" Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true' and '$(ILCompilerTargetsPath)' != ''  and '$(NeedNativePublishSupportForLLVM)' != 'true'" 
+  <Target Name="GenerateILCompilerExplicitPackageReferenceWarning"
+      Condition="'$(SuppressGenerateILCompilerExplicitPackageReferenceWarning)' == '' and '$(AotRuntimePackageLoadedViaSDK)' != 'true' and '$(ILCompilerTargetsPath)' != '' and '$(TargetArchitecture)' != 'wasm'"
       BeforeTargets="ImportRuntimeIlcPackageTarget">
     <Warning Text="Delete explicit 'Microsoft.DotNet.ILCompiler' package reference in your project file. Explicit 'Microsoft.DotNet.ILCompiler' package reference can run into version errors." />
   </Target>
 
+  <!-- NativeAOT-LLVM: override ImportRuntimeIlcPackageTarget to not depend on the SDK-provided ResolvedILCompilerPack item -->
+  <PropertyGroup>
+    <!-- EmitLegacyAssetsFileItems tells the SDK to generate PackageDefinitions -->
+    <EmitLegacyAssetsFileItems>true</EmitLegacyAssetsFileItems>
+  </PropertyGroup>
+
   <!-- Locate the runtime package according to the current target runtime -->
-  <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' and ('$(PublishAot)' == 'true' or '$(NeedNativePublishSupportForLLVM)' == 'true') and $(IlcCalledViaPackage) == 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
-    <Error Condition="'@(ResolvedILCompilerPack)' == '' and '$(NeedNativePublishSupportForLLVM)' != 'true'" Text="The ResolvedILCompilerPack ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
+  <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
+    <Error Condition="'@(PackageDefinitions)' == ''" Text="The PackageDefinitions ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
 
-    <PropertyGroup Condition="'$(NeedNativePublishSupportForLLVM)' != 'true'">
-      <IlcHostPackagePath Condition="'@(ResolvedILCompilerPack)' == '$(IlcHostPackageName)'">@(ResolvedILCompilerPack->'%(PackageDirectory)')</IlcHostPackagePath>
-      <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == '$(RuntimeIlcPackageName)'">@(ResolvedTargetILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
-      <RuntimePackagePath Condition="'@(ResolvedTargetILCompilerPack)' == ''">@(ResolvedILCompilerPack->'%(PackageDirectory)')</RuntimePackagePath>
-    </PropertyGroup>
-
-    <ResolvePackageDependencies
-      ProjectPath="$(MSBuildProjectFullPath)"
-      ProjectAssetsFile="$(ProjectAssetsFile)"
-      ProjectLanguage="$(Language)"
-      TargetFramework="$(TargetFramework)"
-      ContinueOnError="ErrorAndContinue"
-      Condition="'$(NeedNativePublishSupportForLLVM)' == 'true'">
-
-      <Output TaskParameter="PackageDefinitions" ItemName="PackageDefinitions" />
-      <Output TaskParameter="PackageDependencies" ItemName="PackageDependencies" />
-      <Output TaskParameter="TargetDefinitions" ItemName="TargetDefinitions" />
-      <Output TaskParameter="FileDefinitions" ItemName="FileDefinitions" />
-      <Output TaskParameter="FileDependencies" ItemName="FileDependencies" />
-    </ResolvePackageDependencies>
-
-    <PropertyGroup Condition="'$(NeedNativePublishSupportForLLVM)' == 'true'">
+    <PropertyGroup>
       <RuntimePackagePath Condition="'%(PackageDefinitions.Name)' == '$(RuntimeIlcPackageName)'">%(PackageDefinitions.ResolvedPath)</RuntimePackagePath>
       <IlcHostPackagePath Condition="'%(PackageDefinitions.Name)' == '$(IlcHostPackageName)'">%(PackageDefinitions.ResolvedPath)</IlcHostPackagePath>
     </PropertyGroup>


### PR DESCRIPTION
This PR, adds back `SingleEntry.targets` to `src\coreclr\nativeaot\BuildIntegration\Microsoft.DotNet.ILCompiler.LLVM.targets` and basically copies part of what was `NeedNativePublishSupportForSDK6` to `NeedNativePublishSupportForLLVM`.  It also adds a call to `ResolvePackageDependencies` to get `PackageDefinitions` set.

Minor version update to the docs.

As I've replaced `NeedNativePublishSupportForSDK6` I'm basically saying we are not supporting .net SDK 6.

Hopefully this will fix `dotnet publish --self-contained -r browser-wasm`, it does so locally:
```
E:\tmp\consolelocal>dotnet publish --self-contained -r browser-wasm /p:MSBuildEnableWorkloadResolver=false /bl
MSBuild version 17.5.0+6f08c67f3 for .NET
  Determining projects to restore...
  Restored E:\tmp\consolelocal\console.csproj (in 2.87 sec).
  console -> E:\tmp\consolelocal\bin\Debug\net7.0\browser-wasm\console.dll
  Generating native code
  LLVM bitcode generation finished in 69.78 seconds
  console -> E:\tmp\consolelocal\bin\Debug\net7.0\browser-wasm\publish\

E:\tmp\consolelocal>e:\github\emsdk\node\14.18.2_64bit\bin\node --stack-trace-limit=100 bin\Debug\net7.0\browser-wasm\native\console.js
Hello, World!
True
```