### PR TITLE
NativeAOT-LLVM: Emit object nodes as structs not arrays to allow for unaligned relocs.

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -205,7 +205,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 if (!useStruct && nextRelocValid && nextRelocOffset % pointerSize != 0)
                 {
-                    // Switch from array to struct.
+                    // Switch from array to struct. This will need more elements because binary data is output byte-by-byte.
                     useStruct = true;
                     dataSizeInElements = nodeContents.Relocs.Length + dataSizeInBytes - (nodeContents.Relocs.Length * pointerSize);
 

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -78,8 +78,6 @@ namespace ILCompiler.DependencyAnalysis
             LLVMObjectWriter objectWriter = new LLVMObjectWriter(objectFilePath, compilation);
             NodeFactory factory = compilation.NodeFactory;
 
-            var sw = new Stopwatch();
-            sw.Start();
             try
             {
                 foreach (DependencyNode depNode in nodes)
@@ -139,8 +137,6 @@ namespace ILCompiler.DependencyAnalysis
                     objectWriter.EmitObjectNode(node, nodeContents);
                 }
 
-                sw.Stop();
-                Console.WriteLine(sw.Elapsed);
                 objectWriter.FinishObjWriter();
 
                 // Make sure we have released all memory used for mangling names.
@@ -219,7 +215,10 @@ namespace ILCompiler.DependencyAnalysis
                     typeElements = _currentObjectTypes.AsSpan(0, dataSizeInElements);
 
                     // Restart zipping while loop.
-                    dataOffset = elementOffset = relocIndex = 0;
+                    dataOffset = 0;
+                    elementOffset = 0;
+                    relocIndex = 0;
+
                     continue;
                 }
 


### PR DESCRIPTION
This PR enables relocs to be written unaligned in anticipation of merging upstream and `StackTraceMethodMappingNode` where it writes a "command" byte before the relocs.  This is achieved by using a struct for the object node instead of an array.  In many cases this struct will only contain LLVM `ptr`s and here the reading from the node is unchanged.  Reading from `StackTraceMethodMappingNode` when it is tackled will be different...