### PR TITLE
NativeAOT-LLVM: Change hash key to use edgePredBlock

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -895,7 +895,7 @@ void Llvm::fillPhis()
                 BasicBlock* edgePredBlock = edge->getSourceBlock();
                 if (edgePredBlock->bbJumpKind == BBJ_SWITCH)
                 {
-                    predCountMap.AddOrUpdate({predBlock, phiBlock}, edge->getDupCount());
+                    predCountMap.AddOrUpdate({edgePredBlock, phiBlock}, edge->getDupCount());
 
                     if (edgePredBlock == predBlock)
                     {


### PR DESCRIPTION
This PR fixes a bug with the hashmap when there are multiple duplicates in the predecessors list.

cc @dotnet/nativeaot-llvm 