### PR TITLE
[NativeAOT-LLVM] Don't pass `-fwasm-exceptions` to the linker

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -534,7 +534,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- see https://github.com/emscripten-core/emscripten/issues/16836 for the issue that means we have to force the linker to include these symbols before LTO -->
       <!--<CustomLinkerArg Condition="'$(Optimize)' != 'true'" Include="$(WasmOptimizationSetting) -flto" /> -->
       <CustomLinkerArg Condition="'$(IlcLlvmTarget)' != ''" Include="-target $(IlcLlvmTarget)" />
-      <CustomLinkerArg Condition="'$(IlcLlvmExceptionHandlingModel)' == 'wasm'" Include="-fwasm-exceptions" />
     </ItemGroup>
 
     <ItemGroup Condition = "'$(_targetOS)' == 'browser'" >
@@ -547,7 +546,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-s TOTAL_STACK=$(IlcWasmStackSize)" />
       <CustomLinkerArg Condition="'$(WasmEnableJSBigIntIntegration)' == 'true'" Include="-s WASM_BIGINT=1" />
       <CustomLinkerArg Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'" Include="-s DISABLE_EXCEPTION_CATCHING=0" />
-      
+
       <CustomLinkerArg Include="$(EmccFlags)" />
       <CustomLinkerArg Include="-s MAXIMUM_MEMORY=$(EmccMaximumHeapSize)" Condition="'$(EmccMaximumHeapSize)' != ''" />
       <CustomLinkerArg Include="-s INITIAL_MEMORY=$(EmccInitialHeapSize)" Condition="'$(EmccInitialHeapSize)' != ''" />

--- a/src/coreclr/nativeaot/CMakeLists.txt
+++ b/src/coreclr/nativeaot/CMakeLists.txt
@@ -14,9 +14,7 @@ if(MSVC)
 endif (MSVC)
 
 if(CLR_CMAKE_HOST_UNIX)
-  if (NOT CLR_CMAKE_TARGET_ARCH_WASM)     # Native AOT runtime targeting WASM uses C++ exception handling to implement managed exceptions
-    add_compile_options(-fno-exceptions)  # Regular Native AOT runtime doesn't use C++ exception handling
-  endif()
+  add_compile_options(-fno-exceptions)    # Native AOT runtime doesn't use C++ exception handling
   add_compile_options(-nostdlib)
 
   if(CLR_CMAKE_TARGET_APPLE)

--- a/src/coreclr/nativeaot/Runtime/wasm/ExceptionHandling/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/wasm/ExceptionHandling/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(CppExceptionHandling STATIC ExceptionHandling.Cpp.cpp)
 add_library(WasmExceptionHandling STATIC ExceptionHandling.Wasm.cpp)
 add_library(EmulatedExceptionHandling STATIC ExceptionHandling.Emulated.cpp)
 
+target_compile_options(CppExceptionHandling PRIVATE -fexceptions)
 target_compile_options(WasmExceptionHandling PRIVATE -fwasm-exceptions)
 
 install_static_library(CppExceptionHandling aotsdk nativeaot)


### PR DESCRIPTION
This is not needed because we don't actually use any of the C++ exception support, which this flag pulls in, and likewise don't leak exceptions across ABI boundaries.

Diffs for `WasmDebugging.csproj`:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 893912
Total bytes of diff: 824854
Total bytes of delta: -69058 (-7.73% % of base)
Average relative delta: -0.39%
    diff is an improvement
    average relative diff is an improvement

Top method improvements (percentages):
         -71 (-87.65% of base) : 1003.dasm - operator new[](unsigned long, std::nothrow_t const&)
         -71 (-87.65% of base) : 1002.dasm - operator new(unsigned long, std::nothrow_t const&)
         -27 (-69.23% of base) : 1056.dasm - __cxxabiv1::(anonymous namespace)::DtorsManager::~DtorsManager()
          -7 (-41.18% of base) : 1004.dasm - operator delete(void*)
          -7 (-33.33% of base) : 1054.dasm - std::get_new_handler()
         -26 (-27.66% of base) : 1001.dasm - operator new(unsigned long)
         -31 (-15.12% of base) : 1055.dasm - __cxa_thread_atexit

