### PR TITLE
[NativeAOT-LLVM] Implement implicit shadow tail calls

### DIFF
--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -465,6 +465,8 @@ private:
         // defs will increment the count back if there are any non-shadow references.
         varDsc->lvImplicitlyReferenced = 0;
         varDsc->setLvRefCnt(0);
+
+        m_llvm->m_anyAddressExposedShadowLocals |= varDsc->IsAddressExposed();
     }
 
     void LowerAndInsertProlog()
@@ -615,8 +617,11 @@ private:
         if (m_llvm->callHasManagedCallingConvention(call))
         {
             unsigned funcIdx = m_llvm->getLlvmFunctionIndexForBlock(m_llvm->CurrentBlock());
+            bool isTailCall = CanShadowTailCall(call);
+            unsigned calleeShadowStackOffset = m_llvm->getCalleeShadowStackOffset(funcIdx, isTailCall);
+
             GenTree* calleeShadowStack =
-                m_llvm->insertShadowStackAddr(call, m_llvm->getShadowFrameSize(funcIdx), m_llvm->_shadowStackLclNum);
+                m_llvm->insertShadowStackAddr(call, calleeShadowStackOffset, m_llvm->_shadowStackLclNum);
             CallArg* calleeShadowStackArg =
                 call->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(calleeShadowStack, CORINFO_TYPE_PTR));
 
@@ -629,6 +634,23 @@ private:
             // We may have lost track of a shadow local defined by this call. Clear the flag if so.
             call->gtCallMoreFlags &= ~GTF_CALL_M_RETBUFFARG_LCLOPT;
         }
+    }
+
+    bool CanShadowTailCall(GenTreeCall* call)
+    {
+        BasicBlock* block = m_llvm->CurrentBlock();
+        if (!m_llvm->canEmitCallAsShadowTailCall(block->hasTryIndex(), m_llvm->isBlockInFilter(block)))
+        {
+            return false;
+        }
+
+        // We support only the simplest cases for now.
+        if (call->IsNoReturn() || ((call->gtNext != nullptr) && call->gtNext->OperIs(GT_RETURN)))
+        {
+            return true;
+        }
+
+        return false;
     }
 
     //------------------------------------------------------------------------
@@ -673,30 +695,6 @@ private:
 void Llvm::Allocate()
 {
     ShadowStackAllocator(this).Allocate();
-}
-
-//------------------------------------------------------------------------
-// getShadowFrameSize: What is the size of a function's shadow frame?
-//
-// Arguments:
-//    funcIdx - Index representing the function
-//
-// Return Value:
-//    The size of the shadow frame for the given function. We term this
-//    the value by which the shadow stack pointer must be offset before
-//    calling managed code such that the caller will not clobber anything
-//    live on the frame. Note that filters do not have any shadow state
-//    of their own and use the "original" frame from the parent function.
-//
-unsigned Llvm::getShadowFrameSize(unsigned funcIdx) const
-{
-    if (_compiler->funGetFunc(funcIdx)->funKind == FUNC_FILTER)
-    {
-        return 0;
-    }
-
-    assert((_shadowStackLocalsSize % TARGET_POINTER_SIZE) == 0);
-    return _shadowStackLocalsSize;
 }
 
 ValueInitKind Llvm::getInitKindForLocal(unsigned lclNum) const
@@ -760,6 +758,69 @@ void Llvm::displayInitKindForLocal(unsigned lclNum, ValueInitKind initKind)
     }
 }
 #endif // DEBUG
