### PR TITLE
[NativeAOT-LLVM] Prepare the compiler for multithreaded execution

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -8,14 +8,6 @@
 #include "llvm/Bitcode/BitcodeWriter.h"
 #pragma warning (error: 4459)
 
-LLVMContext _llvmContext;
-Module* _module = nullptr;
-
-std::unordered_map<CORINFO_CLASS_HANDLE, Type*>* _llvmStructs = new std::unordered_map<CORINFO_CLASS_HANDLE, Type*>();
-std::unordered_map<CORINFO_CLASS_HANDLE, StructDesc*>* _structDescMap = new std::unordered_map<CORINFO_CLASS_HANDLE, StructDesc*>();
-JitHashTable<CORINFO_LLVM_DEBUG_TYPE_HANDLE, JitSmallPrimitiveKeyFuncs<CORINFO_LLVM_DEBUG_TYPE_HANDLE>, llvm::DIType*, MallocAllocator> s_debugTypesMap({});
-JitHashTable<llvm::DIFile*, JitPtrKeyFuncs<llvm::DIFile>, llvm::DICompileUnit*, MallocAllocator> s_debugCompileUnitsMap({});
-
 // Must be kept in sync with the managed version in "CorInfoImpl.Llvm.cs".
 //
 enum class EEApiId
@@ -34,13 +26,14 @@ enum class EEApiId
     GetDebugTypeForType,
     GetDebugInfoForDebugType,
     GetDebugInfoForCurrentMethod,
+    GetSingleThreadedCompilationContext,
     Count
 };
 
 enum class JitApiId
 {
-    StartThreadContextBoundCompilation,
-    FinishThreadContextBoundCompilation,
+    StartSingleThreadedCompilation,
+    FinishSingleThreadedCompilation,
     Count
 };
 
@@ -100,10 +93,11 @@ var_types Compiler::GetHfaType(CORINFO_CLASS_HANDLE hClass) { return TYP_UNDEF; 
 unsigned Compiler::GetHfaCount(CORINFO_CLASS_HANDLE hClass) { return 0; }
 
 Llvm::Llvm(Compiler* compiler)
-    : _compiler(compiler)
+    : m_pEECorInfo(*((void**)compiler->info.compCompHnd + 1)) // TODO-LLVM: hack. CorInfoImpl* is the first field of JitInterfaceWrapper.
+    , m_context(GetSingleThreadedCompilationContext())
+    , _compiler(compiler)
     , m_info(&compiler->info)
-    , m_pEECorInfo(*((void**)compiler->info.compCompHnd + 1)) // TODO-LLVM: hack. CorInfoImpl* is the first field of JitInterfaceWrapper.
-    , _builder(_llvmContext)
+    , _builder(m_context->Context)
     , _blkToLlvmBlksMap(compiler->getAllocator(CMK_Codegen))
     , _sdsuMap(compiler->getAllocator(CMK_Codegen))
     , _localsMap(compiler->getAllocator(CMK_Codegen))
@@ -859,9 +853,9 @@ uint32_t Llvm::PadOffset(CORINFO_CLASS_HANDLE typeHandle, unsigned atOffset)
     return CallEEApi<EEApiId::PadOffset, uint32_t>(m_pEECorInfo, typeHandle, atOffset);
 }
 
-TypeDescriptor Llvm::GetTypeDescriptor(CORINFO_CLASS_HANDLE typeHandle)
+void Llvm::GetTypeDescriptor(CORINFO_CLASS_HANDLE typeHandle, TypeDescriptor* pTypeDescriptor)
 {
-    return CallEEApi<EEApiId::GetTypeDescriptor, TypeDescriptor>(m_pEECorInfo, typeHandle);
+    CallEEApi<EEApiId::GetTypeDescriptor, void>(m_pEECorInfo, typeHandle, pTypeDescriptor);
 }
 
 const char* Llvm::GetAlternativeFunctionName()
@@ -896,50 +890,54 @@ void Llvm::GetDebugInfoForCurrentMethod(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)
     CallEEApi<EEApiId::GetDebugInfoForCurrentMethod, void>(m_pEECorInfo, pInfo);
 }
 
+SingleThreadedCompilationContext* Llvm::GetSingleThreadedCompilationContext()
+{
+    return CallEEApi<EEApiId::GetSingleThreadedCompilationContext, SingleThreadedCompilationContext*>(m_pEECorInfo);
+}
+
 extern "C" DLLEXPORT void registerLlvmCallbacks(void** jitImports, void** jitExports)
 {
     assert((jitImports != nullptr) && (jitImports[static_cast<int>(EEApiId::Count)] == (void*)0x1234));
     assert(jitExports != nullptr);
 
     memcpy(g_callbacks, jitImports, static_cast<int>(EEApiId::Count) * sizeof(void*));
-    jitExports[static_cast<int>(JitApiId::StartThreadContextBoundCompilation)] = &Llvm::StartThreadContextBoundCompilation;
-    jitExports[static_cast<int>(JitApiId::FinishThreadContextBoundCompilation)] = &Llvm::FinishThreadContextBoundCompilation;
+    jitExports[static_cast<int>(JitApiId::StartSingleThreadedCompilation)] = &Llvm::StartSingleThreadedCompilation;
+    jitExports[static_cast<int>(JitApiId::FinishSingleThreadedCompilation)] = &Llvm::FinishSingleThreadedCompilation;
     jitExports[static_cast<int>(JitApiId::Count)] = (void*)0x1234;
 }
 
