### PR TITLE
[NativeAOT-LLVM] Introduce a shadow stack allocation phase

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -228,6 +228,7 @@ set( JIT_WASM64_SOURCES
   llvm.cpp
   llvmtypes.cpp
   llvmlower.cpp
+  llvmlssa.cpp
   llvmcodegen.cpp
   llvmdebuginfo.cpp
 )
@@ -236,6 +237,7 @@ set( JIT_WASM32_SOURCES
   llvm.cpp
   llvmtypes.cpp
   llvmlower.cpp
+  llvmlssa.cpp
   llvmcodegen.cpp
   llvmdebuginfo.cpp
 )

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5138,17 +5138,21 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     compJitStats();
 
 #if defined(TARGET_WASM)
+    assert(m_llvm != nullptr);
+    auto lowerPhase = [this]() {
+        m_llvm->Lower();
+    };
+    DoPhase(this, PHASE_LOWER_LLVM, lowerPhase);
+
     if (opts.OptimizationEnabled())
     {
         // When optimizing, we'll sort the locals on the shadow stack by ref count.
         lvaMarkLocalVars();
     }
 
-    assert(m_llvm != nullptr);
-    auto lowerPhase = [this]() {
-        m_llvm->Lower();
-    };
-    DoPhase(this, PHASE_LOWER_LLVM, lowerPhase);
+    DoPhase(this, PHASE_ALLOCATE_SHADOW_STACK, [this]() {
+        m_llvm->Allocate();
+    });
 
     fgSsaDomTree = nullptr;
     if (opts.OptimizationEnabled())

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -121,6 +121,7 @@ CompPhaseNameMacro(PHASE_POST_EMIT,                  "Post-Emit",               
 
 #ifdef TARGET_WASM
 CompPhaseNameMacro(PHASE_LOWER_LLVM,                 "LLVM Lowering",                  false, -1, false)
+CompPhaseNameMacro(PHASE_ALLOCATE_SHADOW_STACK,      "Allocate shadow stack slots",    false, -1, false)
 CompPhaseNameMacro(PHASE_BUILD_LLVM,                 "Build LLVM",                     false, -1, false)
 #endif
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -350,7 +350,6 @@ private:
 
     unsigned representAsLclVar(LIR::Use& use);
     GenTree* createStoreNode(var_types nodeType, GenTree* addr, GenTree* data);
-    GenTree* createShadowStackStoreNode(var_types storeType, GenTree* addr, GenTree* data);
     GenTree* insertShadowStackAddr(GenTree* insertBefore, ssize_t offset, unsigned shadowStackLclNum);
 
     bool isPotentialGcSafePoint(GenTree* node);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -339,8 +339,7 @@ private:
     void lowerDivMod(GenTreeOp* divModNode);
     void lowerReturn(GenTreeUnOp* retNode);
 
-    void lowerVirtualStubCallBeforeArgs(GenTreeCall* callNode, unsigned* pThisLclNum, GenTree** pCellArgNode);
-    void lowerVirtualStubCallAfterArgs(GenTreeCall* callNode, unsigned thisArgLclNum, GenTree* cellArgNode);
+    void lowerVirtualStubCall(GenTreeCall* callNode);
     void insertNullCheckForCall(GenTreeCall* callNode);
     void lowerDelegateInvoke(GenTreeCall* callNode);
     void lowerUnmanagedCall(GenTreeCall* callNode);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -3068,7 +3068,8 @@ llvm::BasicBlock* Llvm::createInlineLlvmBlock()
         blocksName = blocksName.take_front(blocksName.find_last_of('.'));
     }
 
-    inlineLlvmBlock->setName(blocksName + "." + Twine(++llvmBlocks->Count));
+    llvmBlocks->Count++;
+    inlineLlvmBlock->setName(blocksName + "." + Twine(llvmBlocks->Count));
 #endif // DEBUG
 
     llvmBlocks->LastBlock = inlineLlvmBlock;

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1428,14 +1428,6 @@ GenTree* Llvm::createStoreNode(var_types storeType, GenTree* addr, GenTree* data
     return storeNode;
 }
 
-GenTree* Llvm::createShadowStackStoreNode(var_types storeType, GenTree* addr, GenTree* data)
-{
-    GenTree* storeNode = createStoreNode(storeType, addr, data);
-    storeNode->gtFlags |= (GTF_IND_TGT_NOT_HEAP | GTF_IND_NONFAULTING);
-
-    return storeNode;
-}
-
 GenTree* Llvm::insertShadowStackAddr(GenTree* insertBefore, ssize_t offset, unsigned shadowStackLclNum)
 {
     assert((shadowStackLclNum == _shadowStackLclNum) || (shadowStackLclNum == _originalShadowStackLclNum));

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -88,8 +88,6 @@ void Llvm::AddUnhandledExceptionHandler()
         }
     }
 
-    // Insert a fail-fast into the filter block. This is an approximation of the helper
-    // codegen will know to actually use for this special block.
     GenTree* catchArg = new (_compiler, GT_CATCH_ARG) GenTree(GT_CATCH_ARG, TYP_REF);
     catchArg->gtFlags |= GTF_ORDER_SIDEEFF;
 
