### PR TITLE
[NativeAOT-LLVM] Implement saturating semantics for float to int conversions

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1586,14 +1586,14 @@ void Llvm::buildCast(GenTreeCast* cast)
                 case TYP_SHORT:
                 case TYP_INT:
                 case TYP_LONG:
-                    castValue = _builder.CreateFPToSI(castFromValue, castToLlvmType);
+                    castValue = _builder.CreateIntrinsic(castToLlvmType, llvm::Intrinsic::fptosi_sat, castFromValue);
                     break;
 
                 case TYP_UBYTE:
                 case TYP_USHORT:
                 case TYP_UINT:
                 case TYP_ULONG:
-                    castValue = _builder.CreateFPToUI(castFromValue, castToLlvmType);
+                    castValue = _builder.CreateIntrinsic(castToLlvmType, llvm::Intrinsic::fptoui_sat, castFromValue);
                     break;
 
                 default:

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -117,6 +117,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   <PropertyGroup Condition="'$(NativeCodeGen)' == 'llvm'">
     <!-- These LLVM options are public and supported. -->
     <WasmEnableJSBigIntIntegration Condition="'$(WasmEnableJSBigIntIntegration)' == ''">true</WasmEnableJSBigIntIntegration>
+    <WasmEnableNonTrappingFloatToIntConversions Condition="'$(WasmEnableNonTrappingFloatToIntConversions)' == ''">true</WasmEnableNonTrappingFloatToIntConversions>
     <!-- Most browsers support WASM EH, so we enable it by default. This is aligned with the upstream behavior. -->
     <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == '' and '$(_targetOS)' == 'browser'">true</WasmEnableExceptionHandling>
 
@@ -403,6 +404,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <CompileWasmArgs>-c $(WasmOptimizationSetting)</CompileWasmArgs>
       <CompileWasmArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(CompileWasmArgs) -g3</CompileWasmArgs>
+      <CompileWasmArgs Condition="'$(WasmEnableNonTrappingFloatToIntConversions)' == 'true'">$(CompileWasmArgs) -mnontrapping-fptoint</CompileWasmArgs>
       <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'wasm'">$(CompileWasmArgs) -fwasm-exceptions</CompileWasmArgs>
     </PropertyGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -400,12 +400,14 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeBinary)))" />
 
-    <PropertyGroup Condition="'$(_targetOS)' == 'browser'">
-      <CompileWasmArgs>-c</CompileWasmArgs>
-      <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'">$(CompileWasmArgs) -s DISABLE_EXCEPTION_CATCHING=0</CompileWasmArgs>
-      <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'wasm'">$(CompileWasmArgs) -fwasm-exceptions</CompileWasmArgs>
+    <PropertyGroup>
+      <CompileWasmArgs>-c $(WasmOptimizationSetting)</CompileWasmArgs>
       <CompileWasmArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(CompileWasmArgs) -g3</CompileWasmArgs>
-      <CompileWasmArgs>$(CompileWasmArgs) $(WasmOptimizationSetting)</CompileWasmArgs>
+      <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'wasm'">$(CompileWasmArgs) -fwasm-exceptions</CompileWasmArgs>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_targetOS)' == 'browser'">
+      <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'">$(CompileWasmArgs) -s DISABLE_EXCEPTION_CATCHING=0</CompileWasmArgs>
 
       <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.bat</ScriptExt>
       <WasmCompilerPath>&quot;$(EMSDK)/upstream/emscripten/emcc$(ScriptExt)&quot;</WasmCompilerPath>
@@ -413,9 +415,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </PropertyGroup>
 
    <PropertyGroup Condition="'$(_targetOS)' == 'wasi'">
-      <CompileWasmArgs>-fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -disable-lsr --sysroot=&quot;$(WASI_SDK_PATH)/share/wasi-sysroot&quot; -target $(IlcLlvmTarget) -c</CompileWasmArgs>
-      <CompileWasmArgs>$(CompileWasmArgs) $(WasmOptimizationSetting)</CompileWasmArgs>
-      <CompileWasmArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(CompileWasmArgs) -g3</CompileWasmArgs>
+      <CompileWasmArgs>$(CompileWasmArgs) -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -disable-lsr --sysroot=&quot;$(WASI_SDK_PATH)/share/wasi-sysroot&quot; -target $(IlcLlvmTarget)</CompileWasmArgs>
 
       <ExeExt Condition="'$(OS)' == 'Windows_NT'">.exe</ExeExt>
       <!-- using Emscripten's clang++ because of a crash in wasi-sdk's clang++ (https://github.com/WebAssembly/wasi-sdk/issues/326) -->

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -384,6 +384,8 @@ internal unsafe partial class Program
 
         TestCkFinite();
 
+        TestFloatToIntConversions();
+
         TestIntOverflows();
 
 #if !CODEGEN_WASI // TODO-LLVM: stack traces on WASI.
@@ -2898,6 +2900,35 @@ internal unsafe partial class Program
     private static unsafe bool CkFinite64(ulong value)
     {
         return CkFiniteTest.CkFinite64(*(double*)(&value));
+    }
+
+    private static void TestFloatToIntConversions()
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static T HideFromOptimizations<T>(T value) => value;
+
+        StartTest("Test float to int conversions");
+        if ((int)HideFromOptimizations(1245.6789d) != 1245)
+        {
+            FailTest("(int)1245.6789d not equal to 1245");
+            return;
+        }
+        if ((int)HideFromOptimizations(double.NaN) != 0)
+        {
+            FailTest("(int)double.NaN not equal to 0");
+            return;
+        }
+        if ((int)HideFromOptimizations(double.PositiveInfinity) != int.MaxValue)
+        {
+            FailTest("(int)double.PositiveInfinity not equal to int.MaxValue");
+            return;
+        }
+        if ((int)HideFromOptimizations(double.NegativeInfinity) != int.MinValue)
+        {
+            FailTest("(int)double.NegativeInfinity not equal to int.MinValue");
+            return;
+        }
+        PassTest();
     }
 
     static void TestIntOverflows()


### PR DESCRIPTION
Using the same intrinsics Rust uses, and which conveniently correspond exactly both to .NET semantics _and_ WASM's non-trapping conversion instructions, which we now enable by default via `-mnontrapping-fptoint`.

Ref: https://github.com/dotnet/runtimelab/issues/2455#issuecomment-2067534258.