### PR TITLE
[Async-2]: Tasklet aging

### DIFF
--- a/src/coreclr/gc/env/gcenv.ee.h
+++ b/src/coreclr/gc/env/gcenv.ee.h
@@ -45,6 +45,10 @@ public:
     static void SyncBlockCachePromotionsGranted(int max_gen);
     static uint32_t GetActiveSyncBlockCount();
 
+    // Tasklet management
+    static void TaskletPromotionsGranted(int condemned, int max_gen, ScanContext* sc);
+    static void TaskletDemote(int condemned, int max_gen, ScanContext* sc);
+
     // Thread functions
     static bool IsPreemptiveGCDisabled();
     static bool EnablePreemptiveGC();

--- a/src/coreclr/gc/env/gctoeeinterface.standalone.inl
+++ b/src/coreclr/gc/env/gctoeeinterface.standalone.inl
@@ -64,6 +64,16 @@ namespace standalone
             ::GCToEEInterface::SyncBlockCachePromotionsGranted(max_gen);
         }
 
+        void TaskletPromotionsGranted(int condemned, int max_gen, ScanContext* sc)
+        {
+            ::GCToEEInterface::TaskletPromotionsGranted(condemned, max_gen, sc);
+        }
+
+        void TaskletDemote(int condemned, int max_gen, ScanContext* sc)
+        {
+            ::GCToEEInterface::TaskletDemote(condemned, max_gen, sc);
+        }
+
         uint32_t GetActiveSyncBlockCount()
         {
             return ::GCToEEInterface::GetActiveSyncBlockCount();

--- a/src/coreclr/gc/gcenv.ee.standalone.inl
+++ b/src/coreclr/gc/gcenv.ee.standalone.inl
@@ -90,13 +90,13 @@ inline void GCToEEInterface::SyncBlockCachePromotionsGranted(int max_gen)
     g_theGCToCLR->SyncBlockCachePromotionsGranted(max_gen);
 }
 
-inline void TaskletPromotionsGranted(int condemned, int max_gen, ScanContext* sc)
+inline void GCToEEInterface::TaskletPromotionsGranted(int condemned, int max_gen, ScanContext* sc)
 {
     assert(g_theGCToCLR != nullptr);
     g_theGCToCLR->TaskletPromotionsGranted(condemned, max_gen, sc);
 }
 
-inline void TaskletDemote(int condemned, int max_gen, ScanContext* sc)
+inline void GCToEEInterface::TaskletDemote(int condemned, int max_gen, ScanContext* sc)
 {
     assert(g_theGCToCLR != nullptr);
     g_theGCToCLR->TaskletDemote(condemned, max_gen, sc);

--- a/src/coreclr/gc/gcenv.ee.standalone.inl
+++ b/src/coreclr/gc/gcenv.ee.standalone.inl
@@ -90,6 +90,18 @@ inline void GCToEEInterface::SyncBlockCachePromotionsGranted(int max_gen)
     g_theGCToCLR->SyncBlockCachePromotionsGranted(max_gen);
 }
 
