### PR TITLE
 [NativeAOT-LLVM] Enable static access expansion

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5081,10 +5081,8 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Expand runtime lookups (an optimization but we'd better run it in tier0 too)
     DoPhase(this, PHASE_EXPAND_RTLOOKUPS, &Compiler::fgExpandRuntimeLookups);
 
-#ifndef TARGET_WASM
     // Partially inline static initializations
     DoPhase(this, PHASE_EXPAND_STATIC_INIT, &Compiler::fgExpandStaticInit);
-#endif // !TARGET_WASM
 
     if (TargetOS::IsWindows)
     {


### PR DESCRIPTION
Looks like it actually works fine...?

Closes #2257.