### PR TITLE
[NativeAOT-LLVM] Eliminate gratituous allocations from the LLVM object writer

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -287,9 +287,11 @@ namespace ILCompiler.DependencyAnalysis
 
 #if DEBUG
             _module.PrintToFile(Path.ChangeExtension(_objectFilePath, ".txt"));
-#endif
             _module.Verify(LLVMVerifierFailureAction.LLVMAbortProcessAction);
+
+            _module.PrintToFile(Path.ChangeExtension(_objectFilePath, "external.txt"));
             _moduleWithExternalFunctions.Verify(LLVMVerifierFailureAction.LLVMAbortProcessAction);
+#endif
 
             string dataLlvmObjectPath = _objectFilePath;
             _module.WriteBitcodeToFile(dataLlvmObjectPath);
@@ -706,7 +708,7 @@ namespace ILCompiler.DependencyAnalysis
 
         private void GetCodeForExternMethodAccessor(ExternMethodAccessorNode node)
         {
-            // TODO: use the Utf8 string directly here.
+            // TODO-LLVM: use the Utf8 string directly here.
             string externFuncName = node.ExternMethodName.ToString();
             LLVMTypeRef externFuncType;
 

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMSharpInterop.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMSharpInterop.cs
@@ -26,10 +26,58 @@ namespace Internal.IL
             LLVM.AddAttributeAtIndex(function, LLVMAttributeIndex.LLVMAttributeFunctionIndex, attribute);
         }
 
-        internal static LLVMValueRef GetNamedAlias(this LLVMModuleRef module, ReadOnlySpan<char> name)
+        internal static LLVMValueRef GetNamedAlias(this LLVMModuleRef module, ReadOnlySpan<byte> name)
         {
-            using var marshaledName = new MarshaledString(name);
-            return LLVM.GetNamedGlobalAlias(module, marshaledName, (nuint)marshaledName.Length);
+            fixed (byte* pName = name)
+            {
+                Debug.Assert(pName[name.Length] == '\0');
+                return LLVM.GetNamedGlobalAlias(module, (sbyte*)pName, (nuint)name.Length);
+            }
+        }
+
+        internal static LLVMValueRef GetNamedFunction(this LLVMModuleRef module, ReadOnlySpan<byte> name)
+        {
+            fixed (byte* pName = name)
+            {
+                Debug.Assert(pName[name.Length] == '\0');
+                return LLVM.GetNamedFunction(module, (sbyte*)pName);
+            }
+        }
+
+        internal static LLVMValueRef GetNamedGlobal(this LLVMModuleRef module, ReadOnlySpan<byte> name)
+        {
+            fixed (byte* pName = name)
+            {
+                Debug.Assert(pName[name.Length] == '\0');
+                return LLVM.GetNamedGlobal(module, (sbyte*)pName);
+            }
+        }
+
+        internal static LLVMValueRef AddAlias(this LLVMModuleRef module, ReadOnlySpan<byte> name, LLVMTypeRef valueType, LLVMValueRef aliasee)
+        {
+            fixed (byte* pName = name)
+            {
+                Debug.Assert(pName[name.Length] == '\0');
+                return LLVM.AddAlias2(module, valueType, 0, aliasee, (sbyte*)pName);
+            }
+        }
+
+        internal static LLVMValueRef AddFunction(this LLVMModuleRef module, ReadOnlySpan<byte> name, LLVMTypeRef type)
+        {
+            fixed (byte* pName = name)
+            {
+                Debug.Assert(pName[name.Length] == '\0');
+                return LLVM.AddFunction(module, (sbyte*)pName, type);
+            }
+        }
+
+        internal static LLVMValueRef AddGlobal(this LLVMModuleRef module, ReadOnlySpan<byte> name, LLVMTypeRef type)
+        {
+            fixed (byte* pName = name)
+            {
+                Debug.Assert(pName[name.Length] == '\0');
+                return LLVM.AddGlobal(module, type, (sbyte*)pName);
+            }
         }
 
         internal static LLVMTypeRef GetValueType(this LLVMValueRef value)


### PR DESCRIPTION
Also make it one-pass, there is no reason for it not to be.

The object writer is still pretty slow (1.5s in Release build for HelloWasm on my machine), but the rest of issues are not as easy to deal with.

Contributes to #2300.