Top methods only present in base:
         -84 (-100.00% of base) : 1000.dasm - aligned_alloc
         -10 (-100.00% of base) : 1609.dasm - (anonymous namespace)::itanium_demangle::TemplateTemplateParamDecl::~TemplateTemplateParamDecl()
         -38 (-100.00% of base) : 1610.dasm - (anonymous namespace)::itanium_demangle::TemplateParamPackDecl::TemplateParamPackDecl((anonymous namespace)::itanium_demangle::Node*)
         -92 (-100.00% of base) : 1611.dasm - (anonymous namespace)::itanium_demangle::TemplateParamPackDecl::printLeft((anonymous namespace)::itanium_demangle::OutputBuffer&) const
         -26 (-100.00% of base) : 1612.dasm - (anonymous namespace)::itanium_demangle::TemplateParamPackDecl::printRight((anonymous namespace)::itanium_demangle::OutputBuffer&) const
         -10 (-100.00% of base) : 1613.dasm - (anonymous namespace)::itanium_demangle::TemplateParamPackDecl::~TemplateParamPackDecl()
         -63 (-100.00% of base) : 1614.dasm - (anonymous namespace)::itanium_demangle::ClosureTypeName::ClosureTypeName((anonymous namespace)::itanium_demangle::NodeArray, (anonymous namespace)::itanium_demangle::NodeArray, (anonymous namespace)::itanium_demangle::StringView)
        -151 (-100.00% of base) : 1615.dasm - (anonymous namespace)::itanium_demangle::ClosureTypeName::printLeft((anonymous namespace)::itanium_demangle::OutputBuffer&) const
        -222 (-100.00% of base) : 1616.dasm - (anonymous namespace)::itanium_demangle::ClosureTypeName::printDeclarator((anonymous namespace)::itanium_demangle::OutputBuffer&) const
         -10 (-100.00% of base) : 1617.dasm - (anonymous namespace)::itanium_demangle::ClosureTypeName::~ClosureTypeName()
         -41 (-100.00% of base) : 1618.dasm - (anonymous namespace)::itanium_demangle::LambdaExpr::LambdaExpr((anonymous namespace)::itanium_demangle::Node const*)
        -139 (-100.00% of base) : 1619.dasm - (anonymous namespace)::itanium_demangle::LambdaExpr::printLeft((anonymous namespace)::itanium_demangle::OutputBuffer&) const
         -15 (-100.00% of base) : 1608.dasm - (anonymous namespace)::itanium_demangle::TemplateTemplateParamDecl::printRight((anonymous namespace)::itanium_demangle::OutputBuffer&) const
         -10 (-100.00% of base) : 1620.dasm - (anonymous namespace)::itanium_demangle::LambdaExpr::~LambdaExpr()
        -206 (-100.00% of base) : 1622.dasm - (anonymous namespace)::itanium_demangle::EnumLiteral::printLeft((anonymous namespace)::itanium_demangle::OutputBuffer&) const
         -67 (-100.00% of base) : 1623.dasm - (anonymous namespace)::itanium_demangle::OutputBuffer::operator<<((anonymous namespace)::itanium_demangle::StringView)
         -10 (-100.00% of base) : 1624.dasm - (anonymous namespace)::itanium_demangle::EnumLiteral::~EnumLiteral()
         -79 (-100.00% of base) : 1625.dasm - (anonymous namespace)::itanium_demangle::FunctionParam* (anonymous namespace)::DefaultAllocator::makeNode<(anonymous namespace)::itanium_demangle::FunctionParam, (anonymous namespace)::itanium_demangle::StringView&>((anonymous namespace)::itanium_demangle::StringView&)
         -43 (-100.00% of base) : 1626.dasm - (anonymous namespace)::itanium_demangle::FunctionParam::FunctionParam((anonymous namespace)::itanium_demangle::StringView)
        -104 (-100.00% of base) : 1627.dasm - (anonymous namespace)::itanium_demangle::FunctionParam::printLeft((anonymous namespace)::itanium_demangle::OutputBuffer&) const

924 total methods with Code Size differences (924 improved, 0 regressed)
```
Closes #2511.