### PR TITLE
[NativeAOT-LLVM] Move `RhpPInvoke` and undefine `BACKGROUND_GC`

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -14076,7 +14076,7 @@ HRESULT gc_heap::initialize_gc (size_t soh_segment_size,
 
 #ifdef WRITE_WATCH
     hardware_write_watch_api_supported();
-#ifdef BACKGROUND_GC_SUPPORTED
+#ifdef BACKGROUND_GC
     if (can_use_write_watch_for_gc_heap() && GCConfig::GetConcurrentGC())
     {
         gc_can_use_concurrent = true;

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -185,12 +185,9 @@ inline void FATAL_GC_ERROR()
 #define FEATURE_PREMORTEM_FINALIZATION
 #define GC_HISTORY
 
+#ifndef TARGET_WASM
 #define BACKGROUND_GC   //concurrent background GC (requires WRITE_WATCH)
-
-// It is no longer possible to build without BACKGROUND_GC defined, so we have to use this duplicate
-#if !defined(TARGET_WASM) || defined(FEATURE_WASM_THREADS)
-#define BACKGROUND_GC_SUPPORTED
-#endif // !defined(TARGET_WASM) || defined(FEATURE_WASM_THREADS)
+#endif
 
 // We need the lower 3 bits in the MT to do our bookkeeping so doubly linked free list is only for 64-bit
 #if defined(BACKGROUND_GC) && defined(HOST_64BIT)

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -185,7 +185,7 @@ inline void FATAL_GC_ERROR()
 #define FEATURE_PREMORTEM_FINALIZATION
 #define GC_HISTORY
 
-#ifndef TARGET_WASM
+#if !defined(TARGET_WASM) || defined(FEATURE_WASM_THREADS)
 #define BACKGROUND_GC   //concurrent background GC (requires WRITE_WATCH)
 #endif
 

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -1297,17 +1297,7 @@ COOP_PINVOKE_HELPER(void, RhpReversePInvokeReturn, (ReversePInvokeFrame * pFrame
 
 #ifdef USE_PORTABLE_HELPERS
 
-#ifdef HOST_WASM
-extern "C" void RhpSetShadowStackTop(void*);
-COOP_PINVOKE_HELPER(void, RhpPInvoke, (void* pShadowStack, PInvokeTransitionFrame* pFrame))
-{
-    // The implementation has to live in this file because of "FORCEINLINE" on "Thread::InlinePInvoke".
-    // Ideally, "InlinePInvoke" would be in "thread.inl", and this function - in "wasm/PInvoke.cpp".
-    RhpSetShadowStackTop(pShadowStack);
-    Thread* pCurThread = ThreadStore::RawGetCurrentThread();
-    pCurThread->InlinePInvoke(pFrame);
-}
-#else // !HOST_WASM
+#ifndef HOST_WASM
 COOP_PINVOKE_HELPER(void, RhpPInvoke, (PInvokeTransitionFrame* pFrame))
 {
     Thread * pCurThread = ThreadStore::RawGetCurrentThread();

--- a/src/coreclr/nativeaot/Runtime/wasm/PInvoke.cpp
+++ b/src/coreclr/nativeaot/Runtime/wasm/PInvoke.cpp
@@ -9,9 +9,23 @@
 #include "daccess.h"
 #include "PalRedhawkCommon.h"
 #include "PalRedhawk.h"
+#include "thread.h"
+#include "threadstore.h"
+#include "thread.inl"
+#include "threadstore.inl"
 
 thread_local void* t_pShadowStackBottom = nullptr;
 thread_local void* t_pShadowStackTop = nullptr;
+
+void* GetShadowStackBottom()
+{
+    return t_pShadowStackBottom;
+}
+
+void* GetShadowStackTop()
+{
+    return t_pShadowStackTop;
+}
 
 COOP_PINVOKE_HELPER(void*, RhpGetOrInitShadowStackTop, ())
 {
@@ -41,12 +55,9 @@ COOP_PINVOKE_HELPER(void, RhpSetShadowStackTop, (void* pShadowStack))
     t_pShadowStackTop = pShadowStack;
 }
 
-void* GetShadowStackBottom()
+COOP_PINVOKE_HELPER(void, RhpPInvoke, (void* pShadowStack, PInvokeTransitionFrame* pFrame))
 {
-    return t_pShadowStackBottom;
-}
-
-void* GetShadowStackTop()
-{
-    return t_pShadowStackTop;
+    RhpSetShadowStackTop(pShadowStack);
+    Thread* pCurThread = ThreadStore::RawGetCurrentThread();
+    pCurThread->InlinePInvoke(pFrame);
 }


### PR DESCRIPTION
See also: #2472.

As somewhat expected, undefining `BACKGROUND_GC` lets us drop a cool 56K of dead native code:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3249451
Total bytes of diff: 3193293
Total bytes of delta: -56158 (-1.73% % of base)
Average relative delta: -6.87%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
        1311 (323.70% of base) : 1130.dasm - WKS::AllocAlign8(alloc_context*, WKS::gc_heap*, unsigned long, unsigned int)
         634 (139.34% of base) : 1131.dasm - WKS::GCHeap::Alloc(gc_alloc_context*, unsigned long, unsigned int)
         768 (50.53% of base) : 1048.dasm - WKS::gc_heap::copy_brick_card_table()
         210 (40.94% of base) : 1133.dasm - WKS::GCHeap::GetTotalBytesInUse()
         124 (32.46% of base) : 1047.dasm - WKS::gc_heap::make_card_table(unsigned char*, unsigned char*)
         135 (25.42% of base) : 1051.dasm - WKS::gc_heap::delete_heap_segment(WKS::heap_segment*, int)
           3 ( 9.38% of base) : 1009.dasm - RhpPInvoke
          42 ( 5.27% of base) : 1158.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_GenericDictionaryCell_MethodLdTokenCell__Create

Top methods only present in diff:
         410 (     ∞ of base) : 1162.dasm - WKS::gc_heap::pm_full_gc_init_or_clear()

Top method improvements (percentages):
        -208 (-99.05% of base) : 1140.dasm - WKS::GCHeap::PublishObject(unsigned char*)
         -72 (-97.30% of base) : 1012.dasm - WKS::GCHeap::WaitUntilConcurrentGCComplete()
         -61 (-93.85% of base) : 1141.dasm - WKS::GCHeap::WaitUntilConcurrentGCCompleteAsync(int)
         -11 (-84.62% of base) : 1143.dasm - WKS::GCHeap::TemporaryDisableConcurrentGC()
         -11 (-84.62% of base) : 1142.dasm - WKS::GCHeap::TemporaryEnableConcurrentGC()
         -21 (-84.00% of base) : 1144.dasm - WKS::GCHeap::IsConcurrentGCEnabled()
         -10 (-71.43% of base) : 1014.dasm - WKS::GCHeap::IsConcurrentGCInProgress()
       -1627 (-62.24% of base) : 1070.dasm - WKS::gc_heap::a_fit_free_list_uoh_p(unsigned long, alloc_context*, unsigned int, int, int)
        -799 (-60.21% of base) : 1060.dasm - WKS::gc_heap::init_semi_shared()
         -16 (-59.26% of base) : 1129.dasm - WKS::GCHeap::GetPromotedBytes(int)
         -67 (-55.83% of base) : 1137.dasm - WKS::GCHeap::SetGcLatencyMode(int)
        -146 (-49.16% of base) : 1083.dasm - WKS::gc_heap::get_total_survived_size()
         -40 (-48.78% of base) : 1135.dasm - WKS::GCHeap::CollectionCount(int, int)
        -642 (-45.47% of base) : 1081.dasm - WKS::gc_heap::joined_generation_to_condemn(int, int, int, int*)
         -85 (-44.74% of base) : 1128.dasm - WKS::GCHeap::IsPromoted(Object*)
        -926 (-41.64% of base) : 1074.dasm - WKS::gc_heap::garbage_collect(int)
        -351 (-40.11% of base) : 1080.dasm - WKS::gc_heap::try_allocate_more_space(alloc_context*, unsigned long, unsigned int, int)
        -695 (-38.85% of base) : 1040.dasm - WKS::gc_heap::grow_brick_card_tables(unsigned char*, unsigned char*, unsigned long, WKS::heap_segment*, WKS::gc_heap*, int)
        -303 (-36.55% of base) : 1132.dasm - WKS::GCHeap::GarbageCollect(int, bool, int)
        -850 (-35.52% of base) : 1079.dasm - WKS::gc_heap::allocate_uoh(int, unsigned long, alloc_context*, unsigned int, int)

Top methods only present in base:
         -37 (-100.00% of base) : 1000.dasm - CLREventStatic::CreateAutoEventNoThrow(bool)
       -1749 (-100.00% of base) : 1122.dasm - WKS::gc_heap::background_process_mark_overflow_internal(unsigned char*, unsigned char*, int)
         -86 (-100.00% of base) : 1078.dasm - WKS::gc_heap::trigger_gc_for_alloc(int, gc_reason, WKS::GCDebugSpinLock*, bool, WKS::msl_take_state)
        -767 (-100.00% of base) : 1125.dasm - WKS::gc_heap::bgc_thread_function()
       -1651 (-100.00% of base) : 1126.dasm - WKS::gc_heap::revisit_written_page(unsigned char*, unsigned char*, int, unsigned char*&, unsigned char*&, int, unsigned long&)
        -789 (-100.00% of base) : 1127.dasm - WKS::gc_heap::bgc_tuning::set_total_gen_sizes(bool, bool)
        -264 (-100.00% of base) : 1134.dasm - WKS::GCHeap::ApproxTotalBytesInUse(int)
        -240 (-100.00% of base) : 1072.dasm - WKS::gc_heap::trigger_ephemeral_gc(gc_reason, WKS::enter_msl_status*)
        -635 (-100.00% of base) : 1069.dasm - WKS::exclusive_sync::uoh_alloc_set(unsigned char*)
        -418 (-100.00% of base) : 1068.dasm - WKS::gc_heap::bgc_uoh_alloc_clr(unsigned char*, unsigned long, alloc_context*, unsigned int, int, int, int, int, WKS::heap_segment*)
        -612 (-100.00% of base) : 1121.dasm - WKS::gc_heap::scan_background_roots(void (*)(Object**, ScanContext*, unsigned int), int, ScanContext*)
        -737 (-100.00% of base) : 1064.dasm - WKS::exclusive_sync::init()
        -192 (-100.00% of base) : 1061.dasm - WKS::gc_heap::create_bgc_threads_support(int)
          -2 (-100.00% of base) : 1057.dasm - WKS::gc_heap::fire_alloc_wait_event_end(WKS::alloc_wait_reason)
          -2 (-100.00% of base) : 1056.dasm - WKS::gc_heap::fire_alloc_wait_event_begin(WKS::alloc_wait_reason)
        -826 (-100.00% of base) : 1055.dasm - WKS::gc_heap::reset_write_watch(int)
        -248 (-100.00% of base) : 1054.dasm - WKS::gc_heap::background_delay_delete_uoh_segments()
       -1560 (-100.00% of base) : 1106.dasm - WKS::gc_heap::bgc_tuning::calculate_tuning(int, bool)
        -216 (-100.00% of base) : 1052.dasm - WKS::gc_heap::decommit_heap_segment(WKS::heap_segment*)
        -958 (-100.00% of base) : 1147.dasm - SoftwareWriteWatch::GetDirty(void*, unsigned long, void**, unsigned long*, bool, bool)
```