### PR TITLE
[NativeAOT-LLVM] Delete the no-longer-needed casts in `cpobj` code

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -466,8 +466,6 @@ private:
     llvm::GlobalVariable* getOrCreateDataSymbol(StringRef symbolName);
     llvm::GlobalValue* getOrCreateSymbol(CORINFO_GENERIC_HANDLE symbolHandle);
 
-    Instruction* getCast(Value* source, Type* targetType);
-    Value* castIfNecessary(Value* source, Type* targetType, llvm::IRBuilder<>* builder = nullptr);
     Value* gepOrAddr(Value* addr, unsigned offset);
     llvm::Constant* getIntPtrConst(target_size_t value, Type* llvmType = nullptr);
     Value* getShadowStack();

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2430,15 +2430,12 @@ void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* struct
             if (fieldDesc->getCorType() == CORINFO_TYPE_CLASS)
             {
                 // We can't be sure the address is on the heap, it could be the result of pointer arithmetic on a local var.
-                emitHelperCall(CORINFO_HELP_CHECKED_ASSIGN_REF,
-                               {address, castIfNecessary(fieldData, getPtrLlvmType())});
-
+                emitHelperCall(CORINFO_HELP_CHECKED_ASSIGN_REF, {address, fieldData});
                 bytesStored += TARGET_POINTER_SIZE;
             }
             else
             {
                 _builder.CreateStore(fieldData, address);
-
                 bytesStored += fieldData->getType()->getPrimitiveSizeInBits() / BITS_PER_BYTE;
             }
         }
@@ -2850,39 +2847,6 @@ llvm::GlobalValue* Llvm::getOrCreateSymbol(CORINFO_GENERIC_HANDLE symbolHandle)
     }
 
     return symbol;
-}
-
-Instruction* Llvm::getCast(Value* source, Type* targetType)
-{
-    Type* sourceType = source->getType();
-    if (sourceType == targetType)
-        return nullptr;
-
-    Type::TypeID sourceTypeID = sourceType->getTypeID();
-    Type::TypeID targetTypeId = targetType->getTypeID();
-
-    if (targetTypeId == Type::PointerTyID)
-    {
-        assert(sourceTypeID == Type::IntegerTyID);
-        return new llvm::IntToPtrInst(source, targetType);
-    }
-
-    assert((targetTypeId == Type::IntegerTyID) && (sourceTypeID == Type::PointerTyID));
-    return new llvm::PtrToIntInst(source, targetType);
-}
-
-Value* Llvm::castIfNecessary(Value* source, Type* targetType, llvm::IRBuilder<>* builder)
-{
-    if (builder == nullptr)
-    {
-        builder = &_builder;
-    }
-
-    llvm::Instruction* castInst = getCast(source, targetType);
-    if (castInst == nullptr)
-        return source;
-
-    return builder->Insert(castInst);
 }
 
 llvm::Constant* Llvm::getIntPtrConst(target_size_t value, Type* llvmType)

--- a/src/coreclr/jit/llvmtypes.h
+++ b/src/coreclr/jit/llvmtypes.h
@@ -49,11 +49,6 @@ public:
     {
         return m_corType;
     }
-
-    bool isGcPointer()
-    {
-        return m_corType == CORINFO_TYPE_CLASS || m_corType == CORINFO_TYPE_BYREF;
-    }
 };
 
 struct StructDesc


### PR DESCRIPTION
We no longer normalize structs with GC pointers to `i32`s.