### PR TITLE
[NativeAOT-LLVM] GC stress and faster checked builds

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5184,7 +5184,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     DoPhase(this, PHASE_BUILD_LLVM, [this]() {
         m_llvm->Compile();
     });
-#else
+#else // !TARGET_WASM
 
 #ifdef TARGET_ARM
     if (compLocallocUsed)
@@ -5259,6 +5259,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
     // Generate PatchpointInfo
     generatePatchpointInfo();
+#endif // !TARGET_WASM
 
     RecordStateAtEndOfCompilation();
 
@@ -5312,8 +5313,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         fprintf(compJitFuncInfoFile, ""); // in our logic this causes a flush
     }
 #endif // FUNC_INFO_LOGGING
-#endif // TARGET_WASM
-
 }
 
 #if FEATURE_LOOP_ALIGN

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -715,6 +715,7 @@ CONFIG_INTEGER(JitDispIns, W("JitDispIns"), 0)
 
 CONFIG_INTEGER(JitCheckLlvmIR, W("JitCheckLlvmIR"), DEBUG_ONLY_BY_DEFAULT)
 CONFIG_INTEGER(JitRunLssaTests, W("JitRunLssaTests"), 0)
+CONFIG_INTEGER(JitGcStress, W("JitGcStress"), 0)
 #endif // TARGET_WASM
 
 CONFIG_INTEGER(JitEnregStructLocals, W("JitEnregStructLocals"), 1) // Allow to enregister locals with struct type.

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -707,13 +707,7 @@ CONFIG_INTEGER(JitDispIns, W("JitDispIns"), 0)
 #endif // DEBUG
 
 #ifdef TARGET_WASM
-#ifdef DEBUG
-#define DEBUG_ONLY_BY_DEFAULT 1
-#else
-#define DEBUG_ONLY_BY_DEFAULT 0
-#endif
-
-CONFIG_INTEGER(JitCheckLlvmIR, W("JitCheckLlvmIR"), DEBUG_ONLY_BY_DEFAULT)
+CONFIG_INTEGER(JitCheckLlvmIR, W("JitCheckLlvmIR"), 0)
 CONFIG_INTEGER(JitRunLssaTests, W("JitRunLssaTests"), 0)
 CONFIG_INTEGER(JitGcStress, W("JitGcStress"), 0)
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -716,6 +716,10 @@ CONFIG_INTEGER(JitDispIns, W("JitDispIns"), 0)
 CONFIG_INTEGER(JitCheckLlvmIR, W("JitCheckLlvmIR"), DEBUG_ONLY_BY_DEFAULT)
 CONFIG_INTEGER(JitRunLssaTests, W("JitRunLssaTests"), 0)
 CONFIG_INTEGER(JitGcStress, W("JitGcStress"), 0)
+
+#ifdef DEBUG
+CONFIG_STRING(JitEnableLssaRange, W("JitEnableLssaRange"))
+#endif // DEBUG
 #endif // TARGET_WASM
 
 CONFIG_INTEGER(JitEnregStructLocals, W("JitEnregStructLocals"), 1) // Allow to enregister locals with struct type.

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -471,6 +471,7 @@ private:
     unsigned getShadowFrameSize(unsigned funcIdx) const;
     unsigned getCalleeShadowStackOffset(unsigned funcIdx, bool isTailCall) const;
     bool canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter) const;
+    bool isPotentialGcSafePoint(GenTree* node) const;
     bool isShadowFrameLocal(LclVarDsc* varDsc) const;
     bool isShadowStackLocal(unsigned lclNum) const;
     bool isFuncletParameter(unsigned lclNum) const;
@@ -558,6 +559,8 @@ private:
 
     void emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFunc);
     Value* emitCheckedArithmeticOperation(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value);
+
+    llvm::CallBase* emitGcStressCall(GenTreeCall* call, llvm::CallBase* callValue);
     llvm::CallBase* emitHelperCall(CorInfoHelpFunc helperFunc, ArrayRef<Value*> sigArgs = {});
     bool canEmitHelperCallAsShadowTailCall(CorInfoHelpFunc helperFunc);
     llvm::CallBase* emitCallOrInvoke(llvm::Function* callee, ArrayRef<Value*> args = {});

--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -219,6 +219,7 @@ if (CLR_CMAKE_TARGET_ARCH_WASM)
     ${ARCH_SOURCES_DIR}/PalRedhawkWasm.cpp
     ${ARCH_SOURCES_DIR}/AllocFast.cpp
     ${ARCH_SOURCES_DIR}/ExceptionHandling/ExceptionHandling.cpp
+    ${ARCH_SOURCES_DIR}/GcStress.cpp
     ${ARCH_SOURCES_DIR}/StubDispatch.cpp
     ${ARCH_SOURCES_DIR}/PInvoke.cpp
   )

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -194,6 +194,10 @@ private:
     //
     PInvokeTransitionFrame* GetTransitionFrame();
 
