### PR TITLE
[NativeAOT-LLVM] Pass GC values in LLVM/WASM registers

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2080,36 +2080,6 @@ void CallArgs::Remove(CallArg* arg)
 
 #if TARGET_WASM
 //------------------------------------------------------------------------
-// RemoveAfter: Remove the argument after the one passed 
-//
-// Removes the argument after the passed argument from argument list.
-// "nullptr" can be passed to indicate that the first argument should be
-// removed.
-//
-// Arguments:
-//    arg - The argument before the one that is to be removed, or null
-//          if the first argument should be removed.
-//
-void CallArgs::RemoveAfter(CallArg* arg)
-{
-    // if arg == nullptr, we are removing the first arg
-    if (arg == nullptr)
-    {
-        assert(m_head != nullptr);
-
-        RemovedWellKnownArg(m_head->GetWellKnownArg());
-        m_head = m_head->GetNext();
-        return;
-    }
-
-    CallArg* nextArg = arg->GetNext();
-    assert(nextArg != nullptr);
-
-    arg->SetNext(nextArg->GetNext());
-    RemovedWellKnownArg(nextArg->GetWellKnownArg());
-}
-
-//------------------------------------------------------------------------
 // MoveLateToEarly: Sets all late nodes as the early nodes
 //
 // Moves and clears all the late nodes, leaving the "CallArgs" as just

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4762,7 +4762,6 @@ public:
     void PushLateBack(CallArg* arg);
     void Remove(CallArg* arg);
 #if TARGET_WASM
-    void RemoveAfter(CallArg* arg);
     void MoveLateToEarly();
 #endif
 

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -124,13 +124,10 @@ Llvm::Llvm(Compiler* compiler)
 
 var_types Llvm::GetArgTypeForStructWasm(CORINFO_CLASS_HANDLE structHnd, structPassingKind* pPassKind)
 {
-    // Note the managed and unmanaged ABIs are the same for structs that do not contain GC pointers. Thus, since
-    // unmanaged calls in general cannot have struct arguments with GC pointers in them, always passing "true" for
-    // "isManagedAbi" is ok. The one scenario which would break down with this handling is FCalls with such args.
-    // Luckily, none currently exist.
-    CorInfoType argType;
+    // Note the managed and unmanaged ABIs are the same in terms of values, but do differ w.r.t by-ref
+    // parameter aliasing guarantees (native assumes no aliasing, we do not).
     bool isPassedByRef;
-    getLlvmArgTypeForArg(/* isManagedAbi */ true, CORINFO_TYPE_VALUECLASS, structHnd, &argType, &isPassedByRef);
+    CorInfoType argType = getLlvmArgTypeForArg(CORINFO_TYPE_VALUECLASS, structHnd, &isPassedByRef);
 
     *pPassKind = isPassedByRef ? Compiler::SPK_ByReference : Compiler::SPK_ByValue;
     return JITtype2varType(argType);
@@ -586,7 +583,7 @@ bool Llvm::helperCallHasManagedCallingConvention(CorInfoHelpFunc helperFunc) con
         { FUNC(CORINFO_HELP_LLVM_EH_UNHANDLED_EXCEPTION) CORINFO_TYPE_VOID, { CORINFO_TYPE_CLASS } },
         { FUNC(CORINFO_HELP_LLVM_DYNAMIC_STACK_ALLOC) CORINFO_TYPE_PTR, { CORINFO_TYPE_INT, CORINFO_TYPE_PTR }, HFIF_NO_RPI_OR_GC },
         { FUNC(CORINFO_HELP_LLVM_DYNAMIC_STACK_RELEASE) CORINFO_TYPE_VOID, { CORINFO_TYPE_PTR }, HFIF_NO_RPI_OR_GC },
-        { FUNC(CORINFO_HELP_LLVM_RESOLVE_INTERFACE_CALL_TARGET) CORINFO_TYPE_PTR, { CORINFO_TYPE_PTR, CORINFO_TYPE_CLASS, CORINFO_TYPE_PTR }, HFIF_NO_SS_SAVE }
+        { FUNC(CORINFO_HELP_LLVM_RESOLVE_INTERFACE_CALL_TARGET) CORINFO_TYPE_PTR, { CORINFO_TYPE_CLASS, CORINFO_TYPE_PTR }, HFIF_SS_ARG }
     };
     // clang-format on
 