-/* static */ void Llvm::StartThreadContextBoundCompilation(const char* path, const char* triple, const char* dataLayout)
+/* static */ SingleThreadedCompilationContext* Llvm::StartSingleThreadedCompilation(
+    const char* path, const char* triple, const char* dataLayout)
 {
-    _module = new Module(path, _llvmContext);
-    _module->setTargetTriple(triple);
-    _module->setDataLayout(dataLayout);
+    SingleThreadedCompilationContext* context = new SingleThreadedCompilationContext(path);
+    context->Module.setTargetTriple(triple);
+    context->Module.setDataLayout(dataLayout);
+
+    return context;
 }
 
-/* static */ void Llvm::FinishThreadContextBoundCompilation()
+/* static */ void Llvm::FinishSingleThreadedCompilation(SingleThreadedCompilationContext* context)
 {
-    assert(_module != nullptr);
-    if (s_debugCompileUnitsMap.GetCount() != 0)
+    assert(context != nullptr);
+
+    Module& module = context->Module;
+    if (context->DebugCompileUnitsMap.GetCount() != 0)
     {
-        _module->addModuleFlag(llvm::Module::Warning, "Dwarf Version", 4);
-        _module->addModuleFlag(llvm::Module::Warning, "Debug Info Version", 3);
+        module.addModuleFlag(llvm::Module::Warning, "Dwarf Version", 4);
+        module.addModuleFlag(llvm::Module::Warning, "Debug Info Version", 3);
     }
 
     std::error_code code;
 
     // TODO-LLVM: put under #ifdef DEBUG. Useful for debugging for now.
-    StringRef outputFilePath = _module->getName();
+    StringRef outputFilePath = module.getName();
     StringRef outputFilePathWithoutExtension = outputFilePath.take_front(outputFilePath.find_last_of('.'));
     llvm::raw_fd_ostream textOutputStream(Twine(outputFilePathWithoutExtension + ".txt").str(), code);
-    _module->print(textOutputStream, nullptr);
+    module.print(textOutputStream, nullptr);
 
-    assert(!llvm::verifyModule(*_module, &llvm::errs()));
+    assert(!llvm::verifyModule(module, &llvm::errs()));
     llvm::raw_fd_ostream bitCodeFileStream(outputFilePath, code);
-    llvm::WriteBitcodeToFile(*_module, bitCodeFileStream);
+    llvm::WriteBitcodeToFile(module, bitCodeFileStream);
 
-    delete _module;
-
-    // The struct descriptor map is notionally a global resource. We should investigate removing it.
-    for (const auto &structDesc : *_structDescMap)
-    {
-        delete structDesc.second;
-    }
+    delete context;
 }

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -76,7 +76,7 @@ bool Llvm::initializeFunctions()
     // TODO-LLVM: investigate.
     if (!strcmp(mangledName, "S_P_CoreLib_System_Globalization_CalendarData__EnumCalendarInfo"))
     {
-        llvm::BasicBlock* llvmBlock = llvm::BasicBlock::Create(_llvmContext, "", rootLlvmFunction);
+        llvm::BasicBlock* llvmBlock = llvm::BasicBlock::Create(m_context->Context, "", rootLlvmFunction);
         _builder.SetInsertPoint(llvmBlock);
         _builder.CreateRet(_builder.getInt8(0));
         return true;
@@ -101,7 +101,7 @@ bool Llvm::initializeFunctions()
         {
             // Filter and catch handler funclets return int32. "HasCatchHandler" handles both cases.
             Type* retLlvmType =
-                ehDsc->HasCatchHandler() ? Type::getInt32Ty(_llvmContext) : Type::getVoidTy(_llvmContext);
+                ehDsc->HasCatchHandler() ? Type::getInt32Ty(m_context->Context) : Type::getVoidTy(m_context->Context);
 
             // All funclets have two arguments: original and actual shadow stacks.
             Type* ptrLlvmType = getPtrLlvmType();
@@ -130,7 +130,7 @@ bool Llvm::initializeFunctions()
 
             Function* llvmFunc =
                 Function::Create(llvmFuncType, Function::InternalLinkage,
-                                 mangledName + Twine("$F") + Twine(funcIdx) + "_" + kindName, _module);
+                                 mangledName + Twine("$F") + Twine(funcIdx) + "_" + kindName, &m_context->Module);
 
             m_functions[funcIdx] = {llvmFunc};
         }
@@ -157,7 +157,7 @@ bool Llvm::initializeFunctions()
                 unsigned enclosingFuncIdx = getLlvmFunctionIndexForProtectedRegion(ehIndex);
                 Function* dispatchLlvmFunc = getLlvmFunctionForIndex(enclosingFuncIdx);
                 dispatchLlvmBlock =
-                    llvm::BasicBlock::Create(_llvmContext, BBNAME("BT", ehDsc->ebdTryBeg->getTryIndex()),
+                    llvm::BasicBlock::Create(m_context->Context, BBNAME("BT", ehDsc->ebdTryBeg->getTryIndex()),
                                              dispatchLlvmFunc);
             }
 
@@ -397,18 +397,18 @@ void Llvm::generateEHDispatch()
 
     // Recover the C++ personality function.
     Type* ptrLlvmType = getPtrLlvmType();
