### PR TITLE
[NativeAOT-LLVM] Implement lazy PI

### DIFF
--- a/docs/using-nativeaot/wasm-interop.md
+++ b/docs/using-nativeaot/wasm-interop.md
@@ -1,0 +1,18 @@
+# WebAssembly interop in NativeAOT
+
+Traditionally, .NET uses lazy PInvoke resolution by default, meaning that managed
+calls are bound to their native counterparts when the PInvoke method is first used.
+
+WebAssembly, as a platform, does not support lazy resolution of functions coming
+from outside the compiled module. This means that by default, PInvoke calls in code
+compiled to WebAssembly with NativeAOT will throw `PlatformNotSupportedException`.
+
+Interacting with native code therefore requires an additional gesture to determine
+what kind of linkage should the AOT compiler use. There are two options:
+
+1) If the native code will be linked-in statically, use [`<DirectPInvoke />`](interop.md).
+2) If the native code will be provided to the WebAssembly module at instantiation time
+   as an import, use the `[WasmImportLinkageAttribute]` on your PInvoke declaration.
+
+Note that the various APIs Emscripten provides to interact with JS fall into the
+first category.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.LazyPInvoke.NotSupported.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.LazyPInvoke.NotSupported.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Internal.Runtime.CompilerHelpers
+{
+    internal static partial class InteropHelpers
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe IntPtr ResolvePInvoke(MethodFixupCell* _)
+        {
+            // We want to aggressively inline this method so that the fixup cell is not retained.
+            return ThrowLazyPInvokeResolutionNotSupportedException();
+        }
+
+        private static IntPtr ThrowLazyPInvokeResolutionNotSupportedException()
+        {
+            // TODO-LLVM-Upstream: use a proper SR.* resource.
+            // TOOD-LLVM-Upstream: factor the "supported" path as an additional file instead of the ifdef.
+            throw new PlatformNotSupportedException("""
+                Lazy PInvoke resolution is not supported when targeting WebAssembly.
+                See https://github.com/dotnet/runtimelab/blob/feature/NativeAOT-LLVM/docs/using-nativeaot/wasm-interop.md.
+                """);
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/InteropHelpers.cs
@@ -22,7 +22,7 @@ namespace Internal.Runtime.CompilerHelpers
     /// <summary>
     /// These methods are used to throw exceptions from generated code.
     /// </summary>
-    internal static class InteropHelpers
+    internal static partial class InteropHelpers
     {
         internal static unsafe byte* StringToAnsiString(string str, bool bestFit, bool throwOnUnmappableChar)
         {
@@ -245,6 +245,7 @@ namespace Internal.Runtime.CompilerHelpers
             return Marshal.PtrToStringAnsi((IntPtr)buffer, (int)Marshal.SysStringByteLen((IntPtr)buffer));
         }
 
+#if !TARGET_WASM
         internal static unsafe IntPtr ResolvePInvoke(MethodFixupCell* pCell)
         {
             if (pCell->Target != IntPtr.Zero)
@@ -409,6 +410,7 @@ namespace Internal.Runtime.CompilerHelpers
 
             return Interop.Kernel32.GetProcAddress(hModule, probedMethodName);
         }
+#endif
 #endif
 
         internal static unsafe void* CoTaskMemAllocAndZeroMemory(int size)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\StartupCodeHelpers.Extensions.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\ArrayHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\InteropHelpers.cs" />
+    <Compile Include="Internal\Runtime\CompilerHelpers\InteropHelpers.LazyPInvoke.NotSupported.cs" Condition="'$(TargetsWasm)' == 'true'" />
     <Compile Include="Internal\Runtime\CompilerHelpers\LdTokenHelpers.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\RuntimeInteropData.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\SynchronizedMethodHelpers.cs" />


### PR DESCRIPTION
Add a WASM-specific `ResolvePInvoke` that simply throws.

Add a small document explaining the two PI linkage options and link to it from the PNSE exception message.

Contributes to #2454. It turns out that https://github.com/dotnet/runtimelab/issues/2454#issuecomment-1846093232 requires work not directly related to that issue:
1) `-sERROR_ON_UNDEFINED_SYMBOLS=0` will have to stay because Emscripten warns on (expectedly) unresolved WASM imports. It will have to be fixed upstream.
2) WASI needs some ICU fixups.

Even once the above two are fixed, we should do something like enable warnings by default, and escalate them to errors only if the relevant MSBuildism is set. We would not want people's builds to fail due to a random missing symbol somewhere (...in the BCL...).