### PR TITLE
[NativeAOT-LLVM] Reject tailcalls in methods with pinned locals

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -256,7 +256,7 @@ private:
     BlockSet m_blocksInFilters = BlockSetOps::UninitVal();
 
     // Shared between LSSA and codegen.
-    bool m_anyAddressExposedShadowLocals = false;
+    bool m_anyAddressExposedOrPinnedShadowLocals = false;
 
     // Codegen members.
     llvm::IRBuilder<> _builder;

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -1015,7 +1015,7 @@ private:
         varDsc->lvImplicitlyReferenced = 0;
         varDsc->setLvRefCnt(0);
 
-        m_llvm->m_anyAddressExposedShadowLocals |= varDsc->IsAddressExposed();
+        m_llvm->m_anyAddressExposedOrPinnedShadowLocals |= (varDsc->IsAddressExposed() || varDsc->lvPinned);
     }
 
     void AssignShadowFrameOffsets(std::vector<unsigned>& shadowFrameLocals)
@@ -1920,7 +1920,8 @@ bool Llvm::canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter) co
     }
 
     // Address-exposed shadow state may be observed by the callee or filters that run in the first pass of EH.
-    if (m_anyAddressExposedShadowLocals)
+    // Likewise with pinning.
+    if (m_anyAddressExposedOrPinnedShadowLocals)
     {
         return false;
     }


### PR DESCRIPTION
Tailcalling risks losing the pin for the callee.

Some regressions, but this is a correctness fix:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3059418
Total bytes of diff: 3059909
Total bytes of delta: 491 (0.02% % of base)
Average relative delta: 2.19%
    diff is a regression
    average relative diff is a regression

Top method regressions (percentages):
           9 (11.39% of base) : 1058.dasm - System.Text.UTF32Encoding__GetByteCount_0
           9 (11.39% of base) : 1055.dasm - System.Text.UnicodeEncoding__GetByteCount_0
          13 ( 8.61% of base) : 1016.dasm - System.Globalization.CompareInfo__IcuStartsWith
          13 ( 8.61% of base) : 1026.dasm - System.Globalization.CompareInfo__IcuEndsWith
          12 ( 8.33% of base) : 1063.dasm - System.Text.UTF8Encoding__GetString
           6 ( 7.79% of base) : 1054.dasm - System.Text.Encoding__GetByteCount_4
           6 ( 6.74% of base) : 1071.dasm - System.Threading.ObjectHeader__GetSyncIndex
           3 ( 6.38% of base) : 1027.dasm - System.Text.Encoding__GetString_0
           6 ( 5.77% of base) : 1052.dasm - System.Text.Encoding__GetBytes_6
           6 ( 5.77% of base) : 1051.dasm - System.Text.Encoding__GetChars_3
          12 ( 5.66% of base) : 1056.dasm - System.Text.UTF32Encoding__GetString
          12 ( 5.66% of base) : 1050.dasm - System.Text.UnicodeEncoding__GetString
          18 ( 5.13% of base) : 1009.dasm - System.Text.DecoderNLS__GetChars_0
          18 ( 5.13% of base) : 1057.dasm - System.Text.UTF32Encoding__GetBytes
          18 ( 5.13% of base) : 1053.dasm - System.Text.UnicodeEncoding__GetBytes
           3 ( 4.55% of base) : 1013.dasm - System.Runtime.InteropServices.PInvokeMarshal__StringToAnsiString
          22 ( 4.48% of base) : 1017.dasm - System.Number__UInt64ToDecStr
           3 ( 4.48% of base) : 1012.dasm - LSSATests_IL_System_Runtime_JitTesting_LSSATestsIL__Optimized_ExposedLocal_Untracked
          15 ( 4.32% of base) : 1066.dasm - System.Text.UTF8Encoding__GetBytes
          15 ( 4.04% of base) : 1002.dasm - HelloWasm_Program__PrintLine

Top method improvements (percentages):
         -14 (-1.93% of base) : 1019.dasm - System.Number__NegativeInt32ToDecStr
          -9 (-1.05% of base) : 1086.dasm - System.Array__CopyImplValueTypeArrayWithInnerGcRefs
          -1 (-0.12% of base) : 1072.dasm - System.Threading.ObjectHeader__TryAcquireUncommon

93 total methods with Code Size differences (3 improved, 90 regressed)
```