### PR TITLE
[NativeAOT-LLVM] Official windows build does not build tests

### DIFF
--- a/eng/pipelines/runtimelab/coreclr-tests.yml
+++ b/eng/pipelines/runtimelab/coreclr-tests.yml
@@ -17,8 +17,8 @@ jobs:
       postBuildSteps:
         - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
           parameters:
-          testFilter: ''
-          runSingleFileTests: false
+            testFilter: ''
+            runSingleFileTests: false
 
 
 #
@@ -37,5 +37,5 @@ jobs:
       postBuildSteps:
         - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
           parameters:
-          testFilter: ''
-          runSingleFileTests: false
+            testFilter: ''
+            runSingleFileTests: false

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -38,8 +38,9 @@ steps:
       displayName: Build WebAssembly tests
 
   - ${{ elseif eq(parameters.osGroup, 'windows') }}:
-    - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} /p:NativeAotMultimodule=true /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-      displayName: Build tests
+    - ${{ if ne(parameters.isOfficialBuild, true) }}:
+      - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.testFilter }} /p:NativeAotMultimodule=true /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+        displayName: Build tests
   - ${{ else }}:
     - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} 'tree nativeaot' /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
       displayName: Build tests


### PR DESCRIPTION
This PR removes the `Build tests` step from the official windows build.  My logic here is

1. At https://github.com/dotnet/runtimelab/blob/c0547d1c13a46c2dee1be023e75c8eca0a0730e2/eng/pipelines/runtimelab.yml#L152 we need the libraries built

2. That happens here https://github.com/dotnet/runtimelab/blob/c0547d1c13a46c2dee1be023e75c8eca0a0730e2/eng/pipelines/runtimelab.yml#L133 where only the subset `libs` is built

3. Therefor we can't/shouldn't run the tests.

Incidentally why is `runtimelab.yml` included in the `runtime` repo?