### PR TITLE
NativeAOT-LLVM: write externals module to external.txt

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -282,7 +282,7 @@ namespace ILCompiler.DependencyAnalysis
             _module.PrintToFile(Path.ChangeExtension(_objectFilePath, ".txt"));
             _module.Verify(LLVMVerifierFailureAction.LLVMAbortProcessAction);
 
-            _module.PrintToFile(Path.ChangeExtension(_objectFilePath, "external.txt"));
+            _moduleWithExternalFunctions.PrintToFile(Path.ChangeExtension(_objectFilePath, "external.txt"));
             _moduleWithExternalFunctions.Verify(LLVMVerifierFailureAction.LLVMAbortProcessAction);
 #endif
 


### PR DESCRIPTION
This PR writes the extenals module to the externals.txt file, which looked like a copy/paste typo.