+inline void TaskletPromotionsGranted(int condemned, int max_gen, ScanContext* sc)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->TaskletPromotionsGranted(condemned, max_gen, sc);
+}
+
+inline void TaskletDemote(int condemned, int max_gen, ScanContext* sc)
+{
+    assert(g_theGCToCLR != nullptr);
+    g_theGCToCLR->TaskletDemote(condemned, max_gen, sc);
+}
+
 inline uint32_t GCToEEInterface::GetActiveSyncBlockCount()
 {
     assert(g_theGCToCLR != nullptr);

--- a/src/coreclr/gc/gcinterface.ee.h
+++ b/src/coreclr/gc/gcinterface.ee.h
@@ -252,6 +252,12 @@ public:
     void SyncBlockCachePromotionsGranted(int max_gen) PURE_VIRTUAL
 
     virtual
+    void TaskletPromotionsGranted(int condemned, int max_gen, ScanContext* sc) PURE_VIRTUAL
+
+    virtual
+    void TaskletDemote(int condemned, int max_gen, ScanContext* sc) PURE_VIRTUAL
+
+    virtual
     uint32_t GetActiveSyncBlockCount() PURE_VIRTUAL
 
     // Queries whether or not the current thread has preemptive GC disabled.

--- a/src/coreclr/gc/gcscan.cpp
+++ b/src/coreclr/gc/gcscan.cpp
@@ -225,11 +225,10 @@ void GCScan::GcDemote (int condemned, int max_gen, ScanContext* sc)
     {
         GCToEEInterface::SyncBlockCacheDemote(max_gen);
 
-        // TODO: this does not need to run on a single thread.
-        //       we should partition tasklet lists by the core number on server GC
+        // TODO: we should partition tasklet lists by the core number on server GC
         //       and do this on multiple threads.
         //       then "sc" argument will be used.
-        //GCToEEInterface::TaskletDemote(condemned, max_gen, sc);
+        GCToEEInterface::TaskletDemote(condemned, max_gen, sc);
     }
 }
 
@@ -240,14 +239,12 @@ void GCScan::GcPromotionsGranted (int condemned, int max_gen, ScanContext* sc)
     {
         GCToEEInterface::SyncBlockCachePromotionsGranted(max_gen);
 
-        // TODO: this does not need to run on a single thread.
-        //       we should partition tasklet lists by the core number on server GC
+        // TODO: we should partition tasklet lists by the core number on server GC
         //       and do this on multiple threads.
         //       then "sc" argument will be used.
-        //GCToEEInterface::TaskletPromotionsGranted(condemned, max_gen, sc);
+        GCToEEInterface::TaskletPromotionsGranted(condemned, max_gen, sc);
     }
 }
-
 
 size_t GCScan::AskForMoreReservedMemory (size_t old_size, size_t need_size)
 {

--- a/src/coreclr/gc/gcscan.cpp
+++ b/src/coreclr/gc/gcscan.cpp
@@ -222,14 +222,30 @@ void GCScan::GcDemote (int condemned, int max_gen, ScanContext* sc)
 {
     Ref_RejuvenateHandles (condemned, max_gen, sc);
     if (!IsServerHeap() || sc->thread_number == 0)
+    {
         GCToEEInterface::SyncBlockCacheDemote(max_gen);
+
+        // TODO: this does not need to run on a single thread.
+        //       we should partition tasklet lists by the core number on server GC
+        //       and do this on multiple threads.
+        //       then "sc" argument will be used.
+        //GCToEEInterface::TaskletDemote(condemned, max_gen, sc);
+    }
 }
 
 void GCScan::GcPromotionsGranted (int condemned, int max_gen, ScanContext* sc)
 {
     Ref_AgeHandles(condemned, max_gen, sc);
     if (!IsServerHeap() || sc->thread_number == 0)
+    {
         GCToEEInterface::SyncBlockCachePromotionsGranted(max_gen);
+
+        // TODO: this does not need to run on a single thread.
+        //       we should partition tasklet lists by the core number on server GC
+        //       and do this on multiple threads.
+        //       then "sc" argument will be used.
+        //GCToEEInterface::TaskletPromotionsGranted(condemned, max_gen, sc);
+    }
 }
 
 

--- a/src/coreclr/gc/sample/gcenv.ee.cpp
+++ b/src/coreclr/gc/sample/gcenv.ee.cpp
@@ -225,6 +225,14 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int /*max_gen*/)
 {
 }
 
+void GCToEEInterface::TaskletPromotionsGranted(int /*condemned*/, int /*max_gen*/, ScanContext* /*sc*/)
+{
+}
+
+void GCToEEInterface::TaskletDemote(int /*condemned*/, int /*max_gen*/, ScanContext* /*sc*/)
+{
+}
+
 void GCToEEInterface::DiagGCStart(int gen, bool isInduced)
 {
 }

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -804,6 +804,7 @@ RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableArm64Rcpc2,             W("EnableArm64Rc
 /// Runtime async
 ///
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_RuntimeAsyncViaJitGeneratedStateMachines, W("RuntimeAsyncViaJitGeneratedStateMachines"), 1, "Use JIT generated state machines instead of unwinding-based runtime async")
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_TaskletAging, W("TaskletAging"), 1, "Enable tasklet aging when tasklet based async is used")
 
 ///
 /// Uncategorized

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -654,6 +654,14 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int /*max_gen*/)
 {
 }
 
