### PR TITLE
[NativeAOT-LLVM] Enable `System.Runtime.Tests` in CI (for Browser)

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMCodegenCompilation.CodeGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/LLVMCodegenCompilation.CodeGen.cs
@@ -77,8 +77,6 @@ namespace ILCompiler
 
         public override TypeDesc GetPrimitiveTypeForTrivialWasmStruct(TypeDesc type)
         {
-            Debug.Assert(IsStruct(type));
-
             int size = type.GetElementSize().AsInt;
             if (size <= sizeof(double) && BitOperations.IsPow2(size))
             {

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -57,6 +57,7 @@ namespace System
         public static bool IsNotNetFramework => !IsNetFramework;
         public static bool IsBsdLike => IsApplePlatform || IsFreeBSD || IsNetBSD;
 
+        public static bool IsWasm => RuntimeInformation.ProcessArchitecture == Architecture.Wasm;
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
         public static bool IsArm64Process => RuntimeInformation.ProcessArchitecture == Architecture.Arm64;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
-    <!-- TODO-LLVM: delete once we upgarde to Emscripten with https://github.com/emscripten-core/emscripten/pull/21071 -->
+    <!-- TODO-LLVM: delete once we upgrade to Emscripten with https://github.com/emscripten-core/emscripten/pull/21071 -->
     <!-- https://github.com/dotnet/runtimelab/issues/2455 -->
     <LinkerArg Include="-sINITIAL_MEMORY=32MB" />
   </ItemGroup>

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
@@ -28,6 +28,12 @@
     <RdXmlFile Include="default.rd.xml" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
+    <!-- TODO-LLVM: delete once we upgarde to Emscripten with https://github.com/emscripten-core/emscripten/pull/21071 -->
+    <!-- https://github.com/dotnet/runtimelab/issues/2455 -->
+    <LinkerArg Include="-sINITIAL_MEMORY=32MB" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\EnumTypes.cs" Link="Common\System\EnumTypes.cs" />
     <Compile Include="$(CommonTestPath)System\FunctionPointerTests.cs" Link="Common\System\FunctionPointerTests.cs" />

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ExceptionTests.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace System.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/2404", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot), nameof(PlatformDetection.IsWasm))]
     public static class ExceptionTests
     {
         private const int COR_E_EXCEPTION = unchecked((int)0x80131500);

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
@@ -46,7 +46,7 @@ namespace System.Runtime.CompilerServices.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         [PlatformSpecific(TestPlatforms.Browser)]
         public static void DynamicCode_Browser()
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/ExceptionServices/ExceptionDispatchInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/ExceptionServices/ExceptionDispatchInfoTests.cs
@@ -17,6 +17,7 @@ namespace System.Runtime.ExceptionServices.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtimelab/issues/2404", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot), nameof(PlatformDetection.IsWasm))]
         public static void StaticThrow_UpdatesStackTraceAppropriately()
         {
             const string RethrowMessageSubstring = "End of stack trace";

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Threading/PeriodicTimerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Threading/PeriodicTimerTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.Threading.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/2505", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot), nameof(PlatformDetection.IsWasm))]
     public class PeriodicTimerTests
     {
         [Fact]

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -593,10 +593,12 @@
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Threading\tests\System.Threading.Tests.csproj" />
   </ItemGroup>
 
-  <!-- NativeAOT-LLVM: Just a few test suites that pass -->
+  <!-- NativeAOT-LLVM: Just a few test suites. -->
   <ItemGroup Condition="'$(TestNativeAot)' == 'true' and '$(TargetsWasm)' == 'true'">
     <SmokeTestProject Remove="@(SmokeTestProject)" />
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Collections.Specialized\tests\System.Collections.Specialized.Tests.csproj" />
+    <!-- S.R.Tests aren't yet passing upstream on WASI. -->
+    <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests\System.Runtime.Tests.csproj" Condition="'$(TargetsBrowser)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(MonoWasmBuildVariant)' == 'multithread'">


### PR DESCRIPTION
Excluding a few known issues, all tests from this suite pass.

```
=== TEST EXECUTION SUMMARY ===
Total: 63173, Errors: 0, Failed: 0, Skipped: 140, Time: 58.6361551s
```