### PR TITLE
[NativeAOT-LLVM] Do not use helpers for long div/mod/mul

### DIFF
--- a/src/coreclr/nativeaot/Runtime/MathHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MathHelpers.cpp
@@ -97,7 +97,7 @@ EXTERN_C NATIVEAOT_API float REDHAWK_CALLCONV RhpFltRound(float value)
     return roundf(value);
 }
 
-#if defined(HOST_ARM) || defined(TARGET_WASM)
+#ifdef HOST_ARM
 EXTERN_C NATIVEAOT_API int32_t REDHAWK_CALLCONV RhpIDiv(int32_t i, int32_t j)
 {
     ASSERT(j && "Divide by zero!");
@@ -196,4 +196,4 @@ EXTERN_C NATIVEAOT_API double REDHAWK_CALLCONV RhpULng2Dbl(uint64_t val)
     return (double)val;
 }
 
-#endif // defined(HOST_ARM) || defined(TARGET_WASM)
+#endif // HOST_ARM

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3095,7 +3095,7 @@ namespace Internal.JitInterface
             pEEInfoOut.osPageSize = new UIntPtr(0x1000);
 
 #if !READYTORUN
-            if (_compilation.TargetArchIsWasm())
+            if (_compilation.NodeFactory.Target.IsWasm)
             {
                 // The low 1024 bytes are reserved by Emscripten; no valid address will point there.
                 pEEInfoOut.maxUncheckedOffsetForNullObject = new UIntPtr(1024 - 1);

--- a/src/coreclr/tools/Common/TypeSystem/Common/TargetDetails.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TargetDetails.cs
@@ -298,6 +298,17 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
+        /// Returns True if compiling for WebAssembly
+        /// </summary>
+        public bool IsWasm
+        {
+            get
+            {
+                return Architecture == TargetArchitecture.Wasm32 || Architecture == TargetArchitecture.Wasm64;
+            }
+        }
+
+        /// <summary>
         /// Returns True if compiling for Windows
         /// </summary>
         public bool IsWindows

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -527,13 +527,6 @@ namespace ILCompiler
             return new CompilationResults(_dependencyGraph, _nodeFactory);
         }
 
-        // TODO-LLVM: delete when IL->LLVM module has gone
-        public bool TargetArchIsWasm()
-        {
-            return TypeSystemContext.Target.Architecture == TargetArchitecture.Wasm32 ||
-                   TypeSystemContext.Target.Architecture == TargetArchitecture.Wasm64;
-        }
-
         private sealed class ILCache : LockFreeReaderHashtable<MethodDesc, ILCache.MethodILData>
         {
             public ILProvider ILProvider { get; }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -83,7 +83,7 @@ namespace Internal.IL
             _compilation = compilation;
             _factory = (ILScanNodeFactory)compilation.NodeFactory;
 
-            if (_compilation.TargetArchIsWasm())
+            if (_factory.Target.IsWasm)
             {
                 // ThrowNullReferenceException is needed by the explicit null checks we generate with LLVM.
                 MetadataType helperType = _compilation.TypeSystemContext.SystemModule.GetKnownType("Internal.Runtime.CompilerHelpers", "ThrowHelpers");
@@ -1288,8 +1288,8 @@ namespace Internal.IL
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.UDiv), "_udiv");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.Div), "_div");
                     }
-                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM64
-                        || _compilation.TargetArchIsWasm())
+                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM64 ||
+                        _compilation.TypeSystemContext.Target.IsWasm)
                     {
                         if (opcode == ILOpcode.div)
                         {
@@ -1307,8 +1307,8 @@ namespace Internal.IL
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.UMod), "_umod");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.Mod), "_mod");
                     }
-                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM64
-                        || _compilation.TargetArchIsWasm())
+                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM64 ||
+                        _compilation.TypeSystemContext.Target.IsWasm)
                     {
                         if (opcode == ILOpcode.rem)
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -1271,10 +1271,8 @@ namespace Internal.IL
                     break;
                 case ILOpcode.mul_ovf:
                 case ILOpcode.mul_ovf_un:
-                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM
-                        || _compilation.TargetArchIsWasm())
+                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM)
                     {
-                        // TODO-LLVM: fix up RyuJit to not use these helpers and delete "TargetArchIsWasm".
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.LMulOfv), "_lmulovf");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.ULMulOvf), "_ulmulovf");
                     }
