### PR TITLE
[NativeAOT-LLVM] Pop fewer virtual unwind frames explicitly

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -389,15 +389,21 @@ public:
     PhaseStatus AddVirtualUnwindFrame();
 
 private:
+    static const unsigned UNWIND_INDEX_NONE = -1;
     static const unsigned UNWIND_INDEX_NOT_IN_TRY = 0;
     static const unsigned UNWIND_INDEX_NOT_IN_TRY_CATCH = 1;
     static const unsigned UNWIND_INDEX_BASE = 2;
 
     void computeBlocksInFilters();
+    ArrayStack<unsigned>* computeUnwindIndexMap();
     CORINFO_GENERIC_HANDLE generateUnwindTable();
 
     bool mayPhysicallyThrow(GenTree* node);
     bool isBlockInFilter(BasicBlock* block) const;
+
+#ifdef DEBUG
+    void printUnwindIndex(ArrayStack<unsigned>* indexMap, unsigned index);
+#endif // DEBUG
 
     // ================================================================================================================
     // |                                           Shadow stack allocation                                            |

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -768,9 +768,17 @@ void Llvm::generateEHDispatch()
 
             Function* hndLlvmFunc = getLlvmFunctionForIndex(ehDsc->ebdFuncIndex);
             emitCallOrInvoke(hndLlvmFunc, {getShadowStack()}, catchPadOpBundle);
-            if ((ehDsc->ebdEnclosingTryIndex == EHblkDsc::NO_ENCLOSING_INDEX) && (m_unwindFrameLclNum != BAD_VAR_NUM))
+
+            // Pop the virtual unwind frame if this is the outermost fault that uses the unwind index.
+            if ((m_unwindIndexMap != nullptr) && (m_unwindIndexMap->Bottom(ehIndex) == UNWIND_INDEX_NOT_IN_TRY_CATCH))
             {
-                emitHelperCall(CORINFO_HELP_LLVM_EH_POP_UNWOUND_VIRTUAL_FRAMES, {}, catchPadOpBundle);
+                if ((ehDsc->ebdEnclosingTryIndex == EHblkDsc::NO_ENCLOSING_INDEX) ||
+                    (m_unwindIndexMap->Bottom(ehDsc->ebdEnclosingTryIndex) != UNWIND_INDEX_NOT_IN_TRY_CATCH))
+                {
+                    assert((ehDsc->ebdEnclosingTryIndex == EHblkDsc::NO_ENCLOSING_INDEX) ||
+                           (m_unwindIndexMap->Bottom(ehDsc->ebdEnclosingTryIndex) == UNWIND_INDEX_NOT_IN_TRY));
+                    emitHelperCall(CORINFO_HELP_LLVM_EH_POP_UNWOUND_VIRTUAL_FRAMES, {}, catchPadOpBundle);
+                }
             }
             emitJmpToOuterDispatch();
         }

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1255,51 +1255,14 @@ PhaseStatus Llvm::AddVirtualUnwindFrame()
 
     // TODO-LLVM: make a distinct flag; using this alias avoids conflicts.
     static const BasicBlockFlags BBF_MAY_THROW = BBF_HAS_CALL;
-    static const unsigned UNWIND_INDEX_NONE = -1;
     static const unsigned UNWIND_INDEX_GROUP_NONE = -1;
 
     // Build the mapping of EH table indices to unwind indices.
