### PR TITLE
[NativeAOT-LLVM] Create throw helper blocks on-demand in codegen

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5083,8 +5083,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Insert GC Polls
     DoPhase(this, PHASE_INSERT_GC_POLLS, &Compiler::fgInsertGCPolls);
 
-    // For WASM we will do this after lowering.
-#if !defined(TARGET_WASM)
+#if !defined(TARGET_WASM) // For LLVM, codegen will handle these.
     // Create any throw helper blocks that might be needed
     //
     DoPhase(this, PHASE_CREATE_THROW_HELPERS, &Compiler::fgCreateThrowHelperBlocks);
@@ -5145,10 +5144,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     DoPhase(this, PHASE_LOWER_LLVM, [this]() {
         m_llvm->Lower();
     });
-
-    // Create any throw helper blocks that might be needed
-    //
-    DoPhase(this, PHASE_CREATE_THROW_HELPERS, &Compiler::fgCreateThrowHelperBlocks);
 
     fgSsaDomTree = nullptr;
     if (opts.OptimizationEnabled())

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4936,11 +4936,7 @@ public:
 
     bool backendRequiresLocalVarLifetimes()
     {
-#if defined(TARGET_WASM)
-        return true;
-#else
         return !opts.MinOpts() || m_pLinearScan->willEnregisterLocalVars();
-#endif
     }
 
     void fgLocalVarLiveness();
@@ -6146,12 +6142,11 @@ private:
     bool        fgRngChkThrowAdded;
     AddCodeDsc* fgExcptnTargetCache[SCK_COUNT];
 
+    void fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind);
     PhaseStatus fgCreateThrowHelperBlocks();
 
 public:
     static unsigned acdHelper(SpecialCodeKind codeKind);
-
-    void fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind);
 
     AddCodeDsc* fgFindExcptnTarget(SpecialCodeKind kind, unsigned refData);
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3102,8 +3102,7 @@ inline bool Compiler::fgIsThrowHlpBlk(BasicBlock* block)
           (call->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_FAIL_FAST)) ||
           (call->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_THROW_ARGUMENTEXCEPTION)) ||
           (call->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_THROW_ARGUMENTOUTOFRANGEEXCEPTION)) ||
-          (call->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_OVERFLOW)) ||
-          (call->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_THROWNULLREF))))
+          (call->AsCall()->gtCallMethHnd == eeFindHelper(CORINFO_HELP_OVERFLOW))))
     {
         return false;
     }
@@ -3117,8 +3116,7 @@ inline bool Compiler::fgIsThrowHlpBlk(BasicBlock* block)
         if (block == add->acdDstBlk)
         {
             return add->acdKind == SCK_RNGCHK_FAIL || add->acdKind == SCK_DIV_BY_ZERO || add->acdKind == SCK_OVERFLOW ||
-                   add->acdKind == SCK_ARG_EXCPN || add->acdKind == SCK_ARG_RNG_EXCPN || add->acdKind == SCK_FAIL_FAST ||
-                   add->acdKind == SCK_NULL_REF_EXCPN;
+                   add->acdKind == SCK_ARG_EXCPN || add->acdKind == SCK_ARG_RNG_EXCPN || add->acdKind == SCK_FAIL_FAST;
         }
     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3497,8 +3497,6 @@ unsigned Compiler::acdHelper(SpecialCodeKind codeKind)
             return CORINFO_HELP_OVERFLOW;
         case SCK_FAIL_FAST:
             return CORINFO_HELP_FAIL_FAST;
-        case SCK_NULL_REF_EXCPN:
-            return CORINFO_HELP_THROWNULLREF;
         default:
             assert(!"Bad codeKind");
             return 0;
@@ -3531,8 +3529,6 @@ const char* sckName(SpecialCodeKind codeKind)
             return "SCK_ARITH_EXCPN";
         case SCK_FAIL_FAST:
             return "SCK_FAIL_FAST";
-        case SCK_NULL_REF_EXCPN:
-            return "SCK_NULL_REF_EXCPN";
         default:
             return "SCK_UNKNOWN";
     }
@@ -3624,7 +3620,6 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
         BBJ_THROW, // SCK_ARG_EXCPN
         BBJ_THROW, // SCK_ARG_RNG_EXCPN
         BBJ_THROW, // SCK_FAIL_FAST