@@ -1283,10 +1281,8 @@ namespace Internal.IL
                     break;
                 case ILOpcode.div:
                 case ILOpcode.div_un:
-                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM
-                        || _compilation.TargetArchIsWasm())
+                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM)
                     {
-                        // TODO-LLVM: fix up RyuJit to not use these helpers and delete "TargetArchIsWasm".
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.ULDiv), "_uldiv");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.LDiv), "_ldiv");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.UDiv), "_udiv");
@@ -1304,10 +1300,8 @@ namespace Internal.IL
                     break;
                 case ILOpcode.rem:
                 case ILOpcode.rem_un:
-                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM
-                        || _compilation.TargetArchIsWasm())
+                    if (_compilation.TypeSystemContext.Target.Architecture == TargetArchitecture.ARM)
                     {
-                        // TODO-LLVM: fix up RyuJit to not use these helpers and delete "TargetArchIsWasm".
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.ULMod), "_ulmod");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.LMod), "_lmod");
                         _dependencies.Add(GetHelperEntrypoint(ReadyToRunHelper.UMod), "_umod");

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1988,7 +1988,7 @@ namespace Internal.JitInterface
         {
             get
             {
-                if (_compilation.TargetArchIsWasm())
+                if (_compilation.TypeSystemContext.Target.IsWasm)
                 {
                     // Only m_pThread used.
                     return this.PointerSize;


### PR DESCRIPTION
These are integration leftovers; there is no reasons to use helpers as LLVM has native instructions for these.

Diff is a bit of a regression because LLVM inlines more aggressively:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3298345
Total bytes of diff: 3300421
Total bytes of delta: 2076 (0.06% % of base)
Average relative delta: 2.39%
    diff is a regression
    average relative diff is a regression

Top method regressions (percentages):
         169 (625.93% of base) : 1133.dasm - S_P_CoreLib_System_Collections_Generic_NonRandomizedStringEqualityComparer_OrdinalComparer__Equals
         157 (245.31% of base) : 1072.dasm - S_P_CoreLib_System_Reflection_TypeNameParser__StartAssemblyName
         969 (55.15% of base) : 1129.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Int64>
         903 (47.01% of base) : 1088.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_NativeLayoutInfoLoadContext__GetType
          76 (27.74% of base) : 1081.dasm - S_P_CoreLib_System_InvokeUtils__CheckArgumentConversions
        1612 (25.63% of base) : 1045.dasm - S_P_CoreLib_System_Globalization_TimeSpanParse__ProcessTerminal_HMS_F_D
         164 (21.41% of base) : 1082.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_MetadataReader__GetMethod
        1502 (18.89% of base) : 1044.dasm - S_P_CoreLib_System_Globalization_TimeSpanParse__ProcessTerminal_HM_S_D
          25 ( 8.99% of base) : 1116.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_EETypeCreator__GetDictionarySlotInVTable
           1 ( 7.69% of base) : 1027.dasm - S_P_CoreLib_System_Threading_ProcessorIdCache__UninlinedThreadStatic
           4 ( 6.56% of base) : 1056.dasm - S_P_CoreLib_System_TimeSpan__get_Minutes
           4 ( 6.45% of base) : 1057.dasm - S_P_CoreLib_System_TimeSpan__get_Hours
          45 ( 5.56% of base) : 1115.dasm - S_P_TypeLoader_Internal_TypeSystem_StandardCanonicalizationAlgorithm__ConvertToCanon_0
           3 ( 5.00% of base) : 1089.dasm - S_P_CoreLib_System_TimeSpan__get_Seconds
          87 ( 4.96% of base) : 1172.dasm - S_P_CoreLib_System_Number_BigInteger__DivRem
           2 ( 2.08% of base) : 1052.dasm - S_P_CoreLib_System_Threading_ManagedThreadId__SetForCurrentThread
          15 ( 2.02% of base) : 1103.dasm - S_P_CoreLib_System_Number__UInt64ToDecChars<Char>
           2 ( 1.71% of base) : 1145.dasm - S_P_CoreLib_System_Threading_ManagedThreadId__GetCurrentThreadId
           1 ( 1.32% of base) : 1142.dasm - S_P_CoreLib_System_Threading_Monitor_DebugBlockingScope__Dispose
           1 ( 1.22% of base) : 1009.dasm - S_P_CoreLib_System_Threading_ProcessorIdCache__RefreshCurrentProcessorId

Top method improvements (percentages):
        -246 (-58.71% of base) : 1083.dasm - S_P_TypeLoader_Internal_TypeSystem_ExceptionTypeNameFormatter__AppendName_5
         -97 (-32.66% of base) : 1101.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_MdBinaryReader__Read_107
        -134 (-30.88% of base) : 1141.dasm - S_P_CoreLib_Interop_Sys__Read
        -220 (-29.85% of base) : 1058.dasm - S_P_CoreLib_System_Reflection_TypeNameParser__ParseNamedOrConstructedGenericTypeName
         -55 (-25.23% of base) : 1086.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeDesc__ConvertToCanonForm
         -81 (-22.38% of base) : 1047.dasm - S_P_CoreLib_System_Number__GetException_0<Int64>
         -61 (-22.02% of base) : 1137.dasm - HelloWasm_Program__TestSignedLongMulOvf
         -52 (-20.63% of base) : 1015.dasm - S_P_CoreLib_System_Number__DigitsToUInt64
         -14 (-18.67% of base) : 1060.dasm - S_P_CoreLib_System_Number_BigInteger__DivideGuessTooBig
         -31 (-17.22% of base) : 1111.dasm - S_P_CoreLib_System_Decimal_DecCalc__DecDivMod1E9
         -62 (-16.99% of base) : 1043.dasm - S_P_CoreLib_System_Globalization_TimeSpanParse__TryTimeToTicks
         -32 (-13.73% of base) : 1173.dasm - S_P_CoreLib_System_Number__DigitsToUInt32
         -20 (-12.82% of base) : 1078.dasm - S_P_CoreLib_System_TimeZoneInfo__GetTimeZoneDirectory
        -295 (-12.12% of base) : 1037.dasm - S_P_CoreLib_System_Globalization_JapaneseCalendar__IcuGetJapaneseEras
          -7 (-11.48% of base) : 1119.dasm - S_P_CoreLib_System_DateTime__get_TimeOfDay
          -7 (-11.11% of base) : 1105.dasm - S_P_CoreLib_System_DateTime__get_Second
          -7 (-10.94% of base) : 1107.dasm - S_P_CoreLib_System_DateTime__get_Minute
         -11 (-10.78% of base) : 1110.dasm - S_P_CoreLib_System_Globalization_GregorianCalendar__GetDayOfWeek
          -7 (-10.77% of base) : 1106.dasm - S_P_CoreLib_System_DateTime__get_Hour
         -75 (-10.30% of base) : 1174.dasm - S_P_CoreLib_System_Collections_Generic_Dictionary_2<Int32__Int32>__Resize_0

Top methods only present in base:
          -7 (-100.00% of base) : 1000.dasm - RhpLDiv
         -65 (-100.00% of base) : 1112.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_MathHelpers__ThrowULngDivByZero
         -27 (-100.00% of base) : 1055.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_MathHelpers__ULMod
         -72 (-100.00% of base) : 1026.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_MathHelpers__LDiv
         -29 (-100.00% of base) : 1165.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_MathHelpers__LMod
         -65 (-100.00% of base) : 1166.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_MathHelpers__ThrowLngDivByZero
         -65 (-100.00% of base) : 1168.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_MathHelpers__ThrowLngArithExc
         -93 (-100.00% of base) : 1014.dasm - S_P_CoreLib_System_ArithmeticException___ctor
         -27 (-100.00% of base) : 1143.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_MathHelpers__ULDiv
          -7 (-100.00% of base) : 1001.dasm - RhpULDiv
          -7 (-100.00% of base) : 1002.dasm - RhpLMod
          -7 (-100.00% of base) : 1003.dasm - RhpULMod
          -7 (-100.00% of base) : 1004.dasm - RhpLMul

178 total methods with Code Size differences (112 improved, 66 regressed)
```
Wondering if we should tune down the native inliner here with an `-Oz` default, or some other more fine-grained switch.

Edit: turns out it won't be super impactful, only ~2.5% in code size savings. Almost no regressions though.

Change also includes a couple improvements and fixes to `wasmjit-diff.ps1`.