### PR TITLE
NativeAOT-LLVM: Wasm separate DWARF debug to different file

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -100,6 +100,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <NativeObject>$(NativeIntermediateOutputPath)$(TargetName)$(NativeObjectExt)</NativeObject>
     <NativeBinary Condition="'$(NativeBinary)' == ''">$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)</NativeBinary>
+    <WasmBinary Condition="'$(_targetArchitecture)' == 'wasm'">$(NativeOutputPath)$(TargetName).wasm</WasmBinary>
     <IlcExportUnmanagedEntrypoints Condition="'$(IlcExportUnmanagedEntrypoints)' == '' and '$(NativeLib)' == 'Shared'">true</IlcExportUnmanagedEntrypoints>
     <ExportsFile Condition="$(ExportsFile) == '' and '$(BuildingFrameworkLibrary)' != 'true'">$(NativeIntermediateOutputPath)$(TargetName)$(ExportsFileExt)</ExportsFile>
 
@@ -390,9 +391,11 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup>
       <LlvmObjects Include="@(_IlcProducedFiles)" Condition="'%(Extension)' == '$(LlvmObjectExt)'">
         <NativeObject>%(RelativeDir)%(Filename)$(NativeObjectExt)</NativeObject>
+        <DwarfObject>&quot;%(RelativeDir)%(Filename).dwo&quot;</DwarfObject>
       </LlvmObjects>
       <NativeObjects Include="@(_IlcProducedFiles)" Condition="'%(Extension)' == '$(NativeObjectExt)'" />
       <NativeObjects Include="@(LlvmObjects->'%(NativeObject)')" />
+      <DwarfObjects Include="@(LlvmObjects->'%(DwarfObject)')" />
     </ItemGroup>
   </Target>
 
@@ -439,11 +442,20 @@ The .NET Foundation licenses this file to you under the MIT license.
       <WasmCompilerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)bin/clang++&quot;</WasmCompilerPath>
       <WasmLinkerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/emscripten/emcc$(EmccScriptExt)&quot;</WasmLinkerPath>
       <WasmLinkerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)emscripten/emcc$(EmccScriptExt)&quot;</WasmLinkerPath>
+      <WasmDwarfLinkerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/bin/llvm-dwp$(ExeExt)&quot;</WasmDwarfLinkerPath>
+      <WasmDwarfLinkerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)/bin/llvm-dwp$(ExeExt)&quot;</WasmDwarfLinkerPath>
     </PropertyGroup>
 
    <PropertyGroup Condition="'$(_targetOS)' == 'wasi'">
       <WasmCompilerPath>&quot;$(WASI_SDK_PATH)/bin/clang++&quot;</WasmCompilerPath>
+      <CompileWasmArgs Condition="'$(WasmSplitDwarf)' == 'true'">$(CompileWasmArgs) -gdwarf-5 -gseparate-dwarf -gpubnames</CompileWasmArgs>
       <WasmLinkerPath>&quot;$(WASI_SDK_PATH)/bin/clang&quot;</WasmLinkerPath>
+      <!--llvm-dwp is not currently part of the WASI SDK. -->
+      <WasmDwarfLInkerPath>&quot;$(EMSDK)/upstream/bin/llvm-dwp$(ExeExt)&quot;</WasmDwarfLInkerPath>
+  </PropertyGroup>
+
+    <PropertyGroup>
+	    <CompileWasmArgs Condition="'$(WasmSplitDwarf)' == 'true'">$(CompileWasmArgs) -gdwarf-5 -gsplit-dwarf -gpubnames</CompileWasmArgs>
     </PropertyGroup>
 
     <!-- Invoke the compilers in parallel. -->
@@ -617,6 +629,8 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)link.rsp" Lines="@(CustomLinkerArg)" Overwrite="true" Encoding="utf-8" />
     <Exec Command="$(WasmLinkerPath) @$(NativeIntermediateOutputPath)link.rsp $(EmccExtraArgs)" EnvironmentVariables="@(EmscriptenEnvVars)" />
+
+    <Exec Command="$(WasmDwarfLinkerPath) -o &quot;$(WasmBinary).dwp&quot; @(DwarfObjects, ' ')" Condition="'$(WasmSplitDwarf)' == 'true'"/>
   </Target>
 
   <Target Name="LinkNative"


### PR DESCRIPTION
This PR utilises `gseparate-dwarf` to move the DWARF metadata to a separate file to reduce the main wasm size.

Debugging still works

![image](https://user-images.githubusercontent.com/2720041/233752448-d958da44-0224-4c72-bcc6-cc61ce18195f.png)
