### PR TITLE
[NativeAOT-LLVM] Fix the `Math.Round` intrinsic

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -3339,7 +3339,7 @@ llvm::Intrinsic::ID Llvm::getLlvmIntrinsic(NamedIntrinsic intrinsicName) const
         case NI_System_Math_Pow:
             return llvm::Intrinsic::pow;
         case NI_System_Math_Round:
-            return llvm::Intrinsic::round;
+            return llvm::Intrinsic::roundeven;
         case NI_System_Math_Sin:
             return llvm::Intrinsic::sin;
         case NI_System_Math_Sqrt:


### PR DESCRIPTION
We want `@llvm.roundeven`, not `@llvm.round`.

Found by the time span division test: https://github.com/dotnet/runtimelab/issues/2307#issuecomment-1922035041.