### PR TITLE
NativeAOT-LLVM: For the msbuild exec task, don't assume a working directory

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/ExecWrapper.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/ExecWrapper.proj
@@ -1,5 +1,5 @@
 <Project DefaultTargets="Exec" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="Exec">
-    <Exec Command="$(ExecCommand)" />
+    <Exec Command="$(ExecCommand)" WorkingDirectory="$(ExecWorkingDirectory)" />
   </Target>
 </Project>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -408,7 +408,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup>
       <ExecProjects Include="$(MSBuildThisFileDirectory)ExecWrapper.proj">
         <AdditionalProperties>
-          ExecCommand=$(WasmCompilerPath) &quot;$(ProjectDir)/%(LlvmObjects.Identity)&quot; -o &quot;$(ProjectDir)/%(LlvmObjects.NativeObject)&quot; $(CompileWasmArgs)
+          ExecCommand=$(WasmCompilerPath) &quot;%(LlvmObjects.Identity)&quot; -o &quot;%(LlvmObjects.NativeObject)&quot; $(CompileWasmArgs)
+          ExecWorkingDirectory=$(MSBuildProjectDirectory)
         </AdditionalProperties>
       </ExecProjects>
     </ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -408,7 +408,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup>
       <ExecProjects Include="$(MSBuildThisFileDirectory)ExecWrapper.proj">
         <AdditionalProperties>
-          ExecCommand=$(WasmCompilerPath) &quot;%(LlvmObjects.Identity)&quot; -o &quot;%(LlvmObjects.NativeObject)&quot; $(CompileWasmArgs)
+          ExecCommand=$(WasmCompilerPath) &quot;$(ProjectDir)/%(LlvmObjects.Identity)&quot; -o &quot;$(ProjectDir)/%(LlvmObjects.NativeObject)&quot; $(CompileWasmArgs)
         </AdditionalProperties>
       </ExecProjects>
     </ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -408,7 +408,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup>
       <ExecProjects Include="$(MSBuildThisFileDirectory)ExecWrapper.proj">
         <AdditionalProperties>
-          ExecCommand=$(WasmCompilerPath) &quot;%(LlvmObjects.Identity)&quot; -o &quot;%(LlvmObjects.NativeObject)&quot; $(CompileWasmArgs)
+          ExecCommand=$(WasmCompilerPath) &quot;%(LlvmObjects.Identity)&quot; -o &quot;%(LlvmObjects.NativeObject)&quot; $(CompileWasmArgs);
           ExecWorkingDirectory=$(MSBuildProjectDirectory)
         </AdditionalProperties>
       </ExecProjects>


### PR DESCRIPTION
This PR uses an absolute path for the `clang++` args as the working directory cannot be assumed.

I was using `MSBuild executable path = "C:\Program Files\dotnet\sdk\8.0.100-preview.5.23303.2\MSBuild.dll"`
and a local package directory, i.e. `nuget.config` like

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <config>
    <add key="globalPackagesFolder" value=".packages" />
  </config>
```
And I observed from `dotnet publish -r wasi-wasm -c Release /p:MSBuildEnableWorkloadResolver=false --self-contained /p:UseAppHost=false /bl` that the clang++ command was failing with, for example:
```
clang++ : error : no such file or directory: 'obj\Release\net8.0\wasi-wasm\native\cswasi.external.bc' [E:\GitHub\cs-wit
-bindgen\.packages\microsoft.dotnet.ilcompiler.llvm\8.0.0-preview.7.23354.2\build\ExecWrapper.proj]
clang++ : error : no input files [E:\GitHub\cs-wit-bindgen\.packages\microsoft.dotnet.ilcompiler.llvm\8.0.0-preview.7.2
3354.2\build\ExecWrapper.proj]
```
The input files were present, but adding `dir && ....` to the exec command revealed the current working directory was
```
Directory of E:\GitHub\cs-wit-bindgen\.packages\microsoft.dotnet.ilcompiler.llvm\8.0.0-preview.7.23354.2\build
```
