### PR TITLE
[NativeAOT-LLVM] Do not use funclets for faults

### DIFF
--- a/src/coreclr/jit/jiteh.h
+++ b/src/coreclr/jit/jiteh.h
@@ -122,7 +122,7 @@ struct EHblkDsc
 #ifdef TARGET_WASM
     // WASM backend rewrites the funclet table in a way that makes the above algorithm
     // insufficient and so uses this auxiliary field for filter funclet indices.
-    unsigned short endFilterFuncIndex;
+    unsigned short ebdFilterFuncIndex;
 #endif // TARGET_WASM
 
 #endif // FEATURE_EH_FUNCLETS

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -172,6 +172,7 @@ struct FunctionInfo
         llvm::AllocaInst** Allocas; // Dense "lclNum -> Alloca*" mapping used for the main function.
         AllocaMap* AllocaMap; // Sparse "lclNum -> Alloca*" mapping used for funclets.
     };
+    llvm::BasicBlock* ResumeLlvmBlock;
     llvm::BasicBlock* ExceptionThrownReturnLlvmBlock;
 };
 
@@ -449,6 +450,7 @@ private:
     void initializeBlocks();
     void generateUnwindBlocks();
     void generateBlocks();
+    void generateThrowHelperBlock(BasicBlock* block);
     void generateBlock(BasicBlock* block);
     void fillPhis();
     void generateAuxiliaryArtifacts();
@@ -527,6 +529,8 @@ private:
 
     EHRegionInfo& getEHRegionInfo(unsigned ehIndex);
     llvm::BasicBlock* getUnwindLlvmBlockForCurrentInvoke();
+    void emitUnwindToOuterHandler();
+    void emitUnwindToOuterHandlerFromFault();
     Function* getOrCreatePersonalityLlvmFunction(CorInfoLlvmEHModel ehModel);
     llvm::CatchPadInst* getCatchPadForHandler(unsigned hndIndex);
     llvm::BasicBlock* getOrCreateExceptionThrownReturnBlock();

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -214,6 +214,7 @@ private:
     // Lowering members.
     LIR::Range* m_currentRange = nullptr;
     SideEffectSet m_scratchSideEffects; // Used for IsInvariantInRange.
+    bool m_anyFilterFunclets = false;
 
     // Shared between unwind index insertion and EH codegen.
     ArrayStack<unsigned>* m_unwindIndexMap = nullptr;

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -3205,7 +3205,7 @@ Value* Llvm::getLocalAddr(unsigned lclNum)
         addrValue = getOrCreateAllocaForLocalInFunclet(lclNum);
     }
 
-    assert(addrValue != nullptr);
+    assert(!IsUninitialized(addrValue) && (addrValue != nullptr));
     return addrValue;
 }
 

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -131,14 +131,16 @@ void Llvm::initializeFunclets()
         EHblkDsc* ehDsc = _compiler->ehGetDsc(ehIndex);
         if (ehDsc->HasFilter())
         {
-            ehDsc->endFilterFuncIndex = funcIdx++;
-            FuncInfoDsc* funcInfo = _compiler->funGetFunc(ehDsc->endFilterFuncIndex);
+            // Filters are funclets because they must be invokable by the first pass.
+            ehDsc->ebdFilterFuncIndex = funcIdx++;
+            FuncInfoDsc* funcInfo = _compiler->funGetFunc(ehDsc->ebdFilterFuncIndex);
             funcInfo->funKind = FUNC_FILTER;
             funcInfo->funEHIndex = ehIndex;
         }
 
-        if (ehDsc->HasFinallyOrFaultHandler())
+        if (ehDsc->HasFinallyHandler())
         {
+            // Finallys are funclets because they have multiple (EH and normal) entries and exits.
             ehDsc->ebdFuncIndex = funcIdx++;
             FuncInfoDsc* funcInfo = _compiler->funGetFunc(ehDsc->ebdFuncIndex);
             funcInfo->funKind = FUNC_HANDLER;
@@ -1816,7 +1818,6 @@ PhaseStatus Llvm::AddVirtualUnwindFrame()
 
     return PhaseStatus::MODIFIED_EVERYTHING;
 }
-
 
 void Llvm::computeBlocksInFilters()
 {


### PR DESCRIPTION
This is the same change as in #2399, but now for fault handlers.

Finallys and filters will have to remain funclets as the LLVM EH representation does not support them directly.

Originally, I also wanted to make it such that only locals live cross-funclet get demoted to the shadow stack. However, that proved challenging, for two reasons:
1) PHIs generated for exceptional flow in RyuJit are not easily translatable into LLVM PHIs, since they are imprecise.
2) Even with correct PHIs, LLVM WASM EH codegen demotes PHIs in `catchpad`s back to `alloca`s, even as it does not really need to. This would be something to fix in LLVM first.

