### PR TITLE
[NativeAOT-LLVM] Initial version of a multi-threaded compiler

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -651,7 +651,14 @@ CONFIG_INTEGER(JitDispIns, W("JitDispIns"), 0)
 #endif // DEBUG
 
 #ifdef TARGET_WASM
+#ifdef DEBUG
+#define DEBUG_ONLY_BY_DEFAULT 1
+#else
+#define DEBUG_ONLY_BY_DEFAULT 0
+#endif
+
 CONFIG_INTEGER(JitUseDynamicStackForLclHeap, W("JitUseDynamicStackForLclHeap"), 0)
+CONFIG_INTEGER(JitCheckLlvmIR, W("JitCheckLlvmIR"), DEBUG_ONLY_BY_DEFAULT)
 #endif // TARGET_WASM
 
 CONFIG_INTEGER(JitEnregStructLocals, W("JitEnregStructLocals"), 1) // Allow to enregister locals with struct type.

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -925,14 +925,16 @@ extern "C" DLLEXPORT void registerLlvmCallbacks(void** jitImports, void** jitExp
     }
 
     std::error_code code;
-
-    // TODO-LLVM: put under #ifdef DEBUG. Useful for debugging for now.
     StringRef outputFilePath = module.getName();
-    StringRef outputFilePathWithoutExtension = outputFilePath.take_front(outputFilePath.find_last_of('.'));
-    llvm::raw_fd_ostream textOutputStream(Twine(outputFilePathWithoutExtension + ".txt").str(), code);
-    module.print(textOutputStream, nullptr);
+    if (JitConfig.JitCheckLlvmIR())
+    {
+        StringRef outputFilePathWithoutExtension = outputFilePath.take_front(outputFilePath.find_last_of('.'));
+        llvm::raw_fd_ostream textOutputStream(Twine(outputFilePathWithoutExtension + ".txt").str(), code);
+        module.print(textOutputStream, nullptr);
 
-    assert(!llvm::verifyModule(module, &llvm::errs()));
+        noway_assert(!llvm::verifyModule(module, &llvm::errs()));
+    }
+
     llvm::raw_fd_ostream bitCodeFileStream(outputFilePath, code);
     llvm::WriteBitcodeToFile(module, bitCodeFileStream);
 

--- a/src/coreclr/nativeaot/BuildIntegration/ExecWrapper.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/ExecWrapper.proj
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Exec" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="Exec">
+    <Exec Command="$(ExecCommand)" />
+  </Target>
+</Project>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -91,7 +91,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <IlcCompileOutput>$(NativeObject)</IlcCompileOutput>
 
     <LinkNativeDependsOn>IlcCompile</LinkNativeDependsOn>
-    <LinkNativeDependsOn Condition="$(NativeCodeGen) == 'llvm'">WasmObjects</LinkNativeDependsOn>
+    <LinkNativeDependsOn Condition="$(NativeCodeGen) == 'llvm'">CompileWasmObjects</LinkNativeDependsOn>
 
     <LinkNativeDependsOnSingleOrLlvm>LinkNativeSingle</LinkNativeDependsOnSingleOrLlvm>
     <LinkNativeDependsOnSingleOrLlvm Condition="$(NativeCodeGen) == 'llvm'">LinkNativeLlvm</LinkNativeDependsOnSingleOrLlvm>
@@ -107,19 +107,15 @@ The .NET Foundation licenses this file to you under the MIT license.
   <PropertyGroup Condition="'$(NativeCodeGen)' == 'llvm'">
     <!-- Most browsers support WASM EH, so we enable it by default. This is aligned with the upstream behavior. -->
     <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == '' and '$(_targetOS)' == 'browser'">true</WasmEnableExceptionHandling>
+
+    <!-- TODO-LLVM: update 'IlcOptimizationPreference' to 'OptimizationPreference' when merging. -->
+    <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) != 'Size' and '$(_targetOS)' == 'browser'">-O3</WasmOptimizationSetting>
+    <!-- TODO-LLVM: test -O1/-O2/-O3 for size with Wasi SDK -->
+    <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) != 'Size' and '$(_targetOS)' == 'wasi'">-O2</WasmOptimizationSetting>
+    <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Size'">-Oz</WasmOptimizationSetting>
+
     <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi'">wasm32-wasi-threads</IlcLlvmTarget>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(NativeCodeGen)' == 'llvm'">
-    <LlvmObjectNames Include="$(TargetName)" />
-    <LlvmObjectNames Include="$(TargetName).data" />
-    <LlvmObjectNames Include="$(TargetName).external" />
-
-    <LlvmObjects Include="@(LlvmObjectNames->'$(NativeIntermediateOutputPath)%(Identity)$(LlvmObjectExt)')">
-      <NativeObject>%(RelativeDir)%(Filename)$(NativeObjectExt)</NativeObject>
-    </LlvmObjects>
-    <NativeObjects Include="@(LlvmObjects->'%(NativeObject)')" />
-  </ItemGroup>
 
   <PropertyGroup Condition="'$(IlcCompileDependsOn)'=='' and '$(NativeCompilationDuringPublish)' != 'false'">
     <IlcCompileDependsOn Condition="'$(BuildingFrameworkLibrary)' != 'true'">Compile;ComputeIlcCompileInputs</IlcCompileDependsOn>
@@ -276,8 +272,13 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="'$(TrimmerDefaultAction)' == 'copyused' or '$(TrimmerDefaultAction)' == 'copy' or '$(TrimMode)' == 'partial'" Include="--defaultrooting" />
       <IlcArg Include="--resilient" />
       <IlcArg Include="@(UnmanagedEntryPointsAssembly->'--generateunmanagedentrypoints:%(Identity)')" />
-      <IlcArg Condition="'$(IlcLlvmTarget)' != ''" Include="--codegenopt:Target=$(IlcLlvmTarget)" />
+
+      <!-- These LLVM options are public and supported. -->
       <IlcArg Condition="'$(WasmEnableExceptionHandling)' == 'true'" Include="--codegenopt:LlvmExceptionHandlingModel=wasm" />
+
+      <!-- These LLVM options are internal and not supported. -->
+      <IlcArg Condition="'$(IlcLlvmTarget)' != ''" Include="--codegenopt:Target=$(IlcLlvmTarget)" />
+      <IlcArg Condition="'$(IlcMaxLlvmModuleCount)' != ''" Include="--codegenopt:MaxLlvmModuleCount=$(IlcMaxLlvmModuleCount)" />
 
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--feature:System.Reflection.IsReflectionExecutionAvailable=false" />
 
