### PR TITLE
NativeAOT-LLVM: map Ilc opimisation settings to emcc

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -342,7 +342,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <CompileEmccArgs>-c</CompileEmccArgs>
       <CompileEmccArgs>$(CompileEmccArgs) -s DISABLE_EXCEPTION_CATCHING=0</CompileEmccArgs>
-      <CompileEmccArgs Condition="'$(NativeDebugSymbols)' != 'true'">$(CompileEmccArgs) -O2</CompileEmccArgs>
       <CompileEmccArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(CompileEmccArgs) -g3</CompileEmccArgs>
       <!-- TODO-LLVM: remove when we update to Emscripten with https://github.com/emscripten-core/emscripten/pull/18443 -->
       <CompileEmccArgs>$(CompileEmccArgs) -s USE_SDL=0 $(EmccOptimizationSetting)</CompileEmccArgs>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -326,6 +326,11 @@ The .NET Foundation licenses this file to you under the MIT license.
 
   </Target>
 
+  <PropertyGroup Condition="'$(NativeCodeGen)' == 'llvm'">
+    <EmccOptimizationSetting Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) != 'Size'">-O3</EmccOptimizationSetting>
+    <EmccOptimizationSetting Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Size'">-Oz</EmccOptimizationSetting>
+  </PropertyGroup>
+
   <Target Name="WasmObjects"
       Inputs="@(LlvmObjects)"
       Outputs="@(NativeObjects)"
@@ -340,7 +345,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CompileEmccArgs Condition="'$(NativeDebugSymbols)' != 'true'">$(CompileEmccArgs) -O2</CompileEmccArgs>
       <CompileEmccArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(CompileEmccArgs) -g3</CompileEmccArgs>
       <!-- TODO-LLVM: remove when we update to Emscripten with https://github.com/emscripten-core/emscripten/pull/18443 -->
-      <CompileEmccArgs>$(CompileEmccArgs) -s USE_SDL=0</CompileEmccArgs>
+      <CompileEmccArgs>$(CompileEmccArgs) -s USE_SDL=0 $(EmccOptimizationSetting)</CompileEmccArgs>
 
       <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.bat</ScriptExt>
       <EmccPath>&quot;$(EMSDK)/upstream/emscripten/emcc$(ScriptExt)&quot;</EmccPath>
@@ -435,8 +440,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-s ALLOW_MEMORY_GROWTH=1" />
       <CustomLinkerArg Include="-s DISABLE_EXCEPTION_CATCHING=0" />
       <CustomLinkerArg Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" />
-      <CustomLinkerArg Condition="'$(NativeDebugSymbols)' != 'true'" Include="-O2 -flto" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' == 'true'" Include="-g3" />
+      <CustomLinkerArg Condition="'$(Optimize)' == 'true'" Include="-flto" />
+      <CustomLinkerArg Condition="'$(EmccOptimizationSetting)' != ''" Include="$(EmccOptimizationSetting)" />
       <CustomLinkerArg Condition="$(NativeLib) == 'Shared'" Include="-Wl,--export,NativeAOT_StaticInitialization" />
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -3928,7 +3928,7 @@ internal unsafe static class Program
     {
         StartTest("Test StackTrace");
 #if DEBUG
-        EndTest(new StackTrace().ToString().Contains("TestStackTrace"));
+        EndTest(new StackTrace().ToString().Contains("TestStackTrace"), new StackTrace().ToString());
 #else
         EndTest(new StackTrace().ToString().Contains("wasm-function"));
 #endif


### PR DESCRIPTION
This PR maps `$(Optimize)` to `-O3` and when `$(IlcOptimizationPreference) == 'Size'` to `-Oz`  .  Emcc has no specific option for speed.  Applies to both compile and link step.

`-flto` is moved from a `NativeDebugSymbols` check to `Optimize`