### PR TITLE
[NativeAOT-LLVM] Fix an EH bug

### DIFF
--- a/src/tests/nativeaot/SmokeTests/HelloWasm/ExceptionHandlingTests.Common.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/ExceptionHandlingTests.Common.cs
@@ -33,6 +33,8 @@ internal unsafe partial class Program
 
         TestThrowInCatch();
 
+        TestUnconditionalThrowInCatch();
+
         TestExceptionInGvmCall();
 
         TestCatchHandlerNeedsGenericContext();
@@ -323,6 +325,30 @@ internal unsafe partial class Program
             }
         }
         EndTest(i == 11);
+    }
+
+    private static void TestUnconditionalThrowInCatch()
+    {
+        StartTest("TestUnconditionalThrowInCatch");
+
+        bool pass = true;
+        try
+        {
+            try
+            {
+                ThrowException(new ArgumentException());
+            }
+            catch (IndexOutOfRangeException)
+            {
+                pass = false;
+                throw new ArgumentException();
+            }
+        }
+        catch (ArgumentException)
+        {
+        }
+
+        EndTest(pass);
     }
 
     private static void TestExceptionInGvmCall()


### PR DESCRIPTION
The code was assuming that if a handler has no "catchret"s, the associated filter(s) will always return "true", which is not true.

With this fix, all `System.Collections` tests run to completion (in Release).

Recommended to review with the "hide whitespaces" option.