### PR TITLE
NativeAOT-LLVM: Export NativeAOT_StaticInitialization implicitly

### DIFF
--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -99,6 +99,16 @@ public static int Answer()
 ```bash
 > dotnet publish /p:NativeLib=Static /p:SelfContained=true -r browser-wasm -c Debug /p:TargetArchitecture=wasm /p:PlatformTarget=AnyCPU /p:MSBuildEnableWorkloadResolver=false /p:EmccExtraArgs="-s EXPORTED_FUNCTIONS=_Answer -s EXPORTED_RUNTIME_METHODS=cwrap" --self-contained
 ```
+From Javascript, before calling your library the runtime must be initialised explicitly.  This is done with the following Javascript
+```js
+// Initialise the .Net runtime
+const corertInit = Module.cwrap('NativeAOT_StaticInitialization', 'number', []);
+corertInit();
+
+// Call your function
+const answer = Module.cwrap('Answer', 'number', []);
+console.log(answer());
+```
 
 #### WebAssembly module imports
 Functions in other WebAssembly modules can be imported and invoked using `DllImport` e.g.

--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -97,7 +97,7 @@ public static int Answer()
 }
 ```
 ```bash
-> dotnet publish /p:NativeLib=Static /p:SelfContained=true -r browser-wasm -c Debug /p:TargetArchitecture=wasm /p:PlatformTarget=AnyCPU /p:MSBuildEnableWorkloadResolver=false /p:EmccExtraArgs="-s EXPORTED_FUNCTIONS=_Answer -s EXPORTED_RUNTIME_METHODS=cwrap --post-js=invokeLibraryFunction.js" --self-contained
+> dotnet publish /p:NativeLib=Shared /p:SelfContained=true -r browser-wasm -c Debug /p:TargetArchitecture=wasm /p:PlatformTarget=AnyCPU /p:MSBuildEnableWorkloadResolver=false /p:EmccExtraArgs="-s EXPORTED_FUNCTIONS=_Answer -s EXPORTED_RUNTIME_METHODS=cwrap --post-js=invokeLibraryFunction.js" --self-contained
 ```
 Where `invokeLibraryFunction.js` is a Javascript file with the callback to call `Answer`, e.g.
 ```js

--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -97,7 +97,7 @@ public static int Answer()
 }
 ```
 ```bash
-> dotnet publish /p:NativeLib=Shared /p:SelfContained=true -r browser-wasm -c Debug /p:TargetArchitecture=wasm /p:PlatformTarget=AnyCPU /p:MSBuildEnableWorkloadResolver=false /p:EmccExtraArgs="-s EXPORTED_FUNCTIONS=_Answer -s EXPORTED_RUNTIME_METHODS=cwrap --post-js=invokeLibraryFunction.js" --self-contained
+> dotnet publish /p:NativeLib=Shared -r browser-wasm -c Debug /p:TargetArchitecture=wasm /p:PlatformTarget=AnyCPU /p:MSBuildEnableWorkloadResolver=false /p:EmccExtraArgs="-s EXPORTED_FUNCTIONS=_Answer -s EXPORTED_RUNTIME_METHODS=cwrap --post-js=invokeLibraryFunction.js" --self-contained
 ```
 Where `invokeLibraryFunction.js` is a Javascript file with the callback to call `Answer`, e.g.
 ```js

--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -97,17 +97,15 @@ public static int Answer()
 }
 ```
 ```bash
-> dotnet publish /p:NativeLib=Static /p:SelfContained=true -r browser-wasm -c Debug /p:TargetArchitecture=wasm /p:PlatformTarget=AnyCPU /p:MSBuildEnableWorkloadResolver=false /p:EmccExtraArgs="-s EXPORTED_FUNCTIONS=_Answer -s EXPORTED_RUNTIME_METHODS=cwrap" --self-contained
+> dotnet publish /p:NativeLib=Static /p:SelfContained=true -r browser-wasm -c Debug /p:TargetArchitecture=wasm /p:PlatformTarget=AnyCPU /p:MSBuildEnableWorkloadResolver=false /p:EmccExtraArgs="-s EXPORTED_FUNCTIONS=_Answer -s EXPORTED_RUNTIME_METHODS=cwrap --post-js=invokeLibraryFunction.js" --self-contained
 ```
-From Javascript, before calling your library the runtime must be initialised explicitly.  This is done with the following Javascript
+Where `invokeLibraryFunction.js` is a Javascript file with the callback to call `Answer`, e.g.
 ```js
