### PR TITLE
[NativeAOT-LLVM] Add support for `JitDisasm`

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -403,6 +403,8 @@ private:
     Value* generateEHDispatchTable(Function* llvmFunc, unsigned innerEHIndex, unsigned outerEHIndex);
     void fillPhis();
     void generateAuxiliaryArtifacts();
+    void verifyGeneratedCode();
+    void displayGeneratedCode();
 
     Value* getGenTreeValue(GenTree* node);
     Value* consumeValue(GenTree* node, Type* targetLlvmType = nullptr);
@@ -510,6 +512,8 @@ private:
 
     Value* getLocalAddr(unsigned lclNum);
     Value* getOrCreateAllocaForLocalInFunclet(unsigned lclNum);
+
+    void displayValue(Value* value);
 
 public:
     bool IsLlvmIntrinsic(NamedIntrinsic intrinsicName) const;

--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -249,9 +249,9 @@ void Llvm::declareDebugVariables()
             if (spilledShadowStackAddr == nullptr)
             {
                 spilledShadowStackAddr = _builder.CreateAlloca(getPtrLlvmType());
-                JITDUMPEXEC(spilledShadowStackAddr->dump());
+                JITDUMPEXEC(displayValue(spilledShadowStackAddr));
                 Instruction* storeInst = _builder.CreateStore(getShadowStack(), spilledShadowStackAddr);
-                JITDUMPEXEC(storeInst->dump());
+                JITDUMPEXEC(displayValue(storeInst));
             }
 
             addressValue = spilledShadowStackAddr;
@@ -272,7 +272,7 @@ void Llvm::declareDebugVariables()
         Instruction* debugInst =
             m_diBuilder->insertDeclare(addressValue, debugVariable, debugExpression, debugLocation, insertInst);
         JITDUMP("Declaring V%02u:\n", lclNum);
-        JITDUMPEXEC(debugInst->dump());
+        JITDUMPEXEC(displayValue(debugInst));
     }
 }
 
@@ -295,7 +295,7 @@ void Llvm::assignDebugVariable(unsigned lclNum, Value* value)
             debugInst = m_diBuilder->insertDbgValueIntrinsic(value, debugVariable, m_diBuilder->createExpression(),
                                                              debugLocation, &*_builder.GetInsertPoint());
         }
-        DBEXEC(CurrentBlock() == nullptr, JITDUMPEXEC(debugInst->dump()));
+        DBEXEC(CurrentBlock() == nullptr, JITDUMPEXEC(displayValue(debugInst)));
     }
 }
 


### PR DESCRIPTION
The usage is the same as `JitDump`, but this switch is usable in Release (upstream and now here).