### PR TITLE
[NativeAOT-LLVM] Add a couple dereferenceability attributes

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -232,7 +232,9 @@ public:
 class Llvm
 {
 private:
+    static const unsigned SHADOW_STACK_ARG_INDEX = 0;
     static const unsigned DEFAULT_SHADOW_STACK_ALIGNMENT = TARGET_POINTER_SIZE;
+    static const unsigned MIN_HEAP_OBJ_SIZE = TARGET_POINTER_SIZE * 2;
 
     void* const m_pEECorInfo; // TODO-LLVM: workaround for not changing the JIT/EE interface.
     SingleThreadedCompilationContext* const m_context;
@@ -484,10 +486,10 @@ public:
     void Compile();
 
 private:
-    const unsigned ROOT_FUNC_IDX = 0;
+    static const unsigned ROOT_FUNC_IDX = 0;
 
     void initializeFunctions();
-    void annotateRootFunction(Function* llvmFunc);
+    void annotateFunctions();
     void generateProlog();
     void initializeShadowStack();
     void initializeLocals();

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -46,8 +46,6 @@ void Llvm::initializeFunctions()
         BADCODE("Duplicate definition");
     }
 
-    annotateRootFunction(rootLlvmFunction);
-
     // First function is always the root.
     m_functions = std::vector<FunctionInfo>(_compiler->compFuncCount());
     m_functions[ROOT_FUNC_IDX] = {rootLlvmFunction};
@@ -109,24 +107,81 @@ void Llvm::initializeFunctions()
 
         m_functions[funcIdx] = {llvmFunc};
     }
+
+    annotateFunctions();
 }
 
-void Llvm::annotateRootFunction(Function* llvmFunc)
+void Llvm::annotateFunctions()
 {
-    if (_compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT))
-    {
-        llvmFunc->addFnAttr(llvm::Attribute::NoInline);
-        llvmFunc->addFnAttr(llvm::Attribute::OptimizeNone);
-    }
-    if ((_compiler->info.compFlags & CORINFO_FLG_DONT_INLINE) != 0)
-    {
-        llvmFunc->addFnAttr(llvm::Attribute::NoInline);
-    }
+    auto addDerefAttr = [this](Function* llvmFunc, unsigned argNum, unsigned derefSize, bool mayBeNull = false) {
+        llvm::Attribute derefAttr = mayBeNull
+            ? llvm::Attribute::getWithDereferenceableOrNullBytes(m_context->Context, derefSize)
+            : llvm::Attribute::getWithDereferenceableBytes(m_context->Context, derefSize);
+        llvmFunc->addParamAttr(argNum, derefAttr);
+    };
 
