### PR TITLE
[NativeAOT-LLVM] Fix a corner-case bug with explicit tail calls

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -626,7 +626,7 @@ void Llvm::generateBlock(BasicBlock* block)
             break;
         case BBJ_EHFAULTRET:
             // "fgCreateMonitorTree" forgets to insert RETFILT nodes for some faults. Compensate.
-            if (!block->lastNode()->OperIs(GT_RETFILT))
+            if (_builder.GetInsertBlock()->getTerminator() == nullptr)
             {
                 emitUnwindToOuterHandlerFromFault();
             }

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/ExceptionHandlingTests.Cpp.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/ExceptionHandlingTests.Cpp.cs
@@ -22,7 +22,7 @@ internal unsafe partial class Program
 
     static int finallyCounter = 0;
 
-    public static int Main()
+    public static void Main()
     {
         if (string.Empty.Length > 0)
         {
@@ -32,7 +32,7 @@ internal unsafe partial class Program
 
         if (!TestTryCatch())
         {
-            return 101;
+            return;
         }
 
         TestGenericExceptions();
@@ -49,7 +49,7 @@ internal unsafe partial class Program
             catch (OutOfMemoryException)
             {
                 Console.WriteLine("Unexpected exception caught");
-                return Fail;
+                return;
             }
         }
         catch (Exception e)
@@ -58,14 +58,14 @@ internal unsafe partial class Program
             if (e.Message != "My exception")
             {
                 Console.WriteLine("Unexpected exception message!");
-                return Fail;
+                return;
             }
 
             string stackTrace = e.StackTrace;
             if (!stackTrace.Contains("Program.Main"))
             {
                 Console.WriteLine("Unexpected stack trace: " + stackTrace);
-                return Fail;
+                return;
             }
             counter++;
         }
@@ -107,7 +107,7 @@ internal unsafe partial class Program
             if (e.Message != "Testing filter")
             {
                 Console.WriteLine("Unexpected exception message!");
-                return Fail;
+                return;
             }
             counter++;
         }
@@ -123,12 +123,12 @@ internal unsafe partial class Program
             if (e.Message != "ThrowExcThroughMethodsWithFinalizers2")
             {
                 Console.WriteLine("Unexpected exception message!");
-                return Fail;
+                return;
             }
             if (finallyCounter != 2)
             {
                 Console.WriteLine("Finalizers didn't execute!");
-                return Fail;
+                return;
             }
             counter++;
         }
@@ -148,14 +148,14 @@ internal unsafe partial class Program
         catch (Exception ex)
         {
             if (ex.Message != "Hello")
-                return Fail;
+                return;
             counter++;
         }
 
         if (counter != 10)
         {
             Console.WriteLine("Unexpected counter value");
-            return Fail;
+            return;
         }
 
         throw new Exception("UnhandledException");


### PR DESCRIPTION
Explicit (`.tail`) void-returning tailcalls suppress the importation of `GT_RETURN`. Compensate for this IR quirk in lowering.

`.tail` is used in the `MainMethodWrapper` to compensate for `NoOptimization`, where this bug was hit by @maraf. We haven't hit it before because all the runtime tests use error codes to communicate success/failure, hence all the main methods are `int`-returning.

Adapted the C++ EH test, which doesn't return normally from `Main`, to test this scenario.