### PR TITLE
[NativeAOT-LLVM] Take advantage of the `clr.aot` subset

### DIFF
--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -70,7 +70,7 @@ For the runtime libraries:
   ./emsdk install 3.1.23
   ./emsdk activate 3.1.23
   ```
-- Run `build clr.nativeaotruntime+clr.nativeaotlibs+libs -c [Debug|Release] -a wasm -os browser`. This will create the architecture-dependent libraries needed for linking and runtime execution, as well as the managed binaries to be used as input to ILC.
+- Run `build clr.aot+libs -c [Debug|Release] -a wasm -os browser`. This will create the architecture-dependent libraries needed for linking and runtime execution, as well as the managed binaries to be used as input to ILC.
 
 For the compilers:
 - Download the LLVM 15.0.6 source from https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/llvm-15.0.6.src.tar.xz
@@ -85,7 +85,7 @@ For the compilers:
 - Configure the LLVM source to use the same runtime as the Jit: `cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Debug -D LLVM_USE_CRT_DEBUG=MTd -DLLVM_INCLUDE_BENCHMARKS=OFF -S f:\llvm-project\llvm-15.0.6.src -B f:\llvm-project\llvm-15.0.6.src\build` or if building for the Release configuration `cmake -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release -D LLVM_USE_CRT_RELEASE=MT -DLLVM_INCLUDE_BENCHMARKS=OFF -S f:\llvm-project\llvm-15.0.6.src -B f:\llvm-project\llvm-15.0.6.src\build`.
 - Build LLVM either from the command line (`cmake --build f:\llvm-project\llvm-15.0.6.src\build --target LLVMCore LLVMBitWriter`) or from VS 2022. Currently the Jit depends only on the output of LLVMCore and LLVMBitWriter projects.  For the Release configuration, `cmake --build f:\llvm-project\llvm-15.0.6.src\build --config Release --target LLVMCore LLVMBitWriter`
 - Set the enviroment variable `LLVM_CMAKE_CONFIG` to locate the LLVM config: `set LLVM_CMAKE_CONFIG=f:/llvm-project/llvm-15.0.6.src/build/lib/cmake/llvm`. This location should contain the file `LLVMConfig.cmake`. `LLVM_CMAKE_CONFIG_DEBUG` and `LLVM_CMAKE_CONFIG_RELEASE` can be used instead of `LLVM_CMAKE_CONFIG` to allow the build to select the config file based on the configuration. If set, these variables take precedence over `LLVM_CMAKE_CONFIG`.
-- Build the Jits and the ILC: `build clr.jit+clr.wasmjit+clr.nativeaotruntime+clr.nativeaotlibs+clr.tools -c [Debug|Release]`. Note that `clr.jit` only needs to be built once.  Add the `libs` subsets if you want the packages for publishing, e.g. `build clr.jit+clr.wasmjit+clr.nativeaotruntime+clr.nativeaotlibs+clr.tools+libs -c Debug`.
+- Build the Jits and the ILC: `build clr.wasmjit+clr.aot -c [Debug|Release]`. Add the `libs` subset if you want the packages for publishing, e.g. `build clr.wasmjit+clr.aot+libs -c Debug`.
 - You can use the `-msbuild` option, `build clr.wasmjit -msbuild`, to generate a Visual Studio solution for the Jit, to be found in `artifacts/obj/coreclr/windows.x64.Debug/ide/jit`.
 
 With the above binaries built, the ILC can be run and debugged as normal. The runtime tests can also be built, in bulk: `src/tests/build nativeaot debug wasm tree nativeaot`, or individually: `cd <test-directory> && dotnet build TestProjectName.csproj /t:BuildNativeAot /p:TestBuildMode=nativeaot /p:TargetArchitecture=wasm /p:TargetOS=browser`, and run as described in the sections below.

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -58,6 +58,7 @@
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
     <DefaultNativeAotSubsets>clr.alljits+clr.tools+clr.nativeaotlibs+clr.nativeaotruntime</DefaultNativeAotSubsets>
+    <DefaultNativeAotSubsets Condition="'$(TargetArchitecture)' == 'wasm'">clr.nativeaotlibs+clr.nativeaotruntime+nativeaot.build</DefaultNativeAotSubsets>
 
     <DefaultMonoSubsets Condition="'$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMDir)' == ''">mono.llvm+</DefaultMonoSubsets>
     <DefaultMonoSubsets Condition="'$(MonoAOTEnableLLVM)' == 'true' and '$(MonoLLVMDir)' == ''">mono.llvm+</DefaultMonoSubsets>
@@ -81,12 +82,10 @@
     <DefaultHostSubsets Condition="'$(RuntimeFlavor)' != '$(PrimaryRuntimeFlavor)'"></DefaultHostSubsets>
     <DefaultHostSubsets Condition="'$(RuntimeFlavor)' != '$(PrimaryRuntimeFlavor)' and '$(TargetsMobile)' != 'true'">host.native</DefaultHostSubsets>
 
-    <!-- Runtime packs fail to build in NativeAOT branch due to incompatible customizations under libraries. See https://github.com/dotnet/runtimelab/issues/106
     <DefaultPacksSubsets>packs.product</DefaultPacksSubsets>
     <DefaultPacksSubsets Condition="'$(BuildMonoAOTCrossCompilerOnly)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">$(DefaultPacksSubsets)+packs.tests</DefaultPacksSubsets>
     <DefaultPacksSubsets Condition="'$(DotNetBuildFromSource)' == 'true'">$(DefaultPacksSubsets)+packs.installers</DefaultPacksSubsets>
     <DefaultPacksSubsets Condition="'$(RuntimeFlavor)' != 'Mono' and '$(ForceBuildMobileManifests)' == 'true'">$(DefaultPacksSubsets)+mono.manifests</DefaultPacksSubsets>
-    -->
   </PropertyGroup>
 
   <PropertyGroup>
@@ -117,6 +116,7 @@
   <ItemGroup>
     <!-- CoreClr Native AOT -->
     <SubsetName Include="NativeAot.Packages" Description="The CoreCLR native AOT compiler." />
+    <SubsetName Include="NativeAot.Build" Description="The CoreCLR native AOT build integration." />
 
     <!-- CoreClr -->
     <SubsetName Include="Clr" Description="The full CoreCLR runtime. Equivalent to: $(DefaultCoreClrSubsets)" />
@@ -391,8 +391,7 @@
     <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\**\src\*.csproj" Category="clr" />
   </ItemGroup>
 
-  <!-- TODO-LLVM: Keeps the command line shorter, but delete when we merge clr.aot -->
-  <ItemGroup Condition="$(_subset.Contains('+clr.nativeaotruntime+'))">
+  <ItemGroup Condition="$(_subset.Contains('+nativeaot.build+'))">
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.Build.Tasks\ILCompiler.Build.Tasks.csproj" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\BuildIntegration\BuildIntegration.proj" Category="clr" />
   </ItemGroup>

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -58,7 +58,7 @@ extends:
     - stage: Build
       jobs:
       #
-      # Build with Release config and Debug runtimeConfiguration - Wasm
+      # Build with Release libraries and Debug runtime
       #
       - ${{ if ne(variables.isOfficialBuild, true) }}:
         - template: /eng/pipelines/common/platform-matrix.yml
@@ -66,52 +66,20 @@ extends:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
             buildConfig: Debug
             platforms:
+          # - Linux_x64
+            - windows_x64
+            - OSX_x64
             - Browser_wasm_win
             jobParameters:
               timeoutInMinutes: 300
               testGroup: innerloop
-              buildArgs: -s clr.nativeaotruntime+clr.nativeaotlibs+libs -lc Release -rc Debug
-              extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
-      #
-      # Build with Release config and Debug runtimeConfiguration - the default subsets - not for Wasm
-      #
-      - ${{ if ne(variables.isOfficialBuild, true) }}:
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/common/global-build-job.yml
-            buildConfig: Debug
-            platforms:
-            #- Linux_x64
-            - windows_x64
-            - OSX_x64
-            jobParameters:
-              timeoutInMinutes: 300
-              testGroup: innerloop
-              buildArgs: -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+nativeaot.packages -lc Release -rc Debug
+              buildArgs: -s clr.aot+libs+nativeaot.packages -lc Release -rc Debug
               extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
               extraStepsParameters:
                 librariesConfiguration: Release
 
       #
-      # Build with Release config and Release runtimeConfiguration (used for official builds) - Wasm
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: Release
-          platforms:
-          - Browser_wasm_win
-          jobParameters:
-            timeoutInMinutes: 300
-            isOfficialBuild: ${{ variables.isOfficialBuild }}
-            testGroup: innerloop
-            buildArgs: -s clr.nativeaotruntime+clr.nativeaotlibs+libs+nativeaot.packages -c Release
-            extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
-            extraStepsParameters:
-              isOfficialBuild: ${{ variables.isOfficialBuild }}
-
-      #
-      # Build with Debug config and Checked runtimeConfiguration
+      # Build with Debug libraries and Checked runtime
       #
       - ${{ if ne(variables.isOfficialBuild, true) }}:
         - template: /eng/pipelines/common/platform-matrix.yml
@@ -119,7 +87,7 @@ extends:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
             buildConfig: Checked
             platforms:
-            #- linux_x64
+          # - linux_x64
             - windows_x64
             jobParameters:
               timeoutInMinutes: 100
@@ -131,7 +99,7 @@ extends:
                 librariesConfiguration: Debug
 
       #
-      # Build with Release config and Release runtimeConfiguration (used for official builds) - the default subsets - not for Wasm
+      # Build with Release libraries and Release runtime (used for official builds) - Wasm
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -145,15 +113,17 @@ extends:
     #     - linux_musl_arm64 # ILCompiler for LLVM depends on libLLVM.runtime.linux-arm64 with version (>= 11.0.0) which is missing https://github.com/microsoft/LLVMSharp/issues/177. TODO: reinstate when we remove LLVMSharp dependency
     #     - windows_x64      # Part of the combined (target + host) WASM build below
           - windows_arm64
-    #     - OSX_x64          # Reinstate when upstream OSX build is merged in https://github.com/dotnet/runtime/pull/75421
+          - OSX_x64
+          - Browser_wasm_win
           jobParameters:
             timeoutInMinutes: 300
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             testGroup: innerloop
-            buildArgs: -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+nativeaot.packages -c Release
+            buildArgs: -s clr.aot+libs+nativeaot.packages -c Release
             extraStepsTemplate: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
             extraStepsParameters:
               isOfficialBuild: ${{ variables.isOfficialBuild }}
+              librariesConfiguration: Release
 
     - ${{ if eq(variables.isOfficialBuild, true) }}:
       - template: /eng/pipelines/official/stages/publish.yml

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -19,7 +19,7 @@ steps:
   # Now we need to build the cross-targeting compilers, RyuJit and ILC. Likewise with packages.
 
   - ${{ if eq(parameters.archType, 'wasm') }}:
-    - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.alljits+clr.wasmjit+clr.nativeaotruntime+clr.nativeaotlibs+clr.tools -c $(buildConfigUpper) $(_officialBuildParameter) -ci
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.wasmjit+clr.aot -c $(buildConfigUpper) $(_officialBuildParameter) -ci
       displayName: Build the ILC and RyuJit cross-compilers
 
     - ${{ if eq(parameters.isOfficialBuild, true) }}:


### PR DESCRIPTION
Reduce command line length and simplify CI.