### PR TITLE
[NativeAOT-LLVM] Optimize always-throwing functions and cctors for size

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -238,6 +238,9 @@ private:
     SideEffectSet m_scratchSideEffects; // Used for IsInvariantInRange.
     bool m_anyFilterFunclets = false;
 
+    // Shared between lowering and codegen.
+    bool m_anyReturns = false;
+
     // Shared between unwind index insertion and EH codegen.
     ArrayStack<unsigned>* m_unwindIndexMap = nullptr;
     BlockSet m_blocksInFilters = BlockSetOps::UninitVal();
@@ -472,6 +475,7 @@ private:
     const unsigned ROOT_FUNC_IDX = 0;
 
     void initializeFunctions();
+    void annotateRootFunction(Function* llvmFunc);
     void generateProlog();
     void initializeShadowStack();
     void initializeLocals();

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -650,6 +650,8 @@ void Llvm::lowerArrLength(GenTreeArrCommon* node)
 
 void Llvm::lowerReturn(GenTreeUnOp* retNode)
 {
+    m_anyReturns = true;
+
     if (retNode->TypeIs(TYP_VOID))
     {
         // Nothing to do.


### PR DESCRIPTION
Initially I was looking at utilizing the `Cold` attribute to mark always-throwing calls, but it turns out marking cold things cold is a code size pessimization due to missing CSEs, so this is just a very minimal change to mark defined functions which we know will be cold as "optsize".

Diffs are also minimal, but nevertheless positive:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3247941
Total bytes of diff: 3247777
Total bytes of delta: -164 (-0.01% % of base)
Average relative delta: -6.47%
    diff is an improvement
    average relative diff is an improvement

Top method improvements (percentages):
         -45 (-7.77% of base) : 1000.dasm - S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport__IDynamicCastableGetInterfaceImplementationFailure
         -33 (-6.85% of base) : 1002.dasm - S_P_CoreLib_System_Text_DecoderExceptionFallbackBuffer__Throw
         -33 (-6.45% of base) : 1001.dasm - S_P_CoreLib_System_Text_EncoderExceptionFallbackBuffer__Fallback_0
         -53 (-4.82% of base) : 1003.dasm - S_P_CoreLib_System_Number___cctor

4 total methods with Code Size differences (4 improved, 0 regressed)
```