### PR TITLE
[NativeAOT-LLVM] Add support for diffing LLVM bitcode to `wasmjit-diff.ps1`

### DIFF
--- a/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
@@ -11,6 +11,7 @@ Param(
     [switch]$Rebuild,
     [switch]$Analyze,
     [switch]$Summary,
+    [switch]$Llvm,
     [ValidateSet("Debug","Checked","Release")][string]$Config = "Release",
     [ValidateSet("Debug","Checked","Release")][string]$IlcConfig = "Release",
     [Nullable[bool]]$DebugSymbols = $null,
@@ -36,6 +37,7 @@ if ($ShowHelp)
     Write-Host "  -Rebuild             : Force-build the 'base' to diff against"
     Write-Host "  -Analyze             : Analyze the results from two project builds"
     Write-Host "  -Summary             : Analyze the results and only print the summary"
+    Write-Host "  -Llvm                : Analyze LLVM bitcode output instead of WASM"
     Write-Host "  -Config              : Test configuration (Debug/Release). Default is Release"
     Write-Host "  -IlcConfig           : ILC configuration (Debug/Checked/Release). Default is Release"
     Write-Host "  -DebugSymbols        : Whether to build with debug symbols. Default is yes"
@@ -47,7 +49,8 @@ if ($ShowHelp)
     Write-Host " of the diffs as well as disassembly files under the ./wasmjit-diff/ directory, which can be"
     Write-Host " further inspected using tools like git-diff."
     Write-Host ""
-    Write-Host " Note: -Analyze depends on https://github.com/WebAssembly/wabt tools being available in PATH."
+    Write-Host " -Analyze depends on https://github.com/WebAssembly/wabt tools being available in PATH."
+    Write-Host " -Llvm depends on llvm-dis being available in PATH."
     Write-Host ""
     return
 }
@@ -78,6 +81,8 @@ $TestProjectDirectory = [IO.Path]::GetDirectoryName($TestProjectPath)
 $RuntimeTestsDirectory = "$RuntimelabDirectory/src/tests"
 $TestProjectDirectoryRelativePath = [System.IO.Path]::GetRelativePath($RuntimeTestsDirectory, $TestProjectDirectory)
 
+$TestProjectNativeObjDirectory = "$RuntimelabDirectory/artifacts/tests/coreclr/obj/$OS.$Arch.$Config/Managed/$TestProjectDirectoryRelativePath/$TestProjectName/native"
+$TestProjectBaseNativeObjDirectory = "$TestProjectNativeObjDirectory.base"
 $TestProjectNativeOutputDirectory = "$RuntimelabDirectory/artifacts/tests/coreclr/$OS.$Arch.$Config/$TestProjectDirectoryRelativePath/$TestProjectName/native"
 $TestProjectBaseNativeOutputDirectory = "$TestProjectNativeOutputDirectory.base"
 $TestProjectWasmOutput = "$TestProjectNativeOutputDirectory/$TestProjectName.wasm"
@@ -118,6 +123,7 @@ if ($Build -or $Rebuild)
 
     if ($BuildingBase)
     {
+        Rename-Item $TestProjectNativeObjDirectory $TestProjectBaseNativeObjDirectory
         Rename-Item $TestProjectNativeOutputDirectory $TestProjectBaseNativeOutputDirectory
     }
 }
@@ -130,51 +136,114 @@ if ($Analyze -or $Summary)
         exit
     }
 
