### PR TITLE
[NativeAOT-LLVM] Pass runSingleFileTests: false for official build

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -148,6 +148,7 @@ extends:
                     uploadIntermediateArtifacts: true
                     isOfficialBuild: true
                     librariesBinArtifactName: libraries_bin_official_allconfigurations
+                    runSingleFileTests: false
 
       # Installer official builds need to build installers and need the libraries all configurations build
       - ${{ if eq(variables.isOfficialBuild, true) }}:


### PR DESCRIPTION
This PR turns off runSingleFileTests for the official build.  Apologies I missed this one.
