### PR TITLE
[NativeAOT-LLVM] Implement more efficient null-checking and use inbounds GEPs

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -409,6 +409,7 @@ private:
     void buildLocalVarAddr(GenTreeLclVarCommon* lclVar);
     void buildAdd(GenTreeOp* node);
     void buildSub(GenTreeOp* node);
+    void buildAddrMode(GenTreeAddrMode* addrMode);
     void buildDivMod(GenTree* node);
     void buildRotate(GenTreeOp* node);
     void buildCast(GenTreeCast* cast);
@@ -469,6 +470,7 @@ private:
     Instruction* getCast(Value* source, Type* targetType);
     Value* castIfNecessary(Value* source, Type* targetType, llvm::IRBuilder<>* builder = nullptr);
     Value* gepOrAddr(Value* addr, unsigned offset);
+    Value* gepOrAddrInBounds(Value* addr, unsigned offset);
     llvm::Constant* getIntPtrConst(target_size_t value, Type* llvmType = nullptr);
     Value* getShadowStack();
     Value* getShadowStackForCallee();

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -8,6 +8,7 @@
 
 #include "alloc.h"
 #include "jitpch.h"
+#include "sideeffects.h"
 #include "jitgcinfo.h"
 #include "llvmtypes.h"
 #include <new>
@@ -195,6 +196,7 @@ private:
 
     // Lowering members.
     LIR::Range* m_currentRange = nullptr;
+    SideEffectSet m_scratchSideEffects; // Used for IsInvariantInRange.
 
     // Codegen members.
     llvm::IRBuilder<> _builder;
@@ -346,12 +348,18 @@ private:
     void lowerCallToShadowStack(GenTreeCall* callNode);
     void lowerCallReturn(GenTreeCall* callNode);
 
+    void lowerAddressToAddressMode(GenTreeIndir* indir);
+    bool isAddressInBounds(GenTree* addr, FieldSeq* fieldSeq, target_size_t offset);
+    unsigned getObjectSizeBound(GenTree* obj);
+
     GenTree* normalizeStructUse(LIR::Use& use, ClassLayout* layout);
 
     unsigned representAsLclVar(LIR::Use& use);
     GenTree* insertShadowStackAddr(GenTree* insertBefore, ssize_t offset, unsigned shadowStackLclNum);
 
     unsigned getCatchArgOffset() const;
+
+    bool isInvariantInRange(GenTree* node, GenTree* endExclusive);
 
     // ================================================================================================================
     // |                                           Shadow stack allocation                                            |
@@ -439,11 +447,13 @@ private:
 
     void buildCallFinally(BasicBlock* block);
 
+    Value* consumeAddressAndEmitNullCheck(GenTreeIndir* indir);
+    void emitNullCheckForAddress(GenTree* addr, Value* addrValue);
+
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
 
     void emitJumpToThrowHelper(Value* jumpCondValue, SpecialCodeKind throwKind);
