### PR TITLE
[NativeAOT-LLVM] Work around LLVM issues with null checks

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2275,8 +2275,8 @@ void Llvm::emitNullCheckForAddress(GenTree* addr, Value* addrValue)
     if (addr->TypeIs(TYP_REF))
     {
         // LLVM's FastISel, used for unoptimized code, is not able to generate sensible WASM unless we do
-        // a comparison using an integer zero here. This workaround saves 2.2% on debug code size.
-        // TODO-LLVM: file a bug on LLVM and fix this.
+        // a comparison using an integer zero here. This workaround saves 5+% on debug code size.
+        // TODO-LLVM: remove once https://github.com/llvm/llvm-project/issues/80053 is fixed.
         if (_compiler->opts.OptimizationDisabled())
         {
             Value* addrValueAsIntPtr = _builder.CreatePtrToInt(addrValue, getIntPtrLlvmType());

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -935,12 +935,6 @@ void Llvm::lowerCallReturn(GenTreeCall* callNode)
 
 void Llvm::lowerAddressToAddressMode(GenTreeIndir* indir)
 {
-    // Only perform this transformation when optimizing. The analysis below is not cheap.
-    if (_compiler->opts.OptimizationDisabled())
-    {
-        return;
-    }
-
     GenTree* addr = indir->Addr();
     if (!addr->OperIs(GT_ADD))
     {

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
@@ -88,6 +88,11 @@ $TestProjectBaseNativeOutputDirectory = "$TestProjectNativeOutputDirectory.base"
 $TestProjectWasmOutput = "$TestProjectNativeOutputDirectory/$TestProjectName.wasm"
 $TestProjectBaseWasmOutput = "$TestProjectBaseNativeOutputDirectory/$TestProjectName.wasm"
 
+if ($Rebuild -and (Test-Path $TestProjectBaseNativeObjDirectory))
+{
+    Remove-Item $TestProjectBaseNativeObjDirectory -Recurse -Force
+}
+
 $TestProjectBaseNativeOutputDirectoryExists = Test-Path $TestProjectBaseNativeOutputDirectory
 if ($Rebuild -and $TestProjectBaseNativeOutputDirectoryExists)
 {


### PR DESCRIPTION
It turns out that LLVM's fast lowering, FastISel, produces very bad debug code for most relops, except for one very specific form of `x == 0`. Use this form in null checking, and enable address mode lowering for a total of `6.4%` wins in code size:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 15594261
Total bytes of diff: 14596617
Total bytes of delta: -997644 (-6.40% % of base)
Average relative delta: -14.05%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
        7678 (79.19% of base) : 2694.dasm - S_P_CoreLib_System_Globalization_OrdinalCasing___cctor
         208 (22.46% of base) : 3459.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_Attributes
         100 (22.42% of base) : 3418.dasm - S_P_CoreLib_System_Reflection_Runtime_General_Helpers___cctor
          77 (19.90% of base) : 4624.dasm - S_P_CoreLib_System_TimeZoneInfo_AdjustmentRule__get_DaylightTransitionEnd
         218 (18.78% of base) : 5012.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_DeclaredPropertyHandles
         218 (18.78% of base) : 3520.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_DeclaredFieldHandles
         218 (18.78% of base) : 1703.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_DeclaredEventHandles
         218 (18.78% of base) : 4157.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_DeclaredMethodAndConstructorHandles
          67 (17.31% of base) : 3996.dasm - S_P_CoreLib_System_TimeZoneInfo_AdjustmentRule__get_DaylightTransitionStart
         178 (14.71% of base) : 2757.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_Name
         195 (13.50% of base) : 2760.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_IsGenericTypeDefinition
         157 (12.89% of base) : 5795.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_TrueCustomAttributes
         201 (12.14% of base) : 4060.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__GetGenericTypeDefinition
         172 (12.13% of base) : 6223.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeGenericParameterTypeInfo__get_Name
          64 (11.39% of base) : 3663.dasm - S_P_CoreLib_System_Reflection_Runtime_ParameterInfos_NativeFormat_NativeFormatMethodParameterInfo__get_Attributes
          64 (10.53% of base) : 6224.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeGenericParameterTypeInfo__get_GenericParameterAttributes
          64 ( 9.60% of base) : 3662.dasm - S_P_CoreLib_System_Reflection_Runtime_ParameterInfos_NativeFormat_NativeFormatMethodParameterInfo__get_Name
          47 ( 8.82% of base) : 2435.dasm - S_P_CoreLib_System_Reflection_Runtime_FieldInfos_NativeFormat_NativeFormatRuntimeFieldInfo__get_ExplicitLayoutFieldOffsetData
          64 ( 8.64% of base) : 3714.dasm - S_P_CoreLib_System_Reflection_Runtime_ParameterInfos_NativeFormat_NativeFormatMethodParameterInfo__get_TrueCustomAttributes
          47 ( 8.42% of base) : 4236.dasm - S_P_CoreLib_System_Reflection_Runtime_FieldInfos_NativeFormat_NativeFormatRuntimeFieldInfo__get_Attributes

Top method improvements (percentages):
        -915 (-51.17% of base) : 4555.dasm - S_P_CoreLib_System_Globalization_CalendarData___ctor
        -641 (-47.66% of base) : 1879.dasm - S_P_CoreLib_System_Globalization_CultureData___ctor
       -1413 (-42.82% of base) : 1868.dasm - S_P_CoreLib_System_Globalization_NumberFormatInfo___ctor_0
       -1009 (-41.47% of base) : 1048.dasm - S_P_CoreLib_System_Text_StringBuilder__AssertInvariants
        -415 (-41.13% of base) : 1152.dasm - S_P_CoreLib_System_Text_StringBuilder___ctor_6
       -4145 (-41.08% of base) : 1880.dasm - S_P_CoreLib_System_Globalization_CultureData__CreateCultureWithInvariantData
        -333 (-40.56% of base) : 3095.dasm - S_P_CoreLib_System_Collections_Hashtable_HashtableEnumerator___ctor
        -575 (-40.18% of base) : 2316.dasm - S_P_TypeLoader_System_Collections_Generic_LowLevelDictionary_2_LowLevelDictEnumerator<System___Canon__System___Canon>__MoveNext
        -795 (-40.09% of base) : 1304.dasm - S_P_CoreLib_System_Text_EncoderReplacementFallbackBuffer__GetNextChar
        -795 (-40.09% of base) : 2108.dasm - S_P_CoreLib_System_Text_DecoderReplacementFallbackBuffer__GetNextChar
        -172 (-39.91% of base) : 6110.dasm - S_P_CoreLib_System_Text_EncoderReplacementFallbackBuffer__Reset
        -549 (-39.87% of base) : 2042.dasm - S_P_CoreLib_System_Resources_ResourceReader__Dispose_0
        -587 (-39.50% of base) : 3043.dasm - S_P_CoreLib_Internal_Reflection_Extensions_NonPortable_CustomAttributeSearcher_1__GetMatchingCustomAttributesIterator_d__2<System___Canon>__System_Collections_Generic_IEnumerable_System_Reflection_CustomAttributeData__GetEnumerator
        -507 (-39.27% of base) : 5356.dasm - S_P_CoreLib_System_Collections_Generic_LowLevelList_1<IntPtr>__Add
        -499 (-39.23% of base) : 6342.dasm - S_P_TypeLoader_System_Collections_Generic_LowLevelList_1<Bool>__Add
        -117 (-38.87% of base) : 2983.dasm - S_P_CoreLib_System_IO_Strategies_BufferedFileStreamStrategy__Dispose$F1_Finally
        -129 (-38.74% of base) : 1153.dasm - S_P_CoreLib_System_Text_StringBuilder__get_Capacity
       -1156 (-38.70% of base) : 3097.dasm - S_P_CoreLib_System_Collections_Hashtable_HashtableEnumerator__MoveNext
        -517 (-38.70% of base) : 6269.dasm - S_P_CoreLib_System_Collections_Generic_LowLevelList_1<S_P_CoreLib_System_Reflection_Runtime_General_QTypeDefRefOrSpec>__Add
        -951 (-38.69% of base) : 1619.dasm - S_P_CoreLib_System_Version__CompareTo_0

5459 total methods with Code Size differences (5420 improved, 39 regressed)
```
I looked briefly at the regressions, they look like some other intersection of LLVM issues with our codegen (particularly #2351).

Upstream issue: https://github.com/llvm/llvm-project/issues/80053.