@@ -117,360 +115,8 @@ void Llvm::AddUnhandledExceptionHandler()
 //
 void Llvm::Lower()
 {
-    lowerSpillTempsLiveAcrossSafePoints();
-    lowerLocalsBeforeNodes();
-    insertProlog();
+    initializeLlvmArgInfo();
     lowerBlocks();
-    lowerLocalsAfterNodes();
-}
-
-//------------------------------------------------------------------------
-// lowerSpillTempsLiveAcrossSafePoints: Spill GC SDSUs live across safe points.
-//
-// Rewrites:
-//   gcTmp = IND<ref>(...)
-//           CALL ; May trigger GC
-//           USE(gcTmp)
-// Into:
-//   gcTmp = IND<ref>(...)
-//           STORE_LCL_VAR<V00>(gcTmp)
-//           CALL ; May trigger GC
-//           USE(LCL_VAR<V00>)
-//
-// Done as a full IR walk pre-pass before the general lowering since we need
-// to know about all GC locals to lay out the shadow stack.
-//
-void Llvm::lowerSpillTempsLiveAcrossSafePoints()
-{
-    // Cannot use raw node pointers as their values influence hash table iteration order.
-    struct DeterministicNodeHashInfo : public HashTableInfo<DeterministicNodeHashInfo>
-    {
-        static bool Equals(GenTree* left, GenTree* right)
-        {
-            return left == right;
-        }
-
-        static unsigned GetHashCode(GenTree* node)
-        {
-            return node->TypeGet() ^ node->OperGet();
-        }
-    };
-
-    // Set of SDSUs live after the current node.
-    SmallHashTable<GenTree*, unsigned, 8, DeterministicNodeHashInfo> liveGcDefs(_compiler->getAllocator(CMK_Codegen));
-    ArrayStack<unsigned> spillLclsRef(_compiler->getAllocator(CMK_Codegen));
-    ArrayStack<unsigned> spillLclsByref(_compiler->getAllocator(CMK_Codegen));
-    ArrayStack<GenTree*> containedOperands(_compiler->getAllocator(CMK_Codegen));
-
-    auto getSpillLcl = [&](GenTree* node) {
-        var_types type = node->TypeGet();
-        ClassLayout* layout = nullptr;
-        unsigned lclNum = BAD_VAR_NUM;
-        switch (type)
-        {
-            case TYP_REF:
-                if (!spillLclsRef.Empty())
-                {
-                    lclNum = spillLclsRef.Pop();
-                }
-                break;
-            case TYP_BYREF:
-                if (!spillLclsByref.Empty())
-                {
-                    lclNum = spillLclsByref.Pop();
-                }
-                break;
-            case TYP_STRUCT:
-                // This case should be **very** rare if at all possible. Just use a new local.
-                layout = node->GetLayout(_compiler);
-                break;
-            default:
-                unreached();
-        }
-
-        if (lclNum == BAD_VAR_NUM)
-        {
-            lclNum = _compiler->lvaGrabTemp(true DEBUGARG("GC SDSU live across a safepoint"));
-            _compiler->lvaGetDesc(lclNum)->lvType = type;
-            if (type == TYP_STRUCT)
-            {
-                _compiler->lvaSetStruct(lclNum, layout, false);
-            }
-        }
-
-        return lclNum;
-    };
-
-    auto releaseSpillLcl = [&](unsigned lclNum) {
-        LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
-        if (varDsc->TypeGet() == TYP_REF)
-        {
-            spillLclsRef.Push(lclNum);
-        }
-        else if (varDsc->TypeGet() == TYP_BYREF)
-        {
-            spillLclsByref.Push(lclNum);
-        }
-    };
-
-    auto isGcTemp = [compiler = _compiler](GenTree* node) {
-        if (varTypeIsGC(node) || node->TypeIs(TYP_STRUCT))
-        {
-            if (node->TypeIs(TYP_STRUCT))
-            {
-                if (node->OperIs(GT_IND))
-                {
-                    return false;
-                }
-                if (!node->GetLayout(compiler)->HasGCPtr())
-                {
-                    return false;
-                }
-            }
-
-            // Locals are handled by the general shadow stack lowering (already "spilled" so to speak).
-            // Local address nodes always point to the stack (native or shadow). Constant handles will
-            // only point to immortal and immovable (frozen) objects.
-            return !node->OperIsLocal() && !node->OperIs(GT_LCL_ADDR) && !node->IsIconHandle();
-        }
-
-        return false;
-    };
-
-    auto spillValue = [this, &getSpillLcl](LIR::Range& blockRange, GenTree* defNode, unsigned* pSpillLclNum) {
-        if (*pSpillLclNum != BAD_VAR_NUM)
-        {
-            // We may have already spilled this def live across multiple safe points.
-            return;
-        }
-
-        unsigned spillLclNum = getSpillLcl(defNode);
-        JITDUMP("Spilling as V%02u:\n", spillLclNum);
-        DISPNODE(defNode);
-
-        GenTree* store = _compiler->gtNewTempAssign(spillLclNum, defNode);
-        blockRange.InsertAfter(defNode, store);
-
-        *pSpillLclNum = spillLclNum;
-    };
-
-    for (BasicBlock* block : _compiler->Blocks())
-    {
-        assert(liveGcDefs.Count() == 0);
-        LIR::Range& blockRange = LIR::AsRange(block);
-
-        for (GenTree* node : blockRange)
-        {
-            if (node->OperIs(GT_LCLHEAP))
-            {
-                // Calculated here as it is needed to lay out the shadow stack.
-                m_lclHeapUsed = true;
-            }
-
-            if (node->isContained())
-            {
-                assert(!isPotentialGcSafePoint(node));
-                continue;
-            }
-
-            // Handle a special case: calls with return buffer pointers need them pinned.
-            if (node->IsCall() && node->AsCall()->gtArgs.HasRetBuffer())
-            {
-                GenTree* retBufNode = node->AsCall()->gtArgs.GetRetBufferArg()->GetNode();
-                if ((retBufNode->gtLIRFlags & LIR::Flags::Mark) != 0)
-                {
-                    unsigned spillLclNum;
-                    liveGcDefs.TryGetValue(retBufNode, &spillLclNum);
-                    spillValue(blockRange, retBufNode, &spillLclNum);
-                    liveGcDefs.AddOrUpdate(retBufNode, spillLclNum);
-                }
-            }
-
-            GenTree* user = node;
-            while (true)
-            {
-                for (GenTree** use : user->UseEdges())
-                {
-                    GenTree* operand = *use;
-                    if (operand->isContained())
-                    {
-                        // Operands of contained nodes are used by the containing nodes. Note this algorithm will
-                        // process contained operands in an out-of-order fashion; that is ok.
-                        assert(operand->OperIs(GT_FIELD_LIST));
-                        containedOperands.Push(operand);
-                        continue;
-                    }
-
-                    if ((operand->gtLIRFlags & LIR::Flags::Mark) != 0)
-                    {
-                        unsigned spillLclNum = BAD_VAR_NUM;
-                        bool operandWasRemoved = liveGcDefs.TryRemove(operand, &spillLclNum);
-                        assert(operandWasRemoved);
-
-                        if (spillLclNum != BAD_VAR_NUM)
-                        {
-                            GenTree* lclVarNode = _compiler->gtNewLclVarNode(spillLclNum);
-
-                            *use = lclVarNode;
-                            blockRange.InsertBefore(user, lclVarNode);
-                            releaseSpillLcl(spillLclNum);
-
-                            JITDUMP("Spilled [%06u] used by [%06u] replaced with V%02u:\n",
-                                    Compiler::dspTreeID(operand), Compiler::dspTreeID(user), spillLclNum);
-                            DISPNODE(lclVarNode);
-                        }
-
-                        operand->gtLIRFlags &= ~LIR::Flags::Mark;
-                    }
-                }
-
-                if (containedOperands.Empty())
-                {
-                    break;
-                }
-
-                user = containedOperands.Pop();
-            }
-
-            // Find out if we need to spill anything.
-            if (isPotentialGcSafePoint(node) && (liveGcDefs.Count() != 0))
-            {
-                JITDUMP("\nFound a safe point with GC SDSUs live across it:\n", Compiler::dspTreeID(node));
-                DISPNODE(node);
-
-                for (auto def : liveGcDefs)
-                {
-                    spillValue(blockRange, def.Key(), &def.Value());
-                }
-            }
-
-            // Add the value defined by this node.
-            if (node->IsValue() && !node->IsUnusedValue() && isGcTemp(node))
-            {
-                node->gtLIRFlags |= LIR::Flags::Mark;
-                liveGcDefs.AddOrUpdate(node, BAD_VAR_NUM);
-            }
-        }
-    }
-}
-
-//------------------------------------------------------------------------
-// lowerLocalsBeforeNodes: strip annotations and insert initializations.
-//
-// We decouple promoted structs from their field locals: for independently
-// promoted ones, we treat the fields as regular temporaries; parameters are
-// initialized explicitly via "STORE_LCL_VAR<field>(LCL_FLD<parent>)". For
-// dependently promoted cases, we will later rewrite all fields to reference
-// the parent instead. We strip the annotations in "lowerLocalsAfterNodes".
-// We also determine the set of locals which will need to go on the shadow
-// stack, zero-initialize them if required, and assign stack offsets.
-//
-void Llvm::lowerLocalsBeforeNodes()
-{
-    populateLlvmArgNums();
-
-    std::vector<unsigned> shadowStackLocals;
-
-    for (unsigned lclNum = 0; lclNum < _compiler->lvaCount; lclNum++)
-    {
-        LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
-
-        // Initialize independently promoted field locals.
-        if (varDsc->lvIsParam && (_compiler->lvaGetPromotionType(varDsc) == Compiler::PROMOTION_TYPE_INDEPENDENT))
-        {
-            for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
-            {
-                unsigned   fieldLclNum = varDsc->lvFieldLclStart + index;
-                LclVarDsc* fieldVarDsc = _compiler->lvaGetDesc(fieldLclNum);
-                if (fieldVarDsc->lvRefCnt(RCS_NORMAL) != 0)
-                {
-                    GenTree* fieldValue =
-                        _compiler->gtNewLclFldNode(lclNum, fieldVarDsc->TypeGet(), fieldVarDsc->lvFldOffset);
-                    initializeLocalInProlog(fieldLclNum, fieldValue);
-
-                    fieldVarDsc->lvHasExplicitInit = true;
-                }
-            }
-        }
-
-        // We don't know if untracked locals are live-in/out of handlers and have to assume the worst.
-        if (!varDsc->lvTracked && _compiler->ehAnyFunclets())
-        {
-            varDsc->lvLiveInOutOfHndlr = 1;
-        }
-
-        // GC locals needs to go on the shadow stack for the scan to find them. Locals live-in/out of handlers
-        // need to be preserved after the native unwind for the funclets to be callable, thus, they too need to
-        // go on the shadow stack (except for parameters to funclets, naturally).
-        //
-        if (!isFuncletParameter(lclNum) && (varDsc->HasGCPtr() || varDsc->lvLiveInOutOfHndlr))
-        {
-            if (_compiler->lvaGetPromotionType(varDsc) == Compiler::PROMOTION_TYPE_INDEPENDENT)
-            {
-                // The individual fields will placed on the shadow stack.
-                continue;
-            }
-            if (_compiler->lvaIsFieldOfDependentlyPromotedStruct(varDsc))
-            {
-                // The fields will be referenced through the parent.
-                continue;
-            }
-
-            if (varDsc->lvRefCnt() == 0)
-            {
-                // No need to place unreferenced temps on the shadow stack.
-                continue;
-            }
-
-            // We may need to insert initialization:
-            //
-            //  1) Zero-init if this is a non-parameter GC local, to fullfill frontend's expectations.
-            //  2) Copy the initial value if this is a parameter with the home on the shadow stack.
-            //
-            // TODO-LLVM: in both cases we should avoid redundant initializations using liveness
-            // info (for tracked locals), sharing code with "initializeLocals" in codegen. However,
-            // that is currently not possible because late liveness runs after lowering.
-            //
-            if (!varDsc->lvHasExplicitInit)
-            {
-                if (varDsc->lvIsParam)
-                {
-                    GenTree* initVal = _compiler->gtNewLclvNode(lclNum, varDsc->TypeGet());
-                    initVal->SetRegNum(REG_LLVM);
-
-                    initializeLocalInProlog(lclNum, initVal);
-                }
-                else if (!_compiler->fgVarNeedsExplicitZeroInit(lclNum, /* bbInALoop */ false, /* bbIsReturn*/ false) ||
-                         varDsc->HasGCPtr())
-                {
-                    var_types zeroType = (varDsc->TypeGet() == TYP_STRUCT) ? TYP_INT : genActualType(varDsc);
-                    initializeLocalInProlog(lclNum, _compiler->gtNewZeroConNode(zeroType));
-                }
-            }
-
-            shadowStackLocals.push_back(lclNum);
-        }
-        else
-        {
-            INDEBUG(varDsc->lvOnFrame = false); // For more accurate frame layout dumping.
-        }
-    }
-
-    if ((shadowStackLocals.size() == 0) && m_lclHeapUsed && doUseDynamicStackForLclHeap())
-    {
-        // The dynamic stack is tied to the shadow one. If we have an empty shadow frame with a non-empty dynamic one,
-        // an ambiguity in what state must be released on return arises - our caller might have an empty shadow frame
-        // as well, but of course we don't want to release its dynamic state accidentally. To solve this, pad out the
-        // shadow frame in methods that use the dynamic stack if it is empty. The need to do this should be pretty rare
-        // so it is ok to waste a shadow stack slot here.
-        unsigned paddingLclNum = _compiler->lvaGrabTempWithImplicitUse(true DEBUGARG("SS padding for the dynamic stack"));
-        _compiler->lvaGetDesc(paddingLclNum)->lvType = TYP_REF;
-        initializeLocalInProlog(paddingLclNum, _compiler->gtNewIconNode(0, TYP_REF));
-
-        shadowStackLocals.push_back(paddingLclNum);
-    }
-
-    assignShadowStackOffsets(shadowStackLocals);
 }
 
 // LLVM Arg layout:
@@ -480,7 +126,7 @@ void Llvm::lowerLocalsBeforeNodes()
 //    - Generic context (if required)
 //    - Rest of the args passed as LLVM parameters
 //
-void Llvm::populateLlvmArgNums()
+void Llvm::initializeLlvmArgInfo()
 {
     if (_compiler->ehAnyFunclets())
     {
@@ -541,123 +187,11 @@ void Llvm::populateLlvmArgNums()
     _llvmArgCount = nextLlvmArgNum;
 }
 
-void Llvm::assignShadowStackOffsets(std::vector<unsigned>& shadowStackLocals)
-{
-    if (_compiler->opts.OptimizationEnabled())
-    {
-        std::sort(shadowStackLocals.begin(), shadowStackLocals.end(),
-                  [compiler = _compiler](unsigned lhsLclNum, unsigned rhsLclNum)
-        {
-            LclVarDsc* lhsVarDsc = compiler->lvaGetDesc(lhsLclNum);
-            LclVarDsc* rhsVarDsc = compiler->lvaGetDesc(rhsLclNum);
-            return lhsVarDsc->lvRefCntWtd() > rhsVarDsc->lvRefCntWtd();
-        });
-    }
-
-    unsigned offset = 0;
-    for (unsigned i = 0; i < shadowStackLocals.size(); i++)
-    {
-        LclVarDsc* varDsc = _compiler->lvaGetDesc(shadowStackLocals.at(i));
-        if ((varDsc->TypeGet() == TYP_STRUCT) && varDsc->GetLayout()->IsBlockLayout())
-        {
-            assert((varDsc->lvSize() % TARGET_POINTER_SIZE) == 0);
-
-            offset = roundUp(offset, TARGET_POINTER_SIZE);
-            varDsc->SetStackOffset(offset);
-            offset += varDsc->lvSize();
-        }
-        else
-        {
-            CorInfoType corInfoType = toCorInfoType(varDsc->TypeGet());
-            CORINFO_CLASS_HANDLE classHandle =
-                varTypeIsStruct(varDsc) ? varDsc->GetLayout()->GetClassHandle() : NO_CLASS_HANDLE;
-
-            offset = padOffset(corInfoType, classHandle, offset);
-            varDsc->SetStackOffset(offset);
-            offset = padNextOffset(corInfoType, classHandle, offset);
-        }
-
-        // We will use this as the indication that the local has a home on the shadow stack.
-        varDsc->SetRegNum(REG_STK);
-    }
-
-    _shadowStackLocalsSize = AlignUp(offset, TARGET_POINTER_SIZE);
-
-    _compiler->compLclFrameSize = _shadowStackLocalsSize;
-    _compiler->lvaDoneFrameLayout = Compiler::TENTATIVE_FRAME_LAYOUT;
-
-    JITDUMP("\nLocals after shadow stack layout:\n");
-    JITDUMPEXEC(_compiler->lvaTableDump());
-    JITDUMP("\n");
-
-    _compiler->lvaDoneFrameLayout = Compiler::INITIAL_FRAME_LAYOUT;
-}
-
-void Llvm::initializeLocalInProlog(unsigned lclNum, GenTree* value)
-{
-    LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
-    JITDUMP("Adding initialization for V%02u, %s:\n", lclNum, varDsc->lvReason);
-
-    GenTreeUnOp* store = _compiler->gtNewStoreLclVarNode(lclNum, value);
-
-    m_prologRange.InsertAtEnd(value);
-    m_prologRange.InsertAtEnd(store);
-
-    DISPTREERANGE(m_prologRange, store);
-}
-
-void Llvm::insertProlog()
-{
-    if (!m_prologRange.IsEmpty())
-    {
-        _compiler->fgEnsureFirstBBisScratch();
-    }
-
-    LIR::Range& firstBlockRange = LIR::AsRange(_compiler->fgFirstBB);
-    if (firstBlockRange.IsEmpty() || !firstBlockRange.FirstNode()->OperIs(GT_IL_OFFSET) ||
-        !firstBlockRange.FirstNode()->AsILOffset()->gtStmtDI.GetRoot().IsValid())
-    {
-        // Insert a zero-offset ILOffset to notify codegen this is the start of user code.
-        DebugInfo zeroILOffsetDi =
-            DebugInfo(_compiler->compInlineContext, ILLocation(0, /* isStackEmpty */ true, /* isCall */ false));
-        GenTree* zeroILOffsetNode = new (_compiler, GT_IL_OFFSET) GenTreeILOffset(zeroILOffsetDi);
-        firstBlockRange.InsertAtBeginning(zeroILOffsetNode);
-    }
-
-    if (!m_prologRange.IsEmpty())
-    {
-        firstBlockRange.InsertAtBeginning(std::move(m_prologRange));
-    }
-}
-
-void Llvm::lowerLocalsAfterNodes()
-{
-    for (unsigned lclNum = 0; lclNum < _compiler->lvaCount; lclNum++)
-    {
-        LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
-        if (varDsc->lvPromoted)
-        {
-            for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
-            {
-                LclVarDsc* fieldVarDsc = _compiler->lvaGetDesc(varDsc->lvFieldLclStart + index);
-
-                fieldVarDsc->lvIsStructField = false;
-                fieldVarDsc->lvParentLcl = BAD_VAR_NUM;
-                fieldVarDsc->lvIsParam = false;
-            }
-
-            varDsc->lvPromoted = false;
-            varDsc->lvFieldLclStart = BAD_VAR_NUM;
-            varDsc->lvFieldCnt = 0;
-        }
-    }
-}
-
 void Llvm::lowerBlocks()
 {
     for (BasicBlock* block : _compiler->Blocks())
     {
-        lowerBlock(block);
+        lowerRange(block, LIR::AsRange(block));
         block->bbFlags |= BBF_MARKED;
     }
 
@@ -669,26 +203,27 @@ void Llvm::lowerBlocks()
     {
         if ((block->bbFlags & BBF_MARKED) == 0)
         {
-            lowerBlock(block);
+            lowerRange(block, LIR::AsRange(block));
         }
 
         block->bbFlags &= ~BBF_MARKED;
     }
-
-    m_currentBlock = nullptr;
 }
 
-void Llvm::lowerBlock(BasicBlock* block)
+void Llvm::lowerRange(BasicBlock* block, LIR::Range& range)
 {
     m_currentBlock = block;
-    m_currentRange = &LIR::AsRange(block);
+    m_currentRange = &range;
 
-    for (GenTree* node : CurrentRange())
+    for (GenTree* node : range)
     {
         lowerNode(node);
     }
 
-    INDEBUG(CurrentRange().CheckLIR(_compiler, /* checkUnusedValues */ true));
+    INDEBUG(range.CheckLIR(_compiler, /* checkUnusedValues */ true));
+
+    m_currentBlock = nullptr;
+    m_currentRange = nullptr;
 }
 
 void Llvm::lowerNode(GenTree* node)
@@ -737,6 +272,10 @@ void Llvm::lowerNode(GenTree* node)
             lowerReturn(node->AsUnOp());
             break;
 
+        case GT_LCLHEAP:
+            lowerLclHeap(node->AsUnOp());
+            break;
+
         default:
             break;
     }
@@ -751,21 +290,9 @@ void Llvm::lowerLocal(GenTreeLclVarCommon* node)
         lowerStoreLcl(node->AsLclVarCommon());
     }
 
-    if ((node->OperIsLocal() || node->OperIs(GT_LCL_ADDR)) &&
-        ConvertShadowStackLocalNode(node->AsLclVarCommon()))
-    {
-        return;
-    }
-
     if (node->OperIsLocalStore() && node->TypeIs(TYP_STRUCT) && genActualTypeIsInt(node->gtGetOp1()))
     {
         node->gtGetOp1()->SetContained();
-    }
-
-    if (node->OperIs(GT_LCL_ADDR) || node->OperIsLocalField())
-    {
-        // Indicates that this local is to live on the LLVM frame, and will not participate in SSA.
-        _compiler->lvaGetDesc(node->AsLclVarCommon())->lvHasLocalAddr = 1;
     }
 }
 
@@ -846,65 +373,6 @@ void Llvm::lowerFieldOfDependentlyPromotedStruct(GenTree* node)
             }
         }
     }