-    Type* int32LlvmType = Type::getInt32Ty(_llvmContext);
+    Type* int32LlvmType = Type::getInt32Ty(m_context->Context);
     Type* cppExcTupleLlvmType = llvm::StructType::get(ptrLlvmType, int32LlvmType);
     llvm::StructType* dispatchDataLlvmType = llvm::StructType::get(cppExcTupleLlvmType, ptrLlvmType);
 
     static const char* const GXX_PERSONALITY_NAME = "__gxx_personality_v0";
-    Function* gxxPersonalityLlvmFunc = _module->getFunction(GXX_PERSONALITY_NAME);
+    Function* gxxPersonalityLlvmFunc = m_context->Module.getFunction(GXX_PERSONALITY_NAME);
     if (gxxPersonalityLlvmFunc == nullptr)
     {
         FunctionType* gxxPersonalityLlvmFuncType =
             FunctionType::get(cppExcTupleLlvmType, {int32LlvmType, ptrLlvmType, ptrLlvmType}, /* isVarArg */ true);
-        gxxPersonalityLlvmFunc =
-            Function::Create(gxxPersonalityLlvmFuncType, Function::ExternalLinkage, GXX_PERSONALITY_NAME, _module);
+        gxxPersonalityLlvmFunc = Function::Create(gxxPersonalityLlvmFuncType, Function::ExternalLinkage,
+                                                  GXX_PERSONALITY_NAME, m_context->Module);
     }
 
     BitVecTraits blockVecTraits(_compiler->fgBBNumMax + 1, _compiler);
@@ -539,7 +539,7 @@ void Llvm::generateEHDispatch()
 
         // The dispatchers rely on this being set to null to detect whether the ongoing dispatch is already "active".
         unsigned dispatcherDataFieldOffset =
-            _module->getDataLayout().getStructLayout(dispatchDataLlvmType)->getElementOffset(1);
+            m_context->Module.getDataLayout().getStructLayout(dispatchDataLlvmType)->getElementOffset(1);
         Value* dispatchDataFieldRefValue = gepOrAddr(dispatchDataRefValue, dispatcherDataFieldOffset);
         _builder.CreateStore(llvm::Constant::getNullValue(ptrLlvmType), dispatchDataFieldRefValue);
 
