### PR TITLE
[NativeAOT-LLVM] Miscellaneous exception handling fixes

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -227,7 +227,15 @@ namespace System.Runtime
         private static bool CallFilterFunclet(void* pFunclet, object exception, void* pShadowFrame)
         {
             WasmEHLogFunletEnter(pFunclet, RhEHClauseKind.RH_EH_CLAUSE_FILTER, pShadowFrame);
-            bool result = ((delegate*<object, void*, int>)pFunclet)(exception, pShadowFrame) != 0;
+            bool result;
+            try
+            {
+                result = ((delegate*<object, void*, int>)pFunclet)(exception, pShadowFrame) != 0;
+            }
+            catch when (true)
+            {
+                result = false; // A filter that throws is treated as if it returned "continue search".
+            }
             WasmEHLogFunletExit(RhEHClauseKind.RH_EH_CLAUSE_FILTER, result ? 1 : 0, pShadowFrame);
 
             return result;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.DebugInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.DebugInfo.cs
@@ -412,6 +412,7 @@ namespace Internal.JitInterface
             int methodIndex = (int)DebugTypesDescriptor.GetMethodFunctionIdTypeIndex(method);
             MemberFunctionIdTypeDescriptor descriptor = _debugFunctions[methodIndex];
 
+            *pInfo = default;
             pInfo->Name = ToPinnedUtf8String(descriptor.Name);
             pInfo->OwnerType = IndexToDebugTypeHandle(descriptor.ParentClass);
             pInfo->Type = IndexToDebugTypeHandle(descriptor.MemberFunction);
@@ -424,16 +425,13 @@ namespace Internal.JitInterface
                 documentPath ??= sequencePoint.Document;
             }
 
-            if (documentPath != null)
+            if (documentPath == null)
             {
-                pInfo->Directory = ToPinnedUtf8String(Path.GetDirectoryName(documentPath));
-                pInfo->FileName = ToPinnedUtf8String(Path.GetFileName(documentPath));
+                return; // No debug info for this method.
             }
-            else
-            {
-                pInfo->Directory = null;
-                pInfo->FileName = null;
-            }
+
+            pInfo->Directory = ToPinnedUtf8String(Path.GetDirectoryName(documentPath));
+            pInfo->FileName = ToPinnedUtf8String(Path.GetFileName(documentPath));
 
             CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO[] lineNumbers = lineNumbersBuilder.ToArray();
             Array.Sort(lineNumbers, static (x, y) => (int)(x.ILOffset - y.ILOffset));


### PR DESCRIPTION
- Invoke the first-chance callback.
- Fix throwing filter handling.

Contributes to #2169.