### PR TITLE
[NativeAOT-LLVM] Enable bigint in emscripten linking

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -538,6 +538,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" />
       <CustomLinkerArg Include="-s GLOBAL_BASE=$(IlcWasmGlobalBase)" />
       <CustomLinkerArg Include="-s TOTAL_STACK=$(IlcWasmStackSize)" />
+      <CustomLinkerArg Include="-s WASM_BIGINT=1" />
       <CustomLinkerArg Condition="'$(WasmEnableJSBigIntIntegration)' == 'true'" Include="-s WASM_BIGINT=1" />
       <CustomLinkerArg Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'" Include="-s DISABLE_EXCEPTION_CATCHING=0" />
       


### PR DESCRIPTION
This PR adds `-s WASM_BIGINT` to the linking step for emscripten (not wasi where we link without emscripten and without javascript support so this doesn't apply).  https://emscripten.org/docs/optimizing/Optimizing-Code.html?highlight=wasm_bigint

Bigint is widely supported now in browsers : https://caniuse.com/bigint

Rough measurements for HelloWasm using powershell
```
Measure-Command {start-process "C:/github/emsdk/upstream/emscripten/emcc.bat" -argumentList "@C:\github\runtimelab\artifacts\tests\coreclr/obj/browser.wasm.Debug/Managed/nativeaot\SmokeTests\HelloWasm\HelloWasm\native\link.rsp --js-library C:\github\runtimelab\src\tests\nativeaot\SmokeTests\HelloWasm\dotnet_support.js --pre-js C:\github\runtimelab\src\tests\nativeaot\SmokeTests\HelloWasm\Microsoft.JSInterop.js --pre-js C:\github\runtimelab\src\tests\nativeaot\SmokeTests\HelloWasm\shell.js --post-js C:\github\runtimelab\src\tests\nativeaot\SmokeTests\HelloWasm\HelloWasm.js" -Wait}
```

And the equivalent for the release build.

Debug
Current : 23191 ms
WIth Bigint: 2035 ms

Release:
Current: 6086 ms
With Bigint: 2028 ms

This improvement, as I understand it, is due to the fact that legalizing i64 is an expensive operation which we naturally avoid enabling BIGINT.