-}
-
-bool Llvm::ConvertShadowStackLocalNode(GenTreeLclVarCommon* lclNode)
-{
-    LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNode->GetLclNum());
-
-    if (isShadowFrameLocal(varDsc) && (lclNode->GetRegNum() != REG_LLVM))
-    {
-        // Funclets (especially filters) will be called by the dispatcher while live state still exists
-        // on shadow frames below (in the tradional sense, where stacks grow down) them. For this reason,
-        // funclets will access state from the original frame via a dedicated shadow stack pointer, and
-        // use the actual shadow stack for calls.
-        unsigned shadowStackLclNum = CurrentBlock()->hasHndIndex() ? _originalShadowStackLclNum : _shadowStackLclNum;
-        GenTree* lclAddress =
-            insertShadowStackAddr(lclNode, varDsc->GetStackOffset() + lclNode->GetLclOffs(), shadowStackLclNum);
-
-        ClassLayout* layout = lclNode->TypeIs(TYP_STRUCT) ? lclNode->GetLayout(_compiler) : nullptr;
-        GenTree* storedValue = nullptr;
-        genTreeOps indirOper;
-        switch (lclNode->OperGet())
-        {
-            case GT_STORE_LCL_VAR:
-            case GT_STORE_LCL_FLD:
-                indirOper = (layout != nullptr) ? GT_STORE_BLK : GT_STOREIND;
-                storedValue = lclNode->Data();
-                break;
-            case GT_LCL_FLD:
-            case GT_LCL_VAR:
-                indirOper = (layout != nullptr) ? GT_BLK : GT_IND;
-                break;
-            case GT_LCL_ADDR:
-                // Local address nodes are directly replaced with the ADD.
-                CurrentRange().Remove(lclAddress);
-                lclNode->ReplaceWith(lclAddress, _compiler);
-                return true;
-            default:
-                unreached();
-        }
-
-        lclNode->ChangeOper(indirOper);
-        lclNode->AsIndir()->SetAddr(lclAddress);
-        lclNode->gtFlags |= GTF_IND_NONFAULTING;
-
-        if (GenTree::OperIsStore(indirOper))
-        {
-            lclNode->gtFlags |= GTF_IND_TGT_NOT_HEAP;
-            lclNode->AsOp()->gtOp2 = storedValue;
-        }
-        if (GenTree::OperIsBlk(indirOper))
-        {
-            lclNode->AsBlk()->SetLayout(layout);
-            lclNode->AsBlk()->gtBlkOpKind = GenTreeBlk::BlkOpKindInvalid;
-        }
-
-        lowerNode(lclNode);
-        return true;
-    }
-
-    return false;
 }
 
 void Llvm::lowerCall(GenTreeCall* callNode)
@@ -1072,8 +540,6 @@ void Llvm::lowerReturn(GenTreeUnOp* retNode)
         retValUse.ReplaceWithLclVar(_compiler);
 
         GenTreeLclVar* lclVarNode = retValUse.Def()->AsLclVar();
-        _compiler->lvaGetDesc(lclVarNode)->lvHasLocalAddr = true;
-
         lclVarNode->SetOper(GT_LCL_FLD);
         lclVarNode->ChangeType(m_info->compRetType);
         if (layout != nullptr)
@@ -1081,6 +547,12 @@ void Llvm::lowerReturn(GenTreeUnOp* retNode)
             lclVarNode->AsLclFld()->SetLayout(layout);
         }
     }
+}
+
+void Llvm::lowerLclHeap(GenTreeUnOp* lclHeapNode)
+{
+    // TODO-LLVM: lower to the dynamic stack helper here.
+    m_lclHeapUsed = true;
 }
 
 void Llvm::lowerVirtualStubCall(GenTreeCall* callNode)
@@ -1092,9 +564,6 @@ void Llvm::lowerVirtualStubCall(GenTreeCall* callNode)
     // Into:
     //  delegate* pTarget = ResolveTarget(SS, @this, pCell)
     //  pTarget(SS, @this, args...)
-    //
-    // TODO-LLVM-Bug: this is currently creating a GC hole where GC arguments to the main call become live
-    // across the stub.
     //
     LIR::Use thisArgUse(CurrentRange(), &callNode->gtArgs.GetThisArg()->EarlyNodeRef(), callNode);
     unsigned thisArgLclNum = representAsLclVar(thisArgUse);
@@ -1245,35 +714,23 @@ void Llvm::lowerUnmanagedCall(GenTreeCall* callNode)
 }
 
 //------------------------------------------------------------------------