+void GCToEEInterface::TaskletPromotionsGranted(int /*condemned*/, int /*max_gen*/, ScanContext* /*sc*/)
+{
+}
+
+void GCToEEInterface::TaskletDemote(int /*condemned*/, int /*max_gen*/, ScanContext* /*sc*/)
+{
+}
+
 uint32_t GCToEEInterface::GetActiveSyncBlockCount()
 {
     return 0;

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -817,6 +817,7 @@ HRESULT EEConfig::sync()
     backpatchEntryPointSlots = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_BackpatchEntryPointSlots) != 0;
 
     runtimeAsyncViaJitGeneratedStateMachines = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_RuntimeAsyncViaJitGeneratedStateMachines) != 0;
+    taskletAging = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_TaskletAging) != 0;
 
 #if defined(FEATURE_GDBJIT) && defined(_DEBUG)
     {

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -115,6 +115,7 @@ public:
     bool          BackpatchEntryPointSlots() const { LIMITED_METHOD_CONTRACT; return backpatchEntryPointSlots; }
 
     bool          RuntimeAsyncViaJitGeneratedStateMachines() const { LIMITED_METHOD_CONTRACT; return runtimeAsyncViaJitGeneratedStateMachines; }
+    bool          TaskletAging() const { LIMITED_METHOD_CONTRACT; return taskletAging; }
 
 #if defined(FEATURE_GDBJIT) && defined(_DEBUG)
     inline bool ShouldDumpElfOnMethod(LPCUTF8 methodName) const
@@ -689,6 +690,7 @@ private: //----------------------------------------------------------------
 #endif
 
     bool runtimeAsyncViaJitGeneratedStateMachines;
+    bool taskletAging;
 public:
 
     enum BitForMask {

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -435,6 +435,7 @@ void GCToEEInterface::TaskletPromotionsGranted(int condemned, int max_gen, ScanC
     }
     CONTRACTL_END;
 
+    AgeTasklets(condemned, max_gen, sc);
 }
 
 void GCToEEInterface::TaskletDemote(int condemned, int max_gen, ScanContext* sc)
@@ -446,6 +447,7 @@ void GCToEEInterface::TaskletDemote(int condemned, int max_gen, ScanContext* sc)
     }
     CONTRACTL_END;
 
+    RejuvenateTasklets(condemned, max_gen, sc);
 }
 
 uint32_t GCToEEInterface::GetActiveSyncBlockCount()

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -328,7 +328,7 @@ void GCToEEInterface::GcScanRoots(promote_func* fn, int condemned, int max_gen, 
 
 #ifndef DACCESS_COMPILE
 // TODO Make tasklet reporting DAC friendly
-    IterateTaskletsForGC(fn, sc);
+    IterateTaskletsForGC(fn, condemned, sc);
 #endif
 }
 
@@ -424,6 +424,28 @@ void GCToEEInterface::SyncBlockCachePromotionsGranted(int max_gen)
     CONTRACTL_END;
 
     SyncBlockCache::GetSyncBlockCache()->GCDone(FALSE, max_gen);