-        BBJ_THROW, // SCK_NULL_REF_EXCPN
     };
 
     noway_assert(sizeof(jumpKinds) == SCK_COUNT); // sanity check
@@ -3693,9 +3688,6 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
                 case SCK_FAIL_FAST:
                     msg = " for FAIL_FAST";
                     break;
-                case SCK_NULL_REF_EXCPN:
-                    msg = " for NULL_REF_EXCPN";
-                    break;
                 default:
                     msg = " for ??";
                     break;
@@ -3743,10 +3735,6 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
                 helper = CORINFO_HELP_FAIL_FAST;
                 break;
 
-            case SCK_NULL_REF_EXCPN:
-                helper = CORINFO_HELP_THROWNULLREF;
-                break;
-
             default:
                 noway_assert(!"unexpected code addition kind");
         }
@@ -3773,12 +3761,6 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
         {
             LIR::AsRange(newBlk).InsertAtEnd(LIR::SeqTree(this, tree));
         }
-
-#if defined(TARGET_WASM)
-        // Llvm has already run it's lower phase so these new blocks need to be lowered here.
-        //
-        m_llvm->LowerRange(newBlk, LIR::AsRange(newBlk));
-#endif
     }
 
     fgRngChkThrowAdded = true;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -63,7 +63,6 @@ enum SpecialCodeKind
     SCK_ARG_EXCPN,                  // target on ArgumentException (currently used only for SIMD intrinsics)
     SCK_ARG_RNG_EXCPN,              // target on ArgumentOutOfRangeException (currently used only for SIMD intrinsics)
     SCK_FAIL_FAST,                  // target for fail fast exception
-    SCK_NULL_REF_EXCPN,             // target on NullReferenceException (only used when targeting LLVM)
     SCK_COUNT
 };
 

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -103,6 +103,7 @@ Llvm::Llvm(Compiler* compiler)
     , _builder(m_context->Context)
     , _sdsuMap(compiler->getAllocator(CMK_Codegen))
     , _localsMap(compiler->getAllocator(CMK_Codegen))
+    , m_throwHelperBlocksMap(compiler->getAllocator(CMK_Codegen))
     , m_ehModel(GetExceptionHandlingModel())
     , m_debugVariablesMap(compiler->getAllocator(CMK_Codegen))
 {

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -465,7 +465,7 @@ private:
         m_prologRange.InsertAtEnd(zeroILOffsetNode);
 
         assert(m_llvm->isFirstBlockCanonical());
-        m_llvm->LowerRange(m_compiler->fgFirstBB, m_prologRange);
+        m_llvm->lowerRange(m_compiler->fgFirstBB, m_prologRange);
         LIR::AsRange(m_compiler->fgFirstBB).InsertAtBeginning(std::move(m_prologRange));
     }
 


### PR DESCRIPTION
There are a number of advantages:
 1) Simpler code - throw helper blocks are very special w.r.t. flowgraph handling
 2) Less coupling with upstream code (SCK_NULLREF_EXCPN and related deleted).
 3) Smaller LLVM.

Unfortunately, LLVM, as it turns out, is quite sensitive to block order, so we get the following diffs:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3286670
Total bytes of diff: 3288259
Total bytes of delta: 1589 (0.05% % of base)
Average relative delta: 5.19%
    diff is a regression
    average relative diff is a regression

