### PR TITLE
[NativeAOT LLVM] Mark all `JSExport` wrapper methods as `UnmanagedCallersOnly`

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Constants.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Constants.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Interop.JavaScript
         public const string ModuleInitializerAttributeGlobal = "global::System.Runtime.CompilerServices.ModuleInitializerAttribute";
         public const string CompilerGeneratedAttributeGlobal = "global::System.Runtime.CompilerServices.CompilerGeneratedAttribute";
         public const string DynamicDependencyAttributeGlobal = "global::System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute";
+        public const string UnmanagedCallersOnlyAttributeGlobal = "global::System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute";
         public const string ThreadStaticGlobal = "global::System.ThreadStaticAttribute";
         public const string TaskGlobal = "global::System.Threading.Tasks.Task";
         public const string SpanGlobal = "global::System.Span";

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Interop.JavaScript
                                     AttributeArgument(
                                         LiteralExpression(
                                             SyntaxKind.StringLiteralExpression,
-                                            Literal(assemblyName + initializerClass + initializerName)
+                                            Literal(FixupSymbolName(assemblyName + initializerClass + initializerName))
                                         )
                                     )
                                     .WithNameEquals(

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSExportGenerator.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Interop.JavaScript
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
+            var assemblyName = context.CompilationProvider.Select(static (c, _) => c.AssemblyName);
+
             // Collect all methods adorned with JSExportAttribute
             var attributedMethods = context.SyntaxProvider
                 .ForAttributeWithMetadataName(Constants.JSExportAttribute,
@@ -103,7 +105,8 @@ namespace Microsoft.Interop.JavaScript
                 .Collect();
 
             IncrementalValueProvider<string> registration = regSyntax
-                .Select(static (data, ct) => GenerateRegSource(data))
+                .Combine(assemblyName)
+                .Select(static (data, ct) => GenerateRegSource(data.Left, data.Right))
                 .Select(static (data, ct) => data.NormalizeWhitespace().ToFullString());
 
             IncrementalValueProvider<ImmutableArray<(string, string)>> generated = generateSingleStub
@@ -139,21 +142,85 @@ namespace Microsoft.Interop.JavaScript
         }
 
         private static MemberDeclarationSyntax PrintGeneratedSource(
-            ContainingSyntaxContext containingSyntaxContext,
+            IncrementalStubGenerationContext context,
             BlockSyntax wrapperStatements, string wrapperName)
         {
 
             MemberDeclarationSyntax wrappperMethod = MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), Identifier(wrapperName))
                 .WithModifiers(TokenList(new[] { Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.UnsafeKeyword) }))
-                .WithAttributeLists(SingletonList(AttributeList(SingletonSeparatedList(
-                    Attribute(IdentifierName(Constants.DebuggerNonUserCodeAttribute))))))
+                .WithAttributeLists(List(
+                    new[] {
+                        AttributeList(
+                            SingletonSeparatedList(
+                                Attribute(
+                                    IdentifierName(Constants.DebuggerNonUserCodeAttribute)
+                                )
+                            )
+                        ),
+                        AttributeList(
+                            SingletonSeparatedList(
+                                Attribute(
+                                    IdentifierName(Constants.UnmanagedCallersOnlyAttributeGlobal)
+                                )
+                                .WithArgumentList(
+                                    AttributeArgumentList(
+                                        SingletonSeparatedList(
+                                            AttributeArgument(
+                                                LiteralExpression(
+                                                    SyntaxKind.StringLiteralExpression,
+                                                    Literal(FixupSymbolName(context.SignatureContext.QualifiedMethodName + "_" + context.SignatureContext.TypesHash))
+                                                )
+                                            )
+                                            .WithNameEquals(
+                                                NameEquals(
+                                                    IdentifierName("EntryPoint")
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    })
+                )
                 .WithParameterList(ParameterList(SingletonSeparatedList(
                     Parameter(Identifier("__arguments_buffer")).WithType(PointerType(ParseTypeName(Constants.JSMarshalerArgumentGlobal))))))
                 .WithBody(wrapperStatements);
 
-            MemberDeclarationSyntax toPrint = containingSyntaxContext.WrapMembersInContainingSyntaxWithUnsafeModifier(wrappperMethod);
+            MemberDeclarationSyntax toPrint = context.ContainingSyntaxContext.WrapMembersInContainingSyntaxWithUnsafeModifier(wrappperMethod);
 
             return toPrint;
+        }
+
+        private static readonly char[] s_charsToReplace = new[] { '.', '-', '+' };
+
+        private static string FixupSymbolName(string name)
+        {
+            UTF8Encoding utf8 = new();
+            byte[] bytes = utf8.GetBytes(name);
+            StringBuilder sb = new();
+
+            foreach (byte b in bytes)
+            {
+                if ((b >= (byte)'0' && b <= (byte)'9') ||
+                    (b >= (byte)'a' && b <= (byte)'z') ||
+                    (b >= (byte)'A' && b <= (byte)'Z') ||
+                    (b == (byte)'_'))
+                {
+                    sb.Append((char)b);
+                }
+                else if (s_charsToReplace.Contains((char)b))
+                {
+                    sb.Append('_');
+                }
+                else
+                {
+                    sb.Append($"_{b:X}_");
+                }
+            }
+
+            var fixedName = sb.ToString();
+            return fixedName;
         }
 
         private static JSExportData? ProcessJSExportAttribute(AttributeData attrData)
@@ -225,7 +292,7 @@ namespace Microsoft.Interop.JavaScript
         }
 
         private static NamespaceDeclarationSyntax GenerateRegSource(
-            ImmutableArray<(StatementSyntax Registration, AttributeListSyntax Attribute)> methods)
+            ImmutableArray<(StatementSyntax Registration, AttributeListSyntax Attribute)> methods, string assemblyName)
         {
             const string generatedNamespace = "System.Runtime.InteropServices.JavaScript";
             const string initializerClass = "__GeneratedInitializer";
@@ -256,6 +323,41 @@ namespace Microsoft.Interop.JavaScript
                             .WithModifiers(TokenList(new[] { Token(SyntaxKind.StaticKeyword) }))
                             .WithBody(Block(registerStatements));
 
+            MemberDeclarationSyntax method_uco = MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), Identifier(initializerName + "_Export"))
+                .WithAttributeLists(SingletonList(AttributeList(
+                    SingletonSeparatedList(
+                        Attribute(
+                            IdentifierName(Constants.UnmanagedCallersOnlyAttributeGlobal)
+                        )
+                        .WithArgumentList(
+                            AttributeArgumentList(
+                                SingletonSeparatedList(
+                                    AttributeArgument(
+                                        LiteralExpression(
+                                            SyntaxKind.StringLiteralExpression,
+                                            Literal(assemblyName + initializerClass + initializerName)
+                                        )
+                                    )
+                                    .WithNameEquals(
+                                        NameEquals(
+                                            IdentifierName("EntryPoint")
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )))
+                .WithModifiers(TokenList(new[] { Token(SyntaxKind.StaticKeyword) }))
+                .WithBody(Block(
+                    ExpressionStatement(
+                        InvocationExpression(
+                            IdentifierName(initializerName)
+                        )
+                    )
+                )
+            );
+
             // when we are running code generated by .NET8 on .NET7 runtime we need to auto initialize the assembly, because .NET7 doesn't call the registration from JS
             // this also keeps the code protected from trimming
             MemberDeclarationSyntax initializerMethod = MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), Identifier(selfInitName))
@@ -279,7 +381,7 @@ namespace Microsoft.Interop.JavaScript
                                 ClassDeclaration(initializerClass)
                                 .WithModifiers(TokenList(new SyntaxToken[]{
                                     Token(SyntaxKind.UnsafeKeyword)}))
-                                .WithMembers(List(new[] { field, initializerMethod, method }))
+                                .WithMembers(List(new[] { field, initializerMethod, method, method_uco }))
                                 .WithAttributeLists(SingletonList(AttributeList(SingletonSeparatedList(
                                     Attribute(IdentifierName(Constants.CompilerGeneratedAttributeGlobal)))
                                 )))));
@@ -314,7 +416,7 @@ namespace Microsoft.Interop.JavaScript
                     }
                     )))));
 
