### PR TITLE
NativeAOT-LLVM: Do not share memory for wasi

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -476,7 +476,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- Wasi has lots of undefined symbols currently, mostly globalization -->
       <CustomLinkerArg Include="-Wl,--unresolved-symbols=ignore-all -lstdc++ -Wl,--error-limit=0 -lpthread -pthread" />
       <CustomLinkerArg Include="--sysroot=&quot;$(WASI_SDK_PATH.Replace(&quot;\&quot;, &quot;/&quot;))/share/wasi-sysroot&quot;" />
-      <CustomLinkerArg Include="-Wl,--import-memory,--export-memory,--max-memory=2147483648" />
+      <CustomLinkerArg Include="-Wl,--max-memory=2147483648" />
       <CustomLinkerArg Include="-lwasi-emulated-process-clocks -lwasi-emulated-signal -lwasi-emulated-mman -lwasi-emulated-getpid" />
     </ItemGroup>
 


### PR DESCRIPTION
This PR removes the sharing of memory for the wasi link by removing `-Wl,--import-memory,--export-memory`.  Many wasi tools are not yet ready for threads (where sharing of memory might be useful), nor is sharing applicable for components which use a shared nothing design.  The user can always add them back with  `LinkerArg` but they can't easily remove them