@@ -601,7 +601,7 @@ void Llvm::generateEHDispatch()
         llvm::BasicBlock* resumeLlvmBlock = funcDispatchData.ResumeLlvmBlock;
         if (resumeLlvmBlock == nullptr)
         {
-            resumeLlvmBlock = llvm::BasicBlock::Create(_llvmContext, "BBDR", llvmFunc);
+            resumeLlvmBlock = llvm::BasicBlock::Create(m_context->Context, "BBDR", llvmFunc);
 
             _builder.SetInsertPoint(resumeLlvmBlock); // No need for a full emit context.
             Value* resumeOperandValue = _builder.CreateLoad(landingPadInst->getType(), dispatchDataRefValue);
@@ -615,8 +615,8 @@ void Llvm::generateEHDispatch()
         llvm::BasicBlock* dispatchSwitchLlvmBlock = funcDispatchData.GetDispatchSwitchLlvmBlock();
         if (ehDsc->HasCatchHandler() && (dispatchSwitchLlvmBlock == nullptr))
         {
-            dispatchSwitchLlvmBlock = llvm::BasicBlock::Create(_llvmContext, "BBDS", llvmFunc, resumeLlvmBlock);
-            llvm::BasicBlock* failFastLlvmBlock = llvm::BasicBlock::Create(_llvmContext, "BBFF", llvmFunc);
+            dispatchSwitchLlvmBlock = llvm::BasicBlock::Create(m_context->Context, "BBDS", llvmFunc, resumeLlvmBlock);
+            llvm::BasicBlock* failFastLlvmBlock = llvm::BasicBlock::Create(m_context->Context, "BBFF", llvmFunc);
 
             LlvmBlockRange dispatchSwitchLlvmBlocks(dispatchSwitchLlvmBlock);
             setCurrentEmitContext(funcIdx, EHblkDsc::NO_ENCLOSING_INDEX, &dispatchSwitchLlvmBlocks);
@@ -732,7 +732,7 @@ void Llvm::generateEHDispatch()
                                 if (predBlock->bbJumpKind == BBJ_EHCATCHRET)
                                 {
                                     llvm::BasicBlock* catchRetLlvmBlock = getLastLlvmBlockForBlock(predBlock);
-                                    llvm::ReturnInst::Create(_llvmContext, destIndexValue, catchRetLlvmBlock);
+                                    llvm::ReturnInst::Create(m_context->Context, destIndexValue, catchRetLlvmBlock);
                                 }
                             }
 
@@ -767,7 +767,7 @@ Value* Llvm::generateEHDispatchTable(Function* llvmFunc, unsigned innerEHIndex, 
     const int LARGE_SECTION_CLAUSE_COUNT = TARGET_POINTER_SIZE * BITS_PER_BYTE;
     const int FIRST_SECTION_CLAUSE_COUNT = LARGE_SECTION_CLAUSE_COUNT / 2;
 
-    Type* firstClauseMaskType = Type::getIntNTy(_llvmContext, FIRST_SECTION_CLAUSE_COUNT);
+    Type* firstClauseMaskType = Type::getIntNTy(m_context->Context, FIRST_SECTION_CLAUSE_COUNT);
     Type* largeClauseMaskType = getIntPtrLlvmType();
 
     unsigned clauseCount = outerEHIndex - innerEHIndex + 1;
@@ -827,12 +827,12 @@ Value* Llvm::generateEHDispatchTable(Function* llvmFunc, unsigned innerEHIndex, 
     {
         llvmTypeBuilder.Push(data.Bottom(i)->getType());
     }
-    llvm::StructType* tableLlvmType = llvm::StructType::get(_llvmContext, {&llvmTypeBuilder.BottomRef(0),
+    llvm::StructType* tableLlvmType = llvm::StructType::get(m_context->Context, {&llvmTypeBuilder.BottomRef(0),
                                                             static_cast<size_t>(llvmTypeBuilder.Height())});
     llvm::Constant* tableValue = llvm::ConstantStruct::get(tableLlvmType, {&data.BottomRef(0),
                                                            static_cast<size_t>(data.Height())});
 
-    llvm::GlobalVariable* tableRef = new llvm::GlobalVariable(*_module, tableLlvmType, /* isConstant */ true,
+    llvm::GlobalVariable* tableRef = new llvm::GlobalVariable(m_context->Module, tableLlvmType, /* isConstant */ true,
                                                              llvm::GlobalVariable::InternalLinkage, tableValue,
                                                              llvmFunc->getName() + "__EHTable");
     tableRef->setAlignment(llvm::MaybeAlign(TARGET_POINTER_SIZE));
@@ -1013,7 +1013,7 @@ Value* Llvm::consumeValue(GenTree* node, Type* targetLlvmType)
                 case GT_GE:
                 case GT_GT:
                     // This is the special case for relops. Ordinary codegen "just knows" they need zero-extension.
-                    assert(nodeValue->getType() == Type::getInt1Ty(_llvmContext));
+                    assert(nodeValue->getType() == Type::getInt1Ty(m_context->Context));
                     trueNodeType = TYP_UBYTE;
                     break;
 
@@ -1254,7 +1254,7 @@ void Llvm::buildLocalVar(GenTreeLclVar* lclVar)
     // Implicit truncating from long to int.
     if ((varDsc->TypeGet() == TYP_LONG) && lclVar->TypeIs(TYP_INT))
     {
-        llvmRef = _builder.CreateTrunc(llvmRef, Type::getInt32Ty(_llvmContext));
+        llvmRef = _builder.CreateTrunc(llvmRef, Type::getInt32Ty(m_context->Context));
     }
 
     mapGenTreeToValue(lclVar, llvmRef);
@@ -1332,7 +1332,7 @@ void Llvm::buildStoreLocalField(GenTreeLclFld* lclFld)
         if (!data->IsIntegralConst(0))
         {
             assert(data->OperIsInitVal());
-            Value* fillValue = consumeValue(data->gtGetOp1(), Type::getInt8Ty(_llvmContext));
+            Value* fillValue = consumeValue(data->gtGetOp1(), Type::getInt8Ty(m_context->Context));
             Value* sizeValue = _builder.getInt32(layout->GetSize());
             _builder.CreateMemSet(addrValue, fillValue, sizeValue, llvm::MaybeAlign());
             return;
@@ -1368,7 +1368,7 @@ void Llvm::buildAdd(GenTreeOp* node)
         Value* offsetValue = consumeValue(op1RawType->isPointerTy() ? op2 : op1, getIntPtrLlvmType());
 
         // GEPs scale indices, use type i8 makes them equivalent to the raw offsets we have in IR
-        addValue = _builder.CreateGEP(Type::getInt8Ty(_llvmContext), baseValue, offsetValue);
+        addValue = _builder.CreateGEP(Type::getInt8Ty(m_context->Context), baseValue, offsetValue);
     }
     else
     {
@@ -1413,7 +1413,7 @@ void Llvm::buildSub(GenTreeOp* node)
         Value* addOffsetValue = _builder.CreateNeg(subOffsetValue);
 
         // GEPs scale indices, use type i8 makes them equivalent to the raw offsets we have in IR
-        subValue = _builder.CreateGEP(Type::getInt8Ty(_llvmContext), baseValue, addOffsetValue);
+        subValue = _builder.CreateGEP(Type::getInt8Ty(m_context->Context), baseValue, addOffsetValue);
     }
     else
     {
@@ -1510,7 +1510,7 @@ void Llvm::buildRotate(GenTreeOp* node)
 
     Type* rotateLlvmType = getLlvmTypeForVarType(node->TypeGet());
     Value* srcValue = consumeValue(node->gtGetOp1(), rotateLlvmType);
-    Value* indexValue = consumeValue(node->gtGetOp2(), Type::getInt32Ty(_llvmContext));
+    Value* indexValue = consumeValue(node->gtGetOp2(), Type::getInt32Ty(m_context->Context));
     if (indexValue->getType() != rotateLlvmType)
     {
         // The intrinsics require all operands have the same type.
@@ -1730,7 +1730,7 @@ void Llvm::buildLclHeap(GenTreeUnOp* lclHeap)
     }
     else
     {
-        llvm::AllocaInst* allocaInst = _builder.CreateAlloca(Type::getInt8Ty(_llvmContext), sizeValue);
+        llvm::AllocaInst* allocaInst = _builder.CreateAlloca(Type::getInt8Ty(m_context->Context), sizeValue);
 
         // LCLHEAP (aka IL's "localloc") is specified to return a pointer "...aligned so that any built-in data type
         // can be stored there using the stind instructions", so we'll be a bit conservative and align it maximally.
@@ -1936,8 +1936,9 @@ void Llvm::buildStoreBlk(GenTreeBlk* blockOp)
     // Check for the "initblk" operation ("dataNode" is either INIT_VAL or constant zero).
     if (blockOp->OperIsInitBlkOp())
     {
-        Value* fillValue = dataNode->OperIsInitVal() ? consumeValue(dataNode->gtGetOp1(), Type::getInt8Ty(_llvmContext))
-                                                     : _builder.getInt8(0);
+        Value* fillValue = dataNode->OperIsInitVal()
+            ? consumeValue(dataNode->gtGetOp1(), Type::getInt8Ty(m_context->Context))
+            : _builder.getInt8(0);
         _builder.CreateMemSet(addrValue, fillValue, _builder.getInt32(layout->GetSize()), llvm::Align());
         return;
     }
@@ -1967,12 +1968,13 @@ void Llvm::buildStoreDynBlk(GenTreeStoreDynBlk* blockOp)
     }
     else
     {
-        srcValue = srcNode->OperIsInitVal() ? consumeValue(srcNode->AsUnOp()->gtGetOp1(), Type::getInt8Ty(_llvmContext))
-                                            : _builder.getInt8(0);
+        srcValue = srcNode->OperIsInitVal()
+            ? consumeValue(srcNode->AsUnOp()->gtGetOp1(), Type::getInt8Ty(m_context->Context))
+            : _builder.getInt8(0);
     }
     // Per ECMA 335, cpblk/initblk only allow int32-sized operands. We'll be a bit more permissive and allow native ints
     // as well (as do other backends).
-    Type* sizeLlvmType = genActualTypeIsInt(sizeNode) ? Type::getInt32Ty(_llvmContext) : getIntPtrLlvmType();
+    Type* sizeLlvmType = genActualTypeIsInt(sizeNode) ? Type::getInt32Ty(m_context->Context) : getIntPtrLlvmType();
     Value* sizeValue = consumeValue(sizeNode, sizeLlvmType);
 
     // STORE_DYN_BLK's contract is that it must not throw any exceptions in case the dynamic size is zero and must throw
@@ -2190,6 +2192,7 @@ void Llvm::buildReturn(GenTree* node)
 
     GenTree* retValNode = node->gtGetOp1();
     Type* retLlvmType = getCurrentLlvmFunction()->getFunctionType()->getReturnType();
+
     Value* retValValue;
     // Special-case returning zero-initialized structs.
     if (node->TypeIs(TYP_STRUCT) && retValNode->IsIntegralConst(0))
@@ -2207,7 +2210,7 @@ void Llvm::buildReturn(GenTree* node)
 void Llvm::buildJTrue(GenTree* node)
 {
     Value* condValue = getGenTreeValue(node->gtGetOp1());
-    assert(condValue->getType() == Type::getInt1Ty(_llvmContext)); // We only expect relops to appear as JTRUE operands.
+    assert(condValue->getType() == Type::getInt1Ty(m_context->Context)); // Only relops expected.
 
     BasicBlock* srcBlock = CurrentBlock();
     llvm::BasicBlock* jmpLlvmBlock = getFirstLlvmBlockForBlock(srcBlock->bbJumpDest);
@@ -2363,7 +2366,7 @@ void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* struct
         Value* fieldData = nullptr;
         if (data->getType()->isStructTy())
         {
-            const llvm::StructLayout* structLayout = _module->getDataLayout().getStructLayout(static_cast<llvm::StructType*>(data->getType()));
+            const llvm::StructLayout* structLayout = m_context->Module.getDataLayout().getStructLayout(static_cast<llvm::StructType*>(data->getType()));
 
             unsigned llvmFieldIndex = structLayout->getElementContainingOffset(fieldOffset);
             fieldData               = _builder.CreateExtractValue(data, llvmFieldIndex);
@@ -2743,10 +2746,10 @@ void Llvm::annotateHelperFunction(CorInfoHelpAnyFunc helperFunc, Function* llvmF
 Function* Llvm::getOrCreateKnownLlvmFunction(
     StringRef name, std::function<FunctionType*()> createFunctionType, std::function<void(Function*)> annotateFunction)
 {
-    Function* llvmFunc = _module->getFunction(name);
+    Function* llvmFunc = m_context->Module.getFunction(name);
     if (llvmFunc == nullptr)
     {
-        llvmFunc = Function::Create(createFunctionType(), Function::ExternalLinkage, name, _module);
+        llvmFunc = Function::Create(createFunctionType(), Function::ExternalLinkage, name, m_context->Module);
         annotateFunction(llvmFunc);
     }
 
@@ -2755,11 +2758,11 @@ Function* Llvm::getOrCreateKnownLlvmFunction(
 
 Function* Llvm::getOrCreateExternalLlvmFunctionAccessor(StringRef name)
 {
-    Function* accessorFuncRef = _module->getFunction(name);
+    Function* accessorFuncRef = m_context->Module.getFunction(name);
     if (accessorFuncRef == nullptr)
     {
         FunctionType* accessorFuncType = FunctionType::get(getPtrLlvmType(), /* isVarArg */ false);
-        accessorFuncRef = Function::Create(accessorFuncType, Function::ExternalLinkage, name, _module);
+        accessorFuncRef = Function::Create(accessorFuncType, Function::ExternalLinkage, name, m_context->Module);
     }
 
     return accessorFuncRef;
@@ -2767,11 +2770,11 @@ Function* Llvm::getOrCreateExternalLlvmFunctionAccessor(StringRef name)
 
 llvm::GlobalVariable* Llvm::getOrCreateDataSymbol(StringRef symbolName)
 {
-    llvm::GlobalVariable* symbol = _module->getGlobalVariable(symbolName);
+    llvm::GlobalVariable* symbol = m_context->Module.getGlobalVariable(symbolName);
     if (symbol == nullptr)
     {
         Type* symbolLlvmType = getPtrLlvmType();
-        symbol = new llvm::GlobalVariable(*_module, symbolLlvmType, false, llvm::GlobalValue::ExternalLinkage,
+        symbol = new llvm::GlobalVariable(m_context->Module, symbolLlvmType, false, llvm::GlobalValue::ExternalLinkage,
                                           nullptr, symbolName);
     }
     return symbol;
@@ -2839,7 +2842,7 @@ Value* Llvm::gepOrAddr(Value* addr, unsigned offset)
         return addr;
     }
 
-    return _builder.CreateGEP(Type::getInt8Ty(_llvmContext), addr, _builder.getInt32(offset));
+    return _builder.CreateGEP(Type::getInt8Ty(m_context->Context), addr, _builder.getInt32(offset));
 }
 
 Value* Llvm::getShadowStack()
@@ -2994,7 +2997,7 @@ llvm::BasicBlock* Llvm::createInlineLlvmBlock()
     Function* llvmFunc = getCurrentLlvmFunction();
     LlvmBlockRange* llvmBlocks = getCurrentLlvmBlocks();
     llvm::BasicBlock* insertBefore = llvmBlocks->LastBlock->getNextNode();
-    llvm::BasicBlock* inlineLlvmBlock = llvm::BasicBlock::Create(_llvmContext, "", llvmFunc, insertBefore);
+    llvm::BasicBlock* inlineLlvmBlock = llvm::BasicBlock::Create(m_context->Context, "", llvmFunc, insertBefore);
 
 #ifdef DEBUG
     StringRef blocksName = llvmBlocks->FirstBlock->getName();
@@ -3023,7 +3026,8 @@ LlvmBlockRange* Llvm::getLlvmBlocksForBlock(BasicBlock* block)
     if (llvmBlockRange == nullptr)
     {
         Function* llvmFunc = getLlvmFunctionForIndex(getLlvmFunctionIndexForBlock(block));
-        llvm::BasicBlock* llvmBlock = llvm::BasicBlock::Create(_llvmContext, BBNAME("BB", block->bbNum), llvmFunc);
+        llvm::BasicBlock* llvmBlock =
+            llvm::BasicBlock::Create(m_context->Context, BBNAME("BB", block->bbNum), llvmFunc);
 
         llvmBlockRange = _blkToLlvmBlksMap.Emplace(block, llvmBlock);
     }
@@ -3064,7 +3068,7 @@ llvm::BasicBlock* Llvm::getOrCreatePrologLlvmBlockForFunction(unsigned funcIdx)
     if ((prologLlvmBlock == nullptr) || !prologLlvmBlock->getName().startswith(PROLOG_BLOCK_NAME))
     {
         Function* llvmFunc = firstLlvmUserBlock->getParent();
-        prologLlvmBlock = llvm::BasicBlock::Create(_llvmContext, PROLOG_BLOCK_NAME, llvmFunc, firstLlvmUserBlock);
+        prologLlvmBlock = llvm::BasicBlock::Create(m_context->Context, PROLOG_BLOCK_NAME, llvmFunc, firstLlvmUserBlock);
 
         // Eagerly insert jump to the user block to simplify calling code.
         llvm::BranchInst::Create(firstLlvmUserBlock, prologLlvmBlock);

--- a/src/coreclr/jit/llvmtypes.h
+++ b/src/coreclr/jit/llvmtypes.h
@@ -12,30 +12,10 @@
 
 struct TypeDescriptor
 {
-private:
-    unsigned              m_fieldCount;
-    CORINFO_FIELD_HANDLE* m_fields;
-    unsigned              m_hasSignificantPadding;
-
-    TypeDescriptor()
-    {
-    }
-
-public:
-    unsigned getFieldCount()
-    {
-        return m_fieldCount;
-    }
-
-    CORINFO_FIELD_HANDLE getField(unsigned index)
-    {
-        return m_fields[index];
-    }
-
-    unsigned hasSignificantPadding()
-    {
-        return m_hasSignificantPadding;
-    }
+    unsigned              Size;
+    unsigned              FieldCount;
+    CORINFO_FIELD_HANDLE* Fields;
+    unsigned              HasSignificantPadding;
 };
 
 struct FieldDesc

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -103,9 +103,8 @@ The .NET Foundation licenses this file to you under the MIT license.
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NativeCodeGen)' == 'llvm'">
-    <!-- TODO-LLVM: remove the IL objects when the IL backend is gone -->
     <LlvmObjectNames Include="$(TargetName)" />
-    <LlvmObjectNames Include="$(TargetName)clrjit" />
+    <LlvmObjectNames Include="$(TargetName).data" />
     <LlvmObjectNames Include="$(TargetName).external" />
 
     <LlvmObjects Include="@(LlvmObjectNames->'$(NativeIntermediateOutputPath)%(Identity)$(LlvmObjectExt)')">

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -338,12 +338,12 @@ namespace ILCompiler.DependencyAnalysis
             }
 
 #if DEBUG
-            _module.PrintToFile(Path.ChangeExtension(_objectFilePath, ".txt"));
+            _module.PrintToFile(Path.ChangeExtension(_objectFilePath, "data.txt"));
 #endif
             _module.Verify(LLVMVerifierFailureAction.LLVMAbortProcessAction);
             _moduleWithExternalFunctions.Verify(LLVMVerifierFailureAction.LLVMAbortProcessAction);
 
-            _module.WriteBitcodeToFile(_objectFilePath);
+            _module.WriteBitcodeToFile(Path.ChangeExtension(_objectFilePath, "data.bc"));
             _moduleWithExternalFunctions.WriteBitcodeToFile(Path.ChangeExtension(_objectFilePath, "external.bc"));
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
@@ -35,7 +35,7 @@ namespace ILCompiler
             LLVMCodegenNodeFactory factory = new LLVMCodegenNodeFactory(_context, _compilationGroup, _metadataManager, _interopStubManager, _nameMangler, _vtableSliceProvider, _dictionaryLayoutProvider, GetPreinitializationManager());
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, new ObjectNode.ObjectNodeComparer(new CompilerComparer()));
 
-            return new LLVMCodegenCompilation(graph, factory, _compilationRoots, GetILProvider(), _debugInformationProvider, _logger, _config, _inliningPolicy, _devirtualizationManager, _instructionSetSupport, _wasmImportPolicy, _methodImportationErrorProvider, options);
+            return new LLVMCodegenCompilation(graph, factory, _compilationRoots, GetILProvider(), _debugInformationProvider, _logger, _config, _inliningPolicy, _devirtualizationManager, _instructionSetSupport, _wasmImportPolicy, _methodImportationErrorProvider, options, _parallelism);
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -27,7 +27,7 @@ namespace ILCompiler
         private readonly Dictionary<string, InstructionSet> _instructionSetMap;
         private readonly ProfileDataManager _profileDataManager;
         protected readonly MethodImportationErrorProvider _methodImportationErrorProvider;
-        private readonly int _parallelism;
+        protected readonly int _parallelism;
 
         public InstructionSetSupport InstructionSetSupport { get; }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -21,10 +21,9 @@ namespace Internal.JitInterface
 {
     internal sealed unsafe partial class CorInfoImpl
     {
-        private static readonly List<IntPtr> s_allocedMemory = new List<IntPtr>();
         private static readonly void*[] s_jitExports = new void*[(int)JitApiId.Count + 1];
 
-        private Dictionary<IntPtr, TypeDescriptor> typeDescriptorDict = new Dictionary<IntPtr, TypeDescriptor>();
+        private void* _pNativeContext; // Per-thread context pointer. Used by the Jit; opaque to the EE.
 
         [UnmanagedCallersOnly]
         public static void addCodeReloc(IntPtr thisHandle, void* handle)
@@ -191,30 +190,25 @@ namespace Internal.JitInterface
             return _this.ObjectToHandle(helperFuncNode);
         }
 
+        [UnmanagedCallersOnly]
+        private static void* getSingleThreadedCompilationContext(IntPtr thisHandle)
+        {
+            return GetThis(thisHandle)._pNativeContext;
+        }
+
         public struct TypeDescriptor
         {
+            public uint Size;
             public uint FieldCount;
             public CORINFO_FIELD_STRUCT_** Fields; // array of CORINFO_FIELD_STRUCT_*
             public uint HasSignificantPadding; // Change to a uint flags if we need more bools
         }
 
         [UnmanagedCallersOnly]
-        public static TypeDescriptor getTypeDescriptor(IntPtr thisHandle, CORINFO_CLASS_STRUCT_* inputType)
+        public static void getTypeDescriptor(IntPtr thisHandle, CORINFO_CLASS_STRUCT_* inputType, TypeDescriptor* pTypeDescriptor)
         {
             var _this = GetThis(thisHandle);
-
-            if (_this.typeDescriptorDict.TryGetValue((IntPtr)inputType, out var typeDescriptor))
-            {
-                return typeDescriptor;
-            }
-
             TypeDesc type = _this.HandleToObject(inputType);
-
-            bool hasSignificantPadding = false;
-            if (type is EcmaType ecmaType)
-            {
-                hasSignificantPadding = ecmaType.IsExplicitLayout || ecmaType.GetClassLayout().Size > 0;
-            };
 
             uint fieldCount = 0;
             foreach (var field in type.GetFields())
@@ -225,30 +219,28 @@ namespace Internal.JitInterface
                 }
             }
 
-            //TODO-LLVM: change to NativeMemory.Alloc when upgraded to .net6
-            IntPtr fieldArray = Marshal.AllocHGlobal((int)(sizeof(CORINFO_FIELD_STRUCT_*) * fieldCount));
-            s_allocedMemory.Add(fieldArray);
-
-            typeDescriptor = new TypeDescriptor
-            {
-                FieldCount = fieldCount,
-                Fields = (CORINFO_FIELD_STRUCT_**)fieldArray,
-                HasSignificantPadding = hasSignificantPadding ? 1u : 0
-            };
+            CORINFO_FIELD_STRUCT_*[] fields = new CORINFO_FIELD_STRUCT_*[fieldCount];
 
             fieldCount = 0;
             foreach (var field in type.GetFields())
             {
                 if (!field.IsStatic)
                 {
-                    typeDescriptor.Fields[fieldCount] = _this.ObjectToHandle(field);
+                    fields[fieldCount] = _this.ObjectToHandle(field);
                     fieldCount++;
                 }
             }
 
-            _this.typeDescriptorDict.Add((IntPtr)inputType, typeDescriptor);
+            bool hasSignificantPadding = false;
+            if (type is EcmaType ecmaType)
+            {
+                hasSignificantPadding = ecmaType.IsExplicitLayout || ecmaType.GetClassLayout().Size > 0;
+            };
 
-            return typeDescriptor;
+            pTypeDescriptor->Size = (uint)type.GetElementSize().AsInt;
+            pTypeDescriptor->FieldCount = fieldCount;
+            pTypeDescriptor->Fields = (CORINFO_FIELD_STRUCT_**)_this.GetPin(fields);
+            pTypeDescriptor->HasSignificantPadding = hasSignificantPadding ? 1u : 0u;
         }
 
         [UnmanagedCallersOnly]
@@ -287,13 +279,14 @@ namespace Internal.JitInterface
             GetDebugTypeForType,
             GetDebugInfoForDebugType,
             GetDebugInfoForCurrentMethod,
+            GetSingleThreadedCompilationContext,
             Count
         }
 
         private enum JitApiId
         {
-            StartThreadContextBoundCompilation,
-            FinishThreadContextBoundCompilation,
+            StartSingleThreadedCompilation,
+            FinishSingleThreadedCompilation,
             Count
         };
 
@@ -322,13 +315,14 @@ namespace Internal.JitInterface
             jitImports[(int)EEApiId.IsRuntimeImport] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, uint>)&isRuntimeImport;
             jitImports[(int)EEApiId.GetPrimitiveTypeForTrivialWasmStruct] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType>)&getPrimitiveTypeForTrivialWasmStruct;
             jitImports[(int)EEApiId.PadOffset] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint, uint>)&padOffset;
-            jitImports[(int)EEApiId.GetTypeDescriptor] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor>)&getTypeDescriptor;
+            jitImports[(int)EEApiId.GetTypeDescriptor] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor*, void>)&getTypeDescriptor;
             jitImports[(int)EEApiId.GetAlternativeFunctionName] = (delegate* unmanaged<IntPtr, byte*>)&getAlternativeFunctionName;
             jitImports[(int)EEApiId.GetExternalMethodAccessor] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, TargetAbiType*, int, IntPtr>)&getExternalMethodAccessor;
             jitImports[(int)EEApiId.GetLlvmHelperFuncEntrypoint] = (delegate* unmanaged<IntPtr, CorInfoHelpLlvmFunc, IntPtr>)&getLlvmHelperFuncEntrypoint;
             jitImports[(int)EEApiId.GetDebugTypeForType] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CORINFO_LLVM_DEBUG_TYPE_HANDLE>)&getDebugTypeForType;
             jitImports[(int)EEApiId.GetDebugInfoForDebugType] = (delegate* unmanaged<IntPtr, CORINFO_LLVM_DEBUG_TYPE_HANDLE, CORINFO_LLVM_TYPE_DEBUG_INFO*, void>)&getDebugInfoForDebugType;
             jitImports[(int)EEApiId.GetDebugInfoForCurrentMethod] = (delegate* unmanaged<IntPtr, CORINFO_LLVM_METHOD_DEBUG_INFO*, void>)&getDebugInfoForCurrentMethod;
+            jitImports[(int)EEApiId.GetSingleThreadedCompilationContext] = (delegate* unmanaged<IntPtr, void*>)&getSingleThreadedCompilationContext;
             jitImports[(int)EEApiId.Count] = (void*)0x1234;
 
 #if DEBUG
@@ -345,28 +339,18 @@ namespace Internal.JitInterface
             }
         }
 