+}
+
+void GCToEEInterface::TaskletPromotionsGranted(int condemned, int max_gen, ScanContext* sc)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+    }
+    CONTRACTL_END;
+
+}
+
+void GCToEEInterface::TaskletDemote(int condemned, int max_gen, ScanContext* sc)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+    }
+    CONTRACTL_END;
+
 }
 
 uint32_t GCToEEInterface::GetActiveSyncBlockCount()

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -80,6 +80,7 @@
 
 static const Entry s_QCall[] =
 {
+    DllImportEntry(RuntimeSuspension_RegisterTasklet)
     DllImportEntry(RuntimeSuspension_DeleteTasklet)
     DllImportEntry(RuntimeSuspension_CaptureTasklets)
     DllImportEntry(Enum_GetValuesAndNames)

--- a/src/coreclr/vm/runtimesuspension.h
+++ b/src/coreclr/vm/runtimesuspension.h
@@ -21,21 +21,3 @@ void UnregisterTasklet(Tasklet* pTasklet);
 void IterateTaskletsForGC(promote_func* pCallback, int condemned, ScanContext* sc);
 void AgeTasklets(int condemned, int max_gen, ScanContext* sc);
 void RejuvenateTasklets(int condemned, int max_gen, ScanContext* sc);
-
-template <typename F>
-void ForEachTasklet(F lambda)
-{
-    CrstHolder crstHolder(&g_taskletCrst);
-    Tasklet* pCurStack = g_pTaskletSentinel->pTaskletNextInLiveList;
-    while (pCurStack != g_pTaskletSentinel)
-    {
-        Tasklet* pCurTasklet = pCurStack;
-        do
-        {
-            lambda(pCurTasklet);
-            pCurTasklet = pCurTasklet->pTaskletPrevInStack;
-        } while (pCurTasklet != NULL);
-
-        pCurStack = pCurStack->pTaskletNextInLiveList;
-    }
-}

--- a/src/coreclr/vm/runtimesuspension.h
+++ b/src/coreclr/vm/runtimesuspension.h
@@ -16,4 +16,4 @@ EXTERN_C FCDECL2(Object*, RuntimeSuspension_ResumeTaskletIntegerRegisterReturn, 
 void RegisterTasklet(Tasklet* pTasklet);
 void InitializeTasklets();
 void UnregisterTasklet(Tasklet* pTasklet);
-void IterateTaskletsForGC(promote_func* pCallback, ScanContext* sc);
+void IterateTaskletsForGC(promote_func* pCallback, int condemned, ScanContext* sc);

--- a/src/coreclr/vm/runtimesuspension.h
+++ b/src/coreclr/vm/runtimesuspension.h
@@ -16,4 +16,20 @@ EXTERN_C FCDECL2(Object*, RuntimeSuspension_ResumeTaskletIntegerRegisterReturn, 
 void RegisterTasklet(Tasklet* pTasklet);
 void InitializeTasklets();
 void UnregisterTasklet(Tasklet* pTasklet);
+
 void IterateTaskletsForGC(promote_func* pCallback, int condemned, ScanContext* sc);
+void AgeTasklets(int condemned, int max_gen, ScanContext* sc);
+void RejuvenateTasklets(int condemned, int max_gen, ScanContext* sc);
+
+template <typename F>
+void ForEachTasklet(F lambda)
+{
+    CrstHolder crstHolder(&g_taskletCrst);
+    Tasklet* pCurTasklet = g_pTaskletSentinel->pTaskletNextInLiveList;
+    while (pCurTasklet != g_pTaskletSentinel)
+    {
+        lambda(pCurTasklet);
+
+        pCurTasklet = pCurTasklet->pTaskletNextInLiveList;
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -521,10 +521,16 @@ namespace System.Runtime.CompilerServices
                 maintainedData._nextTasklet->pTaskletPrevInStack = lastTasklet;
                 lastTasklet->pTaskletNextInStack = maintainedData._nextTasklet;
 
-                // we are suspending, so existing tasklets can now have min age
+                // we are suspending, so change the age of tasklets from -1 (active) to 0 (very young)
+                // NOTE: this is only needed as long as we allow cross-frame byrefs as
+                // that forces us to make age of active tasklets undefined (see comment in PlatformIndependentRestore)
+                // without such byrefs old tasklets could stay old as nothing could change locals of a captured frame.
                 for (Tasklet* current = maintainedData._nextTasklet; current != null; current = current->pTaskletNextInStack)
                 {
-                    current->minGeneration = 0;
+                    if (current->minGeneration == -1)
+                    {
+                        current->minGeneration = 0;
+                    }
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -451,6 +451,7 @@ namespace System.Runtime.CompilerServices
             public IntPtr restoreIPAddress;
             public StackDataInfo* pStackDataInfo;
             public TaskletReturnType taskletReturnType;
+            public int minGeneration;
 
             public int GetMaxStackNeeded() { return pStackDataInfo->StackRequirement; }
         }
@@ -507,6 +508,12 @@ namespace System.Runtime.CompilerServices
             Tasklet* nextTaskletInStack = CaptureCurrentStackIntoTasklets(new StackCrawlMarkHandle(ref stackMark), ref maintainedData.GetReturnPointer(), maintainedData._initialTaskEntry, t_asyncData, out lastTasklet, out var framesCaptured);
             if (nextTaskletInStack == null)
                 throw new OutOfMemoryException();
+
+            // we are suspending, so existing tasklets can now have min age
+            for (Tasklet* current = maintainedData._nextTasklet; current != null; current = current->pTaskletNextInStack)
+            {
+                current->minGeneration = 0;
+            }
 
             maintainedData._oldTaskletNext = maintainedData._nextTasklet;
             lastTasklet->pTaskletNextInStack = maintainedData._nextTasklet;

--- a/src/tests/Loader/async/async2gcRootsScan.cs
+++ b/src/tests/Loader/async/async2gcRootsScan.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 public class Async2RootReporting
 {
-    private static TaskCompletionSource<int> cs = new TaskCompletionSource<int>();
+    private static TaskCompletionSource<int> cs;
 
     // static async Task<int> Recursive(int n)
     static async2 int Recursive(int n)
@@ -16,14 +16,36 @@ public class Async2RootReporting
         Task<int> cTask = cs.Task;
 
         // make some garbage
-        object o = n;
+        object o1 = n;
+        //object o2 = n;
+        //object o3 = n;
+        //object o4 = n;
+        //object o5 = n;
+        //object o6 = n;
+        //object o7 = n;
+        //object o8 = n;
+        //object o9 = n;
+        //object o10 = n;
+        //object o11 = n;
+        //object o12 = n;
 
         if (n == 0)
             return await cTask;
 
         var result = await Recursive(n - 1);
 
-        Assert.Equal(n, (int)o);
+        Assert.Equal(n, (int)o1);
+        //Assert.Equal(n, (int)o2);
+        //Assert.Equal(n, (int)o3);
+        //Assert.Equal(n, (int)o4);
+        //Assert.Equal(n, (int)o5);
+        //Assert.Equal(n, (int)o6);
+        //Assert.Equal(n, (int)o7);
+        //Assert.Equal(n, (int)o8);
+        //Assert.Equal(n, (int)o9);
+        //Assert.Equal(n, (int)o10);
+        //Assert.Equal(n, (int)o11);
+        //Assert.Equal(n, (int)o12);
 
         return result;
     }
@@ -31,33 +53,34 @@ public class Async2RootReporting
     [Fact]
     public static void Test()
     {
-        int numStacks = 1000;
-        int stackDepth = 1000;
-        int numGCs = 200;
+        int numStacks = 10000;
+        int stackDepth = 100;
+        int numGCs = 100;
 
-        Task[] tasks = new Task[numStacks];
-        for (int i = 0; i < tasks.Length; i++)
+        for (; ; )
         {
-            tasks[i] = Recursive(stackDepth);
+            cs = new TaskCompletionSource<int>();
+            Task[] tasks = new Task[numStacks];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Recursive(stackDepth);
+            }
+
+            Stopwatch sw = Stopwatch.StartNew();
+
+            // should not take too long since we are not alocating anything new.
+            for (int i = 0; i < numGCs; i++)
+            {
+                if (i % 10 == 0)
+                    Console.Write('.');
+
+                GC.Collect(0);
+            }
+
+            System.Console.WriteLine("Time: " + sw.ElapsedMilliseconds);
+
+            cs.SetResult(100);
+            Task.WaitAll(tasks);
         }
-
-        Stopwatch sw = Stopwatch.StartNew();
-
-        // should not take too long since we are not alocating anything new.
-        for (int i = 0; i < numGCs; i++)
-        {
-            if (i % 10 == 0)
-                Console.Write('.');
-
-            GC.Collect(0);
-
-            if (sw.ElapsedMilliseconds > 1000000)
-                Assert.Fail("Gen1 GCs take too long");
-        }
-
-        System.Console.WriteLine("Time: " + sw.ElapsedMilliseconds);
-
-        cs.SetResult(100);
-        Task.WaitAll(tasks);
     }
 }

--- a/src/tests/Loader/async/async2gcRootsScan.cs
+++ b/src/tests/Loader/async/async2gcRootsScan.cs
@@ -11,7 +11,7 @@ public class Async2RootReporting
     private static TaskCompletionSource<int> cs;
 
     // static async Task<int> Recursive(int n)
-    static async2 int Recursive(int n)
+    static async2 Task<int> Recursive(int n)
     {
         Task<int> cTask = cs.Task;
 

--- a/src/tests/Loader/async/async2gcRootsScan.cs
+++ b/src/tests/Loader/async/async2gcRootsScan.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using Xunit;
+
+public class Async2RootReporting
+{
+    private static TaskCompletionSource<int> cs = new TaskCompletionSource<int>();
+
+    // static async Task<int> Recursive(int n)
+    static async2 int Recursive(int n)
+    {
+        Task<int> cTask = cs.Task;
+
+        // make some garbage
+        object o = n;
+
+        if (n == 0)
+            return await cTask;
+
+        var result = await Recursive(n - 1);
+
+        Assert.Equal(n, (int)o);
+
+        return result;
+    }
+
+    [Fact]
+    public static void Test()
+    {
+        int numStacks = 1000;
+        int stackDepth = 1000;
+        int numGCs = 200;
+
+        Task[] tasks = new Task[numStacks];
+        for (int i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = Recursive(stackDepth);
+        }
+
+        Stopwatch sw = Stopwatch.StartNew();
+
+        // should not take too long since we are not alocating anything new.
+        for (int i = 0; i < numGCs; i++)
+        {
+            if (i % 10 == 0)
+                Console.Write('.');
+
+            GC.Collect(0);
+
+            if (sw.ElapsedMilliseconds > 1000000)
+                Assert.Fail("Gen1 GCs take too long");
+        }
+
+        System.Console.WriteLine("Time: " + sw.ElapsedMilliseconds);
+
+        cs.SetResult(100);
+        Task.WaitAll(tasks);
+    }
+}

--- a/src/tests/Loader/async/async2gcRootsScan.cs
+++ b/src/tests/Loader/async/async2gcRootsScan.cs
@@ -10,8 +10,8 @@ public class Async2RootReporting
 {
     private static TaskCompletionSource<int> cs;
 
-    // static async Task<int> Recursive(int n)
-    static async2 Task<int> Recursive(int n)
+
+    static async Task<int> Recursive1(int n)
     {
         Task<int> cTask = cs.Task;
 
@@ -32,7 +32,48 @@ public class Async2RootReporting
         if (n == 0)
             return await cTask;
 
-        var result = await Recursive(n - 1);
+        var result = await Recursive1(n - 1);
+
+        Assert.Equal(n, (int)o1);
+        //Assert.Equal(n, (int)o2);
+        //Assert.Equal(n, (int)o3);
+        //Assert.Equal(n, (int)o4);
+        //Assert.Equal(n, (int)o5);
+        //Assert.Equal(n, (int)o6);
+        //Assert.Equal(n, (int)o7);
+        //Assert.Equal(n, (int)o8);
+        //Assert.Equal(n, (int)o9);
+        //Assert.Equal(n, (int)o10);
+        //Assert.Equal(n, (int)o11);
+        //Assert.Equal(n, (int)o12);
+
+        return result;
+    }
+
+    static async2 Task<int> Recursive2(int n)
+    {
+        Task<int> cTask = cs.Task;
+
+        // make some garbage
+        object o1 = n;
+
+// THIS CAUSES CRASHES IN UNWINDER FLAVOR
+        //object o2 = n;
+        //object o3 = n;
+        //object o4 = n;
+        //object o5 = n;
+        //object o6 = n;
+        //object o7 = n;
+        //object o8 = n;
+        //object o9 = n;
+        //object o10 = n;
+        //object o11 = n;
+        //object o12 = n;
+
+        if (n == 0)
+            return await cTask;
+
+        var result = await Recursive2(n - 1);
 
         Assert.Equal(n, (int)o1);
         //Assert.Equal(n, (int)o2);
@@ -57,18 +98,21 @@ public class Async2RootReporting
         int stackDepth = 100;
         int numGCs = 100;
 
-        for (; ; )
+        Console.WriteLine("async-1 ===================== ");
+        var ticks = Environment.TickCount;
+
+        // run a few iterations for 5 seconds total
+        while (Environment.TickCount - ticks < 5000)
         {
             cs = new TaskCompletionSource<int>();
             Task[] tasks = new Task[numStacks];
             for (int i = 0; i < tasks.Length; i++)
             {
-                tasks[i] = Recursive(stackDepth);
+                tasks[i] = Recursive1(stackDepth);
             }
 
-            Stopwatch sw = Stopwatch.StartNew();
+            var ticksStart = Stopwatch.GetTimestamp();
 
-            // should not take too long since we are not alocating anything new.
             for (int i = 0; i < numGCs; i++)
             {
                 if (i % 10 == 0)
@@ -77,7 +121,36 @@ public class Async2RootReporting
                 GC.Collect(0);
             }
 
-            System.Console.WriteLine("Time: " + sw.ElapsedMilliseconds);
+            System.Console.WriteLine("Time per Gen0 GC (microseconds): " + (Stopwatch.GetTimestamp() - ticksStart) * 1000000 / numGCs / Stopwatch.Frequency);
+
+            cs.SetResult(100);
+            Task.WaitAll(tasks);
+        }
+
+        Console.WriteLine("async-2 ===================== ");
+        ticks = Environment.TickCount;
+
+        // run a few iterations for 5 seconds total
+        while (Environment.TickCount - ticks < 5000)
+        {
+            cs = new TaskCompletionSource<int>();
+            Task[] tasks = new Task[numStacks];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Recursive2(stackDepth);
+            }
+
+            var ticksStart = Stopwatch.GetTimestamp();
+
+            for (int i = 0; i < numGCs; i++)
+            {
+                if (i % 10 == 0)
+                    Console.Write('.');
+
+                GC.Collect(0);
+            }
+
+            System.Console.WriteLine("Time per Gen0 GC (microseconds): " + (Stopwatch.GetTimestamp() - ticksStart) * 1000000 / numGCs / Stopwatch.Frequency);
 
             cs.SetResult(100);
             Task.WaitAll(tasks);

--- a/src/tests/Loader/async/async2gcRootsScan.csproj
+++ b/src/tests/Loader/async/async2gcRootsScan.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+   <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Added a test that measures durations of trivial gen-0 GCs in the presence of 10000 suspended tasks, with 100 frames each.
Both async-1 and async-2 are measured.

- Introduced tasklet aging to avoid reporting old stacks in younger GCs. Since a suspended stack cannot suddenly start pointing to younger objects, we can avoid reporting some suspended stacks when they cannot possibly have anything young enough to be of interest to the current GC cycle. 
Tasklet aging considerably reduces GC pauses due to root reporting. 

- Added a switch to turn aging on/off - `DOTNET_TaskletAging`.
The default state is `on`

- Changed the shape of tasklet storage. Instead of one big list, it is a list of lists. The inner lists belong to the same stack. 
This is to enable aging of an entire stack. Also to reduce locking when tasklets are resumed (only resuming/unlinking the head needs a lock)

