### PR TITLE
[NativeAOT-LLVM] Fix the missing time zone data index

### DIFF
--- a/src/native/libs/System.Native/CMakeLists.txt
+++ b/src/native/libs/System.Native/CMakeLists.txt
@@ -164,7 +164,7 @@ endif ()
 if (CLR_CMAKE_TARGET_ARCH_WASM AND DEFINED CMAKE_TZD_DIR)
     # Companion library used by NativeAOT that polyfills "mono_bundled_resources_get_data_resource_values".
     cmake_path(CONVERT "${CMAKE_TZD_DIR}/" TO_CMAKE_PATH_LIST TZ_FILES_DIR NORMALIZE)
-    file(GLOB_RECURSE TZ_FILES RELATIVE "${TZ_FILES_DIR}" "${TZ_FILES_DIR}**/*")
+    file(GLOB_RECURSE TZ_FILES RELATIVE "${TZ_FILES_DIR}" "${TZ_FILES_DIR}*")
     string(REPLACE ";" "\",\"" TZ_FILES "${TZ_FILES}")
     configure_file(pal_datetime_time_zone_data-config.h.in inc/pal_datetime_time_zone_data-config.h)
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -3973,6 +3973,12 @@ internal unsafe partial class Program
             return;
         }
 
+        if (TimeZoneInfo.GetSystemTimeZones().Count == 0)
+        {
+            FailTest("System time zones missing");
+            return;
+        }
+
         PassTest();
     }
 


### PR DESCRIPTION
The "zone.tab" file is used to index system time zones and was missing.

Another fix for a bug from https://github.com/dotnet/runtimelab/issues/2307#issuecomment-1922035041.