@@ -335,16 +336,24 @@ The .NET Foundation licenses this file to you under the MIT license.
 
   </Target>
 
-  <PropertyGroup Condition="'$(NativeCodeGen)' == 'llvm'">
-    <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) != 'Size' and '$(_targetOS)' == 'browser'">-O3</WasmOptimizationSetting>
-    <!-- TODO-LLVM: test -O1/-O2/-O3 for size with Wasi SDK -->
-    <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) != 'Size' and '$(_targetOS)' == 'wasi'">-O2</WasmOptimizationSetting>
-    <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(IlcOptimizationPreference) == 'Size'">-Oz</WasmOptimizationSetting>
-  </PropertyGroup>
+  <Target Name="InitializeTheListOfLlvmObjects"
+      AfterTargets="IlcCompile"
+      BeforeTargets="CompileWasmObjects;LinkNativeLlvm">
+    <ReadLinesFromFile File="$(NativeIntermediateOutputPath)$(TargetName).results.txt">
+      <Output TaskParameter="Lines" ItemName="LlvmObjects" />
+    </ReadLinesFromFile>
 
-  <Target Name="WasmObjects"
+    <ItemGroup>
+      <LlvmObjects>
+        <NativeObject>%(RelativeDir)%(Filename)$(NativeObjectExt)</NativeObject>
+      </LlvmObjects>
+      <NativeObjects Include="@(LlvmObjects->'%(NativeObject)')" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CompileWasmObjects"
       Inputs="@(LlvmObjects)"
-      Outputs="@(NativeObjects)"
+      Outputs="@(LlvmObjects->'%(NativeObject)')"
       DependsOnTargets="IlcCompile;GenerateResFile"
       Condition="'$(NativeCodeGen)' == 'llvm'">
 
@@ -374,7 +383,16 @@ The .NET Foundation licenses this file to you under the MIT license.
       <WasmLinkerPath>&quot;$(WASI_SDK_PATH)/bin/clang&quot;</WasmLinkerPath>
     </PropertyGroup>
 
