### PR TITLE
[NativeAOT-LLVM] Don't use `mmap` in the frozen object manager and enable writeable data

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/MethodTable.cs
@@ -190,8 +190,7 @@ namespace Internal.Runtime
         {
             get
             {
-                // For now just key this off of SupportsRelativePointer to avoid this on both CppCodegen and WASM.
-                return SupportsRelativePointers;
+                return true;
             }
         }
 
@@ -1184,7 +1183,7 @@ namespace Internal.Runtime
 
                 uint offset = GetFieldOffset(EETypeField.ETF_WritableData);
 
-                if (!IsDynamicType)
+                if (!IsDynamicType && SupportsRelativePointers)
                     return (void*)GetField<RelativePointer>(offset).Value;
                 else
                     return (void*)GetField<Pointer>(offset).Value;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Wasm.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Wasm.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable IDE0060 // Remove unused parameter
+
+using System.Runtime.InteropServices;
+
+namespace Internal.Runtime
+{
+    internal unsafe partial class FrozenObjectHeapManager
+    {
+        private static void* ClrVirtualReserve(nuint size)
+        {
+            void* alloc = Interop.Sys.AlignedAlloc(8, size);
+            if (alloc != null)
+            {
+                NativeMemory.Clear(alloc, size);
+            }
+            return alloc;
+        }
+
+        private static void* ClrVirtualCommit(void* pBase, nuint size)
+        {
+            // Already 'commited'.
+            return pBase;
+        }
+
+        private static void ClrVirtualFree(void* pBase, nuint size)
+        {
+            // This will only be called before an OOM. We have no way to do a partial unmap, so do not try.
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -19,8 +19,13 @@ namespace Internal.Runtime
         private readonly LowLevelLock m_Crst = new LowLevelLock();
         private FrozenObjectSegment m_CurrentSegment;
 
+#if TARGET_WASM
+        // WASM doesn't support reserving memory so we use a smaller size.
+        private const nuint FOH_SEGMENT_DEFAULT_SIZE = 64 * 1024;
+#else
         // Default size to reserve for a frozen segment
         private const nuint FOH_SEGMENT_DEFAULT_SIZE = 4 * 1024 * 1024;
+#endif
         // Size to commit on demand in that reserved space
         private const nuint FOH_COMMIT_SIZE = 64 * 1024;
 
@@ -119,7 +124,7 @@ namespace Internal.Runtime
             {
                 m_Size = sizeHint;
 
-                Debug.Assert(m_Size > FOH_COMMIT_SIZE);
+                Debug.Assert(m_Size >= FOH_COMMIT_SIZE);
                 Debug.Assert(m_Size % FOH_COMMIT_SIZE == 0);
 
                 void* alloc = ClrVirtualReserve(m_Size);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -307,7 +307,8 @@
     <Compile Include="System\Threading\ThreadPoolCallbackWrapper.NativeAot.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true' or '$(TargetsBrowser)'=='true' or '$(TargetsWasi)'=='true'">
-    <Compile Include="Internal\Runtime\FrozenObjectHeapManager.Unix.cs" />
+    <Compile Include="Internal\Runtime\FrozenObjectHeapManager.Unix.cs" Condition="'$(TargetsWasm)' != 'true'" />
+    <Compile Include="Internal\Runtime\FrozenObjectHeapManager.Wasm.cs" Condition="'$(TargetsWasm)' == 'true'" />
     <Compile Include="System\Environment.NativeAot.Unix.cs" />
     <Compile Include="System\Runtime\InteropServices\NativeLibrary.NativeAot.Unix.cs" />
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Unix.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -103,8 +103,7 @@ namespace ILCompiler.DependencyAnalysis
             factory.TypeSystemContext.EnsureLoadableType(type);
         }
 
-        public static bool SupportsWritableData(TargetDetails target)
-            => target.SupportsRelativePointers;
+        public static bool SupportsWritableData(TargetDetails target) => true;
 
         public static bool SupportsFrozenRuntimeTypeInstances(TargetDetails target)
             => SupportsWritableData(target);
@@ -1125,11 +1124,17 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (_writableDataNode != null)
             {
-                objData.EmitReloc(_writableDataNode, RelocType.IMAGE_REL_BASED_RELPTR32);
+                if (factory.Target.SupportsRelativePointers)
+                    objData.EmitReloc(_writableDataNode, RelocType.IMAGE_REL_BASED_RELPTR32);
+                else
+                    objData.EmitPointerReloc(_writableDataNode);
             }
             else if (SupportsWritableData(factory.Target))
             {
-                objData.EmitInt(0);
+                if (factory.Target.SupportsRelativePointers)
+                    objData.EmitInt(0);
+                else
+                    objData.EmitZeroPointer();
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMObjectWriter.cs
@@ -248,6 +248,8 @@ namespace ILCompiler.DependencyAnalysis
                 if (nextRelocValid)
                 {
                     Relocation reloc = nodeContents.Relocs[relocIndex];
+                    Debug.Assert(IsSupportedRelocType(node, reloc.RelocType), $"{reloc.RelocType} in {node} not supported");
+
                     long delta;
                     fixed (void* location = &data[reloc.Offset])
                     {
@@ -311,6 +313,16 @@ namespace ILCompiler.DependencyAnalysis
             {
                 _keepAliveList.Add(dataSymbol);
             }
+        }
+
+        private static bool IsSupportedRelocType(ObjectNode node, RelocType type)
+        {
+            if (node is StackTraceMethodMappingNode)
+            {
+                // Stack trace metadata uses relative pointers, but is currently unused.
+                return true;
+            }
+            return type is RelocType.IMAGE_REL_BASED_HIGHLOW;
         }
 
         private void EmitSymbolDef(LLVMValueRef baseSymbol, ReadOnlySpan<byte> symbolIdentifier, int offsetFromBaseSymbol)

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -55,9 +55,7 @@ internal class Program
         TestReadOnlySpan.Run();
         TestStaticInterfaceMethod.Run();
         TestConstrainedCall.Run();
-#if !CODEGEN_WASM
         TestTypeHandles.Run();
-#endif
         TestIsValueType.Run();
         TestIndirectLoads.Run();
         TestInitBlock.Run();


### PR DESCRIPTION
Fixes #2476.
Fixes #2477.

The latter part part of this change will be upstreamed.