-// lowerCallToShadowStack: Lower the call, rewriting its arguments.
-//
-// Initializes the AbiInfo structure to help codegen in signature building.
+// lowerCallToShadowStack: Initialize AbiInfo for signature building.
 //
 void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
 {
-    // Rewrite the args, adding shadow stack, and moving gc tracked args to the shadow stack.
-    // This transformation only applies to calls that have a managed calling convention (e. g.
-    // it doesn't apply to runtime imports, or helpers implemented as FCalls, etc).
-    int sigArgIdx = 0;
-    if (callHasManagedCallingConvention(callNode))
-    {
-        GenTree* calleeShadowStack = insertShadowStackAddr(callNode, getCurrentShadowFrameSize(), _shadowStackLclNum);
-        callNode->gtArgs.PushFront(_compiler, NewCallArg::Primitive(calleeShadowStack, CORINFO_TYPE_PTR));
-        sigArgIdx--;
-    }
-
     const HelperFuncInfo* helperInfo = nullptr;
     if (callNode->IsHelperCall())
     {
         helperInfo = &getHelperFuncInfo(_compiler->eeGetHelperNum(callNode->gtCallMethHnd));
     }
 
+    int sigArgIdx = 0;
     for (CallArg& callArg : callNode->gtArgs.Args())
     {
         GenTree* argNode = callArg.GetNode();
         CorInfoType argSigType;
         CORINFO_CLASS_HANDLE argSigClass;
-        if ((helperInfo == nullptr) || (sigArgIdx < 0))
+        if (helperInfo == nullptr)
         {
             if (callArg.GetWellKnownArg() == WellKnownArg::ThisPointer)
             {
@@ -1321,17 +778,10 @@ void Llvm::lowerCallToShadowStack(GenTreeCall* callNode)
 //
 void Llvm::lowerCallReturn(GenTreeCall* callNode)
 {
-    if (callNode->IsOptimizingRetBufAsLocal() && !callNode->gtArgs.GetRetBufferArg()->GetNode()->OperIs(GT_LCL_ADDR))
-    {
-        // We may have lost track of a shadow local defined by this call. Clear the flag if so.
-        callNode->gtCallMoreFlags &= ~GTF_CALL_M_RETBUFFARG_LCLOPT;
-    }
-
     CorInfoType sigRetType;
     if (callNode->IsHelperCall())
     {
-        CorInfoHelpFunc helperFunc = _compiler->eeGetHelperNum(callNode->gtCallMethHnd);
-        sigRetType = getHelperFuncInfo(helperFunc).GetSigReturnType();
+        sigRetType = getHelperFuncInfo(callNode->GetHelperNum()).GetSigReturnType();
     }
     else if (callNode->gtCorInfoType == CORINFO_TYPE_UNDEF)
     {
@@ -1387,7 +837,6 @@ GenTree* Llvm::normalizeStructUse(LIR::Use& use, ClassLayout* layout)
             case GT_LCL_VAR:
                 node->SetOper(GT_LCL_FLD);
                 node->AsLclFld()->SetLayout(layout);
-                _compiler->lvaGetDesc(node->AsLclFld())->lvHasLocalAddr = true;
                 break;
 
             default:
@@ -1409,28 +858,9 @@ unsigned Llvm::representAsLclVar(LIR::Use& use)
     return use.ReplaceWithLclVar(_compiler);
 }
 
-GenTree* Llvm::createStoreNode(var_types storeType, GenTree* addr, GenTree* data)
-{
-    assert(data->TypeIs(TYP_STRUCT) == (storeType == TYP_STRUCT));
-
-    GenTree* storeNode;
-    if (storeType == TYP_STRUCT)
-    {
-        storeNode =
-            new (_compiler, GT_STORE_BLK) GenTreeBlk(GT_STORE_BLK, storeType, addr, data, data->GetLayout(_compiler));
-    }
-    else
-    {
-        storeNode = new (_compiler, GT_STOREIND) GenTreeStoreInd(storeType, addr, data);
-    }
-    storeNode->gtFlags |= GTF_ASG;
-
-    return storeNode;
-}
-
 GenTree* Llvm::insertShadowStackAddr(GenTree* insertBefore, ssize_t offset, unsigned shadowStackLclNum)
 {
-    assert((shadowStackLclNum == _shadowStackLclNum) || (shadowStackLclNum == _originalShadowStackLclNum));
+    assert(isShadowStackLocal(shadowStackLclNum));
 
     GenTree* shadowStackLcl = _compiler->gtNewLclvNode(shadowStackLclNum, TYP_I_IMPL);
     CurrentRange().InsertBefore(insertBefore, shadowStackLcl);
@@ -1448,122 +878,7 @@ GenTree* Llvm::insertShadowStackAddr(GenTree* insertBefore, ssize_t offset, unsi
     return addNode;
 }
 
-//------------------------------------------------------------------------
-// isPotentialGcSafePoint: Can this node be a GC safe point?
-//
-// Arguments:
-//    node - The node
-//
-// Return Value:
-//    Whether "node" can trigger GC.
-//
-// Notes:
-//    Similar to "Compiler::IsGcSafePoint", with the difference being that
-//    the "conservative" return value for this method is "true".
-//
-bool Llvm::isPotentialGcSafePoint(GenTree* node)
-{
-    if (node->IsCall())
-    {
-        if (node->AsCall()->IsUnmanaged() && node->AsCall()->IsSuppressGCTransition())
-        {
-            return false;
-        }
-        if (node->IsHelperCall())
-        {
-            CorInfoHelpFunc helperFunc = _compiler->eeGetHelperNum(node->AsCall()->gtCallMethHnd);
-            if (getHelperFuncInfo(helperFunc).HasFlags(HFIF_NO_RPI_OR_GC))
-            {
-                return false;
-            }
-        }
-
-        // All other calls are assumed to be possible safe points.
-        return true;
-    }
-
-    return false;
-}
-
-//------------------------------------------------------------------------
-// isShadowFrameLocal: Does the given local have a home on the shadow frame?
-//
-// Arguments:
-//    varDsc - Local's descriptor
-//
-// Return Value:
-//    Whether the given local has a location assigned to it on the shadow
-//    frame. Note the fact it does is not an implication that it is live
-//    on it at all times: the local can be live on the LLVM frame, or the
-//    shadow one, or both.
-//
-bool Llvm::isShadowFrameLocal(LclVarDsc* varDsc) const
-{
-    // Other backends use "lvOnFrame" for this value, but for us it is not
-    // a great fit because we add new locals after shadow frame layout.
-    return varDsc->GetRegNum() == REG_STK;
-}
-
-bool Llvm::isFuncletParameter(unsigned lclNum) const
-{
-    return (lclNum == _shadowStackLclNum) || (lclNum == _originalShadowStackLclNum);
-}
-
-unsigned Llvm::getCurrentShadowFrameSize() const
-{
-    assert(CurrentBlock() != nullptr);
-    unsigned hndIndex = CurrentBlock()->hasHndIndex() ? CurrentBlock()->getHndIndex() : EHblkDsc::NO_ENCLOSING_INDEX;
-    return getShadowFrameSize(hndIndex);
-}
-
-//------------------------------------------------------------------------
-// getShadowFrameSize: What is the size of a function's shadow frame?
-//
-// Arguments:
-//    hndIndex - Handler index representing the function, NO_ENCLOSING_INDEX
-//               is used for the root
-//
-// Return Value:
-//    The size of the shadow frame for the given function. We term this
-//    the value by which the shadow stack pointer must be offset before
-//    calling managed code such that the caller will not clobber anything
-//    live on the frame. Note that funclets do not have any shadow state
-//    of their own and use the "original" frame from the parent function,
-//    with one exception: catch handlers and filters have one readonly
-//    pointer-sized argument representing the exception.
-//
-unsigned Llvm::getShadowFrameSize(unsigned hndIndex) const
-{
-    if (hndIndex == EHblkDsc::NO_ENCLOSING_INDEX)
-    {
-        return getOriginalShadowFrameSize();
-    }
-    if (_compiler->ehGetDsc(hndIndex)->HasCatchHandler())
-    {
-        // For the implicit (readonly) exception object argument.
-        return TARGET_POINTER_SIZE;
-    }
-
-    return 0;
-}
-
-unsigned Llvm::getOriginalShadowFrameSize() const
-{
-    assert((_shadowStackLocalsSize % TARGET_POINTER_SIZE) == 0);
-    return _shadowStackLocalsSize;
-}
-
 unsigned Llvm::getCatchArgOffset() const
 {
     return 0;
-}
-
-bool Llvm::doUseDynamicStackForLclHeap()
-{
-    // TODO-LLVM: add a stress mode.
-    assert(m_lclHeapUsed);
-
-    // We assume LCLHEAPs in methods with EH escape into handlers and so
-    // have to use a special EH-aware allocator instead of the native stack.
-    return _compiler->ehAnyFunclets() || JitConfig.JitUseDynamicStackForLclHeap();
 }

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -1,0 +1,665 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// ================================================================================================================
+// |                                        Linear Shadow Stack Allocator                                         |
+// ================================================================================================================
+
+#include "llvm.h"
+
+void Llvm::Allocate()
+{
+    allocSpillTempsLiveAcrossSafePoints();
+    allocInitializeAndAllocateLocals();
+    allocDissolvePromotedLocals();
+    allocLowerAndInsertProlog();
+    allocRewriteShadowFrameReferences();
+}
+
+//------------------------------------------------------------------------
+// allocSpillTempsLiveAcrossSafePoints: Spill GC SDSUs live across safe points.
+//
+// Rewrites:
+//   gcTmp = IND<ref>(...)
+//           CALL ; May trigger GC
+//           USE(gcTmp)
+// Into:
+//   gcTmp = IND<ref>(...)
+//           STORE_LCL_VAR<V00>(gcTmp)
+//           CALL ; May trigger GC
+//           USE(LCL_VAR<V00>)
+//
+void Llvm::allocSpillTempsLiveAcrossSafePoints()
+{
+    // Cannot use raw node pointers as their values influence hash table iteration order.
+    struct DeterministicNodeHashInfo : public HashTableInfo<DeterministicNodeHashInfo>
+    {
+        static bool Equals(GenTree* left, GenTree* right)
+        {
+            return left == right;
+        }
+
+        static unsigned GetHashCode(GenTree* node)
+        {
+            return node->TypeGet() ^ node->OperGet();
+        }
+    };
+
+    // Set of SDSUs live after the current node.
+    SmallHashTable<GenTree*, unsigned, 8, DeterministicNodeHashInfo> liveGcDefs(_compiler->getAllocator(CMK_Codegen));
+    ArrayStack<unsigned> spillLclsRef(_compiler->getAllocator(CMK_Codegen));
+    ArrayStack<unsigned> spillLclsByref(_compiler->getAllocator(CMK_Codegen));
+    ArrayStack<GenTree*> containedOperands(_compiler->getAllocator(CMK_Codegen));
+
+    auto getSpillLcl = [&](GenTree* node) {
+        var_types type = node->TypeGet();
+        ClassLayout* layout = nullptr;
+        unsigned lclNum = BAD_VAR_NUM;
+        switch (type)
+        {
+            case TYP_REF:
+                if (!spillLclsRef.Empty())
+                {
+                    lclNum = spillLclsRef.Pop();
+                }
+                break;
+            case TYP_BYREF:
+                if (!spillLclsByref.Empty())
+                {
+                    lclNum = spillLclsByref.Pop();
+                }
+                break;
+            case TYP_STRUCT:
+                // This case should be **very** rare if at all possible. Just use a new local.
+                layout = node->GetLayout(_compiler);
+                break;
+            default:
+                unreached();
+        }
+
+        if (lclNum == BAD_VAR_NUM)
+        {
+            lclNum = _compiler->lvaGrabTemp(true DEBUGARG("GC SDSU live across a safepoint"));
+            _compiler->lvaGetDesc(lclNum)->lvType = type;
+            if (type == TYP_STRUCT)
+            {
+                _compiler->lvaSetStruct(lclNum, layout, false);
+            }
+        }
+
+        return lclNum;
+    };
+
+    auto releaseSpillLcl = [&](unsigned lclNum) {
+        LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
+        if (varDsc->TypeGet() == TYP_REF)
+        {
+            spillLclsRef.Push(lclNum);
+        }
+        else if (varDsc->TypeGet() == TYP_BYREF)
+        {
+            spillLclsByref.Push(lclNum);
+        }
+    };
+
+    auto isGcTemp = [compiler = _compiler](GenTree* node) {
+        if (varTypeIsGC(node) || node->TypeIs(TYP_STRUCT))
+        {
+            if (node->TypeIs(TYP_STRUCT))
+            {
+                if (node->OperIs(GT_IND))
+                {
+                    return false;
+                }
+                if (!node->GetLayout(compiler)->HasGCPtr())
+                {
+                    return false;
+                }
+            }
+
+            // Locals are handled by the general shadow stack lowering (already "spilled" so to speak).
+            // Local address nodes always point to the stack (native or shadow). Constant handles will
+            // only point to immortal and immovable (frozen) objects.
+            return !node->OperIsLocal() && !node->OperIs(GT_LCL_ADDR) && !node->IsIconHandle();
+        }
+
+        return false;
+    };
+
+    auto spillValue = [this, &getSpillLcl](LIR::Range& blockRange, GenTree* defNode, unsigned* pSpillLclNum) {
+        if (*pSpillLclNum != BAD_VAR_NUM)
+        {
+            // We may have already spilled this def live across multiple safe points.
+            return;
+        }
+
+        unsigned spillLclNum = getSpillLcl(defNode);
+        JITDUMP("Spilling as V%02u:\n", spillLclNum);
+        DISPNODE(defNode);
+
+        GenTree* store = _compiler->gtNewTempAssign(spillLclNum, defNode);
+        blockRange.InsertAfter(defNode, store);
+
+        *pSpillLclNum = spillLclNum;
+    };
+
+    for (BasicBlock* block : _compiler->Blocks())
+    {
+        assert(liveGcDefs.Count() == 0);
+        LIR::Range& blockRange = LIR::AsRange(block);
+
+        for (GenTree* node : blockRange)
+        {
+            if (node->isContained())
+            {
+                assert(!isPotentialGcSafePoint(node));
+                continue;
+            }
+
+            // Handle a special case: calls with return buffer pointers need them pinned.
+            if (node->IsCall() && node->AsCall()->gtArgs.HasRetBuffer())
+            {
+                GenTree* retBufNode = node->AsCall()->gtArgs.GetRetBufferArg()->GetNode();
+                if ((retBufNode->gtLIRFlags & LIR::Flags::Mark) != 0)
+                {
+                    unsigned spillLclNum;
+                    liveGcDefs.TryGetValue(retBufNode, &spillLclNum);
+                    spillValue(blockRange, retBufNode, &spillLclNum);
+                    liveGcDefs.AddOrUpdate(retBufNode, spillLclNum);
+                }
+            }
+
+            GenTree* user = node;
+            while (true)
+            {
+                for (GenTree** use : user->UseEdges())
+                {
+                    GenTree* operand = *use;
+                    if (operand->isContained())
+                    {
+                        // Operands of contained nodes are used by the containing nodes. Note this algorithm will
+                        // process contained operands in an out-of-order fashion; that is ok.
+                        containedOperands.Push(operand);
+                        continue;
+                    }
+
+                    if ((operand->gtLIRFlags & LIR::Flags::Mark) != 0)
+                    {
+                        unsigned spillLclNum = BAD_VAR_NUM;
+                        bool operandWasRemoved = liveGcDefs.TryRemove(operand, &spillLclNum);
+                        assert(operandWasRemoved);
+
+                        if (spillLclNum != BAD_VAR_NUM)
+                        {
+                            GenTree* lclVarNode = _compiler->gtNewLclVarNode(spillLclNum);
+
+                            *use = lclVarNode;
+                            blockRange.InsertBefore(user, lclVarNode);
+                            releaseSpillLcl(spillLclNum);
+
+                            JITDUMP("Spilled [%06u] used by [%06u] replaced with V%02u:\n",
+                                    Compiler::dspTreeID(operand), Compiler::dspTreeID(user), spillLclNum);
+                            DISPNODE(lclVarNode);
+                        }
+
+                        operand->gtLIRFlags &= ~LIR::Flags::Mark;
+                    }
+                }
+
+                if (containedOperands.Empty())
+                {
+                    break;
+                }
+
+                user = containedOperands.Pop();
+            }
+
+            // Find out if we need to spill anything.
+            if (isPotentialGcSafePoint(node) && (liveGcDefs.Count() != 0))
+            {
+                JITDUMP("\nFound a safe point with GC SDSUs live across it:\n", Compiler::dspTreeID(node));
+                DISPNODE(node);
+
+                for (auto def : liveGcDefs)
+                {
+                    spillValue(blockRange, def.Key(), &def.Value());
+                }
+            }
+
+            // Add the value defined by this node.
+            if (node->IsValue() && !node->IsUnusedValue() && isGcTemp(node))
+            {
+                node->gtLIRFlags |= LIR::Flags::Mark;
+                liveGcDefs.AddOrUpdate(node, BAD_VAR_NUM);
+            }
+        }
+    }
+}
+
+void Llvm::allocInitializeAndAllocateLocals()
+{
+    std::vector<unsigned> shadowFrameLocals;
+
+    for (unsigned lclNum = 0; lclNum < _compiler->lvaCount; lclNum++)
+    {
+        LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
+
+        // We decouple promoted structs from their field locals: for independently promoted ones, we treat the fields
+        // as regular temporaries; parameters are initialized explicitly via "STORE_LCL_VAR<field>(LCL_FLD<parent>)".
+        // For dependently promoted cases, we have rewritten all fields to reference the parent instead.
+        if (varDsc->lvIsParam && (_compiler->lvaGetPromotionType(varDsc) == Compiler::PROMOTION_TYPE_INDEPENDENT))
+        {
+            for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
+            {
+                unsigned   fieldLclNum = varDsc->lvFieldLclStart + index;
+                LclVarDsc* fieldVarDsc = _compiler->lvaGetDesc(fieldLclNum);
+                if (fieldVarDsc->lvRefCnt(RCS_NORMAL) != 0)
+                {
+                    GenTree* fieldValue =
+                        _compiler->gtNewLclFldNode(lclNum, fieldVarDsc->TypeGet(), fieldVarDsc->lvFldOffset);
+                    allocInitializeLocalInProlog(fieldLclNum, fieldValue);
+
+                    fieldVarDsc->lvHasExplicitInit = true;
+                }
+            }
+        }
+
+        // We don't know if untracked locals are live-in/out of handlers and have to assume the worst.
+        if (!varDsc->lvTracked && _compiler->ehAnyFunclets())
+        {
+            varDsc->lvLiveInOutOfHndlr = 1;
+        }
+
+        // GC locals needs to go on the shadow stack for the scan to find them. Locals live-in/out of handlers
+        // need to be preserved after the native unwind for the funclets to be callable, thus, they too need to
+        // go on the shadow stack (except for parameters to funclets, naturally).
+        //
+        if (!isFuncletParameter(lclNum) && (varDsc->HasGCPtr() || varDsc->lvLiveInOutOfHndlr))
+        {
+            if (_compiler->lvaGetPromotionType(varDsc) == Compiler::PROMOTION_TYPE_INDEPENDENT)
+            {
+                // The individual fields will be placed on the shadow stack.
+                continue;
+            }
+            if (_compiler->lvaIsFieldOfDependentlyPromotedStruct(varDsc))
+            {
+                // The fields will be referenced through the parent.
+                continue;
+            }
+
+            if (varDsc->lvRefCnt() == 0)
+            {
+                // No need to place unreferenced temps on the shadow stack.
+                continue;
+            }
+
+            // We may need to insert initialization:
+            //
+            //  1) Zero-init if this is a non-parameter GC local, to fullfill frontend's expectations.
+            //  2) Copy the initial value if this is a parameter with the home on the shadow stack.
+            //
+            // TODO-LLVM: in both cases we should avoid redundant initializations using liveness
+            // info (for tracked locals), sharing code with "initializeLocals" in codegen. However,
+            // that is currently not possible because late liveness runs after lowering.
+            //
+            if (!varDsc->lvHasExplicitInit)
+            {
+                if (varDsc->lvIsParam)
+                {
+                    GenTree* initVal = _compiler->gtNewLclvNode(lclNum, varDsc->TypeGet());
+                    initVal->SetRegNum(REG_LLVM);
+
+                    allocInitializeLocalInProlog(lclNum, initVal);
+                }
+                else if (!_compiler->fgVarNeedsExplicitZeroInit(lclNum, /* bbInALoop */ false, /* bbIsReturn*/ false) ||
+                         varDsc->HasGCPtr())
+                {
+                    var_types zeroType = (varDsc->TypeGet() == TYP_STRUCT) ? TYP_INT : genActualType(varDsc);
+                    allocInitializeLocalInProlog(lclNum, _compiler->gtNewZeroConNode(zeroType));
+                }
+            }
+
+            shadowFrameLocals.push_back(lclNum);
+        }
+        else
+        {
+            INDEBUG(varDsc->lvOnFrame = false); // For more accurate frame layout dumping.
+        }
+    }
+
+    if ((shadowFrameLocals.size() == 0) && m_lclHeapUsed && doUseDynamicStackForLclHeap())
+    {
+        // The dynamic stack is tied to the shadow one. If we have an empty shadow frame with a non-empty dynamic one,
+        // an ambiguity in what state must be released on return arises - our caller might have an empty shadow frame
+        // as well, but of course we don't want to release its dynamic state accidentally. To solve this, pad out the
+        // shadow frame in methods that use the dynamic stack if it is empty. The need to do this should be pretty rare
+        // so it is ok to waste a shadow stack slot here.
+        unsigned padLclNum = _compiler->lvaGrabTempWithImplicitUse(true DEBUGARG("SS padding for the dynamic stack"));
+        _compiler->lvaGetDesc(padLclNum)->lvType = TYP_REF;
+        allocInitializeLocalInProlog(padLclNum, _compiler->gtNewIconNode(0, TYP_REF));
+
+        shadowFrameLocals.push_back(padLclNum);
+    }
+
+    allocAssignShadowFrameOffsets(shadowFrameLocals);
+}
+
+void Llvm::allocDissolvePromotedLocals()
+{
+    // TODO-LLVM-LSSA: fold this into the main initialization loop.
+    for (unsigned lclNum = 0; lclNum < _compiler->lvaCount; lclNum++)
+    {
+        LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
+        if (varDsc->lvPromoted)
+        {
+            for (unsigned index = 0; index < varDsc->lvFieldCnt; index++)
+            {
+                LclVarDsc* fieldVarDsc = _compiler->lvaGetDesc(varDsc->lvFieldLclStart + index);
+
+                fieldVarDsc->lvIsStructField = false;
+                fieldVarDsc->lvParentLcl = BAD_VAR_NUM;
+                fieldVarDsc->lvIsParam = false;
+            }
+
+            varDsc->lvPromoted = false;
+            varDsc->lvFieldLclStart = BAD_VAR_NUM;
+            varDsc->lvFieldCnt = 0;
+        }
+    }
+}
+
+void Llvm::allocAssignShadowFrameOffsets(std::vector<unsigned>& shadowFrameLocals)
+{
+    if (_compiler->opts.OptimizationEnabled())
+    {
+        std::sort(shadowFrameLocals.begin(), shadowFrameLocals.end(),
+                  [compiler = _compiler](unsigned lhsLclNum, unsigned rhsLclNum)
+        {
+            LclVarDsc* lhsVarDsc = compiler->lvaGetDesc(lhsLclNum);
+            LclVarDsc* rhsVarDsc = compiler->lvaGetDesc(rhsLclNum);
+            return lhsVarDsc->lvRefCntWtd() > rhsVarDsc->lvRefCntWtd();
+        });
+    }
+
+    unsigned offset = 0;
+    for (unsigned i = 0; i < shadowFrameLocals.size(); i++)
+    {
+        LclVarDsc* varDsc = _compiler->lvaGetDesc(shadowFrameLocals.at(i));
+        if ((varDsc->TypeGet() == TYP_STRUCT) && varDsc->GetLayout()->IsBlockLayout())
+        {
+            assert((varDsc->lvSize() % TARGET_POINTER_SIZE) == 0);
+
+            offset = roundUp(offset, TARGET_POINTER_SIZE);
+            varDsc->SetStackOffset(offset);
+            offset += varDsc->lvSize();
+        }
+        else
+        {
+            CorInfoType corInfoType = toCorInfoType(varDsc->TypeGet());
+            CORINFO_CLASS_HANDLE classHandle =
+                varTypeIsStruct(varDsc) ? varDsc->GetLayout()->GetClassHandle() : NO_CLASS_HANDLE;
+
+            offset = padOffset(corInfoType, classHandle, offset);
+            varDsc->SetStackOffset(offset);
+            offset = padNextOffset(corInfoType, classHandle, offset);
+        }
+
+        // We will use this as the indication that the local has a home on the shadow stack.
+        varDsc->SetRegNum(REG_STK);
+    }
+
+    _shadowStackLocalsSize = AlignUp(offset, TARGET_POINTER_SIZE);
+
+    _compiler->compLclFrameSize = _shadowStackLocalsSize;
+    _compiler->lvaDoneFrameLayout = Compiler::TENTATIVE_FRAME_LAYOUT;
+
+    JITDUMP("\nLocals after shadow stack layout:\n");
+    JITDUMPEXEC(_compiler->lvaTableDump());
+    JITDUMP("\n");
+
+    _compiler->lvaDoneFrameLayout = Compiler::INITIAL_FRAME_LAYOUT;
+}
+
+void Llvm::allocLowerAndInsertProlog()
+{
+    // Insert a zero-offset ILOffset to notify codegen this is the start of user code.
+    DebugInfo zeroILOffsetDi =
+        DebugInfo(_compiler->compInlineContext, ILLocation(0, /* isStackEmpty */ true, /* isCall */ false));
+    GenTree* zeroILOffsetNode = new (_compiler, GT_IL_OFFSET) GenTreeILOffset(zeroILOffsetDi);
+    m_prologRange.InsertAtEnd(zeroILOffsetNode);
+
+    _compiler->fgEnsureFirstBBisScratch();
+    lowerRange(_compiler->fgFirstBB, m_prologRange);
+    LIR::AsRange(_compiler->fgFirstBB).InsertAtBeginning(std::move(m_prologRange));
+}
+
+void Llvm::allocInitializeLocalInProlog(unsigned lclNum, GenTree* value)
+{
+    LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
+    JITDUMP("Adding initialization for V%02u, %s:\n", lclNum, varDsc->lvReason);
+
+    GenTreeUnOp* store = _compiler->gtNewStoreLclVarNode(lclNum, value);
+
+    m_prologRange.InsertAtEnd(value);
+    m_prologRange.InsertAtEnd(store);
+
+    DISPTREERANGE(m_prologRange, store);
+}
+
+void Llvm::allocRewriteShadowFrameReferences()
+{
+    for (BasicBlock* block : _compiler->Blocks())
+    {
+        m_currentBlock = block;
+        m_currentRange = &LIR::AsRange(block);
+
+        for (GenTree* node : CurrentRange())
+        {
+            if (node->OperIsAnyLocal())
+            {
+                allocRewriteLocal(node->AsLclVarCommon());
+            }
+            else if (node->IsCall())
+            {
+                allocRewriteCall(node->AsCall());
+            }
+        }
+
+        INDEBUG(CurrentRange().CheckLIR(_compiler, /* checkUnusedValues */ true));
+    }
+
+    m_currentBlock = nullptr;
+    m_currentRange = nullptr;
+}
+
+void Llvm::allocRewriteLocal(GenTreeLclVarCommon* lclNode)
+{
+    LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNode->GetLclNum());
+
+    if (isShadowFrameLocal(varDsc) && (lclNode->GetRegNum() != REG_LLVM))
+    {
+        // Funclets (especially filters) will be called by the dispatcher while live state still exists
+        // on shadow frames below (in the tradional sense, where stacks grow down) them. For this reason,
+        // funclets will access state from the original frame via a dedicated shadow stack pointer, and
+        // use the actual shadow stack for calls.
+        unsigned shadowStackLclNum = CurrentBlock()->hasHndIndex() ? _originalShadowStackLclNum : _shadowStackLclNum;
+        GenTree* lclAddress =
+            insertShadowStackAddr(lclNode, varDsc->GetStackOffset() + lclNode->GetLclOffs(), shadowStackLclNum);
+
+        ClassLayout* layout = lclNode->TypeIs(TYP_STRUCT) ? lclNode->GetLayout(_compiler) : nullptr;
+        GenTree* storedValue = nullptr;
+        genTreeOps indirOper;
+        switch (lclNode->OperGet())
+        {
+            case GT_STORE_LCL_VAR:
+            case GT_STORE_LCL_FLD:
+                indirOper = (layout != nullptr) ? GT_STORE_BLK : GT_STOREIND;
+                storedValue = lclNode->Data();
+                break;
+            case GT_LCL_FLD:
+            case GT_LCL_VAR:
+                indirOper = (layout != nullptr) ? GT_BLK : GT_IND;
+                break;
+            case GT_LCL_ADDR:
+                // Local address nodes are directly replaced with the ADD.
+                CurrentRange().Remove(lclAddress);
+                lclNode->ReplaceWith(lclAddress, _compiler);
+                return;
+            default:
+                unreached();
+        }
+
+        lclNode->ChangeOper(indirOper);
+        lclNode->AsIndir()->SetAddr(lclAddress);
+        lclNode->gtFlags |= GTF_IND_NONFAULTING;
+
+        if (GenTree::OperIsStore(indirOper))
+        {
+            lclNode->gtFlags |= GTF_IND_TGT_NOT_HEAP;
+            lclNode->AsIndir()->Data() = storedValue;
+        }
+        if (GenTree::OperIsBlk(indirOper))
+        {
+            lclNode->AsBlk()->SetLayout(layout);
+            lclNode->AsBlk()->gtBlkOpKind = GenTreeBlk::BlkOpKindInvalid;
+        }
+    }
+
+    if (lclNode->OperIsLocalField() || lclNode->OperIs(GT_LCL_ADDR))
+    {
+        // Indicates that this local is to live on the LLVM frame, and will not participate in SSA.
+        varDsc->lvHasLocalAddr = 1;
+    }
+}
+
+void Llvm::allocRewriteCall(GenTreeCall* call)
+{
+    // Add in the shadow stack argument now that we know the shadow frame size.
+    if (callHasManagedCallingConvention(call))
+    {
+        unsigned hndIndex =
+            CurrentBlock()->hasHndIndex() ? CurrentBlock()->getHndIndex() : EHblkDsc::NO_ENCLOSING_INDEX;
+        GenTree* calleeShadowStack = insertShadowStackAddr(call, getShadowFrameSize(hndIndex), _shadowStackLclNum);
+        CallArg* calleeShadowStackArg =
+            call->gtArgs.PushFront(_compiler, NewCallArg::Primitive(calleeShadowStack, CORINFO_TYPE_PTR));
+
+        calleeShadowStackArg->AbiInfo.IsPointer = true;
+        calleeShadowStackArg->AbiInfo.ArgType = TYP_I_IMPL;
+    }
+
+    if (call->IsOptimizingRetBufAsLocal() && !call->gtArgs.GetRetBufferArg()->GetNode()->OperIs(GT_LCL_ADDR))
+    {
+        // We may have lost track of a shadow local defined by this call. Clear the flag if so.
+        call->gtCallMoreFlags &= ~GTF_CALL_M_RETBUFFARG_LCLOPT;
+    }
+}
+
+//------------------------------------------------------------------------
+// isPotentialGcSafePoint: Can this node be a GC safe point?
+//
+// Arguments:
+//    node - The node
+//
+// Return Value:
+//    Whether "node" can trigger GC.
+//
+// Notes:
+//    Similar to "Compiler::IsGcSafePoint", with the difference being that
+//    the "conservative" return value for this method is "true".
+//
+bool Llvm::isPotentialGcSafePoint(GenTree* node)
+{
+    if (node->IsCall())
+    {
+        if (node->AsCall()->IsUnmanaged() && node->AsCall()->IsSuppressGCTransition())
+        {
+            return false;
+        }
+        if (node->IsHelperCall() && getHelperFuncInfo(node->AsCall()->GetHelperNum()).HasFlags(HFIF_NO_RPI_OR_GC))
+        {
+            return false;
+        }
+
+        // All other calls are assumed to be possible safe points.
+        return true;
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------
+// isShadowFrameLocal: Does the given local have a home on the shadow frame?
+//
+// Arguments:
+//    varDsc - Local's descriptor
+//
+// Return Value:
+//    Whether the given local has a location assigned to it on the shadow
+//    frame. Note the fact it does is not an implication that it is live
+//    on it at all times: the local can be live on the LLVM frame, or the
+//    shadow one, or both.
+//
+bool Llvm::isShadowFrameLocal(LclVarDsc* varDsc) const
+{
+    // Other backends use "lvOnFrame" for this value, but for us it is not
+    // a great fit because we add new locals after shadow frame layout.
+    // TODO-LLVM-LSSA: the above is no longer correct. Use "lvOnFrame".
+    return varDsc->GetRegNum() == REG_STK;
+}
+
+bool Llvm::isShadowStackLocal(unsigned lclNum) const
+{
+    return (lclNum == _shadowStackLclNum) || (lclNum == _originalShadowStackLclNum);
+}
+
+bool Llvm::isFuncletParameter(unsigned lclNum) const
+{
+    return isShadowStackLocal(lclNum);
+}
+
+//------------------------------------------------------------------------
+// getShadowFrameSize: What is the size of a function's shadow frame?
+//
+// Arguments:
+//    hndIndex - Handler index representing the function, NO_ENCLOSING_INDEX
+//               is used for the root
+//
+// Return Value:
+//    The size of the shadow frame for the given function. We term this
+//    the value by which the shadow stack pointer must be offset before
+//    calling managed code such that the caller will not clobber anything
+//    live on the frame. Note that funclets do not have any shadow state
+//    of their own and use the "original" frame from the parent function,
+//    with one exception: catch handlers and filters have one readonly
+//    pointer-sized argument representing the exception.
+//
+unsigned Llvm::getShadowFrameSize(unsigned hndIndex) const
+{
+    if (hndIndex == EHblkDsc::NO_ENCLOSING_INDEX)
+    {
+        return getOriginalShadowFrameSize();
+    }
+    if (_compiler->ehGetDsc(hndIndex)->HasCatchHandler())
+    {
+        // For the implicit (readonly) exception object argument.
+        return TARGET_POINTER_SIZE;
+    }
+
+    return 0;
+}
+
+unsigned Llvm::getOriginalShadowFrameSize() const
+{
+    assert((_shadowStackLocalsSize % TARGET_POINTER_SIZE) == 0);
+    return _shadowStackLocalsSize;
+}
+
+bool Llvm::doUseDynamicStackForLclHeap()
+{
+    // TODO-LLVM: add a stress mode.
+    assert(m_lclHeapUsed);
+
+    // We assume LCLHEAPs in methods with EH escape into handlers and so
+    // have to use a special EH-aware allocator instead of the native stack.
+    return _compiler->ehAnyFunclets() || JitConfig.JitUseDynamicStackForLclHeap();
+}


### PR DESCRIPTION
For now, just move code to it from lowering.

This will fix the recently introduced GC hole with interface dispatch.

Diffs are regressions caused by the fix:
```
Total bytes of base: 3414056
Total bytes of diff: 3431153
Total bytes of delta: 17097 (0.50% % of base)
Average relative delta: 8.01%
    diff is a regression
    average relative diff is a regression

Top method regressions (percentages):
          56 (58.33% of base) : 1390.dasm - S_P_CoreLib_System_Convert__ToChar
          56 (58.33% of base) : 1389.dasm - S_P_CoreLib_System_Convert__ToBoolean
          56 (58.33% of base) : 1461.dasm - S_P_CoreLib_System_Convert__ToSByte
          56 (58.33% of base) : 1462.dasm - S_P_CoreLib_System_Convert__ToByte
          56 (58.33% of base) : 1463.dasm - S_P_CoreLib_System_Convert__ToInt16
          56 (58.33% of base) : 1464.dasm - S_P_CoreLib_System_Convert__ToUInt16
          56 (58.33% of base) : 1466.dasm - S_P_CoreLib_System_Convert__ToUInt32
          56 (58.33% of base) : 1465.dasm - S_P_CoreLib_System_Convert__ToInt32
          50 (52.08% of base) : 1468.dasm - S_P_CoreLib_System_Convert__ToUInt64
          50 (52.08% of base) : 1467.dasm - S_P_CoreLib_System_Convert__ToInt64
          50 (50.51% of base) : 1469.dasm - S_P_CoreLib_System_Convert__ToSingle
          12 (50.00% of base) : 1117.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__ToExpectedNamespaceReferenceHandle
          50 (48.54% of base) : 1470.dasm - S_P_CoreLib_System_Convert__ToDouble
          30 (33.71% of base) : 1272.dasm - S_P_CoreLib_System_Type__GetTypeFromHandle
          29 (32.95% of base) : 1551.dasm - S_P_CoreLib_System_Globalization_TextInfo__NeedsTurkishCasing
          24 (30.38% of base) : 1586.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_LdTokenHelpers__GetRuntimeType
          89 (30.27% of base) : 1224.dasm - S_P_CoreLib_System_Text_StringBuilder_AppendInterpolatedStringHandler__AppendFormatted_4
          24 (29.63% of base) : 1009.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_Callbacks__CompareMethodSignatures
          24 (29.63% of base) : 1010.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_Callbacks__GetThreadStaticGCDescForDynamicType
          24 (29.63% of base) : 1008.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_Callbacks__ResolveGenericVirtualMethodTarget

Top method improvements (percentages):
         -64 (-13.91% of base) : 1054.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_MetadataNameExtensions__GetFullName_6
         -14 (-9.59% of base) : 1735.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_MetadataNameExtensions__GetFullName_0
         -14 (-9.59% of base) : 1654.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_MetadataNameExtensions__GetFullName_3
         -14 (-9.59% of base) : 1655.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_MetadataNameExtensions__GetFullName_1
         -35 (-8.95% of base) : 1409.dasm - S_P_TypeLoader_Internal_Metadata_NativeFormat_MetadataTypeHashingAlgorithms__ComputeHashCode
         -54 (-7.85% of base) : 1292.dasm - S_P_CoreLib_System_DateTimeFormat__ExpandStandardFormatToCustomPattern
          -3 (-4.55% of base) : 1241.dasm - S_P_CoreLib_System_Reflection_Runtime_General_Helpers__GetRawDefaultValue$F1_Finally
          -3 (-4.55% of base) : 1565.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__RegisterDynamicGenericTypesAndMethods$F1_Fault
          -3 (-4.55% of base) : 1573.dasm - S_P_CoreLib_System_Reflection_Runtime_General_Helpers__GetRawConstant$F1_Finally
          -3 (-4.55% of base) : 1239.dasm - S_P_CoreLib_System_Reflection_Runtime_General_Helpers__GetDefaultValue$F1_Finally
          -3 (-4.55% of base) : 1091.dasm - S_P_CoreLib_System_Collections_Generic_LowLevelList_1<System___Canon>__InsertRange$F1_Fault
          -3 (-4.55% of base) : 1342.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeDesc__get_UnderlyingType$F1_Finally
          -3 (-4.55% of base) : 1619.dasm - S_P_CoreLib_System_Reflection_Runtime_BindingFlagSupport_Shared__GetImplicitlyOverriddenBaseClassMember<System___Canon>$F1_Finally
          -3 (-4.55% of base) : 1075.dasm - S_P_CoreLib_System_Reflection_Runtime_BindingFlagSupport_QueriedMemberList_1<System___Canon>__Create$F1_Fault
         -72 (-4.42% of base) : 1045.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_MethodNameFormatter__EmitTypeName
         -20 (-4.12% of base) : 1116.dasm - S_P_CoreLib_Microsoft_Win32_SafeHandles_SafeFileHandle__Open
         -10 (-4.07% of base) : 1209.dasm - String__Create<IntPtr>
         -10 (-3.26% of base) : 1186.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo_TypeComponentsCache__GetQueriedMembers_0<System___Canon>
         -38 (-3.10% of base) : 1346.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_ExecutionEnvironmentImplementation__TryGetFieldAccessor
          -3 (-2.94% of base) : 1113.dasm - S_P_CoreLib_System_Reflection_Runtime_CustomAttributes_RuntimeCustomAttributeData__WrapInCustomAttributeTypedArgument$F1_Fault
```

I am also planning to add a stress mode (in a separate change) that would help stop such issues from slipping through in the future.