### PR TITLE
[NativeAOT-LLVM] Implement most of globalization

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -63,7 +63,8 @@
     <DefaultCoreClrSubsets Condition="'$(PrimaryRuntimeFlavor)' != 'CoreCLR'">clr.iltools+clr.packages</DefaultCoreClrSubsets>
 
     <DefaultNativeAotSubsets>clr.alljits+clr.tools+clr.nativeaotlibs+clr.nativeaotruntime</DefaultNativeAotSubsets>
-    <DefaultNativeAotSubsets Condition="'$(TargetArchitecture)' == 'wasm'">clr.nativeaotlibs+clr.nativeaotruntime+nativeaot.build+mono.wasmruntime</DefaultNativeAotSubsets>
+    <DefaultNativeAotSubsets Condition="'$(TargetsWasm)' == 'true'">clr.nativeaotlibs+clr.nativeaotruntime+nativeaot.build</DefaultNativeAotSubsets>
+    <DefaultNativeAotSubsets Condition="'$(TargetsBrowser)' == 'true'">$(DefaultNativeAotSubsets)+mono.wasmruntime</DefaultNativeAotSubsets>
 
     <DefaultMonoSubsets Condition="'$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMDir)' == ''">mono.llvm+</DefaultMonoSubsets>
     <DefaultMonoSubsets Condition="'$(MonoAOTEnableLLVM)' == 'true' and '$(MonoLLVMDir)' == ''">mono.llvm+</DefaultMonoSubsets>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -506,9 +506,16 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeBinary)))" />
 
+    <ItemGroup Condition="'$(InvariantGlobalization)' != 'true'">
+      <NativeLibrary Include="$(IlcFrameworkNativePath)libicuuc.a" />
+      <NativeLibrary Include="$(IlcFrameworkNativePath)libicui18n.a" />
+      <NativeLibrary Include="$(IlcFrameworkNativePath)libicudata.a" />
+      <NativeLibrary Include="$(IlcFrameworkNativePath)libSystem.Globalization.Native.a" />
+      <NativeLibrary Include="$(IlcFrameworkNativePath)libSystem.Globalization.Native.Icudt.a" />
+    </ItemGroup>
+
     <ItemGroup>
       <NativeLibrary Include="$(IlcFrameworkNativePath)libSystem.Native.a" />
-      <NativeLibrary Include="$(IlcFrameworkNativePath)libSystem.Globalization.Native.a" />
       <NativeLibrary Condition="$(NativeLib) == '' and '$(CustomNativeMain)' != 'true'" Include="$(IlcSdkPath)libbootstrapper.o" />
       <NativeLibrary Condition="$(NativeLib) != '' or '$(CustomNativeMain)' == 'true'" Include="$(IlcSdkPath)libbootstrapperdll.o" />
       <NativeLibrary Include="$(IlcSdkPath)libPortableRuntime.a" />
@@ -555,8 +562,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup Condition ="'$(_targetOS)' == 'wasi'" >
       <CustomLinkerArg Include="--sysroot=&quot;$(WASI_SDK_PATH.Replace(&quot;\&quot;, &quot;/&quot;))/share/wasi-sysroot&quot;" />
       <CustomLinkerArg Include="@(CustomLinkerArgExport->'-Wl,--export=%(Identity)')" />
-      <!-- Wasi has lots of undefined symbols currently, mostly globalization -->
-      <CustomLinkerArg Include="-Wl,--unresolved-symbols=ignore-all -Wl,--error-limit=0" />
+      <!-- We want to put 'warn-unresolved-symbols' here, but wasm-ld crashs on that. Oops. -->
+      <CustomLinkerArg Include="-Wl,--unresolved-symbols=ignore-all" />
       <CustomLinkerArg Include="-lstdc++ -lwasi-emulated-process-clocks -lwasi-emulated-signal -lwasi-emulated-getpid" />
       <CustomLinkerArg Include="-Wl,--max-memory=2147483648" />
       <CustomLinkerArg Include="-Wl,--global-base=$(IlcWasmGlobalBase)" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -562,7 +562,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup Condition ="'$(_targetOS)' == 'wasi'" >
       <CustomLinkerArg Include="--sysroot=&quot;$(WASI_SDK_PATH.Replace(&quot;\&quot;, &quot;/&quot;))/share/wasi-sysroot&quot;" />
       <CustomLinkerArg Include="@(CustomLinkerArgExport->'-Wl,--export=%(Identity)')" />
