### PR TITLE
[NativeAOT-LLVM] Normalize struct local field stores

### DIFF
--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -329,9 +329,18 @@ void Llvm::lowerLocal(GenTreeLclVarCommon* node)
         lowerStoreLcl(node->AsLclVarCommon());
     }
 
-    if (node->OperIsLocalStore() && node->TypeIs(TYP_STRUCT) && genActualTypeIsInt(node->gtGetOp1()))
+    if (node->TypeIs(TYP_STRUCT) && node->OperIsLocalStore())
     {
-        node->gtGetOp1()->SetContained();
+        GenTree* value = node->Data();
+        if (genActualTypeIsInt(value))
+        {
+            value->SetContained();
+        }
+        else if (node->OperIs(GT_STORE_LCL_FLD))
+        {
+            // "STORE_LCL_VAR"s already normalized by "lowerStoreLcl".
+            node->AsLclFld()->SetLayout(value->GetLayout(_compiler));
+        }
     }
 
     if (node->OperIsLocalField() || node->OperIs(GT_LCL_ADDR))

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -415,6 +415,8 @@ internal unsafe partial class Program
 
         TestJitUseStruct();
 
+        TestMismatchedStructLocalFieldStore();
+
         TestUnsafe();
 
         TestReadByteArray();
@@ -468,6 +470,27 @@ internal unsafe partial class Program
         var res = JitUseStructProblem(&structWithStruct, structWithIndex);
 
         EndTest(res.Index == structWithIndex.Index && res.Value == structWithIndex.Value);
+    }
+
+    public struct StructWrapper
+    {
+        public readonly Guid WrappedStruct;
+        public StructWrapper(Guid value) => WrappedStruct = value;
+    }
+
+    private static void TestMismatchedStructLocalFieldStore()
+    {
+        const string GuidValue = "0c733a1e-2a1c-11ce-ade5-00aa0044773d";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        bool ExposeAndVerify(ref StructWrapper? x)
+        {
+            return x.HasValue && x.Value.WrappedStruct.ToString() == GuidValue;
+        }
+
+        StartTest("TestMismatchedStructLocalFieldStore");
+        StructWrapper? x = new StructWrapper(Guid.Parse(GuidValue));
+        EndTest(ExposeAndVerify(ref x));
     }
 
     [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
We need the operand and consumer types to match here, much like in all the other places that produce or consume struct types.

Fixes #2555. Although I am yet to verify there are no other problems.