-    <Exec Command="$(WasmCompilerPath) &quot;%(LlvmObjects.Identity)&quot; -o &quot;%(LlvmObjects.NativeObject)&quot; $(CompileWasmArgs)" Condition="'$(EMSDK)' != ''" />
+    <!-- We use a wrapper project to invoke the compilers in parallel. -->
+    <ItemGroup>
+      <ExecProjects Include="$(MSBuildThisFileDirectory)ExecWrapper.proj">
+        <AdditionalProperties>
+          ExecCommand=$(WasmCompilerPath) &quot;%(LlvmObjects.Identity)&quot; -o &quot;%(LlvmObjects.NativeObject)&quot; $(CompileWasmArgs)
+        </AdditionalProperties>
+      </ExecProjects>
+    </ItemGroup>
+
+    <MSBuild Projects="@(ExecProjects)" BuildInParallel="true" Condition="'$(EMSDK)' != ''" />
     <Message Text="Emscripten not found, not linking WebAssembly. To enable WebAssembly linking, install Emscripten and ensure the EMSDK environment variable points to the directory containing upstream/emscripten/emcc.bat"
              Condition="'$(EMSDK)' == '' and '$(_targetOS)' == 'browser'" />
     <Message Text="Wasi SDK not found, not linking WebAssembly. To enable WebAssembly linking, install Wasi SDK and ensure the WASI_SDK_PATH environment variable points to the directory containing share/wasi-sysroot"

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMCodegenCompilation.CodeGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMCodegenCompilation.CodeGen.cs
@@ -1,0 +1,392 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Numerics;
+
+using ILCompiler.DependencyAnalysis;
+
+using Internal.JitInterface;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using LLVMSharp.Interop;
+
+namespace ILCompiler
+{
+    public sealed partial class LLVMCodegenCompilation
+    {
+        private readonly Dictionary<TypeDesc, LLVMTypeRef> _llvmStructs = new();
+
+        // We define an alternative entrypoint for the runtime exports, one that has the (original) managed calling convention.
+        // This allows managed code as well as low-level runtime helpers to avoid the overhead of shadow stack save/restore
+        // when calling the export. Thus, the "mangling" we use here is effectively an ABI contract between the compiler and
+        // runtime.
+        public override string GetRuntimeExportManagedEntrypointName(MethodDesc method)
+        {
+            if (!method.HasCustomAttribute("System.Runtime", "RuntimeExportAttribute"))
+            {
+                return null;
+            }
+
+            return ((EcmaMethod)method).GetRuntimeExportName() + "_Managed";
+        }
+
+        public override ISymbolNode GetExternalMethodAccessor(MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
+        {
+            Debug.Assert(!sig.IsEmpty);
+            string name = PInvokeILProvider.GetDirectCallExternName(method);
+
+            return NodeFactory.ExternSymbolWithAccessor(name, method, sig);
+        }
+
+        public override CorInfoLlvmEHModel GetLlvmExceptionHandlingModel() => Options.ExceptionHandlingModel;
+
+        internal LLVMTypeRef GetLLVMSignatureForMethod(bool isManagedAbi, MethodSignature signature, bool hasHiddenParam)
+        {
+            LLVMTypeRef llvmReturnType = GetLlvmReturnType(signature.ReturnType, out bool isReturnByRef);
+
+            ArrayBuilder<LLVMTypeRef> signatureTypes = default;
+            signatureTypes.Add(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)); // Shadow stack pointer
+
+            if (isReturnByRef)
+            {
+                signatureTypes.Add(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
+            }
+
+            if (hasHiddenParam)
+            {
+                signatureTypes.Add(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
+            }
+
+            // Intentionally skipping the 'this' pointer since it could always be a GC reference
+            // and thus must be on the shadow stack
+            foreach (TypeDesc type in signature)
+            {
+                if (GetLlvmArgTypeForArg(isManagedAbi, type, out LLVMTypeRef llvmArgType, out _))
+                {
+                    signatureTypes.Add(llvmArgType);
+                }
+            }
+
+            return LLVMTypeRef.CreateFunction(llvmReturnType, signatureTypes.ToArray(), false);
+        }
+
+        internal static bool CanStoreTypeOnStack(TypeDesc type)
+        {
+            if (type is DefType defType)
+            {
+                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !ContainsIsByRef(type))
+                {
+                    return true;
+                }
+            }
+            else if (type is PointerType || type is FunctionPointerType)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public override TypeDesc GetPrimitiveTypeForTrivialWasmStruct(TypeDesc type)
+        {
+            Debug.Assert(IsStruct(type));
+
+            int size = type.GetElementSize().AsInt;
+            if (size <= sizeof(double) && BitOperations.IsPow2(size))
+            {
+                while (true)
+                {
+                    FieldDesc singleInstanceField = null;
+                    foreach (FieldDesc field in type.GetFields())
+                    {
+                        if (!field.IsStatic)
+                        {
+                            if (singleInstanceField != null)
+                            {
+                                return null;
+                            }
+
+                            singleInstanceField = field;
+                        }
+                    }
+
+                    if (singleInstanceField == null)
+                    {
+                        return null;
+                    }
+
+                    TypeDesc singleInstanceFieldType = singleInstanceField.FieldType;
+                    if (!IsStruct(singleInstanceFieldType))
+                    {
+                        if (singleInstanceFieldType.GetElementSize().AsInt != size)
+                        {
+                            return null;
+                        }
+
+                        return singleInstanceFieldType;
+                    }
+
+                    type = singleInstanceFieldType;
+                }
+            }
+
+            return null;
+        }
+
+        internal bool GetLlvmArgTypeForArg(bool isManagedAbi, TypeDesc argSigType, out LLVMTypeRef llvmArgType, out bool isPassedByRef)
+        {
+            isPassedByRef = false;
+            bool isLlvmArg = !isManagedAbi || CanStoreTypeOnStack(argSigType);
+            TypeDesc argType = argSigType;
+            if (isLlvmArg && IsStruct(argSigType))
+            {
+                argType = GetPrimitiveTypeForTrivialWasmStruct(argSigType);
+                if (argType == null)
+                {
+                    isPassedByRef = true;
+                }
+            }
+
+            llvmArgType = isPassedByRef ? LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) : GetLLVMTypeForTypeDesc(argType);
+            return isLlvmArg;
+        }
+
+        internal LLVMTypeRef GetLlvmReturnType(TypeDesc sigReturnType, out bool isPassedByRef)
+        {
+            isPassedByRef = IsStruct(sigReturnType) && GetPrimitiveTypeForTrivialWasmStruct(sigReturnType) == null;
+            if (isPassedByRef || sigReturnType.IsVoid)
+            {
+                return LLVMTypeRef.Void;
+            }
+
+            return GetLLVMTypeForTypeDesc(sigReturnType);
+        }
+
+        public override int PadOffset(TypeDesc type, int atOffset)
+        {
+            var fieldAlignment = type is DefType && type.IsValueType ? ((DefType)type).InstanceFieldAlignment : type.Context.Target.LayoutPointerSize;
+            var alignment = LayoutInt.Min(fieldAlignment, new LayoutInt(ComputePackingSize(type))).AsInt;
+            var padding = atOffset.AlignUp(alignment);
+
+            return padding;
+        }
+
+        internal int PadNextOffset(TypeDesc type, int atOffset)
+        {
+            return PadOffset(type, atOffset) + type.GetElementSize().AsInt;
+        }
+
+        internal LLVMTypeRef GetLLVMTypeForTypeDesc(TypeDesc type)
+        {
+            switch (type.Category)
+            {
+                case TypeFlags.Boolean:
+                case TypeFlags.SByte:
+                case TypeFlags.Byte:
+                    return LLVMTypeRef.Int8;
+
+                case TypeFlags.Int16:
+                case TypeFlags.UInt16:
+                case TypeFlags.Char:
+                    return LLVMTypeRef.Int16;
+
+                case TypeFlags.Int32:
+                case TypeFlags.UInt32:
+                    return LLVMTypeRef.Int32;
+
+                case TypeFlags.IntPtr:
+                case TypeFlags.UIntPtr:
+                    return _nodeFactory.Target.PointerSize == 4 ? LLVMTypeRef.Int32 : LLVMTypeRef.Int64;
+
+                case TypeFlags.Array:
+                case TypeFlags.SzArray:
+                case TypeFlags.ByRef:
+                case TypeFlags.Class:
+                case TypeFlags.Interface:
+                case TypeFlags.Pointer:
+                case TypeFlags.FunctionPointer:
+                    return LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
+
+                case TypeFlags.Int64:
+                case TypeFlags.UInt64:
+                    return LLVMTypeRef.Int64;
+
+                case TypeFlags.Single:
+                    return LLVMTypeRef.Float;
+
+                case TypeFlags.Double:
+                    return LLVMTypeRef.Double;
+
+                case TypeFlags.ValueType:
+                case TypeFlags.Nullable:
+                    if (!_llvmStructs.TryGetValue(type, out LLVMTypeRef llvmStructType))
+                    {
+                        // Treat trivial structs like their underlying types for compatibility with the native ABI.
+                        if (GetPrimitiveTypeForTrivialWasmStruct(type) is TypeDesc primitiveType)
+                        {
+                            llvmStructType = GetLLVMTypeForTypeDesc(primitiveType);
+                        }
+                        else
+                        {
+                            List<FieldDesc> sortedFields = new();
+                            foreach (FieldDesc field in type.GetFields())
+                            {
+                                if (!field.IsStatic)
+                                {
+                                    sortedFields.Add(field);
+                                }
+                            }
+
+                            // Sort fields by offset and size in order to handle generating unions
+                            sortedFields.Sort((left, right) =>
+                            {
+                                int leftOffset = left.Offset.AsInt;
+                                int rightOffset = right.Offset.AsInt;
+                                if (leftOffset == rightOffset)
+                                {
+                                    // Sort union fields in a descending order.
+                                    return right.FieldType.GetElementSize().AsInt - left.FieldType.GetElementSize().AsInt;
+                                }
+
+                                return leftOffset - rightOffset;
+                            });
+
+                            List<LLVMTypeRef> llvmFields = new List<LLVMTypeRef>(sortedFields.Count);
+                            int lastOffset = -1;
+                            int nextNewOffset = -1;
+                            TypeDesc prevType = null;
+                            int totalSize = 0;
+
+                            foreach (FieldDesc field in sortedFields)
+                            {
+                                int curOffset = field.Offset.AsInt;
+
+                                if (prevType == null || (curOffset != lastOffset && curOffset >= nextNewOffset))
+                                {
+                                    // The layout should be in order
+                                    Debug.Assert(curOffset > lastOffset);
+
+                                    int prevElementSize;
+                                    if (prevType == null)
+                                    {
+                                        lastOffset = 0;
+                                        prevElementSize = 0;
+                                    }
+                                    else
+                                    {
+                                        prevElementSize = prevType.GetElementSize().AsInt;
+                                    }
+
+                                    // Pad to this field if necessary
+                                    int paddingSize = curOffset - lastOffset - prevElementSize;
+                                    if (paddingSize > 0)
+                                    {
+                                        AddPaddingFields(paddingSize, llvmFields);
+                                        totalSize += paddingSize;
+                                    }
+
+                                    TypeDesc fieldType = field.FieldType;
+                                    int fieldSize = fieldType.GetElementSize().AsInt;
+
+                                    llvmFields.Add(GetLLVMTypeForTypeDesc(fieldType));
+
+                                    totalSize += fieldSize;
+                                    lastOffset = curOffset;
+                                    prevType = fieldType;
+                                    nextNewOffset = curOffset + fieldSize;
+                                }
+                            }
+
+                            // If explicit layout is greater than the sum of fields, add padding
+                            int structSize = type.GetElementSize().AsInt;
+                            if (totalSize < structSize)
+                            {
+                                AddPaddingFields(structSize - totalSize, llvmFields);
+                            }
+
+                            llvmStructType = LLVMTypeRef.CreateStruct(llvmFields.ToArray(), true);
+                        }
+
+                        _llvmStructs[type] = llvmStructType;
+                    }
+                    return llvmStructType;
+
+                case TypeFlags.Enum:
+                    return GetLLVMTypeForTypeDesc(type.UnderlyingType);
+
+                case TypeFlags.Void:
+                    return LLVMTypeRef.Void;
+
+                default:
+                    throw new UnreachableException(type.Category.ToString());
+            }
+        }
+
+        private static bool ContainsIsByRef(TypeDesc type)
+        {
+            if (type.IsByRef || type.IsByRefLike)
+            {
+                return true;
+            }
+
+            foreach (var field in type.GetFields())
+            {
+                if (field.IsStatic)
+                    continue;
+
+                var fieldType = field.FieldType;
+                if (fieldType.IsValueType)
+                {
+                    var fieldDefType = (DefType)fieldType;
+                    if (!fieldDefType.ContainsGCPointers && !fieldDefType.IsByRefLike)
+                        continue;
+
+                    if (ContainsIsByRef(fieldType))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private static int ComputePackingSize(TypeDesc type)
+        {
+            if (type is MetadataType)
+            {
+                var metaType = type as MetadataType;
+                var layoutMetadata = metaType.GetClassLayout();
+
+                // If a type contains pointers then the metadata specified packing size is ignored (On desktop this is disqualification from ManagedSequential)
+                if (layoutMetadata.PackingSize == 0 || metaType.ContainsGCPointers)
+                    return type.Context.Target.DefaultPackingSize;
+                else
+                    return layoutMetadata.PackingSize;
+            }
+            else
+            {
+                return type.Context.Target.DefaultPackingSize;
+            }
+        }
+
+        private static void AddPaddingFields(int paddingSize, List<LLVMTypeRef> llvmFields)
+        {
+            int numInts = paddingSize / 4;
+            int numBytes = paddingSize - numInts * 4;
+            for (int i = 0; i < numInts; i++)
+            {
+                llvmFields.Add(LLVMTypeRef.Int32);
+            }
+            for (int i = 0; i < numBytes; i++)
+            {
+                llvmFields.Add(LLVMTypeRef.Int8);
+            }
+        }
+
+        private static bool IsStruct(TypeDesc type) => type.Category is TypeFlags.ValueType or TypeFlags.Nullable;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -53,7 +53,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private LLVMObjectWriter(string objectFilePath, LLVMCodegenCompilation compilation)
         {
-            _module = LLVMModuleRef.CreateWithName(compilation.Options.ModuleName);
+            _module = LLVMModuleRef.CreateWithName("data");
             _module.Target = compilation.Options.Target;
             _module.DataLayout = compilation.Options.DataLayout;
 
@@ -343,8 +343,16 @@ namespace ILCompiler.DependencyAnalysis
             _module.Verify(LLVMVerifierFailureAction.LLVMAbortProcessAction);
             _moduleWithExternalFunctions.Verify(LLVMVerifierFailureAction.LLVMAbortProcessAction);
 
-            _module.WriteBitcodeToFile(Path.ChangeExtension(_objectFilePath, "data.bc"));
-            _moduleWithExternalFunctions.WriteBitcodeToFile(Path.ChangeExtension(_objectFilePath, "external.bc"));
+            string dataLlvmObjectPath = _objectFilePath;
+            _module.WriteBitcodeToFile(dataLlvmObjectPath);
+
+            string externalLlvmObjectPath = Path.ChangeExtension(_objectFilePath, "external.bc");
+            _moduleWithExternalFunctions.WriteBitcodeToFile(externalLlvmObjectPath);
+
+            LLVMCompilationResults compilationResults = _compilation.GetCompilationResults();
+            compilationResults.Add(dataLlvmObjectPath);
+            compilationResults.Add(externalLlvmObjectPath);
+            compilationResults.SerializeToFile(Path.ChangeExtension(_objectFilePath, "results.txt"));
         }
 
         private void EmitRuntimeExportThunk(LLVMMethodCodeNode methodNode)

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Numerics;
-using System.Threading;
 using System.Threading.Tasks;
 
 using ILCompiler.DependencyAnalysis;
@@ -18,18 +15,14 @@ using Internal.IL;
 using Internal.IL.Stubs;
 using Internal.JitInterface;
 using Internal.TypeSystem;
-using Internal.TypeSystem.Ecma;
-
-using LLVMSharp.Interop;
 
 namespace ILCompiler
 {
-    public sealed class LLVMCodegenCompilation : RyuJitCompilation
+    public sealed partial class LLVMCodegenCompilation : RyuJitCompilation
     {
-        private ConcurrentDictionary<int, CorInfoImpl> _corinfos;
-        private readonly Dictionary<TypeDesc, LLVMTypeRef> _llvmStructs = new();
+        private Dictionary<int, CorInfoImpl> _compilationContexts;
+        private readonly LLVMCompilationResults _compilationResults = new();
         private string _outputFile;
-        private int _bitcodeFileId;
 
         internal LLVMCodegenConfigProvider Options { get; }
         internal ConfigurableWasmImportPolicy ConfigurableWasmImportPolicy { get; }
@@ -48,9 +41,9 @@ namespace ILCompiler
             ConfigurableWasmImportPolicy configurableWasmImportPolicy,
             MethodImportationErrorProvider errorProvider,
             RyuJitCompilationOptions baseOptions,
-            int /* parallelism */ _)
+            int parallelism)
             : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, logger, devirtualizationManager, inliningPolicy, instructionSetSupport,
-                null /* ProfileDataManager */, errorProvider, baseOptions, 1)
+                null /* ProfileDataManager */, errorProvider, baseOptions, parallelism)
         {
             NodeFactory = nodeFactory;
             Options = options;
@@ -61,21 +54,30 @@ namespace ILCompiler
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
 
-            _outputFile = outputFile;
-            _corinfos = new();
-            CorInfoImpl.JitStartCompilation();
-
+            StartCompilation(outputFile);
             _dependencyGraph.ComputeMarkedNodes();
-
-            foreach (var (_, corInfo) in _corinfos)
-            {
-                corInfo.JitFinishSingleThreadedCompilation();
-            }
-            _corinfos = null;
+            Console.WriteLine($"LLVM compilation to IR finished in {stopwatch.Elapsed.TotalSeconds:0.##} seconds");
+            FinishCompilation();
 
             LLVMObjectWriter.EmitObject(outputFile, _dependencyGraph.MarkedNodeList, this, dumper);
 
-            Console.WriteLine($"LLVM bitcode generation finished in {stopwatch.Elapsed.TotalSeconds:0.##} seconds");
+            Console.WriteLine($"LLVM generation of bitcode finished in {stopwatch.Elapsed.TotalSeconds:0.##} seconds");
+        }
+
+        private void StartCompilation(string outputFile)
+        {
+            _outputFile = outputFile;
+            CorInfoImpl.JitStartCompilation();
+        }
+
+        private void FinishCompilation()
+        {
+            foreach ((int _, CorInfoImpl corInfo) in _compilationContexts)
+            {
+                corInfo.JitFinishSingleThreadedCompilation();
+            }
+
+            _compilationContexts = null;
         }
 
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)
@@ -106,69 +108,47 @@ namespace ILCompiler
                 methodsToCompile.Add(methodCodeNodeNeedingCode);
             }
 
-            if (_parallelism == 1)
-            {
-                CompileSingleThreaded(methodsToCompile);
-            }
-            else
-            {
-                CompileMultiThreaded(methodsToCompile);
-            }
+            CompileMethods(methodsToCompile);
         }
 
-        private void CompileMultiThreaded(List<LLVMMethodCodeNode> methodsToCompile)
+        private void CompileMethods(List<LLVMMethodCodeNode> methodsToCompile)
         {
             if (Logger.IsVerbose)
             {
                 Logger.LogMessage($"Compiling {methodsToCompile.Count} methods...");
             }
 
-            Parallel.ForEach(
-                methodsToCompile,
-                new ParallelOptions { MaxDegreeOfParallelism = _parallelism },
-                CompileSingleMethod);
-        }
-
-        private void CompileSingleThreaded(List<LLVMMethodCodeNode> methodsToCompile)
-        {
-            CorInfoImpl corInfo = _corinfos.GetOrAdd(Environment.CurrentManagedThreadId, StartSingleThreadedCompilation);
-
-            foreach (LLVMMethodCodeNode methodCodeNodeNeedingCode in methodsToCompile)
+            int moduleCount = Options.MaxLlvmModuleCount;
+            if (_compilationContexts == null)
             {
-                if (methodCodeNodeNeedingCode.StaticDependenciesAreComputed)
-                    continue;
-
-                if (Logger.IsVerbose)
+                _compilationContexts = new();
+                for (int index = 0; index < moduleCount; index++)
                 {
-                    Logger.LogMessage($"Compiling {methodCodeNodeNeedingCode.Method}...");
+                    CorInfoImpl corInfo = new CorInfoImpl(this);
+                    string outputFilePath = Path.ChangeExtension(_outputFile, null) + $".{index}.bc";
+
+                    corInfo.JitStartSingleThreadedCompilation(outputFilePath, Options.Target, Options.DataLayout);
+                    _compilationResults.Add(outputFilePath);
+                    _compilationContexts[index] = corInfo;
                 }
-
-                CompileSingleMethod(corInfo, methodCodeNodeNeedingCode);
             }
-        }
 
-        private void CompileSingleMethod(LLVMMethodCodeNode methodCodeNodeNeedingCode)
-        {
-            CorInfoImpl corInfo = _corinfos.GetOrAdd(Environment.CurrentManagedThreadId, StartSingleThreadedCompilation);
-            CompileSingleMethod(corInfo, methodCodeNodeNeedingCode);
-        }
-
-        private CorInfoImpl StartSingleThreadedCompilation(int _)
-        {
-            CorInfoImpl corInfo = new CorInfoImpl(this);
-
-            string outputFilePath = _outputFile;
-            if (_parallelism != 1)
+            Parallel.For(0, moduleCount, new() { MaxDegreeOfParallelism = _parallelism }, index =>
             {
-                int id = Interlocked.Increment(ref _bitcodeFileId);
-                outputFilePath = Path.ChangeExtension(_outputFile, null) + $".{id}.bc";
-            }
-            corInfo.JitStartSingleThreadedCompilation(outputFilePath, Options.Target, Options.DataLayout);
+                CorInfoImpl corInfo = _compilationContexts[index];
+                int allMethodsCount = methodsToCompile.Count;
+                int moduleMethodCount = allMethodsCount / moduleCount + 1;
+                int lowMethodIndex = index * moduleMethodCount;
+                int highMethodIndex = Math.Min(lowMethodIndex + moduleMethodCount, allMethodsCount);
 
-            return corInfo;
+                for (int i = lowMethodIndex; i < highMethodIndex; i++)
+                {
+                    CompileSingleMethod(corInfo, methodsToCompile[i]);
+                }
+            });
         }
 