-      <!-- We want to put 'warn-unresolved-symbols' here, but wasm-ld crashs on that. Oops. -->
+      <!-- TODO-LLVM: change to 'warn-unresolved-symbols' once we have a WASI SDK with https://github.com/llvm/llvm-project/pull/78643. -->
       <CustomLinkerArg Include="-Wl,--unresolved-symbols=ignore-all" />
       <CustomLinkerArg Include="-lstdc++ -lwasi-emulated-process-clocks -lwasi-emulated-signal -lwasi-emulated-getpid" />
       <CustomLinkerArg Include="-Wl,--max-memory=2147483648" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1349,7 +1349,7 @@
     <Compile Include="$(CommonPath)Interop\Interop.ICU.cs">
       <Link>Common\Interop\Interop.ICU.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)Interop\Interop.ICU.iOS.cs" Condition="'$(IsiOSLike)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\Interop.ICU.iOS.cs" Condition="'$(IsiOSLike)' == 'true' or ('$(TargetsWasm)' == 'true' and '$(FeatureNativeAot)' == 'true')">
       <Link>Common\Interop\Interop.ICU.iOS.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)Interop\Interop.Idna.cs">
@@ -2468,8 +2468,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureData.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\CultureInfo.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\GlobalizationMode.Unix.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\GlobalizationMode.LoadICU.Unix.cs" Condition="'$(IsiOSLike)' != 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\GlobalizationMode.LoadICU.iOS.cs" Condition="'$(IsiOSLike)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\GlobalizationMode.LoadICU.Unix.cs" Condition="'$(IsiOSLike)' != 'true' and ('$(TargetsWasm)' != 'true' or '$(FeatureNativeAot)' != 'true')" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\GlobalizationMode.LoadICU.iOS.cs" Condition="'$(IsiOSLike)' == 'true' or ('$(TargetsWasm)' == 'true' and '$(FeatureNativeAot)' == 'true')" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Globalization\HijriCalendar.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Guid.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\Directory.Unix.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -12,11 +12,7 @@ namespace System.Globalization
         // validate this implementation detail.
         private static partial class Settings
         {
-#if TARGET_WASM
-            internal static bool Invariant { get; } = true;
-#else
             internal static bool Invariant { get; } = AppContextConfigHelper.GetBooleanConfig("System.Globalization.Invariant", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
-#endif
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             internal static bool Hybrid { get; } = true;
 #elif TARGET_BROWSER

--- a/src/native/libs/System.Globalization.Native/CMakeLists.txt
+++ b/src/native/libs/System.Globalization.Native/CMakeLists.txt
@@ -160,12 +160,6 @@ if(CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_WASI)
     set_target_properties(System.Globalization.Native-Static PROPERTIES OUTPUT_NAME System.Globalization.Native  CLEAN_DIRECT_OUTPUT 1)
 endif()
 
-if (CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
-   add_custom_command(TARGET System.Globalization.Native-Static
-       POST_BUILD 
-       COMMAND ${CMAKE_AR} qL $<TARGET_FILE:System.Globalization.Native-Static> ${CMAKE_ICU_DIR}/lib/libicuuc.a ${CMAKE_ICU_DIR}/lib/libicui18n.a ${CMAKE_ICU_DIR}/lib/libicudata.a)
-endif()
-
 install (TARGETS System.Globalization.Native-Static DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
 
 if(NOT CLR_CMAKE_TARGET_APPLE AND NOT CLR_CMAKE_TARGET_ANDROID AND NOT CLR_CMAKE_TARGET_LINUX_MUSL AND NOT CLR_CMAKE_TARGET_HAIKU)
@@ -178,6 +172,14 @@ if(NOT CLR_CMAKE_TARGET_APPLE AND NOT CLR_CMAKE_TARGET_ANDROID AND NOT CLR_CMAKE
             VERBATIM
         )
     endif()
+endif()
+
+# Package the ICU data files as static libraries for consumption by NativeAOT targeting WASM.
+if (CLR_CMAKE_TARGET_ARCH_WASM)
+    add_library(System.Globalization.Native.Icudt STATIC icu_data_lib.c)
+    file(TO_CMAKE_PATH "${CMAKE_ICU_DIR}/lib/icudt.dat" icu_data_file)
+    target_compile_options(System.Globalization.Native.Icudt PRIVATE -DICU_DATA_FILE=${icu_data_file})
+    install(TARGETS System.Globalization.Native.Icudt DESTINATION ${STATIC_LIB_DESTINATION} COMPONENT libs)
 endif()
 
 if(CLR_CMAKE_TARGET_WIN32)

--- a/src/native/libs/System.Globalization.Native/icu_data_lib.c
+++ b/src/native/libs/System.Globalization.Native/icu_data_lib.c
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+//
+
 #define STR_IMPL(x) #x
 #define STR(x) STR_IMPL(x)
 

--- a/src/native/libs/System.Globalization.Native/icu_data_lib.c
+++ b/src/native/libs/System.Globalization.Native/icu_data_lib.c
@@ -1,0 +1,14 @@
+#define STR_IMPL(x) #x
+#define STR(x) STR_IMPL(x)
+
+// Ideally, we would use actual assembly (.S), but Cmake doesn't recognize emcc as a valid assembler.
+__asm(
+    "  .section .data,\"\",@\n"
+    "  .global static_icu_data\n"
+    "  .align 16\n" // https://unicode-org.github.io/icu/userguide/icu_data/#alignment
+    "static_icu_data:\n"
+    "  .incbin \"" STR(ICU_DATA_FILE) "\"\n"
+    "static_icu_data_end:\n"
+    "  .size static_icu_data, static_icu_data_end - static_icu_data\n"
+    "  .size static_icu_data_end, 1\n"
+);

--- a/src/native/libs/System.Globalization.Native/icu_data_lib.c
+++ b/src/native/libs/System.Globalization.Native/icu_data_lib.c
@@ -9,10 +9,10 @@
 __asm(
     "  .section .data,\"\",@\n"
     "  .global static_icu_data\n"
-    "  .align 16\n" // https://unicode-org.github.io/icu/userguide/icu_data/#alignment
+    "  .balign 16\n" // https://unicode-org.github.io/icu/userguide/icu_data/#alignment
     "static_icu_data:\n"
     "  .incbin \"" STR(ICU_DATA_FILE) "\"\n"
     "static_icu_data_end:\n"
     "  .size static_icu_data, static_icu_data_end - static_icu_data\n"
-    "  .size static_icu_data_end, 1\n"
+    "  .size static_icu_data_end, 0\n"
 );

--- a/src/native/libs/System.Globalization.Native/pal_icushim_static.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim_static.c
@@ -186,6 +186,11 @@ GlobalizationNative_LoadICUData(const char* path)
     }
 #endif
 
+#ifdef TARGET_WASM
+    extern char static_icu_data; // Linked-in data packaged via "icu_data_lib".
+    const char *icu_data = &static_icu_data;
+#else // !TARGET_WASM
+
     const char *icu_data = cstdlib_load_icu_data(path);
 
     if (icu_data == NULL)
@@ -193,6 +198,7 @@ GlobalizationNative_LoadICUData(const char* path)
         log_shim_error("Failed to load ICU data.");
         return 0;
     }
+#endif // !TARGET_WASM
 
     if (load_icu_data(icu_data) == 0)
     {

--- a/src/native/libs/build-native.proj
+++ b/src/native/libs/build-native.proj
@@ -30,8 +30,21 @@
     <PackageReference Include="Microsoft.NETCore.Runtime.ICU.Transport" PrivateAssets="all" Version="$(MicrosoftNETCoreRuntimeICUTransportVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 
+  <Target Name="BuildNativeCommon"
+          DependsOnTargets="GenerateNativeVersionFile">
+    <ItemGroup>
+      <_IcuArtifacts Condition="'$(_IcuDir)' != '' and '$(TargetsAppleMobile)' != 'true'"
+                     Include="$(_IcuDir)/lib/libicuuc.a;
+                              $(_IcuDir)/lib/libicui18n.a;
+                              $(_IcuDir)/lib/libicudata.a;
+                              $(_IcuDir)/lib/*.dat" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_IcuArtifacts)" DestinationFolder="$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(_BuildNativeOutConfig)'))" SkipUnchangedFiles="true" />
+  </Target>
+
   <Target Name="BuildNativeUnix"
-          DependsOnTargets="GenerateNativeVersionFile"
+          DependsOnTargets="BuildNativeCommon"
           BeforeTargets="Build"
           Condition="!$([MSBuild]::IsOsPlatform(Windows))">
     <PropertyGroup>
@@ -54,21 +67,12 @@
       <_BuildNativeUnixArgs>$(_BuildNativeArgs)$(_ProcessorCountArg)$(_PortableBuildArg)$(_CrossBuildArg)$(_BuildNativeCompilerArg)$(_KeepNativeSymbolsBuildArg)$(_CMakeArgs) $(Compiler)</_BuildNativeUnixArgs>
     </PropertyGroup>
 
-    <ItemGroup>
-      <_IcuArtifacts Condition="'$(_IcuDir)' != '' and '$(TargetsAppleMobile)' != 'true'"
-                     Include="$(_IcuDir)/lib/libicuuc.a;
-                              $(_IcuDir)/lib/libicui18n.a;
-                              $(_IcuDir)/lib/libicudata.a;
-                              $(_IcuDir)/lib/*.dat" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(_IcuArtifacts)" DestinationFolder="$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'native', '$(_BuildNativeOutConfig)'))" SkipUnchangedFiles="true" />
     <Message Text="$(MSBuildThisFileDirectory)build-native.sh $(_BuildNativeUnixArgs)" Importance="High"/>
     <Exec Command="&quot;$(MSBuildThisFileDirectory)build-native.sh&quot; $(_BuildNativeUnixArgs)" />
   </Target>
 
   <Target Name="BuildNativeWindows"
-          DependsOnTargets="GenerateNativeVersionFile"
+          DependsOnTargets="BuildNativeCommon"
           BeforeTargets="Build"
           Condition="$([MSBuild]::IsOsPlatform(Windows))">
     <PropertyGroup>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -13,6 +13,8 @@ using System.Reflection;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Collections.Specialized;
+using System.Globalization;
+
 using CpObj;
 using CkFinite;
 
@@ -398,6 +400,8 @@ internal unsafe partial class Program
         }
 
         TestPalRandom();
+
+        TestGlobalization();
 
         TestDefaultConstructorOf();
 
@@ -3961,6 +3965,27 @@ internal unsafe partial class Program
         StartTest("Test pal_random.lib.js integration");
 
         EndTest(Guid.NewGuid() != Guid.NewGuid());
+    }
+
+    static void TestGlobalization()
+    {
+        StartTest("Test simple globalization");
+
+        CultureInfo jp = CultureInfo.GetCultureInfo("jp");
+        if (jp.CompareInfo.Compare("さようなら", "サヨウナラ", CompareOptions.IgnoreKanaType) != 0)
+        {
+            FailTest("Kana-insensitive comparison failed");
+            return;
+        }
+
+        CultureInfo ru = CultureInfo.GetCultureInfo("ru");
+        if (ru.TextInfo.ToTitleCase("до свидания") != "До Свидания")
+        {
+            FailTest("ToTitleCase(ru) comparison failed");
+            return;
+        }
+
+        PassTest();
     }
 
     static void TestDefaultConstructorOf()


### PR DESCRIPTION
How this works:
1) At runtime build time, we receive a transport package with the ICU libraries and data (`icudt.dat` and friends).
2) We package the data file into a static library with some inline assembly magic. We add a bit of code to the shim to locate the symbol in this static library, and tweak the CoreLib code to invoke that path on NativeAOT+WASM.
3) We package all of the resulting ICU static libraries into the runtime package, just like `libSystem.Native.a` and friends.
4) We link in the necessary pieces with the usual mechanism.

Overall few changes are required, but this is notably different from what Mono does, which runs some code at runtime startup that locates the ICU data (either by downloading it, or from the file system, or from the single-file bundle). It means that our `DotNetJsApi` case will still use the static data, but do that startup thing too. We can cross the bridge of reconciling these two approaches once `DotNetJsApi` gets a little more mature.

Another part not yet working is the time zone data, which uses Mono-specific bundling mechanism. It is the last undefined symbol for `HelloWasm` targeting WASI, I will tackle it separately (in #2491).