-    unsigned lastUnwindIndex = UNWIND_INDEX_BASE;
-    CompAllocator alloc = _compiler->getAllocator(CMK_Codegen);
-    ArrayStack<unsigned>* indexMap = new (alloc) ArrayStack<unsigned>(alloc, _compiler->compHndBBtabCount);
-    for (EHblkDsc* ehDsc : EHClauses(_compiler))
-    {
-        if (ehDsc->HasCatchHandler())
-        {
-            indexMap->Push(lastUnwindIndex++);
-        }
-        else
-        {
-            indexMap->Push(UNWIND_INDEX_NOT_IN_TRY_CATCH);
-        }
-    }
-
-    if (lastUnwindIndex == UNWIND_INDEX_BASE)
+    ArrayStack<unsigned>* indexMap = computeUnwindIndexMap();
+    if (indexMap == nullptr)
     {
         // No catch handlers; no need for virtual unwinding.
         return PhaseStatus::MODIFIED_NOTHING;
-    }
-
-    // Now assign indices to potentially nested regions protected by fault/finally handlers.
-    for (unsigned ehIndex = 0; ehIndex < _compiler->compHndBBtabCount; ehIndex++)
-    {
-        EHblkDsc* ehDsc = _compiler->ehGetDsc(ehIndex);
-        if (ehDsc->HasCatchHandler())
-        {
-            continue;
-        }
-
-        while (ehDsc->ebdEnclosingTryIndex != EHblkDsc::NO_ENCLOSING_INDEX)
-        {
-            unsigned index = indexMap->Bottom(ehDsc->ebdEnclosingTryIndex);
-            if (index != UNWIND_INDEX_NOT_IN_TRY_CATCH)
-            {
-                indexMap->BottomRef(ehIndex) = index;
-                break;
-            }
-
-            ehDsc = _compiler->ehGetDsc(ehDsc->ebdEnclosingTryIndex);
-        }
     }
 
     // Compute which blocks may throw and thus need an up-to-date unwind index.
@@ -1673,31 +1636,7 @@ PhaseStatus Llvm::AddVirtualUnwindFrame()
 #ifdef DEBUG
         void PrintUnwindIndex(unsigned index)
         {
-            printf(" (");
-            switch (index)
-            {
-                case UNWIND_INDEX_NONE:
-                    printf("NO");
-                    break;
-                case UNWIND_INDEX_NOT_IN_TRY:
-                    printf("ZR");
-                    break;
-                case UNWIND_INDEX_NOT_IN_TRY_CATCH:
-                    printf("ZF");
-                    break;
-                default:
-                    for (unsigned ehIndex = 0; ehIndex < m_compiler->compHndBBtabCount; ehIndex++)
-                    {
-                        EHblkDsc* ehDsc = m_compiler->ehGetDsc(ehIndex);
-                        if (ehDsc->HasCatchHandler() && (m_indexMap->Bottom(ehIndex) == index))
-                        {
-                            printf("T%u", ehIndex);
-                            break;
-                        }
-                    }
-                    break;
-            }
-            printf(")");
+            m_llvm->printUnwindIndex(m_indexMap, index);
         }
 
         void PrintUnwindIndexGroup(unsigned groupIndex)
@@ -1780,6 +1719,78 @@ void Llvm::computeBlocksInFilters()
             }
         }
     }
