### PR TITLE
[NativeAOT-LLVM] Move liveness and SSA before LSSA

### DIFF
--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -447,6 +447,24 @@ LIR::Range::Range(GenTree* firstNode, GenTree* lastNode) : ReadOnlyRange(firstNo
 }
 
 //------------------------------------------------------------------------
+// LIR::Range::FirstNonPhiNode: Returns the first node after all PHI-related nodes in this range.
+//
+GenTree* LIR::Range::FirstNonPhiNode() const
+{
+    for (GenTree* node : *this)
+    {
+        if (node->IsPhiNode())
+        {
+            continue;
+        }
+
+        return node;
+    }
+
+    return nullptr;
+}
+
+//------------------------------------------------------------------------
 // LIR::Range::FirstNonCatchArgNode: Returns the first node after all catch arg nodes in this range.
 //
 GenTree* LIR::Range::FirstNonCatchArgNode() const

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -258,6 +258,7 @@ public:
         Range();
         Range(Range&& other);
 
+        GenTree* FirstNonPhiNode() const;
         GenTree* FirstNonCatchArgNode() const;
 
         void InsertBefore(GenTree* insertionPoint, GenTree* node);

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -879,8 +879,6 @@ extern "C" DLLEXPORT void registerLlvmCallbacks(void** jitImports, void** jitExp
         StringRef outputFilePathWithoutExtension = outputFilePath.take_front(outputFilePath.find_last_of('.'));
         llvm::raw_fd_ostream textOutputStream(Twine(outputFilePathWithoutExtension + ".txt").str(), code);
         module.print(textOutputStream, nullptr);
-
-        noway_assert(!llvm::verifyModule(module, &llvm::errs()));
     }
 
     llvm::raw_fd_ostream bitCodeFileStream(outputFilePath, code);

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -362,6 +362,12 @@ private:
 
     bool isInvariantInRange(GenTree* node, GenTree* endExclusive);
 
+    void lowerDissolveDependentlyPromotedLocals();
+    void dissolvePromotedLocal(unsigned lclNum);
+
+    void lowerCanonicalizeFirstBlock();
+    bool isFirstBlockCanonical();
+
     // ================================================================================================================
     // |                                           Shadow stack allocation                                            |
     // ================================================================================================================


### PR DESCRIPTION
1) LSSA will use SSA and liveness to allocate precisely in the future.
2) Upcoming EH changes will also require this phase order.
3) LSSA hides opportunities for liveness to eliminate dead code.

We have some nice diffs due to `3`:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3161482
Total bytes of diff: 3150153
Total bytes of delta: -11329 (-0.36% % of base)
Average relative delta: -5.88%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
          80 (114.29% of base) : 1242.dasm - S_P_CoreLib_System_CharEnumerator__System_Collections_IEnumerator_get_Current
          84 (79.25% of base) : 1004.dasm - HelloWasm_Program__TestDispose
         216 (78.55% of base) : 1467.dasm - String__Concat_6
          93 (70.99% of base) : 1003.dasm - HelloWasm_Program__TestDoublePrint
          70 (20.17% of base) : 1465.dasm - HelloWasm_Program__TestRhpAssignRefWithClassInStructGC
         137 (18.74% of base) : 1466.dasm - HelloWasm_Program__TestGeneration2Rooting
         419 ( 8.78% of base) : 1010.dasm - S_P_CoreLib_System_Reflection_CustomAttributeTypedArgument__ToString_0
         194 ( 7.02% of base) : 1363.dasm - S_P_CoreLib_System_InvokeUtils__ConvertOrWidenPrimitivesEnumsAndPointersIfPossible
          12 ( 2.58% of base) : 1164.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilderState__FinishInitNativeLayoutInfo
          47 ( 1.46% of base) : 1387.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_GenericDictionaryCell__ParseAndCreateCell
           6 ( 1.03% of base) : 1374.dasm - S_P_CoreLib_Interop_Sys__GetCwd_0
          36 ( 0.91% of base) : 1229.dasm - S_P_CoreLib_Internal_Reflection_Extensions_NonPortable_CustomAttributeInstantiator__Instantiate
           2 ( 0.62% of base) : 1042.dasm - S_P_CoreLib_System_Globalization_DateTimeFormatInfo__GetInstance

Top method improvements (percentages):
          -7 (-63.64% of base) : 1024.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__EnsureTypeHandleForType$F1_Catch
          -7 (-63.64% of base) : 1455.dasm - HelloWasm_Program__TestI2ConvOvf$F1_Catch
          -7 (-63.64% of base) : 1457.dasm - HelloWasm_Program__TestUnsignedI2ConvOvf$F1_Catch
          -7 (-63.64% of base) : 1458.dasm - HelloWasm_Program__TestUnsignedI2ConvOvf$F2_Catch
          -7 (-63.64% of base) : 1460.dasm - HelloWasm_Program__TestI4ConvOvf$F1_Catch
          -7 (-63.64% of base) : 1462.dasm - HelloWasm_Program__TestUnsignedI4ConvOvf$F1_Catch
          -7 (-63.64% of base) : 1449.dasm - HelloWasm_Program__TestSignedToUnsignedNativeIntConvOvf$F2_Catch
          -7 (-63.64% of base) : 1448.dasm - HelloWasm_Program__TestSignedToUnsignedNativeIntConvOvf$F1_Catch
          -7 (-63.64% of base) : 1453.dasm - HelloWasm_Program__TestUnsignedI1ConvOvf$F1_Catch
          -7 (-63.64% of base) : 1520.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__ExpandHeap$F1_Catch
          -7 (-63.64% of base) : 1451.dasm - HelloWasm_Program__TestI1ConvOvf$F1_Catch
          -7 (-63.64% of base) : 1353.dasm - HelloWasm_Program__TestTryCatchExceptionFromCall$F1_Catch
         -34 (-53.12% of base) : 1070.dasm - HelloWasm_Program__TestCallToGenericInterfaceMethod
        -427 (-43.44% of base) : 1069.dasm - HelloWasm_Program__TestThreadStaticsForSingleThread
        -176 (-31.65% of base) : 1190.dasm - S_P_CoreLib_System_Number__TryInt64ToHexStr<Char>
        -110 (-28.06% of base) : 1433.dasm - HelloWasm_Program__TestI8ConvOvf
          -9 (-27.27% of base) : 1052.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__ToExpectedNamespaceReferenceHandle
        -139 (-26.99% of base) : 1189.dasm - S_P_CoreLib_System_Number__TryUInt64ToBinaryStr<Char>
          -7 (-25.00% of base) : 1352.dasm - HelloWasm_Program__TestTryCatchThrowException$F1_Catch
         -20 (-24.10% of base) : 1108.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeDesc__get_IsMdArray

Top methods only present in base:
          -4 (-100.00% of base) : 1463.dasm - HelloWasm_ClassWithSealedVTable__GetValue
         -23 (-100.00% of base) : 1434.dasm - HelloWasm_Program__TestI8ConvOvf$F4_Catch

575 total methods with Code Size differences (562 improved, 13 regressed)
```

Mechanically, the change mostly shuffles code around and adapts LSSA to remove shadow locals from SSA.

A change to stop double-verifying the LLVM modules and speed up the debug compiler has also been snuck in.