-    $SummaryLineRegex = [Regex]::New(" - func\[(\d+)\] size=(\d+) <(.*)>", "Compiled")
-    function ParseSummary($RawSummary, $SummaryName)
+    if ($Llvm)
     {
-        Write-Host -NoNewLine "Analysing ${SummaryName}"
-
-        $TotalCodeSize = 0
-        $SummaryList = [Collections.Generic.Dictionary[string, object]]::new()
-        $LineIndex = 0
-        $OutputProgressInterval = [int]($RawSummary.Length / 10)
-        foreach ($Line in $RawSummary)
+        $LlvmSummaryLineRegex = [Regex]::New('define.*@"?([^"]*)"?\(.*\).*{', "Compiled")
+        function ParseLlvmSummary($ObjDirectory, $SummaryName)
         {
-            $Matches = $SummaryLineRegex.Matches($Line).Groups
-            if ($Matches.Count -eq 0)
+            Write-Host -NoNewLine "Analysing ${SummaryName}"
+
+            # Use the results file to be resilient against stale bitcode files.
+            $SummaryList = [Collections.Generic.Dictionary[string, object]]::new()
+            $BitcodeFiles = Get-Content "$ObjDirectory/$TestProjectName.results.txt"
+
+            # The results file in the 'base' directory will refer to the original ('diff') files. Fix this up.
+            for ($i = 0; $i -lt $BitcodeFiles.Length; $i++)
             {
-                continue
+                $FileName = [IO.Path]::GetFileName($BitcodeFiles[$i])
+                $BitcodeFiles[$i] = "$ObjDirectory/$FileName"
             }
 
-            $Index = [int]$Matches[1].Value
-            $Size = [int]$Matches[2].Value
-            $Name = [string]$Matches[3].Value
-
-            $TotalCodeSize += $Size
-            while ($SummaryList.ContainsKey($Name))
+            $BitcodeFileIndex = 0
+            $OutputProgressInterval = [Math]::Max([int]($BitcodeFiles.Length / 10), 1)
+            foreach ($BitcodeFile in $BitcodeFiles)
             {
-                # Sometimes we get duplicates with demangled names that wasm-objdump produces. Tolerate them.
-                $Name += "*"
-            }
-            $SummaryList.Add($Name, @{ Index = $Index; Size = $Size })
+                $LlvmAssembly = llvm-dis $BitcodeFile -o -
 
-            if ($LineIndex % $OutputProgressInterval -eq 0)
-            {
-                Write-Host -NoNewLine "."
+                $LineIndex = -1
+                $CurrentFuncName = $null
+                foreach ($Line in $LlvmAssembly)
+                {
+                    $LineIndex++
+
+                    if ($Line -eq "}")
+                    {
+                        $Size = $LineIndex - $CurrentFuncStartLineIndex
+                        $TotalCodeSize += $Size
+                        $SummaryList.Add($CurrentFuncName, @{ Content = $LlvmAssembly; StartLineIndex = $CurrentFuncStartLineIndex; Size = $Size })
+                        continue;
+                    }
+
+                    $Matches = $LlvmSummaryLineRegex.Matches($Line).Groups
+                    if ($Matches.Count -ne 0)
+                    {
+                        $CurrentFuncName = $Matches[1]
+                        $CurrentFuncStartLineIndex = $LineIndex
+                    }
+                }
+
+                if ($BitcodeFileIndex % $OutputProgressInterval -eq 0)
+                {
+                    Write-Host -NoNewLine "."
+                }
+                $BitcodeFileIndex++
             }
-            $LineIndex++
+            Write-Host ""
+
+            return $SummaryList, $TotalCodeSize
         }
-        Write-Host ""
 
-        return $SummaryList, $TotalCodeSize
+        $BaseSummary, $TotalBaseCodeSize = ParseLlvmSummary $TestProjectBaseNativeObjDirectory "base"
+        $DiffSummary, $TotalDiffCodeSize = ParseLlvmSummary $TestProjectNativeObjDirectory "diff"
     }
