### PR TITLE
[NativeAOT-LLVM] Do not spill nulls

### DIFF
--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -132,7 +132,7 @@ private:
                 // Locals are handled by the general shadow stack lowering (already "spilled" so to speak).
                 // Local address nodes always point to the stack (native or shadow). Constant handles will
                 // only point to immortal and immovable (frozen) objects.
-                return !node->OperIsLocal() && !node->OperIs(GT_LCL_ADDR) && !node->IsIconHandle();
+                return !node->OperIsAnyLocal() && !node->IsIconHandle() && !node->IsIntegralConst(0);
             }
 
             return false;


### PR DESCRIPTION
Noticed we were doing this while looking at some diffs.

```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3220731
Total bytes of diff: 3220088
Total bytes of delta: -643 (-0.02% % of base)
Average relative delta: -16.38%
    diff is an improvement
    average relative diff is an improvement

Top method improvements (percentages):
         -20 (-24.10% of base) : 1026.dasm - Double__ToString
         -20 (-24.10% of base) : 1027.dasm - Single__ToString
         -23 (-18.25% of base) : 1007.dasm - S_P_CoreLib_System_Convert__ToUInt64
         -23 (-18.25% of base) : 1009.dasm - S_P_CoreLib_System_Convert__ToInt64
         -23 (-17.83% of base) : 1005.dasm - S_P_CoreLib_System_Convert__ToSingle
         -23 (-17.42% of base) : 1025.dasm - S_P_CoreLib_System_Convert__ToBoolean
         -23 (-17.42% of base) : 1013.dasm - S_P_CoreLib_System_Convert__ToInt32
         -23 (-17.42% of base) : 1011.dasm - S_P_CoreLib_System_Convert__ToUInt32
         -23 (-17.42% of base) : 1019.dasm - S_P_CoreLib_System_Convert__ToByte
         -23 (-17.42% of base) : 1017.dasm - S_P_CoreLib_System_Convert__ToInt16
         -23 (-17.42% of base) : 1021.dasm - S_P_CoreLib_System_Convert__ToSByte
         -23 (-17.42% of base) : 1023.dasm - S_P_CoreLib_System_Convert__ToChar
         -23 (-17.42% of base) : 1015.dasm - S_P_CoreLib_System_Convert__ToUInt16
         -23 (-17.29% of base) : 1003.dasm - S_P_CoreLib_System_Convert__ToDouble
         -23 (-16.91% of base) : 1022.dasm - S_P_CoreLib_System_Enum__System_IConvertible_ToChar
         -23 (-16.91% of base) : 1018.dasm - S_P_CoreLib_System_Enum__System_IConvertible_ToByte
         -23 (-16.91% of base) : 1020.dasm - S_P_CoreLib_System_Enum__System_IConvertible_ToSByte
         -23 (-16.91% of base) : 1012.dasm - S_P_CoreLib_System_Enum__System_IConvertible_ToInt32
         -23 (-16.91% of base) : 1024.dasm - S_P_CoreLib_System_Enum__System_IConvertible_ToBoolean
         -23 (-16.91% of base) : 1010.dasm - S_P_CoreLib_System_Enum__System_IConvertible_ToUInt32

29 total methods with Code Size differences (29 improved, 0 regressed)
```