+
+//------------------------------------------------------------------------
+// getShadowFrameSize: What is the size of a function's shadow frame?
+//
+// Arguments:
+//    funcIdx - Index representing the function
+//
+// Return Value:
+//    The size of the shadow frame for the given function. We term this
+//    the value by which the shadow stack pointer must be offset before
+//    calling managed code such that the caller will not clobber anything
+//    live on the frame. Note that filters do not have any shadow state
+//    of their own and use the "original" frame from the parent function.
+//
+unsigned Llvm::getShadowFrameSize(unsigned funcIdx) const
+{
+    if (_compiler->funGetFunc(funcIdx)->funKind == FUNC_FILTER)
+    {
+        return 0;
+    }
+
+    assert((_shadowStackLocalsSize % TARGET_POINTER_SIZE) == 0);
+    return _shadowStackLocalsSize;
+}
+
+unsigned Llvm::getCalleeShadowStackOffset(unsigned funcIdx, bool isTailCall) const
+{
+    if (isTailCall)
+    {
+        return 0;
+    }
+
+    return getShadowFrameSize(funcIdx);
+}
+
+//------------------------------------------------------------------------
+// canEmitCallAsShadowTailCall: Can a call be made into a shadow tail call?
+//
+// Arguments:
+//    callIsInTry    - Is the call in a protected region
+//    callIsInFilter - Is the call in a filter
+//
+// Return Value:
+//    Whether a call can be made without preserving the current shadow frame.
+//
+bool Llvm::canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter) const
+{
+    // We don't want to tail call anything in debug code, as it leads to a confusing debugging experience where
+    // calls down the stack may modify (corrupt) shadow variables from their callers.
+    if (_compiler->opts.compDbgCode)
+    {
+        return false;
+    }
+
+    // Address-exposed shadow state may be observed by the callee or filters that run in the first pass of EH.
+    if (m_anyAddressExposedShadowLocals)
+    {
+        return false;
+    }
+
+    // Both protected regions and filters induce exceptional flow that may return back to this method.
+    return !callIsInTry && !callIsInFilter;
+}
 
 //------------------------------------------------------------------------
 // isShadowFrameLocal: Does the given local have a home on the shadow frame?


### PR DESCRIPTION
Closes #2213.

Calls in a tail position in methods without implicitly live shadow state can be tail-called, i. e. called on the caller's shadow frame. This is both a code size and performance optimization, the latter because GC needs to do less work.

Diffs:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3214419
Total bytes of diff: 3197845
Total bytes of delta: -16574 (-0.52% % of base)
Average relative delta: -3.99%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
           4 ( 5.06% of base) : 1832.dasm - S_P_CoreLib_System_Reflection_Runtime_Assemblies_NativeFormat_NativeFormatRuntimeAssembly__Equals
           2 ( 4.76% of base) : 3477.dasm - S_P_CoreLib_Interop___GetExceptionForIoErrno_g__ParentDirectoryExists_18_0
          12 ( 4.04% of base) : 2372.dasm - S_P_CoreLib_System_Number__Int32ToHexStr
          12 ( 3.45% of base) : 1022.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_StartupCodeHelpers__RunModuleInitializers
          14 ( 2.60% of base) : 2375.dasm - S_P_CoreLib_System_Number__UInt32ToDecStr_NoSmallNumberCheck
           8 ( 2.56% of base) : 2377.dasm - S_P_CoreLib_System_Number__TryInt32ToHexStr<Char>
          14 ( 2.53% of base) : 2371.dasm - S_P_CoreLib_System_Number__UInt32ToDecStr_0
          14 ( 1.83% of base) : 2370.dasm - S_P_CoreLib_System_Number__NegativeInt32ToDecStr
          12 ( 1.82% of base) : 1034.dasm - S_P_CoreLib_System_Runtime_EH__DispatchException
           2 ( 1.65% of base) : 2783.dasm - S_P_CoreLib_System_RuntimeType__MakeArrayType_0
           2 ( 1.63% of base) : 1262.dasm - S_P_CoreLib_System_Globalization_PersianCalendar__GetDaysInYear
          14 ( 1.61% of base) : 2376.dasm - S_P_CoreLib_System_Number__TryUInt32ToDecStr_0<Char>
           3 ( 1.49% of base) : 2345.dasm - S_P_CoreLib_System_ReadOnlySpan_1<Char>__ToString
           4 ( 1.42% of base) : 3063.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_LowLevelListExtensions__Expand<Bool>
           4 ( 1.37% of base) : 3352.dasm - S_P_CoreLib_System_Decimal__ToString
           2 ( 0.97% of base) : 3473.dasm - S_P_CoreLib_System_Reflection_TypeNameParser__StartAssemblyName
           3 ( 0.89% of base) : 1696.dasm - S_P_TypeLoader_Internal_TypeSystem_ExceptionTypeNameFormatter__GetTypeNamespace
           3 ( 0.89% of base) : 1694.dasm - S_P_TypeLoader_Internal_TypeSystem_ExceptionTypeNameFormatter__GetTypeName
           2 ( 0.76% of base) : 2756.dasm - S_P_CoreLib_System_Comparison_1<S_P_StackTraceMetadata_Internal_StackTraceMetadata_StackTraceMetadata_PerModuleMethodNameResolver_StackTraceData>__InvokeOpenInstanceThunk
           4 ( 0.72% of base) : 3254.dasm - S_P_CoreLib_System_Globalization_NumberFormatInfo___GetInstance_g__GetProviderNonNull_59_0