+}
+
+ArrayStack<unsigned>* Llvm::computeUnwindIndexMap()
+{
+    unsigned lastUnwindIndex = UNWIND_INDEX_BASE;
+    CompAllocator alloc = _compiler->getAllocator(CMK_Codegen);
+    ArrayStack<unsigned>* indexMap = new (alloc) ArrayStack<unsigned>(alloc, _compiler->compHndBBtabCount);
+    for (EHblkDsc* ehDsc : EHClauses(_compiler))
+    {
+        if (ehDsc->HasCatchHandler())
+        {
+            indexMap->Push(lastUnwindIndex++);
+        }
+        else
+        {
+            // Assume for a start that this fault will not use the unwind index.
+            indexMap->Push(UNWIND_INDEX_NOT_IN_TRY);
+        }
+    }
+
+    if (lastUnwindIndex == UNWIND_INDEX_BASE)
+    {
+        return nullptr;
+    }
+
+    // Now revisit our assumption about faults with this inner-to-outer loop.
+    for (unsigned ehIndex = 0; ehIndex < _compiler->compHndBBtabCount; ehIndex++)
+    {
+        EHblkDsc* ehDsc = _compiler->ehGetDsc(ehIndex);
+        if ((indexMap->Bottom(ehIndex) != UNWIND_INDEX_NOT_IN_TRY) &&
+            (ehDsc->ebdEnclosingHndIndex != EHblkDsc::NO_ENCLOSING_INDEX) &&
+            (indexMap->Bottom(ehDsc->ebdEnclosingHndIndex) == UNWIND_INDEX_NOT_IN_TRY))
+        {
+            // The enclosing fault may use the unwind index. Make sure not to pop the frame too early.
+            indexMap->BottomRef(ehDsc->ebdEnclosingHndIndex) = UNWIND_INDEX_NOT_IN_TRY_CATCH;
+        }
+    }
+
+    // Now assign indices to potentially nested regions protected by fault/finally handlers.
+    for (unsigned ehIndex = _compiler->compHndBBtabCount - 1; ehIndex != -1; ehIndex--)
+    {
+        EHblkDsc* ehDsc = _compiler->ehGetDsc(ehIndex);
+        if (ehDsc->HasCatchHandler())
+        {
+            continue;
+        }
+
+        // Since we're iterating outer-to-inner, all enclosing unwind indices are already correct.
+        if (ehDsc->ebdEnclosingTryIndex != EHblkDsc::NO_ENCLOSING_INDEX)
+        {
+            unsigned enclosingUnwindIndex = indexMap->Bottom(ehDsc->ebdEnclosingTryIndex);
+            if (enclosingUnwindIndex != UNWIND_INDEX_NOT_IN_TRY)
+            {
+                indexMap->BottomRef(ehIndex) = enclosingUnwindIndex;
+            }
+        }
+    }
+
+#ifdef DEBUG
+    if (_compiler->verbose)
+    {
+        printf("Unwind index map:\n");
+        for (unsigned ehIndex = 0; ehIndex < _compiler->compHndBBtabCount; ehIndex++)
+        {
+            printf("EH#%u:", ehIndex);
+            printUnwindIndex(indexMap, indexMap->Bottom(ehIndex));
+            printf("\n");
+        }
+    }
+#endif // DEBUG
+
+    return indexMap;
 }
 
 CORINFO_GENERIC_HANDLE Llvm::generateUnwindTable()
@@ -1885,3 +1896,34 @@ bool Llvm::isBlockInFilter(BasicBlock* block) const
     // Ideally, this would be a flag (BBF_*), but we make do with a bitset for now to avoid modifying the frontend.
     return BlockSetOps::IsMember(_compiler, m_blocksInFilters, block->bbNum);
 }
+
+#ifdef DEBUG
+void Llvm::printUnwindIndex(ArrayStack<unsigned>* indexMap, unsigned index)
+{
+    printf(" (");
+    switch (index)
+    {
+        case UNWIND_INDEX_NONE:
+            printf("NO");
+            break;
+        case UNWIND_INDEX_NOT_IN_TRY:
+            printf("ZR");
+            break;
+        case UNWIND_INDEX_NOT_IN_TRY_CATCH:
+            printf("ZF");
+            break;
+        default:
+            for (unsigned ehIndex = 0; ehIndex < _compiler->compHndBBtabCount; ehIndex++)
+            {
+                EHblkDsc* ehDsc = _compiler->ehGetDsc(ehIndex);
+                if (ehDsc->HasCatchHandler() && (indexMap->Bottom(ehIndex) == index))
+                {
+                    printf("T%u", ehIndex);
+                    break;
+                }
+            }
+            break;
+    }
+    printf(")");
+}
+#endif // DEBUG

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/ExceptionHandlingTests.Common.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/ExceptionHandlingTests.Common.cs
@@ -70,6 +70,7 @@ internal unsafe partial class Program
         TestVirtualUnwindStackNoPopOnNestedUnwindingCatch();
         TestVirtualUnwindStackNoPopOnMutuallyProtectingUnwindingCatch();
         TestVirtualUnwindStackPopSelfOnUnwindingFault();
