### PR TITLE
[Async-2] Null out TLS head continuation reference

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -466,7 +466,9 @@ namespace System.Runtime.CompilerServices
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
             awaitableProxy._notifier = state.Notifier;
-            return state.SentinelContinuation!.Next!;
+            Continuation head = state.SentinelContinuation!.Next!;
+            state.SentinelContinuation.Next = null;
+            return head;
         }
 
         private static async Task<T> FinalizeTaskReturningThunk<T>(Continuation continuation)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -462,7 +462,7 @@ namespace System.Runtime.CompilerServices
             public void GetResult() {}
         }
 
-        private static Continuation GetHeadContinuation(AwaitableProxy awaitableProxy)
+        private static Continuation UnlinkHeadContinuation(AwaitableProxy awaitableProxy)
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
             awaitableProxy._notifier = state.Notifier;
@@ -496,7 +496,7 @@ namespace System.Runtime.CompilerServices
 
             while (true)
             {
-                Continuation headContinuation = GetHeadContinuation(awaitableProxy);
+                Continuation headContinuation = UnlinkHeadContinuation(awaitableProxy);
                 await awaitableProxy;
                 Continuation? finalResult = DispatchContinuations(headContinuation, out Exception? ex);
                 if (finalResult != null)
@@ -529,7 +529,7 @@ namespace System.Runtime.CompilerServices
 
             while (true)
             {
-                Continuation headContinuation = GetHeadContinuation(awaitableProxy);
+                Continuation headContinuation = UnlinkHeadContinuation(awaitableProxy);
                 await awaitableProxy;
                 Continuation? finalResult = DispatchContinuations(headContinuation, out Exception? ex);
                 if (finalResult != null)
@@ -566,7 +566,7 @@ namespace System.Runtime.CompilerServices
 
             while (true)
             {
-                Continuation headContinuation = GetHeadContinuation(awaitableProxy);
+                Continuation headContinuation = UnlinkHeadContinuation(awaitableProxy);
                 await awaitableProxy;
                 Continuation? finalResult = DispatchContinuations(headContinuation, out Exception? ex);
                 if (finalResult != null)
@@ -599,7 +599,7 @@ namespace System.Runtime.CompilerServices
 
             while (true)
             {
-                Continuation headContinuation = GetHeadContinuation(awaitableProxy);
+                Continuation headContinuation = UnlinkHeadContinuation(awaitableProxy);
                 await awaitableProxy;
                 Continuation? finalResult = DispatchContinuations(headContinuation, out Exception? ex);
                 if (finalResult != null)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -466,8 +466,9 @@ namespace System.Runtime.CompilerServices
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
             awaitableProxy._notifier = state.Notifier;
-            Continuation head = state.SentinelContinuation!.Next!;
-            state.SentinelContinuation.Next = null;
+            Continuation sentinelContinuation = state.SentinelContinuation!;
+            Continuation head = sentinelContinuation.Next!;
+            sentinelContinuation.Next = null;
             return head;
         }
 


### PR DESCRIPTION
Avoid permanently holding on to a reference to the continuation chain from the previous suspension in TLS.

(I don't think this particularly affects the results of #2425, but seems like we shouldn't be doing it in any case.)