-            return (PrintGeneratedSource(incrementalContext.ContainingSyntaxContext, wrapper, wrapperName),
+            return (PrintGeneratedSource(incrementalContext, wrapper, wrapperName),
                 registration, registrationAttribute,
                 incrementalContext.Diagnostics.Array.AddRange(diagnostics.Diagnostics));
         }


### PR DESCRIPTION
- Add `UnmanagedCallersOnly` to every generated for `JSExport`
- Generate unique entrypoint name in form of `[assembly]namespace/class:method_args_hash` with replaced special chars (the pattern comes from the mono variant)
- Generate registration method with `UnmanagedCallersOnly`

Contributes to https://github.com/dotnet/runtimelab/issues/2434

<details>
  <summary>Example of generated class</summary>

```c#
// <auto-generated/>
namespace System.Runtime.InteropServices.JavaScript
{
    [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]
    unsafe class __GeneratedInitializer
    {
        [global::System.ThreadStaticAttribute]
        static bool initialized;
        [global::System.Runtime.CompilerServices.ModuleInitializerAttribute]
        static internal void __Net7SelfInit_()
        {
            if (Environment.Version.Major == 7)
            {
                __Register_();
            }
        }

        [global::System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute("__Wrapper_Greeting", "Xyz.Interop.MyClass", "BrowserConsoleApp")]
        static void __Register_()
        {
            if (initialized || global::System.Runtime.InteropServices.RuntimeInformation.OSArchitecture != global::System.Runtime.InteropServices.Architecture.Wasm)
                return;
            initialized = true;
            global::System.Runtime.InteropServices.JavaScript.JSFunctionBinding.BindManagedFunction("[BrowserConsoleApp]Xyz.Interop/MyClass:Greeting", 490867262, new global::System.Runtime.InteropServices.JavaScript.JSMarshalerType[] { global::System.Runtime.InteropServices.JavaScript.JSMarshalerType.Int32 });
        }

        [global::System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute(EntryPoint = "BrowserConsoleApp__GeneratedInitializer__Register_")]
        static void __Register__Export()
        {
            __Register_();
        }
    }
}
namespace Xyz
{
    public unsafe partial class Interop
    {
        public unsafe partial class MyClass
        {
            [global::System.Diagnostics.DebuggerNonUserCode]
            [global::System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute(EntryPoint = "_5B_BrowserConsoleApp_5D_Xyz_Interop_2F_MyClass_3A_Greeting_490867262")]
            internal static unsafe void __Wrapper_Greeting(global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument* __arguments_buffer)
            {
                ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __arg_exception = ref __arguments_buffer[0];
                ref global::System.Runtime.InteropServices.JavaScript.JSMarshalerArgument __arg_return = ref __arguments_buffer[1];
                int __retVal = default;
                try
                {
                    __retVal = Xyz.Interop.MyClass.Greeting();
                    __arg_return.ToJS(__retVal);
                }
                catch (global::System.Exception ex)
                {
                    __arg_exception.ToJS(ex);
                }

                // Marshal - Convert managed data to native data.
                __arg_return.ToJS(__retVal);
            }
        }
    }
}

```
</details>