Top method improvements (percentages):
         -22 (-26.51% of base) : 2925.dasm - S_P_CoreLib_System_Reflection_SignatureConstructedGenericType__GetGenericArguments
         -17 (-18.09% of base) : 1488.dasm - S_P_CoreLib_System_Collections_Generic_RandomizedStringEqualityComparer_OrdinalIgnoreCaseComparer__Equals
         -22 (-17.60% of base) : 3019.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeSystemContext_ArrayTypeKey_ArrayTypeKeyHashtable__GetValueHashCode
         -15 (-16.30% of base) : 3447.dasm - S_P_CoreLib_Internal_Runtime_Augments_RuntimeAugments__GetArrayRankOrMinusOneForSzArray
          -7 (-15.91% of base) : 2113.dasm - S_P_CoreLib_System_Collections_Generic_Dictionary_2<System___Canon__IntPtr>__System_Collections_IEnumerable_GetEnumerator
          -7 (-15.91% of base) : 3730.dasm - S_P_CoreLib_System_Collections_Generic_NonRandomizedStringEqualityComparer_OrdinalIgnoreCaseComparer__GetHashCode
          -7 (-15.91% of base) : 3327.dasm - S_P_CoreLib_System_Collections_Generic_Dictionary_2<S_P_CoreLib_System_Collections_Generic_KeyValuePair_2<System___Canon__System___Canon>__System___Canon>__System_Collections_IEnumerable_GetEnumerator
          -7 (-15.91% of base) : 1141.dasm - S_P_CoreLib_System_Collections_Generic_Dictionary_2<System___Canon__System___Canon>__System_Collections_IEnumerable_GetEnumerator
          -7 (-15.91% of base) : 3744.dasm - S_P_CoreLib_System_Collections_Generic_NonRandomizedStringEqualityComparer_OrdinalComparer__GetHashCode
          -7 (-15.91% of base) : 1368.dasm - S_P_CoreLib_System_Runtime_CompilerServices_ConditionalWeakTable_2<System___Canon__System___Canon>__System_Collections_IEnumerable_GetEnumerator
          -7 (-15.91% of base) : 2472.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment_DynamicGenericMethodsHashtable__GetValueHashCode
          -7 (-14.00% of base) : 3261.dasm - S_P_CoreLib_System_Environment__GetEnvironmentVariable
          -3 (-13.64% of base) : 3881.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeArrayTypeInfo__get_SyntheticConstructors_d__18__System_Collections_IEnumerable_GetEnumerator
          -3 (-13.64% of base) : 2548.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__AsEnumerable_d__33__System_Collections_IEnumerable_GetEnumerator
          -3 (-13.64% of base) : 2420.dasm - S_P_CoreLib_System_Security_SecurityException__ToString
          -3 (-13.64% of base) : 1189.dasm - S_P_CoreLib_System_Reflection_Runtime_CustomAttributes_RuntimeCustomAttributeData__GetCustomAttributes_d__16__System_Collections_IEnumerable_GetEnumerator
          -3 (-13.64% of base) : 2482.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__GetTransitiveNamespaces_d__28__System_Collections_IEnumerable_GetEnumerator
          -3 (-13.64% of base) : 4362.dasm - S_P_CoreLib_System_Reflection_Runtime_FieldInfos_RuntimeFieldInfo__get_CustomAttributes_d__2__System_Collections_IEnumerable_GetEnumerator
          -3 (-13.64% of base) : 1203.dasm - S_P_CoreLib_System_Reflection_Runtime_PropertyInfos_RuntimePropertyInfo__get_SetMethod
          -3 (-13.64% of base) : 4045.dasm - S_P_CoreLib_System_Runtime_Loader_LibraryNameVariation__DetermineLibraryNameVariations_d__5__System_Collections_IEnumerable_GetEnumerator

3465 total methods with Code Size differences (3421 improved, 44 regressed)
```