+    else
+    {
+        $WasmSummaryLineRegex = [Regex]::New(" - func\[(\d+)\] size=(\d+) <(.*)>", "Compiled")
+        function ParseWasmSummary($RawSummary, $SummaryName)
+        {
+            Write-Host -NoNewLine "Analysing ${SummaryName}"
 
-    $BaseSummaryRaw = wasm-objdump -x -j Code $TestProjectBaseWasmOutput
-    $DiffSummaryRaw = wasm-objdump -x -j Code $TestProjectWasmOutput
+            $TotalCodeSize = 0
+            $SummaryList = [Collections.Generic.Dictionary[string, object]]::new()
+            $LineIndex = 0
+            $OutputProgressInterval = [int]($RawSummary.Length / 10)
+            foreach ($Line in $RawSummary)
+            {
+                $Matches = $WasmSummaryLineRegex.Matches($Line).Groups
+                if ($Matches.Count -eq 0)
+                {
+                    continue
+                }
 
-    $BaseSummary, $TotalBaseCodeSize = ParseSummary $BaseSummaryRaw "base"
-    $DiffSummary, $TotalDiffCodeSize = ParseSummary $DiffSummaryRaw "diff"
+                $Index = [int]$Matches[1].Value
+                $Size = [int]$Matches[2].Value
+                $Name = [string]$Matches[3].Value
+
+                $TotalCodeSize += $Size
+                while ($SummaryList.ContainsKey($Name))
+                {
+                    # Sometimes we get duplicates with demangled names that wasm-objdump produces. Tolerate them.
+                    $Name += "*"
+                }
+                $SummaryList.Add($Name, @{ Index = $Index; Size = $Size })
+
+                if ($LineIndex % $OutputProgressInterval -eq 0)
+                {
+                    Write-Host -NoNewLine "."
+                }
+                $LineIndex++
+            }
+            Write-Host ""
+
+            return $SummaryList, $TotalCodeSize
+        }
+
+        $BaseSummaryRaw = wasm-objdump -x -j Code $TestProjectBaseWasmOutput
+        $DiffSummaryRaw = wasm-objdump -x -j Code $TestProjectWasmOutput
+
+        $BaseSummary, $TotalBaseCodeSize = ParseWasmSummary $BaseSummaryRaw "base"
+        $DiffSummary, $TotalDiffCodeSize = ParseWasmSummary $DiffSummaryRaw "diff"
+    }
 
     $NullFunc = @{ Index = -1; Size = 0 }
     $Diffs = [Collections.Generic.List[object]]::new()
@@ -227,43 +296,14 @@ if ($Analyze -or $Summary)
             {
                 mkdir $AnalysisDirectory | Write-Verbose
             }
+
             # Only one analysis at a time is currently supported (i. e. subsequent runs will overwrite this directory).
-            $ProjectAnalysisDirectory = "$AnalysisDirectory/$TestProjectName"
+            $DiffKind = $Llvm ? "-LLVM" : ""
+            $ProjectAnalysisDirectory = "$AnalysisDirectory/$TestProjectName$DiffKind"
             if (!(Test-Path $ProjectAnalysisDirectory))
             {
                 mkdir $ProjectAnalysisDirectory | Write-Verbose
             }
-
-            Write-Host "Collecting full disassembly for the base..."
-            $BaseWat = wasm-objdump -d $TestProjectBaseWasmOutput
-            Write-Host "Collecting full disassembly for the diff..."
-            $DiffWat = wasm-objdump -d $TestProjectWasmOutput
-
-            function CreateWatIndex($Wat)
-            {
-                $WatSummary = [Collections.Generic.List[int]]::new()
-                $DefFuncIdx = 0
-                for ($Idx = 0; $Idx -lt $Wat.Length; $Idx++)
-                {
-                    $Line = $Wat[$Idx]
-                    if ($Line.Contains("func["))
-                    {
-                        if ($WatSummary.Count -eq 0)
-                        {
-                            $FuncIdxStart = $Line.IndexOf("[") + 1
-                            $FuncIdxLength = $Line.IndexOf("]") - $FuncIdxStart
-                            $DefFuncIdx = [int]$Line.Substring($FuncIdxStart, $FuncIdxLength)
-                        }
-
-                        $WatSummary.Add($Idx)
-                    }
-                }
-
-                return $DefFuncIdx, $WatSummary
-            }
-
-            $BaseDefFuncIndex, $BaseWatSummary = CreateWatIndex($BaseWat)
-            $DiffDefFuncIndex, $DiffWatSumary = CreateWatIndex($DiffWat)
 
             $BaseProjectAnalysisDirectory = "$ProjectAnalysisDirectory/base"
             if (Test-Path $BaseProjectAnalysisDirectory)