-        private unsafe void CompileSingleMethod(CorInfoImpl corInfo, LLVMMethodCodeNode methodCodeNodeNeedingCode)
+        private void CompileSingleMethod(CorInfoImpl corInfo, LLVMMethodCodeNode methodCodeNodeNeedingCode)
         {
             MethodDesc method = methodCodeNodeNeedingCode.Method;
 
@@ -180,7 +160,8 @@ namespace ILCompiler
             {
                 try
                 {
-                    CompileSingleMethodInternal(corInfo, methodCodeNodeNeedingCode);
+                    corInfo.CompileMethod(methodCodeNodeNeedingCode, null);
+                    methodCodeNodeNeedingCode.CompilationCompleted = true;
                 }
                 catch (TypeSystemException ex)
                 {
@@ -192,7 +173,8 @@ namespace ILCompiler
             {
                 // Try to compile the method again, but with a throwing method body this time.
                 MethodIL throwingIL = TypeSystemThrowingILEmitter.EmitIL(method, exception);
-                CompileSingleMethodInternal(corInfo, methodCodeNodeNeedingCode, throwingIL);
+                corInfo.CompileMethod(methodCodeNodeNeedingCode, throwingIL);
+                methodCodeNodeNeedingCode.CompilationCompleted = true;
 
                 if (exception is TypeSystemException.InvalidProgramException
                     && method.OwningType is MetadataType mdOwningType
@@ -207,379 +189,6 @@ namespace ILCompiler
             }
         }
 
-        private static void CompileSingleMethodInternal(CorInfoImpl corInfo, LLVMMethodCodeNode methodCodeNodeNeedingCode, MethodIL methodIL = null)
-        {
-            corInfo.CompileMethod(methodCodeNodeNeedingCode, methodIL);
-            methodCodeNodeNeedingCode.CompilationCompleted = true;
-        }
-
-        // We define an alternative entrypoint for the runtime exports, one that has the (original) managed calling convention.
-        // This allows managed code as well as low-level runtime helpers to avoid the overhead of shadow stack save/restore
-        // when calling the export. Thus, the "mangling" we use here is effectively an ABI contract between the compiler and
-        // runtime.
-        public override string GetRuntimeExportManagedEntrypointName(MethodDesc method)
-        {
-            if (!method.HasCustomAttribute("System.Runtime", "RuntimeExportAttribute"))
-            {
-                return null;
-            }
-
-            return ((EcmaMethod)method).GetRuntimeExportName() + "_Managed";
-        }
-
-        public override ISymbolNode GetExternalMethodAccessor(MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
-        {
-            Debug.Assert(!sig.IsEmpty);
-            string name = PInvokeILProvider.GetDirectCallExternName(method);
-
-            return NodeFactory.ExternSymbolWithAccessor(name, method, sig);
-        }
-
-        public override CorInfoLlvmEHModel GetLlvmExceptionHandlingModel() => Options.ExceptionHandlingModel;
-
-        internal LLVMTypeRef GetLLVMSignatureForMethod(bool isManagedAbi, MethodSignature signature, bool hasHiddenParam)
-        {
-            LLVMTypeRef llvmReturnType = GetLlvmReturnType(signature.ReturnType, out bool isReturnByRef);
-
-            ArrayBuilder<LLVMTypeRef> signatureTypes = default;
-            signatureTypes.Add(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0)); // Shadow stack pointer
-
-            if (isReturnByRef)
-            {
-                signatureTypes.Add(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
-            }
-
-            if (hasHiddenParam)
-            {
-                signatureTypes.Add(LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0));
-            }
-
-            // Intentionally skipping the 'this' pointer since it could always be a GC reference
-            // and thus must be on the shadow stack
-            foreach (TypeDesc type in signature)
-            {
-                if (GetLlvmArgTypeForArg(isManagedAbi, type, out LLVMTypeRef llvmArgType, out _))
-                {
-                    signatureTypes.Add(llvmArgType);
-                }
-            }
-
-            return LLVMTypeRef.CreateFunction(llvmReturnType, signatureTypes.ToArray(), false);
-        }
-
-        internal static bool CanStoreTypeOnStack(TypeDesc type)
-        {
-            if (type is DefType defType)
-            {
-                if (!defType.IsGCPointer && !defType.ContainsGCPointers && !ContainsIsByRef(type))
-                {
-                    return true;
-                }
-            }
-            else if (type is PointerType || type is FunctionPointerType)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public override TypeDesc GetPrimitiveTypeForTrivialWasmStruct(TypeDesc type)
-        {
-            Debug.Assert(IsStruct(type));
-
-            int size = type.GetElementSize().AsInt;
-            if (size <= sizeof(double) && BitOperations.IsPow2(size))
-            {
-                while (true)
-                {
-                    FieldDesc singleInstanceField = null;
-                    foreach (FieldDesc field in type.GetFields())
-                    {
-                        if (!field.IsStatic)
-                        {
-                            if (singleInstanceField != null)
-                            {
-                                return null;
-                            }
-
-                            singleInstanceField = field;
-                        }
-                    }
-
-                    if (singleInstanceField == null)
-                    {
-                        return null;
-                    }
-
-                    TypeDesc singleInstanceFieldType = singleInstanceField.FieldType;
-                    if (!IsStruct(singleInstanceFieldType))
-                    {
-                        if (singleInstanceFieldType.GetElementSize().AsInt != size)
-                        {
-                            return null;
-                        }
-
-                        return singleInstanceFieldType;
-                    }
-
-                    type = singleInstanceFieldType;
-                }
-            }
-
-            return null;
-        }
-
-        internal bool GetLlvmArgTypeForArg(bool isManagedAbi, TypeDesc argSigType, out LLVMTypeRef llvmArgType, out bool isPassedByRef)
-        {
-            isPassedByRef = false;
-            bool isLlvmArg = !isManagedAbi || CanStoreTypeOnStack(argSigType);
-            TypeDesc argType = argSigType;
-            if (isLlvmArg && IsStruct(argSigType))
-            {
-                argType = GetPrimitiveTypeForTrivialWasmStruct(argSigType);
-                if (argType == null)
-                {
-                    isPassedByRef = true;
-                }
-            }
-
-            llvmArgType = isPassedByRef ? LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0) : GetLLVMTypeForTypeDesc(argType);
-            return isLlvmArg;
-        }
-
-        internal LLVMTypeRef GetLlvmReturnType(TypeDesc sigReturnType, out bool isPassedByRef)
-        {
-            isPassedByRef = IsStruct(sigReturnType) && GetPrimitiveTypeForTrivialWasmStruct(sigReturnType) == null;
-            if (isPassedByRef || sigReturnType.IsVoid)
-            {
-                return LLVMTypeRef.Void;
-            }
-
-            return GetLLVMTypeForTypeDesc(sigReturnType);
-        }
-
-        public override int PadOffset(TypeDesc type, int atOffset)
-        {
-            var fieldAlignment = type is DefType && type.IsValueType ? ((DefType)type).InstanceFieldAlignment : type.Context.Target.LayoutPointerSize;
-            var alignment = LayoutInt.Min(fieldAlignment, new LayoutInt(ComputePackingSize(type))).AsInt;
-            var padding = atOffset.AlignUp(alignment);
-
-            return padding;
-        }
-
-        internal int PadNextOffset(TypeDesc type, int atOffset)
-        {
-            return PadOffset(type, atOffset) + type.GetElementSize().AsInt;
-        }
-
-        internal LLVMTypeRef GetLLVMTypeForTypeDesc(TypeDesc type)
-        {
-            switch (type.Category)
-            {
-                case TypeFlags.Boolean:
-                case TypeFlags.SByte:
-                case TypeFlags.Byte:
-                    return LLVMTypeRef.Int8;
-
-                case TypeFlags.Int16:
-                case TypeFlags.UInt16:
-                case TypeFlags.Char:
-                    return LLVMTypeRef.Int16;
-
-                case TypeFlags.Int32:
-                case TypeFlags.UInt32:
-                    return LLVMTypeRef.Int32;
-
-                case TypeFlags.IntPtr:
-                case TypeFlags.UIntPtr:
-                    return _nodeFactory.Target.PointerSize == 4 ? LLVMTypeRef.Int32 : LLVMTypeRef.Int64;
-
-                case TypeFlags.Array:
-                case TypeFlags.SzArray:
-                case TypeFlags.ByRef:
-                case TypeFlags.Class:
-                case TypeFlags.Interface:
-                case TypeFlags.Pointer:
-                case TypeFlags.FunctionPointer:
-                    return LLVMTypeRef.CreatePointer(LLVMTypeRef.Int8, 0);
-
-                case TypeFlags.Int64:
-                case TypeFlags.UInt64:
-                    return LLVMTypeRef.Int64;
-
-                case TypeFlags.Single:
-                    return LLVMTypeRef.Float;
-
-                case TypeFlags.Double:
-                    return LLVMTypeRef.Double;
-
-                case TypeFlags.ValueType:
-                case TypeFlags.Nullable:
-                    if (!_llvmStructs.TryGetValue(type, out LLVMTypeRef llvmStructType))
-                    {
-                        // Treat trivial structs like their underlying types for compatibility with the native ABI.
-                        if (GetPrimitiveTypeForTrivialWasmStruct(type) is TypeDesc primitiveType)
-                        {
-                            llvmStructType = GetLLVMTypeForTypeDesc(primitiveType);
-                        }
-                        else
-                        {
-                            List<FieldDesc> sortedFields = new();
-                            foreach (FieldDesc field in type.GetFields())
-                            {
-                                if (!field.IsStatic)
-                                {
-                                    sortedFields.Add(field);
-                                }
-                            }
-
-                            // Sort fields by offset and size in order to handle generating unions
-                            sortedFields.Sort((left, right) =>
-                            {
-                                int leftOffset = left.Offset.AsInt;
-                                int rightOffset = right.Offset.AsInt;
-                                if (leftOffset == rightOffset)
-                                {
-                                    // Sort union fields in a descending order.
-                                    return right.FieldType.GetElementSize().AsInt - left.FieldType.GetElementSize().AsInt;
-                                }
-
-                                return leftOffset - rightOffset;
-                            });
-
-                            List<LLVMTypeRef> llvmFields = new List<LLVMTypeRef>(sortedFields.Count);
-                            int lastOffset = -1;
-                            int nextNewOffset = -1;
-                            TypeDesc prevType = null;
-                            int totalSize = 0;
-
-                            foreach (FieldDesc field in sortedFields)
-                            {
-                                int curOffset = field.Offset.AsInt;
-
-                                if (prevType == null || (curOffset != lastOffset && curOffset >= nextNewOffset))
-                                {
-                                    // The layout should be in order
-                                    Debug.Assert(curOffset > lastOffset);
-
-                                    int prevElementSize;
-                                    if (prevType == null)
-                                    {
-                                        lastOffset = 0;
-                                        prevElementSize = 0;
-                                    }
-                                    else
-                                    {
-                                        prevElementSize = prevType.GetElementSize().AsInt;
-                                    }
-
-                                    // Pad to this field if necessary
-                                    int paddingSize = curOffset - lastOffset - prevElementSize;
-                                    if (paddingSize > 0)
-                                    {
-                                        AddPaddingFields(paddingSize, llvmFields);
-                                        totalSize += paddingSize;
-                                    }
-
-                                    TypeDesc fieldType = field.FieldType;
-                                    int fieldSize = fieldType.GetElementSize().AsInt;
-
-                                    llvmFields.Add(GetLLVMTypeForTypeDesc(fieldType));
-
-                                    totalSize += fieldSize;
-                                    lastOffset = curOffset;
-                                    prevType = fieldType;
-                                    nextNewOffset = curOffset + fieldSize;
-                                }
-                            }
-
-                            // If explicit layout is greater than the sum of fields, add padding
-                            int structSize = type.GetElementSize().AsInt;
-                            if (totalSize < structSize)
-                            {
-                                AddPaddingFields(structSize - totalSize, llvmFields);
-                            }
-
-                            llvmStructType = LLVMTypeRef.CreateStruct(llvmFields.ToArray(), true);
-                        }
-
-                        _llvmStructs[type] = llvmStructType;
-                    }
-                    return llvmStructType;
-
-                case TypeFlags.Enum:
-                    return GetLLVMTypeForTypeDesc(type.UnderlyingType);
-
-                case TypeFlags.Void:
-                    return LLVMTypeRef.Void;
-
-                default:
-                    throw new UnreachableException(type.Category.ToString());
-            }
-        }
-
-        private static bool ContainsIsByRef(TypeDesc type)
-        {
-            if (type.IsByRef || type.IsByRefLike)
-            {
-                return true;
-            }
-
-            foreach (var field in type.GetFields())
-            {
-                if (field.IsStatic)
-                    continue;
-
-                var fieldType = field.FieldType;
-                if (fieldType.IsValueType)
-                {
-                    var fieldDefType = (DefType)fieldType;
-                    if (!fieldDefType.ContainsGCPointers && !fieldDefType.IsByRefLike)
-                        continue;
-
-                    if (ContainsIsByRef(fieldType))
-                    {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
-        private static int ComputePackingSize(TypeDesc type)
-        {
-            if (type is MetadataType)
-            {
-                var metaType = type as MetadataType;
-                var layoutMetadata = metaType.GetClassLayout();
-
-                // If a type contains pointers then the metadata specified packing size is ignored (On desktop this is disqualification from ManagedSequential)
-                if (layoutMetadata.PackingSize == 0 || metaType.ContainsGCPointers)
-                    return type.Context.Target.DefaultPackingSize;
-                else
-                    return layoutMetadata.PackingSize;
-            }
-            else
-            {
-                return type.Context.Target.DefaultPackingSize;
-            }
-        }
-
-        private static void AddPaddingFields(int paddingSize, List<LLVMTypeRef> llvmFields)
-        {
-            int numInts = paddingSize / 4;
-            int numBytes = paddingSize - numInts * 4;
-            for (int i = 0; i < numInts; i++)
-            {
-                llvmFields.Add(LLVMTypeRef.Int32);
-            }
-            for (int i = 0; i < numBytes; i++)
-            {
-                llvmFields.Add(LLVMTypeRef.Int8);
-            }
-        }
-
-        private static bool IsStruct(TypeDesc type) => type.Category is TypeFlags.ValueType or TypeFlags.Nullable;
+        internal LLVMCompilationResults GetCompilationResults() => _compilationResults;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 
 using ILCompiler.DependencyAnalysis;
@@ -41,21 +42,25 @@ namespace ILCompiler
     {
         internal void SetOptions(IEnumerable<KeyValuePair<string, string>> options)
         {
-            foreach (var (name, value) in options)
+            foreach ((string name, string value) in options)
             {
                 switch (name)
                 {
                     case "Target":
                         Target = value;
                         break;
-                    case "ModuleName":
-                        ModuleName = value;
-                        break;
                     case "DataLayout":
                         DataLayout = value;
                         break;
                     case "LlvmExceptionHandlingModel" when value is "wasm":
                         ExceptionHandlingModel = CorInfoLlvmEHModel.Wasm;
+                        break;
+                    case "MaxLlvmModuleCount":
+                        MaxLlvmModuleCount = int.Parse(value);
+                        if (MaxLlvmModuleCount < 1)
+                        {
+                            throw new InvalidOperationException("LLVM module count must be positive");
+                        }
                         break;
                     default:
                         break;
@@ -72,7 +77,9 @@ namespace ILCompiler
         // S128 natural alignment of stack
         public string DataLayout { get; private set; } = "e-m:e-p:32:32-i64:64-n32:64-S128";
         public string Target { get; private set; } = "wasm32-unknown-emscripten";
-        public string ModuleName { get; private set; } = "netscripten";
         public CorInfoLlvmEHModel ExceptionHandlingModel { get; private set; } = CorInfoLlvmEHModel.Cpp;
+
+        // Below options are debug-only and not supported.
+        public int MaxLlvmModuleCount { get; private set; } = 8;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCompilationResults.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCompilationResults.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace ILCompiler
+{
+    internal sealed class LLVMCompilationResults
+    {
+        private readonly List<string> _files = new();
+
+        public void Add(string file)
+        {
+            Debug.Assert(!_files.Contains(file));
+            _files.Add(file);
+        }
+
+        public void SerializeToFile(string path)
+        {
+            // Sort the files here so that downstream consumers don't have to.
+            _files.Sort(StringComparer.Ordinal);
+            File.WriteAllLines(path, _files);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/ILCompiler.LLVM.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/ILCompiler.LLVM.csproj
@@ -12,7 +12,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
-
   <ItemGroup>
     <ProjectReference Include="..\ILCompiler.DependencyAnalysisFramework\ILCompiler.DependencyAnalysisFramework.csproj" />
     <ProjectReference Include="..\ILCompiler.MetadataTransform\ILCompiler.MetadataTransform.csproj" />
@@ -20,12 +19,15 @@
     <ProjectReference Include="..\ILCompiler.TypeSystem\ILCompiler.TypeSystem.csproj" />
     <ProjectReference Include="..\ILCompiler.Compiler\ILCompiler.Compiler.csproj" />
   </ItemGroup>
+
   <ItemGroup>
+    <Compile Include="CodeGen\LLVMCodegenCompilation.CodeGen.cs" />
     <Compile Include="CodeGen\LLVMSharpInterop.cs" />
     <Compile Include="CodeGen\LLVMObjectWriter.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ExternMethodAccessorNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\LLVMCodegenNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\LLVMMethodCodeNode.cs" />
+    <Compile Include="Compiler\LLVMCompilationResults.cs" />
     <Compile Include="Compiler\LLVMNodeMangler.cs" />
     <Compile Include="Compiler\LLVMCodegenCompilation.cs" />
     <Compile Include="Compiler\LLVMCodegenCompilationBuilder.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
This change implements the multi-threading scheme described in #2293.

We partition the incoming into `8` modules, regardless of the `--parallelism` setting, which achieves the desired determinism characteristics. These modules are compiled on multiple threads both when generating LLVM and when generating machine code (i. e. invoking `clang`).

The peformance results of this work can be summarized as "modest", though some gains, especially in Release builds, are quite visible (up to 2x speedups on my machine). For yet unclear reasons, parallelism inside ILC itself is not fully utilized, however, that is also not the bottleneck of the build, as especially in Debug a lot of time is spent in `wasm-esmcripten-finalize.exe`. Time is also spent with the disk interactions - ideally the next step would be to move the Clang part of the build in-process (or do something like thin-LTO).

I have put together a small sheet of the results as they apply to `HelloWasm` on my machine:


Module count | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |   | NAOT ILC / 8
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Total   compilation time (Release) | 01:03.3 | 42.0 | 37.8 | 33.7 | 33.1 | 32.8 | 30.9 | 30.3 |   | 26.6
  |   | 01:04.7 | 41.9 | 39.2 | 33.1 | 32.5 | 32.9 | 31.6 | 30.1 |   | 27.6
  |   |   |   |   |   |   |   |   |   |   |  
Bitcode   compilation time (Release) | 6.66 | 5.36 | 5.04 | 4.75 | 4.58 | 4.57 | 4.45 | 4.55 |   | 3.84
  |   | 7.72 | 5.34 | 4.84 | 4.78 | 5 | 4.6 | 4.46 | 4.53 |   | 3.71
  |   |   |   |   |   |   |   |   |   |   |  
WASM file   size | 4.672 | 4.537 | 4.5 | 4.483 | 4.467 | 4.451 | 4.457 | 4.455 |   | 
  |   |   |   |   |   |   |   |   |   |   |  
Total   compilation time (Debug) | 1:05.9 | 53.4 | 51.8 | 49.6 |   |   |   | 49.3 |   | 46.6
  |   | 1:04.9 | 53.1 | 52.9 |   |   |   |   |   |   | 44.7
  |   |   |   |   |   |   |   |   |   |   |  
Bitcode   compilation time (Debug) | 13.65 | 11.05 | 10.72 | 10.14 |   |   |   | 9.92 |   | 5.62
  |   | 13.82 | 11.12 | 10.65 |   |   |   |   |   |   | 5.31

Note that the measurement were done using a CoreCLR-based ILC (except for the `NAOT / 8` column).