### PR TITLE
[NativeAOT-LLVM] Simpler and more precise init semantics for locals

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -128,6 +128,14 @@ struct HelperFuncInfo
     size_t GetSigArgCount(unsigned* callArgCount = nullptr) const;
 };
 
+enum class ValueInitKind
+{
+    None,
+    Param,
+    Zero,
+    Uninit
+};
+
 struct PhiPair
 {
     GenTreeLclVar* StoreNode;
@@ -354,10 +362,16 @@ public:
 private:
     friend class ShadowStackAllocator;
 
+    ValueInitKind getInitKindForLocal(unsigned lclNum) const;
+#ifdef DEBUG
+    void displayInitKindForLocal(unsigned lclNum, ValueInitKind initKind);
+#endif // DEBUG
+
     unsigned getShadowFrameSize(unsigned hndIndex) const;
     bool isShadowFrameLocal(LclVarDsc* varDsc) const;
     bool isShadowStackLocal(unsigned lclNum) const;
     bool isFuncletParameter(unsigned lclNum) const;
+
     bool doUseDynamicStackForLclHeap() const;
 
     // ================================================================================================================


### PR DESCRIPTION
This cleans up the optimized LLVM IR output considerably as we no longer produce many unused "freeze undef"s.

A couple diffs from reducing redundant initializations:
```
Total bytes of base: 3407685
Total bytes of diff: 3406131
Total bytes of delta: -1554 (-0.05% % of base)
Average relative delta: -5.89%
    diff is an improvement
    average relative diff is an improvement

Top method improvements (percentages):
        -724 (-13.24% of base) : 1012.dasm - S_P_CoreLib_Internal_Reflection_Extensions_NonPortable_CustomAttributeInstantiator__Instantiate
         -44 (-11.49% of base) : 1002.dasm - HelloWasm_Program__TestPalRandom
         -17 (-10.18% of base) : 1010.dasm - S_P_CoreLib_System_Decimal__System_IConvertible_ToSByte
         -17 (-10.18% of base) : 1003.dasm - S_P_CoreLib_System_Decimal__System_IConvertible_ToUInt64
         -17 (-10.18% of base) : 1004.dasm - S_P_CoreLib_System_Decimal__System_IConvertible_ToInt64
         -17 (-10.18% of base) : 1005.dasm - S_P_CoreLib_System_Decimal__System_IConvertible_ToUInt32
         -17 (-10.18% of base) : 1006.dasm - S_P_CoreLib_System_Decimal__System_IConvertible_ToInt32
         -17 (-10.18% of base) : 1007.dasm - S_P_CoreLib_System_Decimal__System_IConvertible_ToUInt16
         -17 (-10.18% of base) : 1008.dasm - S_P_CoreLib_System_Decimal__System_IConvertible_ToInt16
         -17 (-10.18% of base) : 1009.dasm - S_P_CoreLib_System_Decimal__System_IConvertible_ToByte
        -505 (-8.04% of base) : 1001.dasm - S_P_CoreLib_System_Reflection_CustomAttributeTypedArgument__ToString_0
         -17 (-7.80% of base) : 1024.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__IsStaticMethodSignature
          -7 (-3.63% of base) : 1016.dasm - S_P_CoreLib_System_Func_1<S_P_CoreLib_System_Threading_Tasks_VoidTaskResult>__InvokeOpenStaticThunk
          -7 (-3.38% of base) : 1020.dasm - S_P_CoreLib_System_Func_2<System___Canon__S_P_CoreLib_System_Threading_Tasks_VoidTaskResult>__InvokeOpenStaticThunk
          -7 (-3.37% of base) : 1022.dasm - S_P_CoreLib_System_Func_2<System___Canon__S_P_CoreLib_System_Threading_Tasks_VoidTaskResult>__InvokeOpenInstanceThunk
          -7 (-3.26% of base) : 1015.dasm - S_P_CoreLib_System_Func_1<S_P_CoreLib_System_Threading_Tasks_VoidTaskResult>__InvokeClosedStaticThunk
          -7 (-3.26% of base) : 1017.dasm - S_P_CoreLib_System_Func_1<S_P_CoreLib_System_Threading_Tasks_VoidTaskResult>__InvokeInstanceClosedOverGenericMethodThunk
          -7 (-3.11% of base) : 1013.dasm - Internal_CompilerGenerated__Module___<DynamicInvoke>None<S_P_CoreLib_System_Threading_Tasks_VoidTaskResult>
          -7 (-3.06% of base) : 1019.dasm - S_P_CoreLib_System_Func_2<System___Canon__S_P_CoreLib_System_Threading_Tasks_VoidTaskResult>__InvokeClosedStaticThunk
          -7 (-3.06% of base) : 1021.dasm - S_P_CoreLib_System_Func_2<System___Canon__S_P_CoreLib_System_Threading_Tasks_VoidTaskResult>__InvokeInstanceClosedOverGenericMethodThunk

27 total methods with Code Size differences (27 improved, 0 regressed)
```