### PR TITLE
[NativeAOT-LLVM] Always use `memset` in `buildStoreLocalField`

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -451,6 +451,7 @@ private:
     Value* consumeAddressAndEmitNullCheck(GenTreeIndir* indir);
     void emitNullCheckForAddress(GenTree* addr, Value* addrValue);
 
+    Value* consumeInitVal(GenTree* initVal);
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
 


### PR DESCRIPTION
It turns out there is no benefit to complicating the code with null value stores.

No diffs in optimized code.