-    if (!llvmFunc->hasFnAttribute(llvm::Attribute::OptimizeNone) &&
-        (!m_anyReturns || (_compiler->opts.compCodeOpt == Compiler::SMALL_CODE)))
+    for (unsigned funcIdx = 0; funcIdx < _compiler->compFuncCount(); funcIdx++)
     {
-        llvmFunc->addFnAttr(llvm::Attribute::OptimizeForSize);
+        Function* llvmFunc = m_functions[funcIdx].LlvmFunction;
+        if (llvmFunc == nullptr)
+        {
+            continue;
+        }
+
+        if (_compiler->opts.jitFlags->IsSet(JitFlags::JIT_FLAG_MIN_OPT))
+        {
+            llvmFunc->addFnAttr(llvm::Attribute::NoInline);
+            llvmFunc->addFnAttr(llvm::Attribute::OptimizeNone);
+        }
+
+        if (funcIdx == ROOT_FUNC_IDX)
+        {
+            if ((_compiler->info.compFlags & CORINFO_FLG_DONT_INLINE) != 0)
+            {
+                llvmFunc->addFnAttr(llvm::Attribute::NoInline);
+            }
+        }
+
+        if (_compiler->opts.OptimizationEnabled())
+        {
+            if (!m_anyReturns || (_compiler->opts.compCodeOpt == Compiler::SMALL_CODE))
+            {
+                assert(!llvmFunc->hasFnAttribute(llvm::Attribute::OptimizeNone));
+                llvmFunc->addFnAttr(llvm::Attribute::OptimizeForSize);
+            }
+
+            // Mark the shadow stack dereferenceable.
+            if ((funcIdx != ROOT_FUNC_IDX) || _compiler->lvaGetDesc(_shadowStackLclNum)->lvIsParam)
+            {
+                unsigned derefSize = getShadowFrameSize(funcIdx);
+                if (derefSize != 0)
+                {
+                    addDerefAttr(llvmFunc, SHADOW_STACK_ARG_INDEX, derefSize);
+                }
+            }
+
+            if (funcIdx == ROOT_FUNC_IDX)
+            {
+                // Mark the return buffer dereferenceable.
+                if (m_info->compRetBuffArg != BAD_VAR_NUM)
+                {
+                    unsigned argNum = _compiler->lvaGetDesc(m_info->compRetBuffArg)->lvLlvmArgNum;
+                    unsigned derefSize = m_info->compCompHnd->getClassSize(m_info->compMethodInfo->args.retTypeClass);
+                    addDerefAttr(llvmFunc, argNum, derefSize, /* mayBeNull */ true);
+                }
+
+                // Mark implicit byrefs dereferenceable.
+                for (unsigned lclNum = 0; lclNum < m_info->compArgsCount; lclNum++)
+                {
+                    if (_compiler->lvaIsImplicitByRefLocal(lclNum))
+                    {
+                        LclVarDsc* varDsc = _compiler->lvaGetDesc(lclNum);
+                        assert(varDsc->lvIsParam);
+                        addDerefAttr(llvmFunc, varDsc->lvLlvmArgNum, varDsc->GetLayout()->GetSize());
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -3095,7 +3150,7 @@ Value* Llvm::getShadowStack()
     }
 
     // Note that funclets have the shadow stack arg in the 0th position.
-    return getCurrentLlvmFunction()->getArg(0);
+    return getCurrentLlvmFunction()->getArg(SHADOW_STACK_ARG_INDEX);
 }
 
 // Shadow stack moved up to avoid overwriting anything on the stack in the compiling method

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1107,7 +1107,7 @@ unsigned Llvm::getObjectSizeBound(GenTree* obj)
     assert(obj->TypeIs(TYP_REF));
 
     // TODO-LLVM-CQ: improve this estimate using "gtGetClassHandle".
-    return TARGET_POINTER_SIZE * 2;
+    return MIN_HEAP_OBJ_SIZE;
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
For the shadow stack, return buffer and implicit byrefs.

Additionally, annotate the whole funclet tree with `optnone`/`optsize`, not just the root function.

The diffs are modest, and come from more usage of the WASM address modes:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3059418
Total bytes of diff: 3058843
Total bytes of delta: -575 (-0.02% % of base)
Average relative delta: -1.26%
    diff is an improvement
    average relative diff is an improvement

Top method improvements (percentages):
         -92 (-5.47% of base) : 1005.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_MethodNameFormatter__EmitMethodParameters_0
         -62 (-3.21% of base) : 1011.dasm - System.Reflection.Runtime.General.NativeFormatMetadataReaderExtensions__TryParseConstantEnumArray
         -10 (-3.12% of base) : 1028.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_MethodNameFormatter_SigTypeContext__FromMethod
         -12 (-1.98% of base) : 1014.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilderState__GetFieldGCLayout
         -28 (-1.92% of base) : 1024.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetMethodInvokeMetadataFromInvokeMap
         -13 (-1.65% of base) : 1012.dasm - System.Reflection.Runtime.MethodInfos.RuntimeMethodHelpers__GetRuntimeParameters<System.Reflection.Runtime.MethodInfos.NativeFormat.NativeFormatMethodCommon>
         -19 (-1.63% of base) : 1010.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TemplateLocator__TryGetTypeTemplate_Internal
         -21 (-1.52% of base) : 1002.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetMetadataForNamedType
         -20 (-1.46% of base) : 1008.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TemplateLocator__TryGetGenericMethodTemplate_Internal
         -21 (-1.42% of base) : 1009.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryLookupExactMethodPointer
         -19 (-1.35% of base) : 1001.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_StackTraceMetadata__GetMethodNameFromStartAddressIfAvailable
         -21 (-1.32% of base) : 1004.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetFieldAccessMetadataFromFieldAccessMap
         -12 (-1.18% of base) : 1019.dasm - System.TimeZoneInfo_AdjustmentRule__ValidateAdjustmentRule
         -15 (-1.16% of base) : 1003.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetStaticGenericTypeForComponents
         -21 (-1.14% of base) : 1006.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__ResolveInterfaceGenericVirtualMethodSlot
         -55 (-1.12% of base) : 1025.dasm - System.Reflection.CustomAttributeTypedArgument__ToString_0
         -33 (-1.11% of base) : 1020.dasm - System.Reflection.Runtime.Assemblies.NativeFormat.NativeFormatRuntimeAssembly__CreateCaseInsensitiveTypeDictionary
          -6 (-1.05% of base) : 1013.dasm - Internal.Metadata.NativeFormat.MetadataReader__GetNamespaceDefinition
         -21 (-0.97% of base) : 1007.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__ResolveGenericVirtualMethodTarget_0
         -22 (-0.76% of base) : 1030.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetStaticGenericMethodComponents

31 total methods with Code Size differences (31 improved, 0 regressed)
```
```diff
- 41 04                      |       i32.const 4
- 6a                         |       i32.add
- 28 02 00                   |       i32.load 2 0
+ 28 02 04                   |       i32.load 2 4
```