-    void emitNullCheckForIndir(GenTreeIndir* indir, Value* addrValue);
     Value* emitCheckedArithmeticOperation(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value);
     llvm::CallBase* emitHelperCall(CorInfoHelpFunc                  helperFunc,
                                    ArrayRef<Value*>                 sigArgs = {},

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1931,9 +1931,7 @@ void Llvm::buildCall(GenTreeCall* call)
 void Llvm::buildInd(GenTreeIndir* indNode)
 {
     Type* loadLlvmType = getLlvmTypeForVarType(indNode->TypeGet());
-    Value* addrValue = consumeValue(indNode->Addr(), getPtrLlvmType());
-
-    emitNullCheckForIndir(indNode, addrValue);
+    Value* addrValue = consumeAddressAndEmitNullCheck(indNode);
     Value* loadValue = _builder.CreateLoad(loadLlvmType, addrValue);
 
     mapGenTreeToValue(indNode, loadValue);
@@ -1942,9 +1940,7 @@ void Llvm::buildInd(GenTreeIndir* indNode)
 void Llvm::buildBlk(GenTreeBlk* blkNode)
 {
     Type* blkLlvmType = getLlvmTypeForStruct(blkNode->GetLayout());
-    Value* addrValue = consumeValue(blkNode->Addr(), getPtrLlvmType());
-
-    emitNullCheckForIndir(blkNode, addrValue);
+    Value* addrValue = consumeAddressAndEmitNullCheck(blkNode);
     Value* blkValue = _builder.CreateLoad(blkLlvmType, addrValue);
 
     mapGenTreeToValue(blkNode, blkValue);
@@ -1955,10 +1951,8 @@ void Llvm::buildStoreInd(GenTreeStoreInd* storeIndOp)
     GCInfo::WriteBarrierForm wbf = getGCInfo()->gcIsWriteBarrierCandidate(storeIndOp);
 
     Type* storeLlvmType = getLlvmTypeForVarType(storeIndOp->TypeGet());
-    Value* addrValue = consumeValue(storeIndOp->Addr(), getPtrLlvmType());
+    Value* addrValue = consumeAddressAndEmitNullCheck(storeIndOp);
     Value* dataValue = consumeValue(storeIndOp->Data(), storeLlvmType);;
-
-    emitNullCheckForIndir(storeIndOp, addrValue);
 
     switch (wbf)
     {
@@ -1985,9 +1979,7 @@ void Llvm::buildStoreBlk(GenTreeBlk* blockOp)
     ClassLayout* layout = blockOp->GetLayout();
     GenTree* addrNode = blockOp->Addr();
     GenTree* dataNode = blockOp->Data();
-    Value* addrValue = consumeValue(addrNode, getPtrLlvmType());
-
-    emitNullCheckForIndir(blockOp, addrValue);
+    Value* addrValue = consumeAddressAndEmitNullCheck(blockOp);
 
     // Check for the "initblk" operation ("dataNode" is either INIT_VAL or constant zero).
     if (blockOp->OperIsInitBlkOp())
@@ -2016,21 +2008,8 @@ void Llvm::buildStoreDynBlk(GenTreeStoreDynBlk* blockOp)
     GenTree* srcNode = blockOp->Data();
     GenTree* sizeNode = blockOp->gtDynamicSize;
 
-    Value* dstAddrValue = consumeValue(blockOp->Addr(), getPtrLlvmType());
-    Value* srcValue;
-    if (isCopyBlock)
-    {
-        srcValue = consumeValue(srcNode->AsIndir()->Addr(), getPtrLlvmType());
-    }
-    else
-    {
-        srcValue = srcNode->OperIsInitVal()
-            ? consumeValue(srcNode->AsUnOp()->gtGetOp1(), Type::getInt8Ty(m_context->Context))
-            : _builder.getInt8(0);
-    }
-    // Per ECMA 335, cpblk/initblk only allow int32-sized operands. We'll be a bit more permissive and allow native ints
-    // as well (as do other backends).
-    Type* sizeLlvmType = genActualTypeIsInt(sizeNode) ? Type::getInt32Ty(m_context->Context) : getIntPtrLlvmType();
+    // STORE_DYN_BLK accepts native-sized size operands.
+    Type* sizeLlvmType = getIntPtrLlvmType();
     Value* sizeValue = consumeValue(sizeNode, sizeLlvmType);
 
     // STORE_DYN_BLK's contract is that it must not throw any exceptions in case the dynamic size is zero and must throw
@@ -2045,9 +2024,6 @@ void Llvm::buildStoreDynBlk(GenTreeStoreDynBlk* blockOp)
     // have the right semantics (don't throw NREs).
     if (dstAddrMayBeNull || srcAddrMayBeNull)
     {
-        checkSizeLlvmBlock = _builder.GetInsertBlock();
-        nullChecksLlvmBlock = createInlineLlvmBlock();
-        _builder.SetInsertPoint(nullChecksLlvmBlock);
         //
         // if (sizeIsZeroValue) goto PASSED; else goto CHECK_DST; (we'll add this below)
         // CHECK_DST:
@@ -2058,27 +2034,27 @@ void Llvm::buildStoreDynBlk(GenTreeStoreDynBlk* blockOp)
         //   memcpy/memset
         // PASSED:
         //
-        if (dstAddrMayBeNull)
-        {
-            emitNullCheckForIndir(blockOp, dstAddrValue);
-        }
-        if (srcAddrMayBeNull)
-        {
-            emitNullCheckForIndir(srcNode->AsIndir(), srcValue);
-        }
+        checkSizeLlvmBlock = _builder.GetInsertBlock();
+        nullChecksLlvmBlock = createInlineLlvmBlock();
+        _builder.SetInsertPoint(nullChecksLlvmBlock);
     }
 
     // Technically cpblk/initblk specify that they expect their sources/destinations to be aligned, but in
     // practice these instructions are used like memcpy/memset, which do not require this. So we do not try
     // to be more precise with the alignment specification here as well.
     // TODO-LLVM: volatile STORE_DYN_BLK.
+    Value* dstAddrValue = consumeAddressAndEmitNullCheck(blockOp);
     if (isCopyBlock)
     {
-        _builder.CreateMemCpy(dstAddrValue, llvm::MaybeAlign(), srcValue, llvm::MaybeAlign(), sizeValue);
+        Value* srcAddrValue = consumeAddressAndEmitNullCheck(srcNode->AsIndir());
+        _builder.CreateMemCpy(dstAddrValue, llvm::MaybeAlign(), srcAddrValue, llvm::MaybeAlign(), sizeValue);
     }
     else
     {
-        _builder.CreateMemSet(dstAddrValue, srcValue, sizeValue, llvm::MaybeAlign());
+        Value* initValue = srcNode->OperIsInitVal()
+            ? consumeValue(srcNode->AsUnOp()->gtGetOp1(), Type::getInt8Ty(m_context->Context))
+            : _builder.getInt8(0);
+        _builder.CreateMemSet(dstAddrValue, initValue, sizeValue, llvm::MaybeAlign());
     }
 
     if (checkSizeLlvmBlock != nullptr)
@@ -2320,8 +2296,7 @@ void Llvm::buildSwitch(GenTreeUnOp* switchNode)
 
 void Llvm::buildNullCheck(GenTreeIndir* nullCheckNode)
 {
-    Value* addrValue = consumeValue(nullCheckNode->Addr(), getPtrLlvmType());
-    emitNullCheckForIndir(nullCheckNode, addrValue);
+    consumeAddressAndEmitNullCheck(nullCheckNode);
 }
 
 void Llvm::buildBoundsCheck(GenTreeBoundsChk* boundsCheckNode)
@@ -2408,6 +2383,49 @@ void Llvm::buildCallFinally(BasicBlock* block)
         assert(block->isBBCallAlwaysPair());
         _builder.CreateBr(getFirstLlvmBlockForBlock(block->bbNext));
     }
+}
+
+Value* Llvm::consumeAddressAndEmitNullCheck(GenTreeIndir* indir)
+{
+    GenTree* addr = indir->Addr();
+    unsigned offset = 0;
+    if (addr->isContained())
+    {
+        assert(addr->OperIs(GT_LEA) && addr->AsAddrMode()->HasBase() && !addr->AsAddrMode()->HasIndex());
+        offset = addr->AsAddrMode()->Offset();
+        addr = addr->AsAddrMode()->Base();
+    }
+
+    Value* addrValue = consumeValue(addr, getPtrLlvmType());
+
+    if ((indir->gtFlags & GTF_IND_NONFAULTING) == 0)
+    {
+        // Note how we emit the check **before** the inbounds GEP so as to avoid the latter producing poison.
+        emitNullCheckForAddress(addr, addrValue);
+    }
+
+    addrValue = gepOrAddrInBounds(addrValue, offset);
+    return addrValue;
+}
+
+void Llvm::emitNullCheckForAddress(GenTree* addr, Value* addrValue)
+{
+    // The frontend's contract with the backend is that it will not insert null checks for accesses which
+    // are inside the "[0..compMaxUncheckedOffsetForNullObject]" range. Thus, we usually need to check not
+    // just for "null", but "null + small offset". However, for TYP_REF, we know it will either be a valid
+    // object on heap, or null, and can utilize the more direct form.
+    Value* isNullValue;
+    if (addr->TypeIs(TYP_REF))
+    {
+        isNullValue = _builder.CreateIsNull(addrValue);
+    }
+    else
+    {
+        Value* checkValue = getIntPtrConst(_compiler->compMaxUncheckedOffsetForNullObject + 1, addrValue->getType());
+        isNullValue = _builder.CreateICmpULT(addrValue, checkValue);
+    }
+
+    emitJumpToThrowHelper(isNullValue, SCK_NULL_REF_EXCPN);
 }
 
 void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc)
@@ -2517,21 +2535,6 @@ void Llvm::emitJumpToThrowHelper(Value* jumpCondValue, SpecialCodeKind throwKind
         _builder.CreateUnreachable();
 
         _builder.SetInsertPoint(nextLlvmBlock);
-    }
-}
-
-void Llvm::emitNullCheckForIndir(GenTreeIndir* indir, Value* addrValue)
-{
-    if ((indir->gtFlags & GTF_IND_NONFAULTING) == 0)
-    {
-        assert(addrValue->getType()->isPointerTy());
-
-        // The frontend's contract with the backend is that it will not insert null checks for accesses which
-        // are inside the "[0..compMaxUncheckedOffsetForNullObject]" range. Thus, we need to check not just
-        // for "null", but "null + small offset".
-        Value* checkValue = getIntPtrConst(_compiler->compMaxUncheckedOffsetForNullObject + 1, addrValue->getType());
-        Value* isNullValue = _builder.CreateICmpULT(addrValue, checkValue);
-        emitJumpToThrowHelper(isNullValue, SCK_NULL_REF_EXCPN);
     }
 }
 