Top method regressions (percentages):
         127 (153.01% of base) : 1150.dasm - S_P_TypeLoader_Internal_TypeSystem_CanonType__GetHashCode
         127 (153.01% of base) : 1148.dasm - S_P_TypeLoader_Internal_TypeSystem_UniversalCanonType__GetHashCode
         127 (138.04% of base) : 1149.dasm - S_P_TypeLoader_Internal_TypeSystem_CanonType__get_BaseType
         144 (91.14% of base) : 1005.dasm - HelloWasm_Program__ldindTest
         218 (85.49% of base) : 1116.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_EETypeCreator__GetInstanceGCDescSize
         272 (85.27% of base) : 1004.dasm - HelloWasm_Program_MixedArgFuncClass__MixedArgFunc
         144 (79.56% of base) : 1042.dasm - HelloWasm_Program___TestVirtualUnwindStackNoPopOnThrow_g__TestVirtualUnwindStackNoPopOnThrow_NotInTryCatch_229_0
         124 (79.49% of base) : 1035.dasm - HelloWasm_Program___TestVirtualUnwindStackPopSelfOnNestedUnwindingFault_g__TestVirtualUnwindStackPopSelfOnNestedUnwindingFault_Faults_237_0
         120 (68.57% of base) : 1175.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_MdBinaryReader__Read_18
          41 (50.00% of base) : 1061.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_GenericDictionaryCell_InterfaceCallCell__Create
         126 (43.45% of base) : 1126.dasm - S_P_TypeLoader_Internal_NativeFormat_NativeParser__GetParserForBagElementKind
          86 (43.43% of base) : 1098.dasm - S_P_TypeLoader_Internal_Runtime_MethodTable__get_GenericVariance
          58 (42.65% of base) : 1044.dasm - HelloWasm_Program___TestVirtualUnwindStackPopOnThrow_g__TestVirtualUnwindStackPopOnThrow_NotInTry_228_0
         104 (38.38% of base) : 1028.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_FieldAccessors_PointerTypeFieldAccessorForStaticFields__GetFieldBypassCctor
         141 (29.81% of base) : 1117.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_EETypeCreator__CreateInstanceGCDesc
         135 (26.01% of base) : 1141.dasm - S_P_TypeLoader_Internal_TypeSystem_NoMetadata_NoMetadataType__get_BaseType
          40 (24.84% of base) : 1059.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_GenericDictionaryCell_ThreadStaticIndexCell__Create
          37 (21.89% of base) : 1060.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_GenericDictionaryCell_FieldLdTokenCell__Create
         201 (19.76% of base) : 1128.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilderState__get_InstanceGCLayout
          30 (18.18% of base) : 1157.dasm - HelloWasm_Program__TestUnsignedLongAddOvf

Top method improvements (percentages):
         -55 (-67.90% of base) : 1124.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeSystemContext_ArrayTypeKey_ArrayTypeKeyHashtable__GetKeyHashCode
         -93 (-61.18% of base) : 1026.dasm - HelloWasm_Program__TestLclVarAddr
        -120 (-40.13% of base) : 1201.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_MdBinaryReader__Read_24
         -88 (-36.36% of base) : 1027.dasm - HelloWasm_Program__TestJitUseStruct
        -110 (-35.95% of base) : 1114.dasm - S_P_CoreLib_Internal_Reflection_Core_Execution_ExecutionDomain__GetNamedTypeForHandle
         -45 (-32.37% of base) : 1123.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeSystemContext_ArrayTypeKey_ArrayTypeKeyHashtable__GetValueHashCode
         -81 (-25.00% of base) : 1078.dasm - S_P_CoreLib_System_Globalization_DateTimeFormatInfo__PMDesignatorTChar<Char>
        -422 (-23.90% of base) : 1125.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_NativeLayoutInterfacesAlgorithm__ComputeRuntimeInterfaces
         -54 (-22.31% of base) : 1089.dasm - S_P_CoreLib_System_IO_RandomAccess__ValidateInput
        -135 (-20.96% of base) : 1127.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_NoMetadataRuntimeInterfacesAlgorithm__ComputeRuntimeInterfaces
        -126 (-17.12% of base) : 1093.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_MetadataReader__GetNamespaceDefinition
        -116 (-16.67% of base) : 1112.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtable_2<System___Canon__System___Canon>__TryGetValue
        -115 (-14.82% of base) : 1118.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtable_2<System___Canon__System___Canon>__Expand
         -31 (-13.48% of base) : 1023.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilder__FinishBaseTypeAndDictionaries
        -207 (-11.35% of base) : 1074.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__GVMLookupForSlotWorker
        -114 (-9.28% of base) : 1119.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtable_2<System___Canon__System___Canon>__TryAddOrGetExisting
         -70 (-6.42% of base) : 1122.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeSystemContext___ctor_0
         -15 (-2.79% of base) : 1121.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeSystemContext__get_LoadFactor
         -10 (-2.58% of base) : 1172.dasm - HelloWasm_Program___TestDeepContainedNestedDispatchIntraFrame_g__TestDeepContainedNestedDispatchSingleFrame_TrySix_243_6
          -1 (-2.56% of base) : 1030.dasm - HelloWasm_Program__DoNotThrowException

204 total methods with Code Size differences (101 improved, 103 regressed)
```
Most are inlining noise, but in some cases we get worse/better codegen due to the new order. Replicating the old older would be complex, so I opted for simpler code.