With the above two issues, locals get forced to the native stack, and that has larger size overhead in the usual case than using the shadow one.

Not many diffs, as expected:
```
Total bytes of base: 3287466
Total bytes of diff: 3286541
Total bytes of delta: -925 (-0.03% % of base)
Average relative delta: -5.48%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
          16 ( 2.54% of base) : 1013.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__GetRuntimeFieldHandleForComponents_0
          16 ( 1.58% of base) : 1011.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__GetRuntimeMethodHandleForComponents
           3 ( 1.42% of base) : 1015.dasm - HelloWasm_Program___TestDeepUncontainedNestedDispatchIntraFrame_g__TestDeepUncontainedNestedDispatchIntraFrame_TopFault_251_2
           3 ( 0.71% of base) : 1001.dasm - HelloWasm_Program__TryFinallyWithCatch
           2 ( 0.35% of base) : 1019.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__RegisterDynamicThreadStaticsInfo

Top methods only present in diff:
         150 (     ∞ of base) : 1023.dasm - S_P_CoreLib_Interop_Sys__ReadLink_0$F1_Finally
          29 (     ∞ of base) : 1021.dasm - S_P_CoreLib_System_Globalization_CultureInfo__GetCultureInfo_0$F1_Finally
         127 (     ∞ of base) : 1020.dasm - HelloWasm_Program___TestVirtualUnwindStackPopSelfOnNestedUnwindingFault_g__TestVirtualUnwindStackPopSelfOnNestedUnwindingFault_Faults_237_0$F1_Finally
         142 (     ∞ of base) : 1022.dasm - S_P_CoreLib_System_TimeZoneInfo__EnumerateFilesRecursively$F1_Finally

Top method improvements (percentages):
        -161 (-55.90% of base) : 1009.dasm - S_P_CoreLib_System_Reflection_Runtime_BindingFlagSupport_NameFilterCaseInsensitive__Matches_0
        -107 (-12.49% of base) : 1010.dasm - S_P_CoreLib_System_Reflection_Runtime_Assemblies_NativeFormat_NativeFormatRuntimeAssembly__get_AllScopes_d__30__MoveNext
        -106 (-12.44% of base) : 1016.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__CoreGetDeclaredSyntheticConstructors_d__183__MoveNext
         -45 (-11.34% of base) : 1006.dasm - S_P_CoreLib_Interop_Sys__OpenDir
        -106 (-10.84% of base) : 1005.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__CoreGetDeclaredSyntheticMethods_d__185__MoveNext
        -107 (-10.34% of base) : 1004.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_RuntimeNamedMethodInfo_1__get_CustomAttributes_d__7<S_P_CoreLib_System_Reflection_Runtime_MethodInfos_NativeFormat_NativeFormatMethodCommon>__MoveNext
        -111 (-8.75% of base) : 1014.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeNamedTypeInfo__get_CustomAttributes_d__4__MoveNext
        -109 (-7.79% of base) : 1018.dasm - S_P_CoreLib_System_Reflection_Runtime_FieldInfos_RuntimeFieldInfo__get_CustomAttributes_d__2__MoveNext
        -107 (-6.73% of base) : 1012.dasm - S_P_CoreLib_System_Reflection_Runtime_ParameterInfos_RuntimeFatMethodParameterInfo__get_CustomAttributes_d__2__MoveNext
          -3 (-0.82% of base) : 1002.dasm - HelloWasm_Program___TestDeepContainedNestedDispatchIntraFrame_g__TestDeepContainedNestedDispatchSingleFrame_TryFour_243_4
          -3 (-0.77% of base) : 1017.dasm - HelloWasm_Program___TestDeepContainedNestedDispatchIntraFrame_g__TestDeepContainedNestedDispatchSingleFrame_TrySix_243_6

Top methods only present in base:
        -127 (-100.00% of base) : 1000.dasm - HelloWasm_Program___TestVirtualUnwindStackPopSelfOnNestedUnwindingFault_g__TestVirtualUnwindStackPopSelfOnNestedUnwindingFault_Faults_237_0$F2_Finally
        -142 (-100.00% of base) : 1007.dasm - S_P_CoreLib_System_TimeZoneInfo__EnumerateFilesRecursively$F3_Finally
         -29 (-100.00% of base) : 1003.dasm - S_P_CoreLib_System_Globalization_CultureInfo__GetCultureInfo_0$F2_Finally
        -150 (-100.00% of base) : 1008.dasm - S_P_CoreLib_Interop_Sys__ReadLink_0$F2_Finally

24 total methods with Code Size differences (15 improved, 9 regressed)
```

Contributes to #2169.