@@ -277,54 +317,114 @@ if ($Analyze -or $Summary)
             $DiffProjectAnalysisDirectory = "$ProjectAnalysisDirectory/diff"
             if (Test-Path $DiffProjectAnalysisDirectory)
             {
-                Remove-Item $DiffProjectAnalysisDirectory/* -Recurse            
+                Remove-Item $DiffProjectAnalysisDirectory/* -Recurse
             }
             else
             {
                 mkdir $DiffProjectAnalysisDirectory | Write-Verbose
             }
 
-            function CreateDiffFile($DiffFileName, $FuncIndex, $IsBase)
+            if ($Llvm)
             {
-                if ($IsBase)
+                function CreateDiffFileLlvm($DiffFileName, $Func, $IsBase)
                 {
-                    $DefFuncIndex = $BaseDefFuncIndex
-                    $Wat = $BaseWat
-                    $WatSummary = $BaseWatSummary
-                    $DiffFileDirectory = $BaseProjectAnalysisDirectory
-                }
-                else
-                {
-                    $DefFuncIndex = $DiffDefFuncIndex
-                    $Wat = $DiffWat
-                    $WatSummary = $DiffWatSumary
-                    $DiffFileDirectory = $DiffProjectAnalysisDirectory
-                }
+                    $DiffFileDirectory = $IsBase ? $BaseProjectAnalysisDirectory : $DiffProjectAnalysisDirectory
+                    $FuncContent = $Func.Content
+                    $StartTextIndex = $Func.StartLineIndex
+                    $EndTextIndex = $StartTextIndex + $Func.Size + 1
 
-                Write-Verbose "$DefFuncIndex, $FuncIndex"
-                $WatSummaryIndex = $FuncIndex - $DefFuncIndex
-                $StartTextIndex = $WatSummary[$WatSummaryIndex]
-                $EndTextIndex = ($WatSummaryIndex + 1) -eq $WatSummary.Count ? $Wat.Length : $WatSummary[$WatSummaryIndex + 1]
-                Write-Verbose "$StartTextIndex, $EndTextIndex"
-
-                $StreamWriter = [IO.StreamWriter]::New("$DiffFileDirectory/$DiffFileName")
-                for ($Idx = $StartTextIndex; $Idx -lt $EndTextIndex; $Idx++)
-                {
-                    $Line = $Wat[$Idx]
-
-                    # Trim the leading offsets to get clean diffs.
-                    if ($Idx -eq $StartTextIndex)
+                    $StreamWriter = [IO.StreamWriter]::New("$DiffFileDirectory/$DiffFileName")
+                    for ($Idx = $StartTextIndex; $Idx -lt $EndTextIndex; $Idx++)
                     {
-                        $StartLineOffset = $Line.IndexOf("func")
+                        $Line = $FuncContent[$Idx]
+                        # Strip !dbg directives to make the diff more readable.
+                        $IndexOfDbg = $Line.IndexOf(", !dbg")
+                        if ($IndexOfDbg -ne -1)
+                        {
+                            $Line = $Line.Substring(0, $IndexOfDbg)
+                        }
+
+                        $StreamWriter.WriteLine($Line)
+                    }
+                    $StreamWriter.Close()
+                }
+            }
+            else
+            {
+                Write-Host "Collecting full disassembly for the base..."
+                $BaseWat = wasm-objdump -d $TestProjectBaseWasmOutput
+                Write-Host "Collecting full disassembly for the diff..."
+                $DiffWat = wasm-objdump -d $TestProjectWasmOutput
+
+                function CreateWatIndex($Wat)
+                {
+                    $WatSummary = [Collections.Generic.List[int]]::new()
+                    $DefFuncIdx = 0
+                    for ($Idx = 0; $Idx -lt $Wat.Length; $Idx++)
+                    {
+                        $Line = $Wat[$Idx]
+                        if ($Line.Contains("func["))
+                        {
+                            if ($WatSummary.Count -eq 0)
+                            {
+                                $FuncIdxStart = $Line.IndexOf("[") + 1
+                                $FuncIdxLength = $Line.IndexOf("]") - $FuncIdxStart
+                                $DefFuncIdx = [int]$Line.Substring($FuncIdxStart, $FuncIdxLength)
+                            }
+
+                            $WatSummary.Add($Idx)
+                        }
+                    }
+
+                    return $DefFuncIdx, $WatSummary
+                }
+
+                $BaseDefFuncIndex, $BaseWatSummary = CreateWatIndex($BaseWat)
+                $DiffDefFuncIndex, $DiffWatSumary = CreateWatIndex($DiffWat)
+
+                function CreateDiffFileWasm($DiffFileName, $Func, $IsBase)
+                {
+                    $FuncIndex = $Func.Index
+                    if ($IsBase)
+                    {
+                        $DefFuncIndex = $BaseDefFuncIndex
+                        $Wat = $BaseWat
+                        $WatSummary = $BaseWatSummary
+                        $DiffFileDirectory = $BaseProjectAnalysisDirectory
                     }
                     else
                     {
-                        $StartLineOffset = $Line.IndexOf(":") + 1
+                        $DefFuncIndex = $DiffDefFuncIndex
+                        $Wat = $DiffWat
+                        $WatSummary = $DiffWatSumary
+                        $DiffFileDirectory = $DiffProjectAnalysisDirectory
                     }
 
-                    $StreamWriter.WriteLine($Line.Substring($StartLineOffset))
+                    Write-Verbose "$DefFuncIndex, $FuncIndex"
+                    $WatSummaryIndex = $FuncIndex - $DefFuncIndex
+                    $StartTextIndex = $WatSummary[$WatSummaryIndex]
+                    $EndTextIndex = ($WatSummaryIndex + 1) -eq $WatSummary.Count ? $Wat.Length : $WatSummary[$WatSummaryIndex + 1]
+                    Write-Verbose "$StartTextIndex, $EndTextIndex"
+
+                    $StreamWriter = [IO.StreamWriter]::New("$DiffFileDirectory/$DiffFileName")
+                    for ($Idx = $StartTextIndex; $Idx -lt $EndTextIndex; $Idx++)
+                    {
+                        $Line = $Wat[$Idx]
+
+                        # Trim the leading offsets to get clean diffs.
+                        if ($Idx -eq $StartTextIndex)
+                        {
+                            $StartLineOffset = $Line.IndexOf("func")
+                        }
+                        else
+                        {
+                            $StartLineOffset = $Line.IndexOf(":") + 1
+                        }
+
+                        $StreamWriter.WriteLine($Line.Substring($StartLineOffset))
+                    }
+                    $StreamWriter.Close()
                 }
-                $StreamWriter.Close()
             }
 
             $OutputProgressIndex = 0
@@ -336,11 +436,25 @@ if ($Analyze -or $Summary)
                 # Create files on disk for this diff.
                 if ($Diff.Base.Size -ne 0)
                 {
-                    CreateDiffFile $Diff.DiffFileName $Diff.Base.Index -IsBase $true
+                    if ($Llvm)
+                    {
+                        CreateDiffFileLlvm $Diff.DiffFileName $Diff.Base -IsBase $true
+                    }
+                    else
+                    {
+                        CreateDiffFileWasm $Diff.DiffFileName $Diff.Base -IsBase $true
+                    }
                 }
                 if ($Diff.Diff.Size -ne 0)
                 {
-                    CreateDiffFile $Diff.DiffFileName $Diff.Diff.Index -IsBase $false
+                    if ($Llvm)
+                    {
+                        CreateDiffFileLlvm $Diff.DiffFileName $Diff.Diff -IsBase $false
+                    }
+                    else
+                    {
+                        CreateDiffFileWasm $Diff.DiffFileName $Diff.Diff -IsBase $false
+                    }
                 }
                 if ($OutputProgressIndex % $OutputProgressInterval -eq 0)
                 {


### PR DESCRIPTION
This works pretty much the same as the existing diffing of WASM, we just read the bitcode files with `llvm-dis` instead of the final result with `wasm-objdump`.

Sample usage:
```
> ./wasmjit-diff -s -l -a
Analysing base..........
Analysing diff..........
Writing diff files...........

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 703578
Total bytes of diff: 681871
Total bytes of delta: -21707 (-3.09% % of base)
Average relative delta: -3.68%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
          20 (13.25% of base) : 1640.dasm - S_P_CoreLib_System_Globalization_NumberFormatInfo___ctor_0
          16 ( 9.09% of base) : 1836.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_ConstraintValidator__NormalizedPrimitiveTypeSizeForIntegerTypes
           6 ( 7.69% of base) : 3360.dasm - S_P_CoreLib_System_Collections_Generic_LowLevelList_1<System___Canon>__Add
           6 ( 7.69% of base) : 2227.dasm - S_P_TypeLoader_System_Collections_Generic_LowLevelList_1<System___Canon>__Add
          34 ( 6.85% of base) : 3052.dasm - S_P_CoreLib_System_Globalization_CultureData__GetNFIValues
           4 ( 6.06% of base) : 3203.dasm - S_P_CoreLib_System_TypeInitializationException___ctor_0
           4 ( 5.97% of base) : 2524.dasm - S_P_CoreLib_System_Text_ValueStringBuilder__GrowAndAppend
           7 ( 5.83% of base) : 1572.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_FieldAccessors_ValueTypeFieldAccessorForStaticFields__GetFieldBypassCctor
           4 ( 5.80% of base) : 2714.dasm - S_P_CoreLib_System_Reflection_RuntimeAssemblyName__get_FullName
           4 ( 5.71% of base) : 2572.dasm - S_P_CoreLib_System_Reflection_TypeNameParser___ParseNamedTypeName_g__ApplyLeadingDotCompatQuirk_20_0
           5 ( 5.62% of base) : 2586.dasm - S_P_TypeLoader_System_Collections_Generic_LowLevelList_1<Bool>__Add
           5 ( 5.56% of base) : 2146.dasm - S_P_CoreLib_System_Collections_Generic_LowLevelList_1<IntPtr>__Add
           7 ( 5.51% of base) : 1570.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_FieldAccessors_PointerTypeFieldAccessorForStaticFields__GetFieldBypassCctor
          21 ( 5.51% of base) : 3132.dasm - S_P_CoreLib_System_Decimal_DecCalc__InternalRound
          28 ( 5.51% of base) : 1241.dasm - S_P_CoreLib_System_Enum__ToObject_0
           5 ( 5.49% of base) : 3534.dasm - S_P_Reflection_Execution_System_Collections_Generic_LowLevelList_1<S_P_Reflection_Execution_Internal_Reflection_Execution_ExecutionEnvironmentImplementation_FunctionPointerOffsetPair>__Add
           5 ( 5.43% of base) : 3266.dasm - S_P_CoreLib_System_Runtime_RuntimeExports__RhGetCurrentThreadStackTrace
           6 ( 5.41% of base) : 3154.dasm - S_P_CoreLib_System_Number_BigInteger__MultiplyPow10
           6 ( 5.36% of base) : 2329.dasm - S_P_CoreLib_System_Reflection_Runtime_BindingFlagSupport_QueriedMemberList_1<System___Canon>__Add
          14 ( 5.34% of base) : 3050.dasm - S_P_CoreLib_System_Globalization_DateTimeFormatInfo__InitializeOverridableProperties

Top method improvements (percentages):
          -1 (-20.00% of base) : 1379.dasm - String__GetNonRandomizedHashCodeOrdinalIgnoreCase$F1_Finally
          -8 (-17.78% of base) : 1336.dasm - HelloWasm_Program__TestStoreFromGenericMethod
         -18 (-17.48% of base) : 1339.dasm - HelloWasm_Program__TestGenericStructHandling
          -6 (-13.95% of base) : 1337.dasm - HelloWasm_Program__TestConstrainedValueTypeCallVirt
         -52 (-13.90% of base) : 3435.dasm - S_P_CoreLib_System_Globalization_GlobalizationMode__LoadAppLocalIcuCore
        -110 (-13.55% of base) : 2778.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_CustomMethodMapper_StringActions__get_Map
         -20 (-13.33% of base) : 1451.dasm - S_P_CoreLib_System_Globalization_GlobalizationMode__LoadAppLocalIcu
          -6 (-13.33% of base) : 1338.dasm - HelloWasm_Program__TestBoxToGenericTypeFromDirectMethod
         -86 (-12.84% of base) : 2779.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_CustomMethodMapper_NullableActions__get_Map
          -6 (-12.77% of base) : 2626.dasm - S_P_CoreLib_System_MemoryExtensions__Split
         -56 (-12.70% of base) : 3458.dasm - S_P_CoreLib_System_Reflection_Runtime_CustomAttributes_NativeFormat_NativeFormatCustomAttributeData__GetNamedArguments
         -50 (-12.50% of base) : 1278.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__TryParseConstantEnumArray
         -10 (-12.20% of base) : 3336.dasm - S_P_CoreLib_System_CrashInfo__WriteChars
         -10 (-12.20% of base) : 1880.dasm - S_P_CoreLib_System_Reflection_AssemblyNameParser__Parse
         -14 (-12.07% of base) : 1387.dasm - S_P_CoreLib_System_Text_Encoding__GetCharsWithFallback
         -14 (-12.07% of base) : 1385.dasm - S_P_CoreLib_System_Text_Encoding__GetBytesWithFallback
          -6 (-12.00% of base) : 2579.dasm - S_P_CoreLib_System_Runtime_Serialization_SerializationInfo__GetThreadDeserializationTracker
          -8 (-11.94% of base) : 1147.dasm - HelloWasm_Program__StoreChildInC1
         -61 (-11.82% of base) : 3520.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__ParseConstantNumericValue
         -10 (-11.76% of base) : 1862.dasm - S_P_CoreLib_System_Globalization_DateTimeFormatInfo__DecimalSeparatorTChar<Char>

2543 total methods with Code Size differences (2227 improved, 316 regressed)
```
LLVM diffs are in general not as useful as WASM diffs - you should always start from the latter. For example, the same diff looks like this in the final output:
```
> ./wasmjit-diff -s
Analysing base..........
Analysing diff..........

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3220731
Total bytes of diff: 3209366
Total bytes of delta: -11365 (-0.35% % of base)
Average relative delta: -0.70%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
         128 (30.26% of base) : 1017.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<Int32>__InitializeTlsBucketsAndTrimming
         128 (30.26% of base) : 1020.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<UInt8>__InitializeTlsBucketsAndTrimming
         128 (30.26% of base) : 1019.dasm - S_P_CoreLib_System_Buffers_SharedArrayPool_1<Char>__InitializeTlsBucketsAndTrimming
         252 (15.59% of base) : 1417.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__GVMLookupForSlotWorker
          35 (10.87% of base) : 1983.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeSystemContext_GenericTypeInstanceKey__Equals_0
          14 (10.45% of base) : 1676.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_NamespaceDefinitionHandle__Equals
          14 (10.45% of base) : 1838.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_ConstantStringValueHandle__Equals
          14 (10.45% of base) : 1832.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_ScopeDefinitionHandle__Equals
          14 (10.45% of base) : 1840.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_MethodSignatureHandle__Equals
          14 (10.45% of base) : 1842.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_ConstantStringArrayHandle__Equals
          14 (10.45% of base) : 1083.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_GenericParameterHandle__Equals
          14 (10.45% of base) : 1085.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_TypeDefinitionHandle__Equals
           7 ( 8.43% of base) : 2278.dasm - Single__ToString
           7 ( 8.43% of base) : 2277.dasm - Double__ToString
          12 ( 8.00% of base) : 2137.dasm - S_P_CoreLib_System_Reflection_CustomAttributeData__get_AttributeType
          12 ( 6.70% of base) : 1390.dasm - S_P_CoreLib_System_BadImageFormatException__SetMessageField
          32 ( 6.37% of base) : 1985.dasm - S_P_TypeLoader_System_Collections_Generic_LowLevelDictionary_2<S_P_TypeLoader_Internal_TypeSystem_TypeSystemContext_GenericTypeInstanceKey__System___Canon>__Find
          11 ( 6.36% of base) : 2553.dasm - S_P_TypeLoader_Internal_TypeSystem_ThrowHelper_Format__OwningModule_0
          10 ( 5.21% of base) : 1817.dasm - S_P_CoreLib_System_Globalization_CalendarData___c___GetCalendarInfo_b__34_0
          17 ( 5.04% of base) : 1246.dasm - S_P_CoreLib_System_Globalization_GlobalizationMode__LoadAppLocalIcu

Top method improvements (percentages):
         -68 (-17.48% of base) : 1207.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_MethodInvokers_MethodInvokerWithMethodInvokeInfo__CreateMethodInvoker
         -70 (-16.28% of base) : 2452.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_RuntimePlainConstructorInfo_1<S_P_CoreLib_System_Reflection_Runtime_MethodInfos_NativeFormat_NativeFormatMethodCommon>__get_MetadataDefinitionMethod
         -95 (-15.91% of base) : 2130.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_NativeFormat_NativeFormatMethodCommon__GetGenericTypeParametersWithSpecifiedOwningMethod
        -142 (-15.24% of base) : 1893.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__IsCustomAttributeOfType
        -122 (-14.93% of base) : 2125.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_NativeFormat_NativeFormatMethodCommon__get_QualifiedMethodSignature
         -86 (-14.43% of base) : 1434.dasm - S_P_CoreLib_System_Number__FormatDecimal
         -69 (-13.27% of base) : 1398.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_NativeFormat_NativeFormatMethodCommon__get_RuntimeMethodCommonOfUninstantiatedMethod
         -69 (-13.27% of base) : 2019.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_MetadataNameExtensions__GetFullName_5
         -92 (-13.20% of base) : 1876.dasm - String__SplitInternal
        -110 (-12.72% of base) : 1670.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifierW_2_Container<S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo_UnificationKey__System___Canon>__Add
         -64 (-12.62% of base) : 1035.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_TypeRefDefOrSpecsForDirectlyImplementedInterfaces
         -89 (-12.21% of base) : 2084.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifierW_2_Container<IntPtr__System___Canon>__Add
         -84 (-12.12% of base) : 1640.dasm - S_P_TypeLoader_Internal_TypeSystem_NoMetadata_RuntimeMethodDesc__GetCanonMethodTarget
         -99 (-11.90% of base) : 2300.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifierW_2_Container<S_P_CoreLib_System_Reflection_Runtime_Assemblies_NativeFormat_NativeFormatRuntimeAssembly_RuntimeAssemblyKey__System___Canon>__Add
        -127 (-11.87% of base) : 1593.dasm - S_P_CoreLib_System_Number___FormatUInt64_g__FormatUInt64Slow_47_0
        -101 (-11.62% of base) : 2537.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifierW_2_Container<S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeGenericParameterTypeInfoForTypes_UnificationKey__System___Canon>__Add
         -99 (-11.45% of base) : 1234.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NamespaceChain___ctor
        -136 (-11.30% of base) : 1386.dasm - S_P_CoreLib_System_Number___FormatInt64_g__FormatInt64Slow_45_0
         -81 (-11.01% of base) : 2348.dasm - S_P_CoreLib_System_TimeZoneInfo__PopulateDisplayName
         -84 (-10.97% of base) : 1343.dasm - S_P_CoreLib_System_Enum__TryFormatPrimitiveDefault<Int8__UInt8>

1595 total methods with Code Size differences (844 improved, 751 regressed)
```
However, they are very useful in understanding the source/cause of WASM diffs.

Contributes to #2397.

Review note: this change is best viewed with the "no whitespace diffs" option in GH.