+        TestVirtualUnwindStackPopSelfOnNestedUnwindingFault();
         TestVirtualUnwindStackPopOnUnwindingFault();
         TestVirtualUnwindStackNoPopOnUnwindingFault();
         TestVirtualUnwindStackNoPopOnNestedUnwindingFault();
@@ -1062,6 +1063,49 @@ internal unsafe partial class Program
         try
         {
             TestVirtualUnwindStackPopOnUnwindingFault_NotInTry();
+        }
+        catch
+        {
+            VerifyVirtualUnwindStack();
+        }
+
+        PassTest();
+    }
+
+    private static void TestVirtualUnwindStackPopSelfOnNestedUnwindingFault()
+    {
+        StartTest("Test that the virtual unwind frame is unlinked by a nested unwinding fault");
+
+        void TestVirtualUnwindStackPopSelfOnNestedUnwindingFault_Faults()
+        {
+            try
+            {
+                try
+                {
+                    ThrowNewException();
+                }
+                finally
+                {
+                    // This fault should release the virtual unwind frame.
+                    try
+                    {
+                        ThrowNewException();
+                    }
+                    catch
+                    {
+                        DoNotThrowException();
+                    }
+                }
+            }
+            finally
+            {
+                DoNotThrowException();
+            }
+        }
+
+        try
+        {
+            TestVirtualUnwindStackPopSelfOnNestedUnwindingFault_Faults();
         }
         catch
         {


### PR DESCRIPTION
When we are unwinding past a virtual frame, we must unlink it. For top-level faults this is done via an explicit helper call in codegen and we assumed that all faults could use the virtual unwind frame of their parent function.

This change refines this so that only faults with nested catch handlers need to do this while for others, the responsibility for releasing the frame is "pushed down" to the inner handler.

This is achieved by giving top-level EH regions protected by faults `NOT_IN_TRY` unwind index instead of `NOT_IN_TRY_CATCH`.

An example of where this optimization helps is when we have the common `try { } catch { } finally { }` pattern in C#, which is represented as `try { try { } catch { } } finally { }` in IL.

Diffs are as expected:
```
Top method improvements (percentages):
         -15 (-3.42% of base) : 1004.dasm - HelloWasm_Program__TryFinallyWithCatch
         -15 (-3.40% of base) : 1002.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__EnsureTypeHandleForType
          -8 (-2.86% of base) : 1003.dasm - HelloWasm_Program__TryFinally
         -22 (-2.82% of base) : 1011.dasm - S_P_CoreLib_System_Reflection_DynamicInvokeInfo__InvokeWithManyArguments
          -8 (-2.65% of base) : 1012.dasm - HelloWasm_Program___TestIntraFrameFilterOrderDeep_g__InnerInnerFilterAndFinally_223_2
          -8 (-2.63% of base) : 1006.dasm - HelloWasm_Program___TestIntraFrameFilterOrderDeep_g__InnerFilterAndFinally_223_1
          -8 (-2.61% of base) : 1005.dasm - HelloWasm_Program___TestIntraFrameFilterOrderBasic_g__InnerFilterAndFinally_222_1
         -22 (-2.48% of base) : 1013.dasm - S_P_CoreLib_System_Runtime_CompilerServices_ClassConstructorRunner__EnsureClassConstructorRun
         -15 (-2.42% of base) : 1010.dasm - S_P_CoreLib_System_Globalization_CompareInfo_SortHandleCache__GetCachedSortHandle
         -10 (-1.96% of base) : 1014.dasm - S_P_CoreLib_System_Gen2GcCallback__Finalize
         -17 (-1.30% of base) : 1001.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__GetPropertyImpl
          -8 (-0.67% of base) : 1009.dasm - S_P_CoreLib_System_Reflection_DynamicInvokeInfo__Invoke
          -8 (-0.35% of base) : 1007.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__RegisterDynamicGenericTypesAndMethods
```
