### PR TITLE
[Async-2] Fix resumption stub target in the presence of backpatching

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -579,7 +579,7 @@ void Async2Transformation::Transform(
     // Fill in 'state'
     newContinuation       = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
     unsigned stateOffset  = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationStateFldHnd);
-    GenTree* stateNumNode = m_comp->gtNewIconNode((ssize_t)stateNum, TYP_I_IMPL);
+    GenTree* stateNumNode = m_comp->gtNewIconNode((ssize_t)stateNum, TYP_INT);
     GenTree* storeState   = StoreAtOffset(newContinuation, stateOffset, stateNumNode);
     LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, storeState));
 

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -818,6 +818,7 @@ public:
           m_pPatchpointInfoFromRuntime(NULL),
           m_ilOffset(0),
 #endif
+          m_finalCodeAddressSlot(NULL),
           m_gphCache()
     {
         CONTRACTL
@@ -901,6 +902,8 @@ public:
 
     void WriteCode(EEJitManager * jitMgr);
 
+    void PublishFinalCodeAddress(PCODE addr);
+
     void setPatchpointInfo(PatchpointInfo* patchpointInfo) override final;
     PatchpointInfo* getOSRInfo(unsigned* ilOffset) override final;
 
@@ -979,6 +982,7 @@ protected :
     PatchpointInfo        * m_pPatchpointInfoFromRuntime;
     unsigned                m_ilOffset;
 #endif
+    PCODE* m_finalCodeAddressSlot;
 
     // The first time a call is made to CEEJitInfo::GetProfilingHandle() from this thread
     // for this method, these values are filled in.   Thereafter, these values are used


### PR DESCRIPTION
The slot the tier 0 method gets is backpatched to point to the tier 1 method, so allocate a new slot for the target address to ensure that resumption stubs always resume in the right native code version.

Also fix the size used when storing the state field; we were storing 8 bytes, but the field is only 4 bytes (this wouldn't cause any ill effects as the flags field comes right after).

@VSadov This fixes the #2425 failure.