### PR TITLE
[NativeAOT-LLVM] Codegen fixes for libraries tests

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -318,12 +318,13 @@ public:
 
 private:
     void lowerSpillTempsLiveAcrossSafePoints();
-    void lowerLocals();
+    void lowerLocalsBeforeNodes();
     void populateLlvmArgNums();
     void assignShadowStackOffsets(std::vector<unsigned>& shadowStackLocals, unsigned shadowStackParamCount);
     void initializeLocalInProlog(unsigned lclNum, GenTree* value);
 
     void insertProlog();
+    void lowerLocalsAfterNodes();
 
     void lowerBlocks();
     void lowerBlock(BasicBlock* block);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2786,6 +2786,7 @@ Function* Llvm::getOrCreateKnownLlvmFunction(
     Function* llvmFunc = m_context->Module.getFunction(name);
     if (llvmFunc == nullptr)
     {
+        assert(m_context->Module.getNamedValue(name) == nullptr); // No duplicate symbols!
         llvmFunc = Function::Create(createFunctionType(), Function::ExternalLinkage, name, m_context->Module);
         annotateFunction(llvmFunc);
     }
@@ -2831,6 +2832,7 @@ llvm::GlobalVariable* Llvm::getOrCreateDataSymbol(StringRef symbolName)
     llvm::GlobalVariable* symbol = m_context->Module.getGlobalVariable(symbolName);
     if (symbol == nullptr)
     {
+        assert(m_context->Module.getNamedValue(symbolName) == nullptr); // No duplicate symbols!
         Type* symbolLlvmType = getPtrLlvmType();
         symbol = new llvm::GlobalVariable(m_context->Module, symbolLlvmType, false, llvm::GlobalValue::ExternalLinkage,
                                           nullptr, symbolName);

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -454,7 +454,7 @@ void Llvm::lowerLocalsBeforeNodes()
                 else if (!_compiler->fgVarNeedsExplicitZeroInit(lclNum, /* bbInALoop */ false, /* bbIsReturn*/ false) ||
                          varDsc->HasGCPtr())
                 {
-                    var_types zeroType = (varDsc->TypeGet() == TYP_STRUCT) ? TYP_INT : genActualType(varDsc);
+                    var_types zeroType = (varDsc->TypeGet() == TYP_STRUCT) ? TYP_INT : varDsc->TypeGet();
                     initializeLocalInProlog(lclNum, _compiler->gtNewZeroConNode(zeroType));
                 }
             }
@@ -1266,9 +1266,8 @@ void Llvm::lowerDelegateInvoke(GenTreeCall* callNode)
     delegateThis = _compiler->gtNewLclvNode(delegateThisLclNum, TYP_REF);
     GenTree* callTargetOffset = _compiler->gtNewIconNode(eeInfo->offsetOfDelegateFirstTarget, TYP_I_IMPL);
     GenTree* callTargetAddr = _compiler->gtNewOperNode(GT_ADD, TYP_BYREF, delegateThis, callTargetOffset);
-    GenTree* callTarget = _compiler->gtNewIndir(TYP_I_IMPL, callTargetAddr);
-    callTarget->SetAllEffectsFlags(GTF_EMPTY);
-    callTarget->gtFlags |= GTF_IND_NONFAULTING | GTF_ORDER_SIDEEFF;
+    GenTree* callTarget = _compiler->gtNewIndir(TYP_I_IMPL, callTargetAddr, GTF_IND_NONFAULTING);
+    callTarget->gtFlags |= GTF_ORDER_SIDEEFF;
 
     CurrentRange().InsertBefore(callNode, delegateThis, callTargetOffset, callTargetAddr, callTarget);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternSymbolNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternSymbolNode.cs
@@ -23,6 +23,8 @@ namespace ILCompiler.DependencyAnalysis
             _isIndirection = isIndirection;
         }
 
+        public Utf8String Utf8Name => _name;
+
         protected override string GetName(NodeFactory factory) => $"ExternSymbol {_name}{(_isIndirection ? " (indirected)" : "")}";
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -133,12 +133,9 @@ namespace Internal.JitInterface
             IMethodNode methodNode = _this._methodCodeNode;
             RyuJitCompilation compilation = _this._compilation;
 
-            string alternativeName = compilation.GetRuntimeExportManagedEntrypointName(methodNode.Method) ?? compilation.NodeFactory.GetSymbolAlternateName(methodNode);
-            if ((alternativeName == null) && methodNode.Method.IsUnmanagedCallersOnly)
-            {
-                // TODO-LLVM: delete once the IL backend is gone.
-                alternativeName = methodNode.Method.Name;
-            }
+            string alternativeName =
+                compilation.GetRuntimeExportManagedEntrypointName(methodNode.Method) ??
+                compilation.NodeFactory.GetSymbolAlternateName(methodNode);
 
             return (alternativeName != null) ? (byte*)_this.GetPin(StringToUTF8(alternativeName)) : null;
         }


### PR DESCRIPTION
This is enough to compile S.R.Tests in Release and Debug. Unfortunately, Release crashes on thread creation (we need a Wasm-specific TP implementation like Mono has), while Debug crashes on functions having too many locals (perhaps we can tune our debug codegen to be less naive).

Contributes to #2307.