### PR TITLE
NativeAOT-LLVM: Remove ILLink target

### DIFF
--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -19,13 +19,13 @@ from the project's root directory. New package sources must be added after the `
 
 Once you have added the package sources, add a reference to the ILCompiler package either by running
 ```bash
-> dotnet add package Microsoft.DotNet.ILCompiler -v 7.0.0-*
+> dotnet add package Microsoft.DotNet.ILCompiler -v 8.0.0-*
 ```
 
 or by adding the following element to the project file:
 ```xml
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="7.0.0-*" />
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="8.0.0-*" />
   </ItemGroup>
 ```
 
@@ -64,7 +64,17 @@ For WebAssembly, it is always a cross-architecture scenario as the compiler runs
 <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="8.0.0-*" />
 ```
 
-Then, the required package reference is
+Then, remove 
+```xml
+<NativeAot>true</NativeAot>
+```
+from any `PropertyGroup` tags if you have it. Instead, add
+```xml
+<PropertyGroup>
+  <PublishTrimmed>true</PublishTrimmed>
+</PropertyGroup>
+```
+The required package reference is
 ```xml
 <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM; runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-*" />
 ```

--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -66,7 +66,7 @@ For WebAssembly, it is always a cross-architecture scenario as the compiler runs
 
 Then, remove 
 ```xml
-<NativeAot>true</NativeAot>
+<PublishAot>true</PublishAot>
 ```
 from any `PropertyGroup` tags if you have it. Instead, add
 ```xml

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -93,7 +93,13 @@ With the above binaries built, the ILC can be run and debugged as normal. The ru
 Working on the Jit itself, one possible workflow is taking advantage of the generated VS project:
 - Open the Ilc solution and add the aforementioned Jit project, `clrjit_browser_wasm32_x64.vcxproj`. Then in the project properties, General section, change the output folder to the full path for `artifacts\bin\coreclr\windows.x64.Debug\ilc` e.g. `E:\GitHub\runtimelab\artifacts\bin\coreclr\windows.x64.Debug\ilc`. Build `clrjit_browser_wasm32_x64` project and you should now be able to change and put breakpoints in the C++ code.
 
-It is also possible to publish an ordinary console project for Wasm using packages produced by the build: `build nativeaot.packages && build nativeaot.packages -a wasm -os browser`, assuming all the binaries mentioned above have been built (note that the order is important - the build always produces an architecture-independent package that has a dependency on an architecture-dependent one, and we want that architecture-dependent package to be built for Wasm). Add the `path-to-repo/artifacts/packages/[Debug|Release]/Shipping` directory to your project's `NuGet.Config`, and the following two references to the project file itself:
+It is also possible to publish an ordinary console project for Wasm using packages produced by the build: `build nativeaot.packages && build nativeaot.packages -a wasm -os browser`, assuming all the binaries mentioned above have been built (note that the order is important - the build always produces an architecture-independent package that has a dependency on an architecture-dependent one, and we want that architecture-dependent package to be built for Wasm). Add the `path-to-repo/artifacts/packages/[Debug|Release]/Shipping` directory to your project's `NuGet.Config`, add the property
+```xml
+<PropertyGroup>
+  <PublishTrimmed>true</PublishTrimmed>
+</PropertyGroup>
+```
+and the following two references to the project file itself:
 ```xml
 <ItemGroup>
   <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-dev" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -118,7 +118,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <IlcCompileDependsOn Condition="'$(BuildingFrameworkLibrary)' != 'true'">Compile;ComputeIlcCompileInputs</IlcCompileDependsOn>
     <IlcCompileDependsOn Condition="'$(IlcMultiModule)' == 'true' and '$(BuildingFrameworkLibrary)' != 'true'">$(IlcCompileDependsOn);BuildFrameworkLib</IlcCompileDependsOn>
     <IlcCompileDependsOn>$(IlcCompileDependsOn);SetupOSSpecificProps</IlcCompileDependsOn>
-    <IlcCompileDependsOn Condition="'$(NativeCodeGen)' != 'llvm'">$(IlcCompileDependsOn);PrepareForILLink</IlcCompileDependsOn>
+    <IlcCompileDependsOn>$(IlcCompileDependsOn);PrepareForILLink</IlcCompileDependsOn>
   </PropertyGroup>
 
   <ItemGroup Condition="$(IlcSystemModule) == ''">

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -118,7 +118,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <IlcCompileDependsOn Condition="'$(BuildingFrameworkLibrary)' != 'true'">Compile;ComputeIlcCompileInputs</IlcCompileDependsOn>
     <IlcCompileDependsOn Condition="'$(IlcMultiModule)' == 'true' and '$(BuildingFrameworkLibrary)' != 'true'">$(IlcCompileDependsOn);BuildFrameworkLib</IlcCompileDependsOn>
     <IlcCompileDependsOn>$(IlcCompileDependsOn);SetupOSSpecificProps</IlcCompileDependsOn>
-    <IlcCompileDependsOn>$(IlcCompileDependsOn);PrepareForILLink</IlcCompileDependsOn>
+    <IlcCompileDependsOn Condition="'$(NativeCodeGen)' != 'llvm'">$(IlcCompileDependsOn);PrepareForILLink</IlcCompileDependsOn>
   </PropertyGroup>
 
   <ItemGroup Condition="$(IlcSystemModule) == ''">
@@ -199,11 +199,9 @@ The .NET Foundation licenses this file to you under the MIT license.
     <MSBuild Projects="@(ProjectToBuild)" BuildInParallel="true" />
   </Target>
 
-  <!-- NativeAOT-LLVM note: 'BeforeTargets="_RunILLink"' should be deleted once upstream uses .NET 7 SDK -->
   <Target Name="WriteIlcRspFileForCompilation"
       Inputs="@(IlcCompileInput);@(RdXmlFile);@(TrimmerRootDescriptor)"
       Outputs="%(ManagedBinary.IlcRspFile)"
-      BeforeTargets="_RunILLink"
       DependsOnTargets="$(IlcCompileDependsOn)">
 
     <ItemGroup>


### PR DESCRIPTION
This PR removes the `dependson` for `PrepareForILLink` and the `_RunILLink` .

I think this will fix: #2235