@@ -602,26 +599,7 @@ bool Llvm::helperCallHasManagedCallingConvention(CorInfoHelpFunc helperFunc) con
     return info;
 }
 
-bool Llvm::canStoreArgOnLlvmStack(CorInfoType argSigType, CORINFO_CLASS_HANDLE argSigClass)
-{
-    switch (argSigType)
-    {
-        case CORINFO_TYPE_BYREF:
-        case CORINFO_TYPE_CLASS:
-        case CORINFO_TYPE_REFANY:
-            return false;
-        case CORINFO_TYPE_VALUECLASS:
-            return !_compiler->typGetObjLayout(argSigClass)->HasGCPtr();
-        default:
-            return true;
-    }
-}
-
-bool Llvm::getLlvmArgTypeForArg(bool                 isManagedAbi,
-                                CorInfoType          argSigType,
-                                CORINFO_CLASS_HANDLE argSigClass,
-                                CorInfoType*         pArgType,
-                                bool*                pIsByRef)
+CorInfoType Llvm::getLlvmArgTypeForArg(CorInfoType argSigType, CORINFO_CLASS_HANDLE argSigClass, bool* pIsByRef)
 {
     assert(argSigType != CORINFO_TYPE_UNDEF);
     if (argSigType == CORINFO_TYPE_REFANY)
@@ -631,30 +609,25 @@ bool Llvm::getLlvmArgTypeForArg(bool                 isManagedAbi,
     //
     // WASM C ABI is documented here: https://github.com/WebAssembly/tool-conventions/blob/main/BasicCABI.md.
     // In essense, structs are passed by reference except if they are trivial wrappers of a primitive (scalar).
-    // We follow this rule for the native calling convention as well as non-GC structs. GC structs are passed
-    // by value on the shadow stack in the managed calling convention.
+    // We follow this rule for the native calling convention as well as the managed one.
     //
     bool isByRef = false;
-    bool isLlvmArg = !isManagedAbi || canStoreArgOnLlvmStack(argSigType, argSigClass);
     CorInfoType argType = argSigType;
-    if (isLlvmArg && (argSigType == CORINFO_TYPE_VALUECLASS))
+    if (argSigType == CORINFO_TYPE_VALUECLASS)
     {
         argType = GetPrimitiveTypeForTrivialWasmStruct(argSigClass);
         if (argType == CORINFO_TYPE_UNDEF)
         {
+            argType = CORINFO_TYPE_PTR;
             isByRef = true;
         }
     }
 
-    if (pArgType != nullptr)
-    {
-        *pArgType = isByRef ? CORINFO_TYPE_PTR : argType;
-    }
     if (pIsByRef != nullptr)
     {
         *pIsByRef = isByRef;
     }
-    return isLlvmArg;
+    return argType;
 }
 
 CorInfoType Llvm::getLlvmReturnType(CorInfoType sigRetType, CORINFO_CLASS_HANDLE sigRetClass, bool* pIsByRef)

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -249,12 +249,7 @@ private:
 
     static const HelperFuncInfo& getHelperFuncInfo(CorInfoHelpFunc helperFunc);
 
-    bool canStoreArgOnLlvmStack(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
-    bool getLlvmArgTypeForArg(bool                 isManagedAbi,
-                              CorInfoType          argSigType,
-                              CORINFO_CLASS_HANDLE argSigClass,
-                              CorInfoType*         pArgType = nullptr,
-                              bool*                pIsByRef = nullptr);
+    CorInfoType getLlvmArgTypeForArg(CorInfoType argSigType, CORINFO_CLASS_HANDLE argSigClass, bool* pIsByRef = nullptr);
     CorInfoType getLlvmReturnType(CorInfoType sigRetType, CORINFO_CLASS_HANDLE sigRetClass, bool* pIsByRef = nullptr);
 
     unsigned padOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned atOffset);
@@ -322,7 +317,7 @@ private:
     void lowerSpillTempsLiveAcrossSafePoints();
     void lowerLocalsBeforeNodes();
     void populateLlvmArgNums();
-    void assignShadowStackOffsets(std::vector<unsigned>& shadowStackLocals, unsigned shadowStackParamCount);
+    void assignShadowStackOffsets(std::vector<unsigned>& shadowStackLocals);
     void initializeLocalInProlog(unsigned lclNum, GenTree* value);
 
     void insertProlog();
@@ -345,12 +340,11 @@ private:
     void lowerReturn(GenTreeUnOp* retNode);
 
     void lowerVirtualStubCallBeforeArgs(GenTreeCall* callNode, unsigned* pThisLclNum, GenTree** pCellArgNode);
-    void lowerVirtualStubCallAfterArgs(
-        GenTreeCall* callNode, unsigned thisArgLclNum, GenTree* cellArgNode, unsigned shadowArgsSize);
+    void lowerVirtualStubCallAfterArgs(GenTreeCall* callNode, unsigned thisArgLclNum, GenTree* cellArgNode);
     void insertNullCheckForCall(GenTreeCall* callNode);
     void lowerDelegateInvoke(GenTreeCall* callNode);
     void lowerUnmanagedCall(GenTreeCall* callNode);
-    unsigned lowerCallToShadowStack(GenTreeCall* callNode);
+    void lowerCallToShadowStack(GenTreeCall* callNode);
     void lowerCallReturn(GenTreeCall* callNode);
 
     GenTree* normalizeStructUse(LIR::Use& use, ClassLayout* layout);

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -207,7 +207,9 @@ namespace System.Runtime
             }
 
             WasmEHLogFunletEnter(pCatchFunclet, RhEHClauseKind.RH_EH_CLAUSE_TYPED, pCatchShadowFrame);
