### PR TITLE
 [NativeAOT-LLVM] Fix the wasm test build scripts

### DIFF
--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -46,16 +46,11 @@ steps:
       displayName: Build tests
 
   - ${{ if eq(parameters.runSingleFileTests, true) }}:
-    - ${{ if eq(parameters.platform, 'browser_wasm_win') }}:
+    - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:
       - script: |
           call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}
-        displayName: Run WebAssembly Browser tests in single file mode
-    - ${{ elseif eq(parameters.platform, 'wasi_wasm_win') }}:
-      - script: |
-          call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} wasi
-        displayName: Run WebAssembly Wasi tests in single file mode
+          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
+        displayName: Run WebAssembly tests in single file mode
     - ${{ elseif eq(parameters.osGroup, 'windows') }}:
       - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }}
         displayName: Run tests in single file mode

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -71,8 +71,9 @@ if /i "%1" == "--"                       (set processedArgs=!processedArgs! %1&s
 if /i "%1" == "x64"                      (set __BuildArch=x64&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "x86"                      (set __BuildArch=x86&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "arm64"                    (set __BuildArch=arm64&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "wasm"                     (set __BuildArch=wasm&set __TargetOS=browser&set __DistroRid=browser-wasm&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "wasi"                     (set __TargetOS=wasi&set __DistroRid=wasi-wasm&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "wasm"                     (set __BuildArch=wasm&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "wasi"                     (set __TargetOS=wasi&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "browser"                  (set __TargetOS=browser&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if /i "%1" == "debug"                    (set __BuildType=Debug&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "release"                  (set __BuildType=Release&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -183,6 +184,14 @@ if defined __TestArgParsing (
 @if defined _echo @echo on
 
 echo %__MsgPrefix%Commencing CoreCLR test build
+
+if "%__BuildArch%" == "wasm" (
+    if "%__TargetOS%" == "windows" (
+        set __TargetOS=browser
+    )
+
+    set __DistroRid=%__TargetOS%-%__BuildArch%
+)
 
 set "__OSPlatformConfig=%__TargetOS%.%__BuildArch%.%__BuildType%"
 set "__BinDir=%__RootBinDir%\bin\coreclr\%__OSPlatformConfig%"

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -46,8 +46,9 @@ if /i "%1" == "-help" goto Usage
 if /i "%1" == "x64"                                     (set __BuildArch=x64&shift&goto Arg_Loop)
 if /i "%1" == "x86"                                     (set __BuildArch=x86&shift&goto Arg_Loop)
 if /i "%1" == "arm64"                                   (set __BuildArch=arm64&shift&goto Arg_Loop)
-if /i "%1" == "wasm"                                    (set __BuildArch=wasm&set __TargetOS=browser&set __DistroRid=browser-wasm&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "wasm"                                    (set __BuildArch=wasm&shift&goto Arg_Loop)
 if /i "%1" == "wasi"                                    (set __TargetOS=wasi&shift&goto Arg_Loop)
+if /i "%1" == "browser"                                 (set __TargetOS=browser&shift&goto Arg_Loop)
 
 if /i "%1" == "debug"                                   (set __BuildType=Debug&shift&goto Arg_Loop)
 if /i "%1" == "release"                                 (set __BuildType=Release&shift&goto Arg_Loop)
@@ -97,6 +98,12 @@ if defined __TestEnv (if not exist %__TestEnv% echo %__MsgPrefix%Error: Test Env
 
 :: Set the remaining variables based upon the determined configuration
 set __MSBuildBuildArch=%__BuildArch%
+
+if "%__BuildArch%" == "wasm" (
+    if "%__TargetOS%" == "windows" (
+        set __TargetOS=browser
+    )
+)
 
 set "__BinDir=%__RootBinDir%\bin\coreclr\%__TargetOS%.%__BuildArch%.%__BuildType%"
 set "__TestWorkingDir=%__RootBinDir%\tests\coreclr\%__TargetOS%.%__BuildArch%.%__BuildType%"


### PR DESCRIPTION
Due to how these were structured, unintended things could happen, e. g. `./build wasi wasm` would build for `browser-wasm`.