### PR TITLE
NativeAOT-LLVM: Only build the host for one target: browser_wasm_win.

### DIFF
--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -22,7 +22,7 @@ steps:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.wasmjit+clr.aot -c $(buildConfigUpper) $(_officialBuildParameter) -ci
       displayName: Build the ILC and RyuJit cross-compilers
 
-    - ${{ if eq(parameters.isOfficialBuild, true) }}:
+    - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.platform, 'browser_wasm_win')) }}:
       - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) $(_officialBuildParameter) -ci
         displayName: Build host packages
 


### PR DESCRIPTION
This PR attempts to address #2276 by just building the host (win-x64) package for one of the wasm targets, `browser_wasm_win`.

Thanks @SingleAccretion !