-// Initialise the .Net runtime
-const corertInit = Module.cwrap('NativeAOT_StaticInitialization', 'number', []);
-corertInit();
-
-// Call your function
-const answer = Module.cwrap('Answer', 'number', []);
-console.log(answer());
+Module['onRuntimeInitialized'] = function() { 
+  // Call your function
+  const answer = Module.cwrap('Answer', 'number', []);
+  console.log(answer())
+};
 ```
 
 #### WebAssembly module imports

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -118,7 +118,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <IlcCompileDependsOn Condition="'$(BuildingFrameworkLibrary)' != 'true'">Compile;ComputeIlcCompileInputs</IlcCompileDependsOn>
     <IlcCompileDependsOn Condition="'$(IlcMultiModule)' == 'true' and '$(BuildingFrameworkLibrary)' != 'true'">$(IlcCompileDependsOn);BuildFrameworkLib</IlcCompileDependsOn>
     <IlcCompileDependsOn>$(IlcCompileDependsOn);SetupOSSpecificProps</IlcCompileDependsOn>
-    <IlcCompileDependsOn>$(IlcCompileDependsOn);PrepareForILLink</IlcCompileDependsOn>
+    <IlcCompileDependsOn Condition="'$(NativeCodeGen)' != 'llvm'">$(IlcCompileDependsOn);PrepareForILLink</IlcCompileDependsOn>
   </PropertyGroup>
 
   <ItemGroup Condition="$(IlcSystemModule) == ''">
@@ -437,7 +437,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' != 'true'" Include="-O2 -flto" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' == 'true'" Include="-g3" />
-      <CustomLinkerArg Condition="$(NativeLib) == 'Shared'" Include="-Wl,--export,NativeAOT_StaticInitialization" />
+      <CustomLinkerArg Condition="$(NativeLib) != ''" Include="-Wl,--export,NativeAOT_StaticInitialization" />
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -437,7 +437,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' != 'true'" Include="-O2 -flto" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' == 'true'" Include="-g3" />
-      <CustomLinkerArg Condition="$(NativeLib) != ''" Include="-Wl,--export,NativeAOT_StaticInitialization" />
+      <CustomLinkerArg Condition="$(NativeLib) == 'Shared'" Include="-Wl,--export,NativeAOT_StaticInitialization" />
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -118,7 +118,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <IlcCompileDependsOn Condition="'$(BuildingFrameworkLibrary)' != 'true'">Compile;ComputeIlcCompileInputs</IlcCompileDependsOn>
     <IlcCompileDependsOn Condition="'$(IlcMultiModule)' == 'true' and '$(BuildingFrameworkLibrary)' != 'true'">$(IlcCompileDependsOn);BuildFrameworkLib</IlcCompileDependsOn>
     <IlcCompileDependsOn>$(IlcCompileDependsOn);SetupOSSpecificProps</IlcCompileDependsOn>
-    <IlcCompileDependsOn Condition="'$(NativeCodeGen)' != 'llvm'">$(IlcCompileDependsOn);PrepareForILLink</IlcCompileDependsOn>
+    <IlcCompileDependsOn>$(IlcCompileDependsOn);PrepareForILLink</IlcCompileDependsOn>
   </PropertyGroup>
 
   <ItemGroup Condition="$(IlcSystemModule) == ''">


### PR DESCRIPTION
This PR changes the condition for exporting `NativeAOT_StaticInitialization` to include static libraries and adds a bit of documentation.

Closes: #2259