-            int catchRetIdx = ((delegate*<object, void*, int>)pCatchFunclet)(exception, pCatchShadowFrame);
+            // Implicitly pass the callee's shadow stack.
+            void* pCallCatch = (delegate*<void*, void*, object, void*, int>)&InternalCalls.RhpCallCatchOrFilterFunclet;
+            int catchRetIdx = ((delegate*<void*, object, void*, int>)pCallCatch)(pCatchShadowFrame, exception, pCatchFunclet);
             WasmEHLogFunletExit(RhEHClauseKind.RH_EH_CLAUSE_TYPED, catchRetIdx, pCatchShadowFrame);
 
             return catchRetIdx;
@@ -219,7 +221,9 @@ namespace System.Runtime
             bool result;
             try
             {
-                result = ((delegate*<object, void*, int>)pFunclet)(exception, pShadowFrame) != 0;
+                // Implicitly pass the callee's shadow stack.
+                void* pCallFilter = (delegate*<void*, void*, object, void*, int>)&InternalCalls.RhpCallCatchOrFilterFunclet;
+                result = ((delegate*<void*, object, void*, int>)pCallFilter)(pShadowFrame, exception, pFunclet) != 0;
             }
             catch when (true)
             {

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/InternalCalls.cs
@@ -154,13 +154,6 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern unsafe void RhpAssignRef(ref object address, object obj);
 
-#if TARGET_WASM
-        // TODO-LLVM: the IL backend needs this for store indirect, when all code is through the RyuJIT backend, remove it
-        [RuntimeImport(Redhawk.BaseName, "RhpCheckedAssignRef")]
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern unsafe void RhpCheckedAssignRef(ref object address, object obj);
-#endif
-
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [RuntimeImport(Redhawk.BaseName, "RhpGcSafeZeroMemory")]
         internal static extern unsafe ref byte RhpGcSafeZeroMemory(ref byte dmem, nuint size);
@@ -278,6 +271,10 @@ namespace System.Runtime
         [RuntimeImport(Redhawk.BaseName, "RhpReleaseNativeException")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern unsafe void RhpReleaseNativeException(void* pDispatchData);
+
+        [RuntimeImport(Redhawk.BaseName, "RhpCallCatchOrFilterFunclet")]
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern unsafe int RhpCallCatchOrFilterFunclet(void* pShadowFrame, void* pOriginalShadowFrame, object exception, void* pFunclet);
 #endif
 
         [RuntimeImport(Redhawk.BaseName, "RhpGetNumThunkBlocksPerMapping")]

--- a/src/coreclr/nativeaot/Runtime/wasm/StubDispatch.cpp
+++ b/src/coreclr/nativeaot/Runtime/wasm/StubDispatch.cpp
@@ -22,17 +22,11 @@
 //
 
 // Cache miss case, call the runtime to resolve the target and update the cache.
-extern "C" void* RhpCidResolveWasm_Managed(void* pShadowStack, void* pCell);
-extern "C" void* RuntimeResolveInterfaceDispatch(void* pShadowStack, Object* pObject, InterfaceDispatchCell* pCell)
-{
-    *(Object**)pShadowStack = pObject;
-    void* pTarget = RhpCidResolveWasm_Managed(pShadowStack, pCell);
-
-    return pTarget;
-}
+extern "C" void* RhpCidResolveWasm_Managed(void* pShadowStack, Object* pObject, void* pCell);
 
 COOP_PINVOKE_HELPER(void*, RhpResolveInterfaceDispatch, (void* pShadowStack, Object* pObject, InterfaceDispatchCell* pCell))
 {
+    ASSERT(pObject != nullptr);
     InterfaceDispatchCache* pCache = (InterfaceDispatchCache*)pCell->GetCache();
     if (pCache != nullptr)
     {
@@ -47,11 +41,11 @@ COOP_PINVOKE_HELPER(void*, RhpResolveInterfaceDispatch, (void* pShadowStack, Obj
         }
     }
 
-    return RuntimeResolveInterfaceDispatch(pShadowStack, pObject, pCell);
+    return RhpCidResolveWasm_Managed(pShadowStack, pObject, pCell);
 }
 
-extern "C" void* RhpInitialInterfaceDispatch(void*, Object*, InterfaceDispatchCell*) __attribute__((alias ("RuntimeResolveInterfaceDispatch")));
-extern "C" void* RhpInitialDynamicInterfaceDispatch(void*, Object*, InterfaceDispatchCell*) __attribute__((alias ("RuntimeResolveInterfaceDispatch")));
+extern "C" void* RhpInitialInterfaceDispatch(void*, Object*, InterfaceDispatchCell*) __attribute__((alias ("RhpResolveInterfaceDispatch")));
+extern "C" void* RhpInitialDynamicInterfaceDispatch(void*, Object*, InterfaceDispatchCell*) __attribute__((alias ("RhpResolveInterfaceDispatch")));
 extern "C" void* RhpInterfaceDispatch1(void*, Object*, InterfaceDispatchCell*) __attribute__((alias ("RhpResolveInterfaceDispatch")));
 extern "C" void* RhpInterfaceDispatch2(void*, Object*, InterfaceDispatchCell*) __attribute__((alias ("RhpResolveInterfaceDispatch")));
 extern "C" void* RhpInterfaceDispatch4(void*, Object*, InterfaceDispatchCell*) __attribute__((alias ("RhpResolveInterfaceDispatch")));


### PR DESCRIPTION
So far, our ABI has been that we pass GC values on the shadow stack. This strategy trades the code size of the callsite for the  code of the callee, i. e. makes the former larger so that the latter is smaller.

However, in general, we would expect functions to have more than one callee, i. e. should bias our ABI towards pushing  repetitive code down into callees, where it would be naturally deduplicated.

This change implements just that: instead of passing GC arguments on the shadow stack, they are passed in LLVM/WASM  registers, and then eagerly spilled in the prolog (ensuring no GC holes). As the diffs indicate, this is a major code size win:

```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3298081
Total bytes of diff: 3167897
Total bytes of delta: -130184 (-3.95% % of base)
Average relative delta: -9.11%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
         172 (215.00% of base) : 5779.dasm - S_P_CoreLib_System_SZGenericArrayEnumerator_1<S_P_CoreLib_System_Reflection_CustomAttributeNamedArgument>__System_Collections_IEnumerator_get_Current
         112 (121.74% of base) : 4295.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__GetCustomAttributesData
         252 (85.14% of base) : 3322.dasm - S_P_TypeLoader_Internal_Metadata_NativeFormat_MetadataTypeHashingAlgorithms__AppendNamespaceHashCode
         147 (75.77% of base) : 3044.dasm - S_P_CoreLib_System_Diagnostics_StackTrace__ToString
           4 (57.14% of base) : 1456.dasm - S_P_TypeLoader_Internal_TypeSystem_MethodDesc__GetMethodDefinition
           4 (57.14% of base) : 4155.dasm - S_P_TypeLoader_Internal_TypeSystem_GenericParameterDesc__ConvertToCanonFormImpl
           4 (57.14% of base) : 4376.dasm - S_P_TypeLoader_Internal_TypeSystem_CanonType__ConvertToCanonFormImpl
           4 (57.14% of base) : 4372.dasm - S_P_TypeLoader_Internal_TypeSystem_UniversalCanonType__ConvertToCanonFormImpl
           4 (57.14% of base) : 5542.dasm - HelloWasm_Program_ClassForMetaTests__ReturnsParam
           4 (57.14% of base) : 3575.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeDesc__GetTypeDefinition
           4 (57.14% of base) : 4289.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__get_UnderlyingSystemType
           4 (57.14% of base) : 1074.dasm - String__ToString
           4 (57.14% of base) : 1608.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__System_ICloneable_Clone
           4 (57.14% of base) : 4323.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeNamedTypeInfo__get_AnchoringTypeDefinitionForDeclaredMembers
           4 (57.14% of base) : 1088.dasm - String__Clone
           4 (57.14% of base) : 3680.dasm - S_P_CoreLib_System_Reflection_SignatureType__get_UnderlyingSystemType
         239 (54.20% of base) : 4783.dasm - S_P_CoreLib_System_Reflection_TypeNameParser__get_PeekSecond
           8 (50.00% of base) : 3019.dasm - S_P_CoreLib_System_Reflection_Assembly__Equals
           8 (50.00% of base) : 5561.dasm - Object__ReferenceEquals
           8 (50.00% of base) : 3595.dasm - S_P_TypeLoader_Internal_TypeSystem_MethodDesc__Equals

Top methods only present in diff:
          23 (     ∞ of base) : 6727.dasm - legalstub$dynCall_viiji
          15 (     ∞ of base) : 6685.dasm - dynCall_vijji
          21 (     ∞ of base) : 6686.dasm - dynCall_iijiiiij
          17 (     ∞ of base) : 6687.dasm - dynCall_iijjii
          19 (     ∞ of base) : 6688.dasm - dynCall_iiijiii
          15 (     ∞ of base) : 6689.dasm - dynCall_viiji
          37 (     ∞ of base) : 6690.dasm - legalstub$dynCall_iiiiiiijiiii
          17 (     ∞ of base) : 6657.dasm - dynCall_iijiij
          35 (     ∞ of base) : 6691.dasm - legalstub$dynCall_iiiiiiiijii
          47 (     ∞ of base) : 6692.dasm - legalstub$dynCall_jijji
          13 (     ∞ of base) : 6656.dasm - dynCall_jiij
          19 (     ∞ of base) : 6684.dasm - dynCall_vijjiii
          25 (     ∞ of base) : 6693.dasm - legalstub$dynCall_viijii
          37 (     ∞ of base) : 6694.dasm - legalstub$dynCall_jiij
          15 (     ∞ of base) : 6654.dasm - dynCall_jijji
          27 (     ∞ of base) : 6653.dasm - dynCall_iiiiiiiijii
          29 (     ∞ of base) : 6652.dasm - dynCall_iiiiiiijiiii
          18 (     ∞ of base) : 6651.dasm - RhpCallCatchOrFilterFunclet
          33 (     ∞ of base) : 6695.dasm - legalstub$dynCall_iijiij
          33 (     ∞ of base) : 6697.dasm - legalstub$dynCall_iijiiiiiii

Top method improvements (percentages):
         -10 (-83.33% of base) : 4379.dasm - S_P_CoreLib_System_Runtime_InteropServices_SafeHandle__Finalize$F1_Fault
         -17 (-60.71% of base) : 6615.dasm - RhTypeCast_CheckArrayStore
         -17 (-56.67% of base) : 6608.dasm - RhUnbox
         -17 (-56.67% of base) : 6616.dasm - RhpStelemRef
         -22 (-56.41% of base) : 6123.dasm - S_P_CoreLib_System_IO_TextWriter_SyncTextWriter__Dispose$F1_Fault
        -236 (-56.06% of base) : 3040.dasm - S_P_CoreLib_System_Exception__get_StackTrace
       -1044 (-55.74% of base) : 2232.dasm - S_P_CoreLib_System_Enum__System_ISpanFormattable_TryFormat
        -114 (-54.03% of base) : 1133.dasm - S_P_CoreLib_System_Runtime_EH__CallFilterFunclet
         -33 (-53.23% of base) : 5458.dasm - S_P_CoreLib_System_Globalization_CompareInfo__IndexOfCore
        -357 (-51.74% of base) : 2929.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_NativeFormat_NativeFormatMethodCommon__Equals
          -9 (-50.00% of base) : 6604.dasm - RhpThrowEx
          -9 (-50.00% of base) : 6603.dasm - RhpHandleUnhandledException
         -19 (-48.72% of base) : 5523.dasm - S_P_CoreLib_System_IO_TextWriter_SyncTextWriter__Write_4$F1_Fault
         -19 (-48.72% of base) : 6121.dasm - S_P_CoreLib_System_IO_TextWriter_SyncTextWriter__Write_0$F1_Fault
         -19 (-48.72% of base) : 5517.dasm - S_P_CoreLib_System_IO_TextWriter_SyncTextWriter__WriteLine_6$F1_Fault
         -19 (-48.72% of base) : 5519.dasm - S_P_CoreLib_System_IO_TextWriter_SyncTextWriter__WriteLine$F1_Fault
         -19 (-48.72% of base) : 5521.dasm - S_P_CoreLib_System_IO_TextWriter_SyncTextWriter__Write_11$F1_Fault
         -10 (-47.62% of base) : 5554.dasm - HelloWasm_TestClass__TestVirtualMethod
         -10 (-47.62% of base) : 5551.dasm - HelloWasm_TestClass__TestVirtualMethod2
         -10 (-47.62% of base) : 5553.dasm - HelloWasm_TestClass__VirtualDelegateTarget

Top methods only present in base:
         -16 (-100.00% of base) : 1000.dasm - RuntimeResolveInterfaceDispatch
         -17 (-100.00% of base) : 6631.dasm - dynCall_iiijjj
         -29 (-100.00% of base) : 6649.dasm - legalstub$dynCall_vijj
         -21 (-100.00% of base) : 6620.dasm - dynCall_iiiiiiji
         -19 (-100.00% of base) : 6621.dasm - dynCall_iiiiiij
         -15 (-100.00% of base) : 6622.dasm - dynCall_vijii
         -21 (-100.00% of base) : 6623.dasm - dynCall_iijiiiii
         -17 (-100.00% of base) : 6625.dasm - dynCall_jijjji
         -17 (-100.00% of base) : 6626.dasm - dynCall_iijjji
         -25 (-100.00% of base) : 6627.dasm - dynCall_jiiiiiiiii
         -21 (-100.00% of base) : 6629.dasm - dynCall_viiiiiij
         -21 (-100.00% of base) : 6632.dasm - dynCall_iiijjjjj
         -21 (-100.00% of base) : 6634.dasm - dynCall_vijiiiii
         -33 (-100.00% of base) : 6650.dasm - legalstub$dynCall_vijjii
         -17 (-100.00% of base) : 6636.dasm - dynCall_vijjii
         -29 (-100.00% of base) : 6648.dasm - legalstub$dynCall_vijiiiii
         -61 (-100.00% of base) : 6647.dasm - legalstub$dynCall_iiijjjjj
         -41 (-100.00% of base) : 6646.dasm - legalstub$dynCall_iiijjj
         -29 (-100.00% of base) : 6645.dasm - legalstub$dynCall_viiiiiij
         -41 (-100.00% of base) : 6644.dasm - legalstub$dynCall_jiiiiiiiii

5728 total methods with Code Size differences (4642 improved, 1086 regressed)
```

It is also a very nice simplification, as the native and managed ABIs become identical as far as the ways of passing values are concerned.