### PR TITLE
[NativeAOT-LLVM] Double-align the shadow frame when necessary

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -254,9 +254,6 @@ private:
     CorInfoType getLlvmArgTypeForArg(CorInfoType argSigType, CORINFO_CLASS_HANDLE argSigClass, bool* pIsByRef = nullptr);
     CorInfoType getLlvmReturnType(CorInfoType sigRetType, CORINFO_CLASS_HANDLE sigRetClass, bool* pIsByRef = nullptr);
 
-    unsigned padOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned atOffset);
-    unsigned padNextOffset(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHandle, unsigned atOffset);
-
     static CorInfoType toCorInfoType(var_types varType);
     static CorInfoType getLlvmArgTypeForCallArg(CallArg* arg);
     TargetAbiType getAbiTypeForType(var_types type);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -174,6 +174,8 @@ public:
 class Llvm
 {
 private:
+    static const unsigned DEFAULT_SHADOW_STACK_ALIGNMENT = TARGET_POINTER_SIZE;
+
     void* const m_pEECorInfo; // TODO-LLVM: workaround for not changing the JIT/EE interface.
     SingleThreadedCompilationContext* const m_context;
     Compiler* const _compiler;
@@ -210,6 +212,7 @@ private:
     unsigned m_lineNumberCount;
     CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO* m_lineNumbers;
 
+    unsigned m_shadowFrameAlignment = DEFAULT_SHADOW_STACK_ALIGNMENT;
     unsigned _shadowStackLocalsSize = 0;
     unsigned _originalShadowStackLclNum = BAD_VAR_NUM;
     unsigned _shadowStackLclNum = BAD_VAR_NUM;
@@ -372,6 +375,7 @@ private:
 
     bool initializeFunctions();
     void generateProlog();
+    void initializeShadowStack();
     void initializeLocals();
     void generateBlocks();
     void generateBlock(BasicBlock* block);
@@ -454,6 +458,7 @@ private:
     Instruction* getCast(Value* source, Type* targetType);
     Value* castIfNecessary(Value* source, Type* targetType, llvm::IRBuilder<>* builder = nullptr);
     Value* gepOrAddr(Value* addr, unsigned offset);
+    llvm::Constant* getIntPtrConst(target_size_t value, Type* llvmType = nullptr);
     Value* getShadowStack();
     Value* getShadowStackForCallee();
     Value* getOriginalShadowStack();

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMCodegenCompilation.CodeGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMCodegenCompilation.CodeGen.cs
@@ -149,20 +149,6 @@ namespace ILCompiler
             return isPassedByRef ? LLVMTypeRef.Void : GetLLVMTypeForTypeDesc(returnType);
         }
 
-        public override int PadOffset(TypeDesc type, int atOffset)
-        {
-            var fieldAlignment = type is DefType && type.IsValueType ? ((DefType)type).InstanceFieldAlignment : type.Context.Target.LayoutPointerSize;
-            var alignment = LayoutInt.Min(fieldAlignment, new LayoutInt(ComputePackingSize(type))).AsInt;
-            var padding = atOffset.AlignUp(alignment);
-
-            return padding;
-        }
-
-        internal int PadNextOffset(TypeDesc type, int atOffset)
-        {
-            return PadOffset(type, atOffset) + type.GetElementSize().AsInt;
-        }
-
         internal LLVMTypeRef GetLLVMTypeForTypeDesc(TypeDesc type)
         {
             switch (type.Category)
@@ -212,25 +198,6 @@ namespace ILCompiler
 
                 default:
                     throw new UnreachableException(type.Category.ToString());
-            }
-        }
-
-        private static int ComputePackingSize(TypeDesc type)
-        {
-            if (type is MetadataType)
-            {
-                var metaType = type as MetadataType;
-                var layoutMetadata = metaType.GetClassLayout();
-
-                // If a type contains pointers then the metadata specified packing size is ignored (On desktop this is disqualification from ManagedSequential)
-                if (layoutMetadata.PackingSize == 0 || metaType.ContainsGCPointers)
-                    return type.Context.Target.DefaultPackingSize;
-                else
-                    return layoutMetadata.PackingSize;
-            }
-            else
-            {
-                return type.Context.Target.DefaultPackingSize;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -140,15 +140,6 @@ namespace Internal.JitInterface
         }
 
         [UnmanagedCallersOnly]
-        public static uint padOffset(IntPtr thisHandle, CORINFO_CLASS_STRUCT_* structHnd, uint atOffset)
-        {
-            var _this = GetThis(thisHandle);
-            TypeDesc type = _this.HandleToObject(structHnd);
-
-            return (uint)_this._compilation.PadOffset(type, (int)atOffset);
-        }
-
-        [UnmanagedCallersOnly]
         public static byte* getAlternativeFunctionName(IntPtr thisHandle)
         {
             CorInfoImpl _this = GetThis(thisHandle);
@@ -259,7 +250,6 @@ namespace Internal.JitInterface
             AddCodeReloc,
             IsRuntimeImport,
             GetPrimitiveTypeForTrivialWasmStruct,
-            PadOffset,
             GetTypeDescriptor,
             GetAlternativeFunctionName,
             GetExternalMethodAccessor,
@@ -290,7 +280,6 @@ namespace Internal.JitInterface
             jitImports[(int)EEApiId.AddCodeReloc] = (delegate* unmanaged<IntPtr, void*, void>)&addCodeReloc;
             jitImports[(int)EEApiId.IsRuntimeImport] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, uint>)&isRuntimeImport;
             jitImports[(int)EEApiId.GetPrimitiveTypeForTrivialWasmStruct] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType>)&getPrimitiveTypeForTrivialWasmStruct;
-            jitImports[(int)EEApiId.PadOffset] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, uint, uint>)&padOffset;
             jitImports[(int)EEApiId.GetTypeDescriptor] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor*, void>)&getTypeDescriptor;
             jitImports[(int)EEApiId.GetAlternativeFunctionName] = (delegate* unmanaged<IntPtr, byte*>)&getAlternativeFunctionName;
             jitImports[(int)EEApiId.GetExternalMethodAccessor] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, TargetAbiType*, int, IntPtr>)&getExternalMethodAccessor;

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/ExceptionHandlingTests.Common.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/ExceptionHandlingTests.Common.cs
@@ -764,7 +764,6 @@ internal unsafe partial class Program
                     {
                         byte* stk = stackalloc byte[StkAllocSize];
                         SideEffect(stk);
-                        Console.WriteLine((int)stk);
                     }
                     catch (Exception)
                     {

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
@@ -144,6 +144,11 @@ if ($Analyze -or $Summary)
             $Name = [string]$Matches[3].Value
 
             $TotalCodeSize += $Size
+            while ($SummaryList.ContainsKey($Name))
+            {
+                # Sometimes we get duplicates with demangled names that wasm-objdump produces. Tolerate them.
+                $Name += "*"
+            }
             $SummaryList.Add($Name, @{ Index = $Index; Size = $Size })
 
             if ($LineIndex % $OutputProgressInterval -eq 0)


### PR DESCRIPTION
Fixes the lack of 8-byte alignment for shadow frames with double-aligned structs.