@@ -2931,13 +2934,12 @@ Value* Llvm::gepOrAddr(Value* addr, unsigned offset)
 
 Value* Llvm::gepOrAddrInBounds(Value* addr, unsigned offset)
 {
-    Value* gepValue = gepOrAddr(addr, offset);
-    if (offset != 0)
+    if (offset == 0)
     {
-        llvm::cast<llvm::GetElementPtrInst>(gepValue)->setIsInBounds();
+        return addr;
     }
 
-    return gepValue;
+    return _builder.CreateInBoundsGEP(Type::getInt8Ty(m_context->Context), addr, _builder.getInt32(offset));
 }
 
 Value* Llvm::getShadowStack()

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -870,12 +870,12 @@ GenTree* Llvm::insertShadowStackAddr(GenTree* insertBefore, ssize_t offset, unsi
         return shadowStackLcl;
     }
 
-    GenTree* offsetNode = _compiler->gtNewIconNode(offset, TYP_I_IMPL);
-    CurrentRange().InsertBefore(insertBefore, offsetNode);
-    GenTree* addNode = _compiler->gtNewOperNode(GT_ADD, TYP_I_IMPL, shadowStackLcl, offsetNode);
-    CurrentRange().InsertBefore(insertBefore, addNode);
+    // Using an address mode node here explicitizes our assumption that the shadow stack does not overflow.
+    assert(offset < getShadowFrameSize(EHblkDsc::NO_ENCLOSING_INDEX));
+    GenTree* addrModeNode = new (_compiler, GT_LEA) GenTreeAddrMode(TYP_I_IMPL, shadowStackLcl, nullptr, 0, offset);
+    CurrentRange().InsertBefore(insertBefore, addrModeNode);
 
