### PR TITLE
[NativeAOT-LLVM] Don't hook into LLVM error reporting in the Jit

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -108,8 +108,6 @@ Llvm::Llvm(Compiler* compiler)
 
 /* static */ void Llvm::ConfigureDiagnosticOutput()
 {
-    llvm::sys::PrintStackTraceOnErrorSignal("");
-
 #ifdef HOST_WINDOWS
     // Disable popups for CRT asserts (which LLVM uses).
     ::_set_error_mode(_OUT_TO_STDERR);


### PR DESCRIPTION
It overrides the CLR's, effectively swallowing what would otherwise be uncaught managed exceptions. This can turn simple ILC failures into cryptic errors like truncated LLVM output.

@dotnet/nativeaot-llvm 