### PR TITLE
[NativeAOT-LLVM] Enable warn-as-error for libraries tests in CI

### DIFF
--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -59,10 +59,9 @@ steps:
         displayName: Run tests in single file mode
 
   - ${{ if and(ne(parameters.isOfficialBuild, true), eq(parameters.archType, 'wasm')) }}:
-    # We disable warn-as-error due to missing symbols warnings from emcc.
     - script: |
           call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-          $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -test -warnAsError 0 -a ${{ parameters.archType }} -os ${{ parameters.osGroup }} -lc ${{ parameters.librariesConfiguration }} -rc $(buildConfigUpper) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true
+          $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -test -a ${{ parameters.archType }} -os ${{ parameters.osGroup }} -lc ${{ parameters.librariesConfiguration }} -rc $(buildConfigUpper) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true
       displayName: Build and run WebAssembly libraries tests
 
 # Upload unsigned artifacts

--- a/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
@@ -33,6 +33,9 @@
     <EmccExportedRuntimeMethod Include="runtimeKeepalivePush" />
     <EmccExportedRuntimeMethod Include="runtimeKeepalivePop" />
     <EmccExportedRuntimeMethod Include="callMain" />
+
+    <!-- Pseudo-namespace for the JS interop symbols. -->
+    <DirectPInvoke Include="System.Runtime.InteropServices.JavaScript" />
   </ItemGroup>
 
   <Target Name="PrepareDotNetJsApiForLinking">

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -285,8 +285,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(DirectPInvoke->'--directpinvoke:%(Identity)')" />
       <IlcArg Include="@(DirectPInvokeList->'--directpinvokelist:%(Identity)')" />
-      <IlcArg Include="@(WasmImport->'--wasmimport:%(Identity)')" />
-      <IlcArg Include="@(WasmImportList->'--wasmimportlist:%(Identity)')" />
       <IlcArg Include="@(_TrimmerFeatureSettings->'--feature:%(Identity)=%(Value)')" />
       <IlcArg Include="@(RuntimeHostConfigurationOption->'--runtimeknob:%(Identity)=%(Value)')" />
       <IlcArg Include="--runtimeknob:RUNTIME_IDENTIFIER=$(RuntimeIdentifier)" />

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.NativeAOT.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.NativeAOT.cs
@@ -10,15 +10,17 @@ internal static partial class Interop
 {
     internal static unsafe partial class Runtime
     {
+        private const string JSLibrary = "System.Runtime.InteropServices.JavaScript";
+
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern void ReleaseCSOwnedObject(IntPtr jsHandle);
-        [LibraryImport("*", EntryPoint = "mono_wasm_bind_js_import", StringMarshalling = StringMarshalling.Utf16)]
+        [LibraryImport(JSLibrary, EntryPoint = "mono_wasm_bind_js_import", StringMarshalling = StringMarshalling.Utf16)]
         public static unsafe partial void BindJSImport(void* signature, out int is_exception, out IntPtr result);
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void InvokeJSFunction(IntPtr bound_function_js_handle, void* data);
-        [LibraryImport("*", EntryPoint = "mono_wasm_invoke_js_import", StringMarshalling = StringMarshalling.Utf16)]
+        [LibraryImport(JSLibrary, EntryPoint = "mono_wasm_invoke_js_import", StringMarshalling = StringMarshalling.Utf16)]
         public static unsafe partial void InvokeJSImport(IntPtr fn_handle, void* data);
-        [LibraryImport("*", EntryPoint = "mono_wasm_bind_cs_function", StringMarshalling = StringMarshalling.Utf16)]
+        [LibraryImport(JSLibrary, EntryPoint = "mono_wasm_bind_cs_function", StringMarshalling = StringMarshalling.Utf16)]
         public static unsafe partial void BindCSFunction(string fully_qualified_name, int fully_qualified_name_length, int signature_hash, void* signature, out int is_exception);
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void ResolveOrRejectPromise(void* data);


### PR DESCRIPTION
The recent changes now enable us to do this.

Contributes to #2455.