### PR TITLE
NativeAOT-LLVM: Change name of Wasm Import function name to include the module prefix

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMCodegenCompilation.CodeGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMCodegenCompilation.CodeGen.cs
@@ -34,8 +34,9 @@ namespace ILCompiler
         {
             Debug.Assert(!sig.IsEmpty);
             string name = PInvokeILProvider.GetDirectCallExternName(method);
+            ConfigurableWasmImportPolicy.TryGetWasmModule(name, out string wasmModuleName);
 
-            return NodeFactory.ExternSymbolWithAccessor(name, method, sig);
+            return NodeFactory.ExternSymbolWithAccessor(name, method, sig, wasmModuleName);
         }
 
         public override CorInfoLlvmEHModel GetLlvmExceptionHandlingModel() => Options.ExceptionHandlingModel;

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -766,7 +766,7 @@ namespace ILCompiler.DependencyAnalysis
         private void GetCodeForExternMethodAccessor(ExternMethodAccessorNode node)
         {
             // TODO-LLVM: use the Utf8 string directly here.
-            string externFuncName = node.ExternMethodName.ToString();
+            string externFuncName = node.ExternFuncName.ToString();
             LLVMTypeRef externFuncType;
 
             if (node.Signature != null)
@@ -811,10 +811,10 @@ namespace ILCompiler.DependencyAnalysis
             LLVMValueRef externFunc = externFuncModule.AddFunction(externFuncName, externFuncType);
 
             // Add import attributes if specified.
-            if (_compilation.ConfigurableWasmImportPolicy.TryGetWasmModule(externFuncName, out string wasmModuleName))
+            if (node.WasmModuleName != null)
             {
-                externFunc.AddFunctionAttribute("wasm-import-name", externFuncName);
-                externFunc.AddFunctionAttribute("wasm-import-module", wasmModuleName);
+                externFunc.AddFunctionAttribute("wasm-import-name", node.WasmImportFuncName);
+                externFunc.AddFunctionAttribute("wasm-import-module", node.WasmModuleName);
             }
 
             // Define the accessor function.

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
@@ -47,7 +47,7 @@ namespace ILCompiler.DependencyAnalysis
             return _runtimeExports.TryGetValue(name, out EcmaMethod export) ? MethodEntrypoint(export) : null;
         }
 
-        internal ExternMethodAccessorNode ExternSymbolWithAccessor(string name, MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
+        internal ExternMethodAccessorNode ExternSymbolWithAccessor(string name, MethodDesc method, ReadOnlySpan<TargetAbiType> sig, string wasmModuleName)
         {
             Dictionary<string, ExternMethodAccessorNode> map = _externSymbolsWithAccessors;
 
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis
 
                 if (!exists)
                 {
-                    node = new ExternMethodAccessorNode(name);
+                    node = new ExternMethodAccessorNode(name, wasmModuleName);
                     node.Signature = sig.ToArray();
                 }
                 else if (!node.Signature.AsSpan().SequenceEqual(sig))


### PR DESCRIPTION
This PR solves a problem creating a Wasm Component that defines a WIT world where the same name function is both imported and exported, directly or via an interface, e.g.

```
world many-arguments {
  import imports: interface {
    many-arguments: func(
      a1: u64,
      a2: u64,
      a3: u64,
      a4: u64,
      a5: u64,
      a6: u64,
      a7: u64,
      a8: u64,
      a9: u64,
      a10: u64,
      a11: u64,
      a12: u64,
      a13: u64,
      a14: u64,
      a15: u64,
      a16: u64,
    )
  }
  export many-arguments: func(
    a1: u64,
    a2: u64,
    a3: u64,
    a4: u64,
    a5: u64,
    a6: u64,
    a7: u64,
    a8: u64,
    a9: u64,
    a10: u64,
    a11: u64,
    a12: u64,
    a13: u64,
    a14: u64,
    a15: u64,
    a16: u64,
  )
}
```
Previously this would have created and extern with the name ` many-arguments` and an alias for the export with the same name.  This resulted in the linker making calls to the extern call back into the export and not the actual imported function.

I have added the module name to the extern (the Wasm import) where a `WasmImport` is defined.  Maybe not the best strategy?

cc @dotnet/nativeaot-llvm 