+#ifdef HOST_WASM
+    void GcScanWasmShadowStack(ScanFunc* pfnEnumCallback, ScanContext* pvCallbackData);
+#endif
+
     void GcScanRootsWorker(ScanFunc* pfnEnumCallback, ScanContext* pvCallbackData, StackFrameIterator & sfIter);
 
     // Tracks the amount of bytes that were reserved for threads in their gc_alloc_context and went unused when they died.

--- a/src/coreclr/nativeaot/Runtime/wasm/GcStress.cpp
+++ b/src/coreclr/nativeaot/Runtime/wasm/GcStress.cpp
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <cstdio>
+
+#include "common.h"
+#include "gcenv.h"
+#include "gcenv.ee.h"
+#include "gcheaputilities.h"
+#include "gchandleutilities.h"
+
+#include "thread.h"
+#include "threadstore.h"
+#include "threadstore.inl"
+#include "thread.inl"
+
+COOP_PINVOKE_HELPER(void*, RhpGcStressOnce, (void* obj, uint8_t* pFlag))
+{
+    if (*pFlag)
+    {
+        // This helper will only stress each safe point once.
+        return obj;
+    }
+
+    // The GarbageCollect operation below may trash the last win32 error. We save the error here so that it can be
+    // restored after the GC operation;
+    int32_t lastErrorOnEntry = PalGetLastError();
+
+    Thread* pThread = ThreadStore::GetCurrentThread();
+    if (!pThread->IsSuppressGcStressSet() && !pThread->IsDoNotTriggerGcSet())
+    {
+        // GC-protect our exposed object.
+        GCFrameRegistration gc;
+        if (obj != nullptr)
+        {
+            gc.m_pThread = pThread;
+            gc.m_pObjRefs = &obj;
+            gc.m_numObjRefs = 1;
+            gc.m_MaybeInterior = 1;
+            pThread->PushGCFrameRegistration(&gc);
+        }
+
+        GCHeapUtilities::GetGCHeap()->GarbageCollect();
+
+        if (obj != nullptr)
+        {
+            pThread->PopGCFrameRegistration(&gc);
+        }
+        *pFlag = true;
+    }
+
+    // Restore the saved error
+    PalSetLastError(lastErrorOnEntry);
+    return obj;
+}
+
+COOP_PINVOKE_HELPER(Object*, RhpCheckObj, (Object* obj))
+{
+    if (obj != nullptr)
+    {
+        MethodTable* pMT = obj->GetMethodTable();
+        if (!pMT->Validate())
+        {
+            printf("Corrupt object/pMT: [%p]/[%p]\n", obj, pMT);
+            RhFailFast();
+        }
+    }
+
+    return obj;
+}

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -73,10 +73,10 @@ namespace ILCompiler
 
         private void FinishCompilation()
         {
-            foreach ((int _, CorInfoImpl corInfo) in _compilationContexts)
+            Parallel.ForEach(_compilationContexts, new() { MaxDegreeOfParallelism = _parallelism }, context =>
             {
-                corInfo.JitFinishSingleThreadedCompilation();
-            }
+                context.Value.JitFinishSingleThreadedCompilation();
+            });
 
             _compilationContexts = null;
         }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -739,6 +739,13 @@ namespace Internal.JitInterface
                 case CorInfoHelpFunc.CORINFO_HELP_GETCLASSFROMMETHODPARAM:
                     return _compilation.NodeFactory.MethodEntrypoint(_compilation.NodeFactory.TypeSystemContext.GetHelperEntryPoint("SynchronizedMethodHelpers", "GetClassFromMethodParam"));
 
+                case CorInfoHelpFunc.CORINFO_HELP_STRESS_GC:
+                    mangledName = "RhpGcStressOnce";
+                    break;
+                case CorInfoHelpFunc.CORINFO_HELP_CHECK_OBJ:
+                    mangledName = "RhpCheckObj";
+                    break;
+
                 case CorInfoHelpFunc.CORINFO_HELP_GVMLOOKUP_FOR_SLOT:
                     id = ReadyToRunHelper.GVMLookupForSlot;
                     break;


### PR DESCRIPTION
Adds a `JitGcStress` compiler knob that will cause codegen to insert calls to a GC-triggering helper after each safe point in the method. This makes GC holes dramatically easier to reproduce. I've now used this successfully to root cause the problem in #2514. We should also consider enabling this on some of our tests, though this change does not do that.

I am also making two tweaks to make the Checked build faster here:
1) Parallelize the writing of bitcode. This will also help large compiles.
2) _Disable_ writing out of textual IR by default (can still be enabled via `--codegenopt:JitCheckLlvmIR=1`). I've found that the tradeoff this makes in making the checked build slower means I am almost always using a Release build + `llvm-dis` instead.