-    return addNode;
+    return addrModeNode;
 }
 
 unsigned Llvm::getCatchArgOffset() const


### PR DESCRIPTION
Two intertwined optimizations in this change:
1) Use GEPs for "in bounds" address calculation, represented as `GT_LEA` in IR (we're bending the general semantics a bit, but it's ok). The definition of "in bounds" is (necessarily) the same as [LLVM's](https://llvm.org/docs/LangRef.html#id234). The primary benefit of this is that we can see the folding of address computation into WASM's addressing modes. Contributes to #2256.
2) Use the LEA support to enable a more efficient form of null-checking in case we know the underlying object is either allocated, or literal "null". For now, this is only true for `TYP_REF` objects, as both byrefs and pointers can be "almost zero" (the former due to RyuJit's own, somewhat confusing, "based on" pointers model, the latter - because they have no special semantics).

The end result is these nice diffs:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3381138
Total bytes of diff: 3164944
Total bytes of delta: -216194 (-6.39% % of base)
Average relative delta: -12.00%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
         222 (472.34% of base) : 3271.dasm - S_P_CoreLib_System_Collections_Generic_Dictionary_2<System___Canon__IntPtr>__System_Collections_IEnumerable_GetEnumerator
         114 (80.85% of base) : 4066.dasm - S_P_CoreLib_System_Globalization_CultureInfo__GetFormat
         285 (35.19% of base) : 3454.dasm - String__Equals_1
         211 (34.14% of base) : 1457.dasm - S_P_CoreLib_System_DateTimeFormat__ExpandStandardFormatToCustomPattern
         217 (25.29% of base) : 2051.dasm - S_P_CoreLib_System_Globalization_HebrewCalendar__GetDatePart
          13 (10.57% of base) : 2385.dasm - S_P_CoreLib_System_Reflection_Runtime_Dispensers_DefaultDispenserPolicy__GetAlgorithm
          40 ( 6.38% of base) : 3510.dasm - String__Concat_12
           8 ( 3.88% of base) : 1145.dasm - S_P_CoreLib_System_Reflection_CustomAttributeNamedArgument__get_ArgumentType
           3 ( 2.11% of base) : 2225.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__InitializeInstance
           2 ( 2.11% of base) : 5323.dasm - S_P_CoreLib_System_Type__get_DefaultBinder
           4 ( 1.68% of base) : 4902.dasm - S_P_CoreLib_Internal_Runtime_MethodTable__get_GenericVariance
           4 ( 1.68% of base) : 2001.dasm - S_P_TypeLoader_Internal_Runtime_MethodTable__get_GenericVariance
           6 ( 1.46% of base) : 5193.dasm - S_P_CoreLib_System_Runtime_TypeCast__CheckCast
           2 ( 1.42% of base) : 4925.dasm - S_P_CoreLib_System_Runtime_InteropServices_SafeHandle__DangerousAddRef
           2 ( 1.10% of base) : 3780.dasm - S_P_CoreLib_System_Threading_ManagedThreadId__RecycleId
           2 ( 0.76% of base) : 5602.dasm - S_P_CoreLib_System_Decimal__ToByte
           2 ( 0.76% of base) : 5603.dasm - S_P_CoreLib_System_Decimal__ToUInt16

Top method improvements (percentages):
         -32 (-41.03% of base) : 1057.dasm - S_P_CoreLib_System_Threading_Thread___cctor
        -155 (-38.94% of base) : 3788.dasm - S_P_CoreLib_System_Globalization_TextInfo__NeedsTurkishCasing
        -184 (-38.33% of base) : 3791.dasm - S_P_CoreLib_System_Globalization_TextInfo__PopulateIsAsciiCasingSameAsInvariant
         -32 (-38.10% of base) : 1069.dasm - S_P_CoreLib_System_Environment___cctor
         -25 (-37.31% of base) : 4147.dasm - S_P_CoreLib_System_Reflection_Runtime_Assemblies_NativeFormat_NativeFormatRuntimeAssembly__CreateCaseInsensitiveTypeDictionary$F1_Fault
         -25 (-37.31% of base) : 3368.dasm - S_P_CoreLib_Internal_Reflection_Extensions_NonPortable_CustomAttributeInstantiator__Instantiate$F1_Fault
         -33 (-37.08% of base) : 4273.dasm - S_P_CoreLib_System_Text_StringBuilder__Append_1
         -24 (-36.36% of base) : 2286.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<Char>__Trim$F1_Fault
         -24 (-36.36% of base) : 2273.dasm - S_P_CoreLib_System_TimeZoneInfo__CompareTimeZoneFile$F1_Finally
         -24 (-36.36% of base) : 1196.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__get_ImplementedInterfaces$F1_Fault
         -24 (-36.36% of base) : 2239.dasm - S_P_CoreLib_System_Reflection_Runtime_Assemblies_NativeFormat_NativeFormatRuntimeAssembly__UncachedGetTypeCoreCaseSensitive$F1_Finally
         -24 (-36.36% of base) : 2857.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<Int32>__Trim$F1_Fault
         -24 (-36.36% of base) : 5713.dasm - S_P_TypeLoader_Internal_TypeSystem_CastingHelper__IsConstrainedAsGCPointer$F1_Finally
         -24 (-36.36% of base) : 2284.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<UInt8>__Trim$F2_Fault
         -24 (-36.36% of base) : 2287.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<Char>__Trim$F2_Fault
         -24 (-36.36% of base) : 2858.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<Int32>__Trim$F2_Fault
         -24 (-36.36% of base) : 2283.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<UInt8>__Trim$F1_Fault
         -24 (-36.36% of base) : 2713.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__RegisterDynamicGenericTypesAndMethods$F2_Fault
         -24 (-36.36% of base) : 2143.dasm - S_P_CoreLib_System_Reflection_Runtime_General_Helpers__GetRawConstant$F1_Finally
         -24 (-36.36% of base) : 4604.dasm - S_P_CoreLib_System_IO_File__ReadAllBytes$F1_Fault

4748 total methods with Code Size differences (4731 improved, 17 regressed)
```