### PR TITLE
[NativeAOT-LLVM] Add "noalis" to allocator helpers

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2769,6 +2769,10 @@ void Llvm::annotateHelperFunction(CorInfoHelpFunc helperFunc, Function* llvmFunc
     {
         llvmFunc->addRetAttr(llvm::Attribute::NonNull);
     }
+    if (properties.IsAllocator(helperFunc))
+    {
+        llvmFunc->addRetAttr(llvm::Attribute::NoAlias);
+    }
 }
 
 Function* Llvm::getOrCreateKnownLlvmFunction(


### PR DESCRIPTION
This communicates to LLVM that the returned pointer will always be newly allocated and will not alias with anything known prior.

Diffs:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3164865
Total bytes of diff: 3161901
Total bytes of delta: -2964 (-0.09% % of base)
Average relative delta: -4.43%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
         419 ( 8.78% of base) : 1011.dasm - S_P_CoreLib_System_Reflection_CustomAttributeTypedArgument__ToString_0
          17 ( 4.76% of base) : 1013.dasm - S_P_CoreLib_System_Collections_Generic_LowLevelDictionary_2<S_P_CoreLib_Internal_Runtime_CompilerServices_FunctionPointerOps_GenericMethodDescriptorInfo__UInt32>__UncheckedAdd
          47 ( 4.46% of base) : 1097.dasm - S_P_CoreLib_System_Globalization_CalendarData__InitializeEraNames
          11 ( 1.90% of base) : 1122.dasm - S_P_CoreLib_System_Collections_Generic_LowLevelDictionary_2<S_P_CoreLib_Internal_Runtime_CompilerServices_OpenMethodResolver__IntPtr>__UncheckedAdd
           4 ( 0.25% of base) : 1152.dasm - S_P_CoreLib_System_Globalization_CalendarData___ctor_0

Top method improvements (percentages):
         -48 (-44.86% of base) : 1091.dasm - S_P_CoreLib_System_ThrowHelper__CreateEndOfFileException
         -34 (-36.56% of base) : 1105.dasm - S_P_CoreLib_System_Enum__CreateInvalidFormatSpecifierException
         -34 (-36.56% of base) : 1073.dasm - S_P_CoreLib_System_Enum__CreateUnknownEnumTypeException
         -29 (-23.39% of base) : 1188.dasm - S_P_CoreLib_Internal_Reflection_Extensions_NonPortable_CustomAttributeSearcher_1<System___Canon>__GetAttributeUsage
         -50 (-20.41% of base) : 1080.dasm - S_P_CoreLib_System_Number__GetException_0<UInt64>
         -50 (-20.41% of base) : 1086.dasm - S_P_CoreLib_System_Number__GetException_0<UInt8>
         -50 (-20.41% of base) : 1083.dasm - S_P_CoreLib_System_Number__GetException_0<Int32>
         -50 (-20.41% of base) : 1087.dasm - S_P_CoreLib_System_Number__GetException_0<Int8>
         -50 (-20.41% of base) : 1082.dasm - S_P_CoreLib_System_Number__GetException_0<UInt32>
         -50 (-20.41% of base) : 1085.dasm - S_P_CoreLib_System_Number__GetException_0<Int16>
         -50 (-20.41% of base) : 1084.dasm - S_P_CoreLib_System_Number__GetException_0<UInt16>
         -50 (-20.41% of base) : 1081.dasm - S_P_CoreLib_System_Number__GetException_0<Int64>
        -123 (-20.40% of base) : 1018.dasm - String__LastIndexOf_7
         -34 (-18.78% of base) : 1068.dasm - S_P_CoreLib_System_InvokeUtils__CreateChangeTypeException
        -123 (-17.50% of base) : 1125.dasm - String__IndexOf_8
         -11 (-17.19% of base) : 1002.dasm - ILHelpers_ILHelpers_ILHelpersTest__InlineAssignByte
         -21 (-16.15% of base) : 1116.dasm - S_P_CoreLib_System_Version__Clone
         -85 (-14.24% of base) : 1129.dasm - S_P_CoreLib_System_Globalization_CalendricalCalculationsHelper___cctor
        -299 (-14.07% of base) : 1115.dasm - S_P_CoreLib_Interop__GetExceptionForIoErrno
         -16 (-13.01% of base) : 1093.dasm - S_P_CoreLib_System_Globalization_CultureInfo__GetCalendarInstance

195 total methods with Code Size differences (190 improved, 5 regressed)
```
One example I looked at showed how this annotation helped get rid of a good amount of shadow stack shuffling (since stores to the stack could be assumed to not alias stores to the object, I assume).