### PR TITLE
[NativeAOT-LLVM] Do not create useless 'alloca's for shadow locals

### DIFF
--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1479,7 +1479,7 @@ PhaseStatus Llvm::AddVirtualUnwindFrame()
             }
 
             ClassLayout* unwindFrameLayout = m_compiler->typGetBlkLayout(3 * TARGET_POINTER_SIZE);
-            unsigned unwindFrameLclNum = m_compiler->lvaGrabTempWithImplicitUse(false DEBUGARG("virtual unwind frame"));
+            unsigned unwindFrameLclNum = m_compiler->lvaGrabTemp(false DEBUGARG("virtual unwind frame"));
             m_compiler->lvaSetStruct(unwindFrameLclNum, unwindFrameLayout, /* unsafeValueClsCheck */ false);
             m_compiler->lvaSetVarAddrExposed(unwindFrameLclNum DEBUGARG(AddressExposedReason::ESCAPE_ADDRESS));
             m_compiler->lvaGetDesc(unwindFrameLclNum)->lvHasExplicitInit = true;


### PR DESCRIPTION
Most shadow locals do not need to be materialized in `alloca`s or LLVM registers. Account for this by maintaining an accurate reference count of them during LSSA.

Diffs (debug code, there are none in optimized code, as expected):
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 16135112
Total bytes of diff: 15594933
Total bytes of delta: -540179 (-3.35% % of base)
Average relative delta: -6.62%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
         197 ( 8.16% of base) : 6654.dasm - S_P_CoreLib_System_Globalization_CalendricalCalculationsHelper__EquationOfTime
         345 ( 5.57% of base) : 7436.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__CompareTypeSigs
          93 ( 5.03% of base) : 4514.dasm - S_P_CoreLib_System_TimeZoneInfo__ParseTimeOfDay
         293 ( 4.01% of base) : 4504.dasm - S_P_CoreLib_System_DateTimeFormat__TryFormatR<Char>
          68 ( 3.76% of base) : 6536.dasm - S_P_CoreLib_System_Number__TryUInt32ToBinaryStr<UInt8>
         109 ( 3.75% of base) : 1624.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_ConstraintValidator__SatisfiesConstraints
         569 ( 3.59% of base) : 4812.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Char__UInt64>
         569 ( 3.59% of base) : 4286.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Char__Int64>
          49 ( 3.34% of base) : 5937.dasm - S_P_CoreLib_System_Number__TryUInt32ToBinaryStr<Char>
         522 ( 3.32% of base) : 3900.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Char__UInt32>
         522 ( 3.32% of base) : 4281.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Char__Int32>
         526 ( 3.27% of base) : 4291.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Char__UInt8>
          60 ( 3.26% of base) : 6537.dasm - S_P_CoreLib_System_Number__TryInt32ToHexStr<UInt8>
         526 ( 3.26% of base) : 7448.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Char__UInt16>
         526 ( 3.22% of base) : 2903.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Char__Int8>
         526 ( 3.22% of base) : 4297.dasm - S_P_CoreLib_System_Number__TryParseBinaryIntegerStyle<Char__Int16>
          82 ( 3.11% of base) : 4502.dasm - S_P_CoreLib_System_DateTimeFormat__TryFormatu<Char>
          63 ( 2.96% of base) : 4503.dasm - S_P_CoreLib_System_DateTimeFormat__TryFormatS<Char>
          86 ( 2.85% of base) : 2129.dasm - S_P_CoreLib_System_Number__FindSection
          41 ( 2.75% of base) : 5108.dasm - S_P_CoreLib_System_Number__TryInt64ToHexStr<Char>

Top method improvements (percentages):
         -99 (-61.11% of base) : 5776.dasm - S_P_CoreLib_System_Runtime_GCStress__Initialize
       -1285 (-53.08% of base) : 2916.dasm - S_P_CoreLib_System_Runtime_RuntimeExports__RhpCalculateStackTraceWorker
         -71 (-51.82% of base) : 2929.dasm - S_P_CoreLib_Interop_Sys__Abort
         -71 (-51.82% of base) : 3960.dasm - HelloWasm_Program__NativeIntToDoubleWrongAnother
         -71 (-51.82% of base) : 3964.dasm - HelloWasm_Program__MemSetWrongAnother
         -57 (-51.82% of base) : 3316.dasm - S_P_CoreLib_System_Globalization_OrdinalCasing__get_NoCasingPage
         -57 (-49.14% of base) : 6168.dasm - S_P_CoreLib_System_GC__GetGCMemoryInfo
         -57 (-47.50% of base) : 7503.dasm - S_P_CoreLib_System_SR__get_IO_SeekAppendOverwrite
         -57 (-47.50% of base) : 5448.dasm - S_P_CoreLib_System_SR__get_Format_InvalidString
         -57 (-47.50% of base) : 6451.dasm - S_P_CoreLib_System_SR__get_Argument_InvalidSeekOrigin
         -57 (-47.50% of base) : 3716.dasm - S_P_CoreLib_System_SR__get_InvalidOperation_DateTimeParsing
         -57 (-47.50% of base) : 6085.dasm - S_P_CoreLib_System_SR__get_ArgumentOutOfRange_DateArithmetic
         -57 (-47.50% of base) : 5958.dasm - S_P_CoreLib_System_SR__get_InvalidOperation_UnknownEnumType
         -68 (-46.58% of base) : 6595.dasm - S_P_CoreLib_System_TimeZoneInfo__GetLocalTimeZoneCore
         -68 (-46.58% of base) : 3468.dasm - S_P_CoreLib_System_Globalization_CultureInfo__GetUserDefaultUICulture
         -57 (-45.24% of base) : 4330.dasm - S_P_CoreLib_System_IO_Path__GetInvalidPathChars
         -30 (-42.86% of base) : 3107.dasm - S_P_CoreLib_System_TimeZoneInfo__GetUtcStandardDisplayName
         -30 (-42.86% of base) : 3522.dasm - S_P_CoreLib_System_AppContext__GetBaseDirectoryCore
        -115 (-39.25% of base) : 4817.dasm - S_P_CoreLib_System_Runtime_InternalCalls__RhpGetGcTotalMemory
         -57 (-38.51% of base) : 3615.dasm - S_P_CoreLib_System_NotImplemented__get_ByDesign

7640 total methods with Code Size differences (7548 improved, 92 regressed)
```
This does not move the needle much in the extreme cases, but it's an improvement nevertheless.