-        public static void JitFinishCompilation()
-        {
-            foreach (var ptr in s_allocedMemory)
-            {
-                Marshal.FreeHGlobal(ptr);
-            }
-
-            s_allocedMemory.Clear();
-        }
-
-        public static void JitStartThreadContextBoundCompilation(string outputFileName, string triple, string dataLayout)
+        public void JitStartSingleThreadedCompilation(string outputFileName, string triple, string dataLayout)
         {
             fixed (byte* pOutputFileName = StringToUTF8(outputFileName), pTriple = StringToUTF8(triple), pDataLayout = StringToUTF8(dataLayout))
             {
-                var pExport = (delegate* unmanaged<byte*, byte*, byte*, void>)s_jitExports[(int)JitApiId.StartThreadContextBoundCompilation];
-                pExport(pOutputFileName, pTriple, pDataLayout);
+                var pExport = (delegate* unmanaged<byte*, byte*, byte*, void*>)s_jitExports[(int)JitApiId.StartSingleThreadedCompilation];
+                _pNativeContext = pExport(pOutputFileName, pTriple, pDataLayout);
             }
         }
 
-        public static void JitFinishThreadContextBoundCompilation()
+        public void JitFinishSingleThreadedCompilation()
         {
-            ((delegate* unmanaged<void>)s_jitExports[(int)JitApiId.FinishThreadContextBoundCompilation])();
+            ((delegate* unmanaged<void*, void>)s_jitExports[(int)JitApiId.FinishSingleThreadedCompilation])(_pNativeContext);
         }
     }
 


### PR DESCRIPTION
Encapsulate LLVM state dependent on single-threaded access into a "context". Current implementation will produce one bitcode file per one single-threaded context.

This change does not enable `--parallelism:<not 1>` by itself, as some significant problems still remain:
1) Determinism. Regular backends achieve this by sorting already-produced nodes.
2) Build integration. For proper MSBuild incrementality, we would like to have a list of inputs and outputs (bitcode files) that is known ahead of time. Not hard to fix.
3) Last I measured, the gains were underwhelming (~30% bitcode generation time reduction). This needs to be investigated in more depth.

So mostly this change is just making sure we are well set up for writing MT-safe code by default in the compiler.