### PR TITLE
[NativeAOT-LLVM] Resolve some warnings, replace some `std` types with Jit types

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -27,10 +27,6 @@ extern ICorJitHost* g_jitHost;
 
 #ifdef TARGET_WASM
 #include "llvm.h"
-
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-
 #endif // TARGET_WASM
 
 unsigned Compiler::jitTotalMethodCompiled = 0;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5,8 +5,6 @@
 
 #ifdef TARGET_WASM
 #include "llvm.h"
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif // TARGET_WASM
 
 #ifdef _MSC_VER

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -5,8 +5,6 @@
 
 #ifdef TARGET_WASM
 #include "llvm.h"
-#define max(a, b) (((a) > (b)) ? (a) : (b))
-#define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif // TARGET_WASM
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -4,10 +4,15 @@
 #include "jitpch.h"
 #include "llvm.h"
 
-#pragma warning (disable: 4459)
+// TODO-LLVM-Upstream: figure out how to fix these warnings in LLVM headers.
+#pragma warning(push)
+#pragma warning (disable : 4242)
+#pragma warning (disable : 4244)
+#pragma warning (disable : 4459)
+#pragma warning (disable : 4267)
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Support/Signals.h"
-#pragma warning (error: 4459)
+#pragma warning(pop)
 
 // Must be kept in sync with the managed version in "CorInfoImpl.Llvm.cs".
 //

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -110,6 +110,7 @@ Llvm::Llvm(Compiler* compiler)
     , _sdsuMap(compiler->getAllocator(CMK_Codegen))
     , _localsMap(compiler->getAllocator(CMK_Codegen))
     , m_throwHelperBlocksMap(compiler->getAllocator(CMK_Codegen))
+    , m_phiPairs(compiler->getAllocator(CMK_Codegen))
     , m_ehModel(GetExceptionHandlingModel())
     , m_debugVariablesMap(compiler->getAllocator(CMK_Codegen))
 {

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -14,13 +14,13 @@
 #include <new>
 
 // these break std::min/max in LLVM's headers
-#undef min
-#undef max
+#undef min // TODO-LLVM: delete.
+#undef max // TODO-LLVM: delete.
 // this breaks StringMap.h
 #undef NumItems
 
-// Remove these disables where possible and convert to push/pop elsewhere.
-// See https://github.com/dotnet/runtimelab/issues/2554
+// TODO-LLVM-Upstream: figure out how to fix these warnings in LLVM headers.
+#pragma warning(push)
 #pragma warning(disable : 4146)
 #pragma warning(disable : 4242)
 #pragma warning(disable : 4244)
@@ -32,6 +32,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/IR/IntrinsicsWebAssembly.h"
+#pragma warning(pop)
 
 #include <unordered_map>
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -13,9 +13,6 @@
 #include "llvmtypes.h"
 #include <new>
 
-// these break std::min/max in LLVM's headers
-#undef min // TODO-LLVM: delete.
-#undef max // TODO-LLVM: delete.
 // this breaks StringMap.h
 #undef NumItems
 

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -31,8 +31,6 @@
 #include "llvm/IR/IntrinsicsWebAssembly.h"
 #pragma warning(pop)
 
-#include <unordered_map>
-
 using llvm::LLVMContext;
 using llvm::Module;
 using llvm::Function;
@@ -108,7 +106,12 @@ struct MallocAllocator
     template <typename T>
     T* allocate(size_t count)
     {
-        return static_cast<T*>(malloc(count * sizeof(T)));
+        void* p = malloc(count * sizeof(T));
+        if (p == nullptr)
+        {
+            NOMEM();
+        }
+        return static_cast<T*>(p);
     }
 
     void deallocate(void* p)
@@ -116,6 +119,18 @@ struct MallocAllocator
         free(p);
     }
 };
+
+template <typename T>
+inline ArrayRef<T> AsRef(ArrayStack<T>& stack)
+{
+    return stack.Empty() ? ArrayRef<T>() : ArrayRef<T>(&stack.BottomRef(0), static_cast<size_t>(stack.Height()));
+}
+
+template <typename T>
+inline ArrayRef<T> AsRef(const jitstd::vector<T>& vec)
+{
+    return vec.empty() ? ArrayRef<T>() : ArrayRef<T>(&vec[0], vec.size());
+}
 
 enum HelperFuncInfoFlags
 {
@@ -223,12 +238,17 @@ class SingleThreadedCompilationContext
 public:
     LLVMContext Context;
     Module Module;
-    std::unordered_map<CORINFO_CLASS_HANDLE, Type*> LlvmStructTypesMap;
-    std::unordered_map<CORINFO_CLASS_HANDLE, StructDesc*> StructDescMap;
+    JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, Type*, MallocAllocator> LlvmStructTypesMap;
+    JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, StructDesc*, MallocAllocator> StructDescMap;
     JitHashTable<CORINFO_LLVM_DEBUG_TYPE_HANDLE, JitSmallPrimitiveKeyFuncs<CORINFO_LLVM_DEBUG_TYPE_HANDLE>, llvm::DIType*, MallocAllocator> DebugTypesMap;
     JitHashTable<llvm::DIFile*, JitPtrKeyFuncs<llvm::DIFile>, llvm::DICompileUnit*, MallocAllocator> DebugCompileUnitsMap;
 
-    SingleThreadedCompilationContext(StringRef name) : Module(name, Context), DebugTypesMap({}), DebugCompileUnitsMap({})
+    SingleThreadedCompilationContext(StringRef name)
+        : Module(name, Context)
+        , LlvmStructTypesMap({})
+        , StructDescMap({})
+        , DebugTypesMap({})
+        , DebugCompileUnitsMap({})
     {
     }
 };
@@ -269,11 +289,11 @@ private:
     JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, Value*> _sdsuMap;
     JitHashTable<SSAName, SSAName, Value*> _localsMap;
     JitHashTable<ThrowHelperKey, ThrowHelperKey, llvm::BasicBlock*> m_throwHelperBlocksMap;
-    std::vector<PhiPair> _phiPairs;
-    std::vector<FunctionInfo> m_functions;
+    jitstd::vector<PhiPair> m_phiPairs;
+    FunctionInfo* m_functions;
 
     CorInfoLlvmEHModel m_ehModel;
-    std::vector<EHRegionInfo> m_EHRegionsInfo;
+    EHRegionInfo* m_EHRegionsInfo;
     Value* m_exceptionThrownAddressValue = nullptr;
 
     Value* m_rootFunctionShadowStackValue = nullptr;
@@ -383,7 +403,7 @@ private:
     Type* getLlvmTypeForCorInfoType(CorInfoType corInfoType, CORINFO_CLASS_HANDLE classHnd);
 
     unsigned getElementSize(CORINFO_CLASS_HANDLE fieldClassHandle, CorInfoType corInfoType);
-    void addPaddingFields(unsigned paddingSize, std::vector<Type*>& llvmFields);
+    void addPaddingFields(unsigned paddingSize, ArrayStack<Type*>& llvmFields);
 
     Type* getPtrLlvmType();
     Type* getIntPtrLlvmType();

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -47,7 +47,7 @@ void Llvm::initializeFunctions()
     }
 
     // First function is always the root.
-    m_functions = std::vector<FunctionInfo>(_compiler->compFuncCount());
+    m_functions = new (_compiler->getAllocator(CMK_Codegen)) FunctionInfo[_compiler->compFuncCount()]();
     m_functions[ROOT_FUNC_IDX] = {rootLlvmFunction};
 
     for (unsigned funcIdx = 1; funcIdx < _compiler->compFuncCount(); funcIdx++)
@@ -360,7 +360,7 @@ void Llvm::generateUnwindBlocks()
     // Generate the unwind blocks used to catch native exceptions during the second pass.
     // We generate these before the rest of the code because throwing calls need a certain
     // amount of pieces filled in (in particular, "catchswitch"es in the Wasm EH model).
-    m_EHRegionsInfo = std::vector<EHRegionInfo>(_compiler->compHndBBtabCount);
+    m_EHRegionsInfo = new (_compiler->getAllocator(CMK_Codegen)) EHRegionInfo[_compiler->compHndBBtabCount]();
 
     struct FunctionData
     {
@@ -385,7 +385,8 @@ void Llvm::generateUnwindBlocks()
 
     // There is no meaningful source location we can attach to the unwind blocks. None of them are "user" code.
     llvm::DILocation* unwindBlocksDebugLoc = getArtificialDebugLocation();
-    std::vector<FunctionData> functionData(_compiler->compFuncCount());
+    jitstd::vector<FunctionData> functionData(
+        _compiler->compFuncCount(), FunctionData{}, _compiler->getAllocator(CMK_Codegen));
 
     // Note the iteration order: outer -> inner.
     for (unsigned ehIndex = _compiler->compHndBBtabCount - 1; ehIndex != -1; ehIndex--)
@@ -766,7 +767,7 @@ void Llvm::fillPhis()
         return predCount;
     };
 
-    for (PhiPair phiPair : _phiPairs)
+    for (PhiPair phiPair : m_phiPairs)
     {
         llvm::PHINode* llvmPhiNode = phiPair.LlvmPhiNode;
         GenTreeLclVar* phiStore = phiPair.StoreNode;
@@ -803,9 +804,9 @@ void Llvm::generateAuxiliaryArtifacts()
 void Llvm::verifyGeneratedCode()
 {
 #ifdef DEBUG
-    for (FunctionInfo& funcInfo : m_functions)
+    for (unsigned funcIdx = 0; funcIdx < _compiler->compFuncCount(); funcIdx++)
     {
-        Function* llvmFunc = funcInfo.LlvmFunction;
+        Function* llvmFunc = m_functions[funcIdx].LlvmFunction;
         if (llvmFunc != nullptr)
         {
             assert(!llvm::verifyFunction(*llvmFunc, &llvm::errs()));
@@ -822,9 +823,9 @@ void Llvm::displayGeneratedCode()
         JITDUMP("LLVM IR for %s after codegen:\n", _compiler->info.compFullName);
         JITDUMP("-------------------------------------------------------------------------------------------------------------------\n\n");
 
-        for (FunctionInfo& funcInfo : m_functions)
+        for (unsigned funcIdx = 0; funcIdx < _compiler->compFuncCount(); funcIdx++)
         {
-            Function* llvmFunc = funcInfo.LlvmFunction;
+            Function* llvmFunc = m_functions[funcIdx].LlvmFunction;
             if (llvmFunc != nullptr)
             {
                 displayValue(llvmFunc);
@@ -1178,7 +1179,7 @@ void Llvm::buildStoreLocalVar(GenTreeLclVar* lclVar)
     {
         if (lclVar->Data()->OperIs(GT_PHI))
         {
-            _phiPairs.push_back({lclVar, llvm::cast<llvm::PHINode>(localValue)});
+            m_phiPairs.push_back({lclVar, llvm::cast<llvm::PHINode>(localValue)});
         }
 
         _localsMap.Set({lclNum, lclVar->GetSsaNum()}, localValue);
@@ -1742,13 +1743,13 @@ void Llvm::buildIntegralConst(GenTreeIntConCommon* node)
 
 void Llvm::buildCall(GenTreeCall* call)
 {
-    std::vector<Value*> argVec = std::vector<Value*>();
+    ArrayStack<Value*> argVec(_compiler->getAllocator(CMK_Codegen));
     for (CallArg& arg : call->gtArgs.Args())
     {
         Type* argLlvmType = getLlvmTypeForCorInfoType(getLlvmArgTypeForCallArg(&arg), arg.GetSignatureClassHandle());
         Value* argValue = consumeValue(arg.GetNode(), argLlvmType);
 
-        argVec.push_back(argValue);
+        argVec.Push(argValue);
     }
 
     // We may come back into managed from the unmanaged call so store the shadow stack. Note that for regular unmanaged
@@ -1760,7 +1761,7 @@ void Llvm::buildCall(GenTreeCall* call)
     }
 
     llvm::FunctionCallee llvmFuncCallee = consumeCallTarget(call);
-    llvm::CallBase* callValue = emitCallOrInvoke(llvmFuncCallee, argVec, mayPhysicallyThrow(call));
+    llvm::CallBase* callValue = emitCallOrInvoke(llvmFuncCallee, AsRef(argVec), mayPhysicallyThrow(call));
 
     if (JitConfig.JitGcStress())
     {
@@ -2550,10 +2551,14 @@ llvm::CallBase* Llvm::emitHelperCall(CorInfoHelpFunc helperFunc, ArrayRef<Value*
     if (helperCallHasShadowStackArg(helperFunc))
     {
         Value* shadowStackArg = getShadowStackForCallee(canEmitHelperCallAsShadowTailCall(helperFunc));
-        std::vector<Value*> args = sigArgs.vec();
-        args.insert(args.begin(), shadowStackArg);
+        ArrayStack<Value*> args(_compiler->getAllocator(CMK_Codegen), static_cast<int>(sigArgs.size() + 1));
+        args.Push(shadowStackArg);
+        for (Value* sigArg : sigArgs)
+        {
+            args.Push(sigArg);
+        }
 
-        call = emitCallOrInvoke(helperLlvmFunc, args);
+        call = emitCallOrInvoke(helperLlvmFunc, AsRef(args));
     }
     else
     {
@@ -2636,7 +2641,7 @@ llvm::CallBase* Llvm::emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Val
 
 FunctionType* Llvm::createFunctionType()
 {
-    std::vector<Type*> argVec(_llvmArgCount);
+    jitstd::vector<Type*> argVec(_llvmArgCount, nullptr, _compiler->getAllocator(CMK_Codegen));
     for (unsigned i = 0; i < _compiler->lvaCount; i++)
     {
         LclVarDsc* varDsc = _compiler->lvaGetDesc(i);
@@ -2651,7 +2656,7 @@ FunctionType* Llvm::createFunctionType()
     CorInfoType retType = getLlvmReturnType(sig->retType, sig->retTypeClass);
     Type* retLlvmType = getLlvmTypeForCorInfoType(retType, sig->retTypeClass);
 
-    return FunctionType::get(retLlvmType, argVec, /* isVarArg */ false);
+    return FunctionType::get(retLlvmType, AsRef(argVec), /* isVarArg */ false);
 }
 
 llvm::FunctionCallee Llvm::consumeCallTarget(GenTreeCall* call)
@@ -2703,25 +2708,25 @@ FunctionType* Llvm::createFunctionTypeForSignature(CORINFO_SIG_INFO* pSig)
     CorInfoType retType = getLlvmReturnType(pSig->retType, pSig->retTypeClass, &isReturnByRef);
     Type* retLlvmType = getLlvmTypeForCorInfoType(retType, pSig->retTypeClass);
 
-    std::vector<Type*> llvmParamTypes{};
+    ArrayStack<Type*> llvmParamTypes(_compiler->getAllocator(CMK_Codegen));
     if (isManagedCallConv)
     {
-        llvmParamTypes.push_back(getPtrLlvmType()); // The shadow stack.
+        llvmParamTypes.Push(getPtrLlvmType()); // The shadow stack.
     }
 
     if (pSig->hasImplicitThis())
     {
-        llvmParamTypes.push_back(getPtrLlvmType());
+        llvmParamTypes.Push(getPtrLlvmType());
     }
 
     if (isReturnByRef)
     {
-        llvmParamTypes.push_back(getPtrLlvmType());
+        llvmParamTypes.Push(getPtrLlvmType());
     }
 
     if (pSig->hasTypeArg())
     {
-        llvmParamTypes.push_back(getPtrLlvmType());
+        llvmParamTypes.Push(getPtrLlvmType());
     }
 
     CORINFO_ARG_LIST_HANDLE sigArgs = pSig->args;
@@ -2731,34 +2736,34 @@ FunctionType* Llvm::createFunctionTypeForSignature(CORINFO_SIG_INFO* pSig)
         CorInfoType argSigType = strip(m_info->compCompHnd->getArgType(pSig, sigArgs, &argSigClass));
         CorInfoType argType = getLlvmArgTypeForArg(argSigType, argSigClass);
 
-        llvmParamTypes.push_back(getLlvmTypeForCorInfoType(argType, argSigClass));
+        llvmParamTypes.Push(getLlvmTypeForCorInfoType(argType, argSigClass));
     }
 
-    return FunctionType::get(retLlvmType, llvmParamTypes, /* isVarArg */ false);
+    return FunctionType::get(retLlvmType, AsRef(llvmParamTypes), /* isVarArg */ false);
 }
 
 FunctionType* Llvm::createFunctionTypeForCall(GenTreeCall* call)
 {
     llvm::Type* retLlvmType = getLlvmTypeForCorInfoType(call->gtCorInfoType, call->gtRetClsHnd);
 
-    std::vector<llvm::Type*> argVec = std::vector<llvm::Type*>();
+    ArrayStack<Type*> argVec(_compiler->getAllocator(CMK_Codegen));
     for (CallArg& arg : call->gtArgs.Args())
     {
-        argVec.push_back(getLlvmTypeForCorInfoType(getLlvmArgTypeForCallArg(&arg), arg.GetSignatureClassHandle()));
+        argVec.Push(getLlvmTypeForCorInfoType(getLlvmArgTypeForCallArg(&arg), arg.GetSignatureClassHandle()));
     }
 
-    return FunctionType::get(retLlvmType, argVec, /* isVarArg */ false);
+    return FunctionType::get(retLlvmType, AsRef(argVec), /* isVarArg */ false);
 }
 
 FunctionType* Llvm::createFunctionTypeForHelper(CorInfoHelpFunc helperFunc)
 {
     const bool isManagedHelper = helperCallHasManagedCallingConvention(helperFunc);
     const HelperFuncInfo& helperInfo = getHelperFuncInfo(helperFunc);
-    std::vector<Type*> argVec = std::vector<Type*>();
 
+    ArrayStack<Type*> argVec(_compiler->getAllocator(CMK_Codegen));
     if (helperCallHasShadowStackArg(helperFunc))
     {
-        argVec.push_back(getPtrLlvmType());
+        argVec.Push(getPtrLlvmType());
     }
 
     size_t sigArgCount = helperInfo.GetSigArgCount();
@@ -2771,7 +2776,7 @@ FunctionType* Llvm::createFunctionTypeForHelper(CorInfoHelpFunc helperFunc)
         CorInfoType argType = getLlvmArgTypeForArg(argSigType, argSigClass, &isArgPassedByRef);
         assert(!isArgPassedByRef);
 
-        argVec.push_back(getLlvmTypeForCorInfoType(argType, argSigClass));
+        argVec.Push(getLlvmTypeForCorInfoType(argType, argSigClass));
     }
 
     bool isReturnByRef;
@@ -2780,7 +2785,7 @@ FunctionType* Llvm::createFunctionTypeForHelper(CorInfoHelpFunc helperFunc)
     assert(!isReturnByRef);
 
     Type* retLlvmType = getLlvmTypeForCorInfoType(retType, sigRetClass);
-    FunctionType* llvmFuncType = FunctionType::get(retLlvmType, argVec, /* isVarArg */ false);
+    FunctionType* llvmFuncType = FunctionType::get(retLlvmType, AsRef(argVec), /* isVarArg */ false);
 
     return llvmFuncType;
 }
@@ -2849,6 +2854,7 @@ Function* Llvm::getOrCreateKnownLlvmFunction(
 
 EHRegionInfo& Llvm::getEHRegionInfo(unsigned ehIndex)
 {
+    assert(ehIndex < _compiler->compHndBBtabCount);
     return m_EHRegionsInfo[ehIndex];
 }
 
@@ -3231,7 +3237,6 @@ unsigned Llvm::getLlvmFunctionIndexForProtectedRegion(unsigned tryIndex) const
 
 bool Llvm::isLlvmFunctionReachable(unsigned funcIdx) const
 {
-    assert(m_functions.size() != 0);
     return m_functions[funcIdx].LlvmFunction != nullptr;
 }
 

--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -579,7 +579,7 @@ DISubroutineType* Llvm::createDebugTypeForFunctionType(CORINFO_LLVM_FUNCTION_TYP
 
 DIType* Llvm::createFixedArrayDebugType(DIType* elementDebugType, unsigned size)
 {
-    unsigned sizeInBits = elementDebugType->getSizeInBits() * size;
+    uint64_t sizeInBits = elementDebugType->getSizeInBits() * size;
     llvm::DISubrange* boundsRange = m_diBuilder->getOrCreateSubrange(0, size);
     DINodeArray boundsArray = m_diBuilder->getOrCreateArray(boundsRange);
     DIType* debugType =

--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -457,22 +457,23 @@ DIType* Llvm::createDebugTypeForCompositeType(
         m_diBuilder->createReplaceableCompositeType(DW_TAG_structure_type, name, nullptr, debugFile, 0));
     m_context->DebugTypesMap.Set(debugTypeHandle, declType.get());
 
-    unsigned index = 0;
-    std::vector<Metadata*> debugElements((pInfo->BaseClass != NO_DEBUG_TYPE) + pInfo->InstanceFieldCount);
+    unsigned debugElementsCount = (pInfo->BaseClass != NO_DEBUG_TYPE) + pInfo->InstanceFieldCount;
+    ArrayStack<Metadata*> debugElements(_compiler->getAllocator(CMK_DebugInfo), debugElementsCount);
     if (pInfo->BaseClass != NO_DEBUG_TYPE)
     {
         DIType* baseDebugType = getOrCreateDebugType(pInfo->BaseClass);
-        debugElements[index++] = m_diBuilder->createInheritance(declType.get(), baseDebugType, 0, 0, DINode::FlagZero);
+        debugElements.Push(m_diBuilder->createInheritance(declType.get(), baseDebugType, 0, 0, DINode::FlagZero));
     }
 
     for (size_t i = 0; i < pInfo->InstanceFieldCount; i++)
     {
         CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* pFieldInfo = &pInfo->InstanceFields[i];
         DIType* fieldDebugType = getOrCreateDebugType(pFieldInfo->Type);
-        debugElements[index++] = createDebugMember(pFieldInfo->Name, fieldDebugType, pFieldInfo->Offset);
+        DIDerivedType* debugField = createDebugMember(pFieldInfo->Name, fieldDebugType, pFieldInfo->Offset);
+        debugElements.Push(debugField);
     }
 
-    DIType* debugType = createClassDebugType(name, pInfo->Size, debugElements);
+    DIType* debugType = createClassDebugType(name, pInfo->Size, AsRef(debugElements));
     m_diBuilder->replaceTemporary(std::move(declType), debugType);
 
     // TODO-LLVM-DI: static fields.
@@ -481,16 +482,15 @@ DIType* Llvm::createDebugTypeForCompositeType(
 
 DIType* Llvm::createDebugTypeForEnumType(CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO* pInfo)
 {
-    std::vector<Metadata*> elements(pInfo->ElementCount);
+    ArrayStack<Metadata*> elements(_compiler->getAllocator(CMK_DebugInfo), static_cast<unsigned>(pInfo->ElementCount));
     for (size_t i = 0; i < pInfo->ElementCount; i++)
     {
         CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* pElementInfo = &pInfo->Elements[i];
         llvm::DIEnumerator* element = m_diBuilder->createEnumerator(pElementInfo->Name, pElementInfo->Value);
-
-        elements[i] = element;
+        elements.Push(element);
     }
 
-    DINodeArray elementsArray = m_diBuilder->getOrCreateArray(elements);
+    DINodeArray elementsArray = m_diBuilder->getOrCreateArray(AsRef(elements));
     DIType* underlyingDebugType = getOrCreateDebugType(pInfo->ElementType);
     DIType* enumDebugType =
         m_diBuilder->createEnumerationType(nullptr, pInfo->Name, getUnknownDebugFile(), 0,
@@ -506,31 +506,31 @@ DIType* Llvm::createDebugTypeForArrayType(CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO* pI
     // Where <bounds> (for an MD array) is an array of [LowerBound..., Length...].
     unsigned rank = pInfo->Rank;
     bool isMDArray = pInfo->IsMultiDimensional != 0;
-    std::vector<Metadata*> members = std::vector<Metadata*>();
+    ArrayStack<Metadata*> members(_compiler->getAllocator(CMK_DebugInfo));
 
     DIType* lengthDebugType = createDebugTypeForPrimitive(CORINFO_TYPE_INT);
     DIDerivedType* lengthDebugField = createDebugMember("Length", lengthDebugType, OFFSETOF__CORINFO_Array__length);
-    members.push_back(lengthDebugField);
+    members.Push(lengthDebugField);
 
     if (isMDArray)
     {
         unsigned lowerBoundsOffset = _compiler->eeGetMDArrayLowerBoundOffset(rank, 0);
         DIType* boundsDebugType = createFixedArrayDebugType(lengthDebugType, rank);
         DIDerivedType* lowerBoundsDebugField = createDebugMember("LowerBounds", boundsDebugType, lowerBoundsOffset);
-        members.push_back(lowerBoundsDebugField);
+        members.Push(lowerBoundsDebugField);
 
         unsigned lengthsOffset = _compiler->eeGetMDArrayLengthOffset(rank, 0);
         DIDerivedType* lengthsDebugField = createDebugMember("Lengths", boundsDebugType, lengthsOffset);
-        members.push_back(lengthsDebugField);
+        members.Push(lengthsDebugField);
     }
 
     unsigned dataOffset = isMDArray ? _compiler->eeGetMDArrayDataOffset(rank) : _compiler->eeGetArrayDataOffset();
     DIType* elementDebugType = getOrCreateDebugType(pInfo->ElementType);
     DIType* dataDebugType = createFixedArrayDebugType(elementDebugType, 0);
     DIDerivedType* dataDebugField = createDebugMember("Data", dataDebugType, dataOffset);
-    members.push_back(dataDebugField);
+    members.Push(dataDebugField);
 
-    DIType* debugType = createClassDebugType(pInfo->Name, dataOffset, members);
+    DIType* debugType = createClassDebugType(pInfo->Name, dataOffset, AsRef(members));
     return debugType;
 }
 
@@ -560,20 +560,20 @@ DIType* Llvm::createDebugTypeForPointerType(CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO
 
 DISubroutineType* Llvm::createDebugTypeForFunctionType(CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO* pInfo)
 {
-    std::vector<Metadata*> debugParameters = std::vector<Metadata*>();
-    debugParameters.push_back(getOrCreateDebugType(pInfo->ReturnType));
+    ArrayStack<Metadata*> debugParameters(_compiler->getAllocator(CMK_DebugInfo));
+    debugParameters.Push(getOrCreateDebugType(pInfo->ReturnType));
 
     if (pInfo->TypeOfThisPointer != NO_DEBUG_TYPE)
     {
-        debugParameters.push_back(getOrCreateDebugType(pInfo->TypeOfThisPointer));
+        debugParameters.Push(getOrCreateDebugType(pInfo->TypeOfThisPointer));
     }
 
     for (size_t i = 0; i < pInfo->NumberOfArguments; i++)
     {
-        debugParameters.push_back(getOrCreateDebugType(pInfo->ArgumentTypes[i]));
+        debugParameters.Push(getOrCreateDebugType(pInfo->ArgumentTypes[i]));
     }
 
-    llvm::DITypeRefArray debugParametersArray = m_diBuilder->getOrCreateTypeArray(debugParameters);
+    llvm::DITypeRefArray debugParametersArray = m_diBuilder->getOrCreateTypeArray(AsRef(debugParameters));
     return m_diBuilder->createSubroutineType(debugParametersArray);
 }
 

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -125,7 +125,7 @@ void Llvm::initializeFunclets()
     }
 
     // Our exception handling only needs a subset of handlers to be true funclets.
-    unsigned funcIdx = 1;
+    unsigned short funcIdx = 1;
     for (unsigned ehIndex = _compiler->compHndBBtabCount - 1; ehIndex != -1; ehIndex--)
     {
         EHblkDsc* ehDsc = _compiler->ehGetDsc(ehIndex);
@@ -135,7 +135,7 @@ void Llvm::initializeFunclets()
             ehDsc->ebdFilterFuncIndex = funcIdx++;
             FuncInfoDsc* funcInfo = _compiler->funGetFunc(ehDsc->ebdFilterFuncIndex);
             funcInfo->funKind = FUNC_FILTER;
-            funcInfo->funEHIndex = ehIndex;
+            funcInfo->funEHIndex = static_cast<unsigned short>(ehIndex);
 
             m_anyFilterFunclets = true;
         }
@@ -146,7 +146,7 @@ void Llvm::initializeFunclets()
             ehDsc->ebdFuncIndex = funcIdx++;
             FuncInfoDsc* funcInfo = _compiler->funGetFunc(ehDsc->ebdFuncIndex);
             funcInfo->funKind = FUNC_HANDLER;
-            funcInfo->funEHIndex = ehIndex;
+            funcInfo->funEHIndex = static_cast<unsigned short>(ehIndex);
         }
         // It is up to us to decide what "ebdFuncIndex" should mean for handlers that
         // are not funclets. It is convenient to make it refer to the enclosing funclet.

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -7,6 +7,7 @@
 
 #include "llvm.h"
 #include "ssarenamestate.h"
+#include "jitstd/algorithm.h"
 
 // TODO-LLVM-LSSA: only enable this in Debug - test using a Checked compiler in CI.
 #define FEATURE_LSSA_ALLOCATION_RESULT
@@ -1022,8 +1023,8 @@ private:
     {
         if (m_compiler->opts.OptimizationEnabled())
         {
-            std::sort(&*shadowFrameLocals.begin(), &*shadowFrameLocals.end(),
-                      [compiler = m_compiler](unsigned lhsLclNum, unsigned rhsLclNum)
+            jitstd::sort(shadowFrameLocals.begin(), shadowFrameLocals.end(),
+                         [compiler = m_compiler](unsigned lhsLclNum, unsigned rhsLclNum)
             {
                 LclVarDsc* lhsVarDsc = compiler->lvaGetDesc(lhsLclNum);
                 LclVarDsc* rhsVarDsc = compiler->lvaGetDesc(rhsLclNum);

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -1442,7 +1442,7 @@ private:
                 {
                     unsigned Slot;
                     unsigned short FieldOffset;
-                    unsigned short FieldEndOffset;
+                    unsigned short StoreSize;
                     IRValue Local;
                     IRValue Value;
                 };
@@ -1522,7 +1522,7 @@ private:
                 unsigned storeSize =
                     lclNode->TypeIs(TYP_STRUCT) ? lclNode->GetLayout(m_compiler)->GetSize() : genTypeSize(lclNode);
                 action.FieldOffset = lclNode->GetLclOffs();
-                action.FieldEndOffset = action.FieldOffset + storeSize;
+                action.StoreSize = static_cast<unsigned short>(storeSize);
             }
             action.Local = GetLocalValue(lclNode->GetLclNum(), lclNode->GetSsaNum());
 
@@ -1674,7 +1674,8 @@ private:
                     if ((action.Kind == AllocationActionKind::StoreField) ||
                         (action.Kind == AllocationActionKind::LoadField))
                     {
-                        PrintFormatted(pBuffer, format, action.FieldOffset, action.FieldEndOffset, action.Slot);
+                        PrintFormatted(
+                            pBuffer, format, action.FieldOffset, action.FieldOffset + action.StoreSize, action.Slot);
                     }
                     else
                     {

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -962,7 +962,7 @@ private:
     {
         JITDUMP("\nIn Lssa::AllocateAndInitializeLocals\n");
 
-        std::vector<unsigned> shadowFrameLocals;
+        jitstd::vector<unsigned> shadowFrameLocals(m_compiler->getAllocator(CMK_LSRA));
         for (unsigned lclNum = 0; lclNum < m_compiler->lvaCount; lclNum++)
         {
             LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
@@ -1018,11 +1018,11 @@ private:
         m_llvm->m_anyAddressExposedOrPinnedShadowLocals |= (varDsc->IsAddressExposed() || varDsc->lvPinned);
     }
 
-    void AssignShadowFrameOffsets(std::vector<unsigned>& shadowFrameLocals)
+    void AssignShadowFrameOffsets(jitstd::vector<unsigned>& shadowFrameLocals)
     {
         if (m_compiler->opts.OptimizationEnabled())
         {
-            std::sort(shadowFrameLocals.begin(), shadowFrameLocals.end(),
+            std::sort(&*shadowFrameLocals.begin(), &*shadowFrameLocals.end(),
                       [compiler = m_compiler](unsigned lhsLclNum, unsigned rhsLclNum)
             {
                 LclVarDsc* lhsVarDsc = compiler->lvaGetDesc(lhsLclNum);

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -9,19 +9,16 @@
 
 StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
 {
-    auto& map = m_context->StructDescMap;
-
-    if (map.find(structHandle) == map.end())
+    StructDesc* structDesc;
+    if (!m_context->StructDescMap.Lookup(structHandle, &structDesc))
     {
         TypeDescriptor structTypeDescriptor;
         GetTypeDescriptor(structHandle, &structTypeDescriptor);
 
         unsigned structSize = structTypeDescriptor.Size;
-        std::vector<CORINFO_FIELD_HANDLE> sparseFields = std::vector<CORINFO_FIELD_HANDLE>(structSize);
-        std::vector<unsigned> sparseFieldSizes = std::vector<unsigned>(structSize);
-
-        for (unsigned i = 0; i < structSize; i++)
-            sparseFields[i] = nullptr;
+        jitstd::vector<CORINFO_FIELD_HANDLE> sparseFields(
+            structSize, NO_FIELD_HANDLE, _compiler->getAllocator(CMK_Codegen));
+        jitstd::vector<unsigned> sparseFieldSizes(structSize, 0, _compiler->getAllocator(CMK_Codegen));
 
         // determine the largest field for unions, and get fields in order of offset
         for (unsigned i = 0; i < structTypeDescriptor.FieldCount; i++)
@@ -65,8 +62,8 @@ StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
             }
         }
 
-        FieldDesc*  fields     = new FieldDesc[fieldCount];
-        StructDesc* structDesc = new StructDesc(fieldCount, fields, structTypeDescriptor.HasSignificantPadding);
+        FieldDesc* fields = new FieldDesc[fieldCount];
+        structDesc = new StructDesc(fieldCount, fields, structTypeDescriptor.HasSignificantPadding);
 
         unsigned fieldIx = 0;
         for (unsigned fldOffset = 0; fldOffset < structSize; fldOffset++)
@@ -84,10 +81,10 @@ StructDesc* Llvm::getStructDesc(CORINFO_CLASS_HANDLE structHandle)
             fieldIx++;
         }
 
-        map.insert({structHandle, structDesc});
+        m_context->StructDescMap.Set(structHandle, structDesc);
     }
 
-    return map.at(structHandle);
+    return structDesc;
 }
 
 Type* Llvm::getLlvmTypeForStruct(ClassLayout* classLayout)
@@ -102,12 +99,9 @@ Type* Llvm::getLlvmTypeForStruct(ClassLayout* classLayout)
 
 Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
 {
-    auto& map = m_context->LlvmStructTypesMap;
-
-    if (map.find(structHandle) == map.end())
+    Type* llvmStructType;
+    if (!m_context->LlvmStructTypesMap.Lookup(structHandle, &llvmStructType))
     {
-        Type* llvmStructType;
-
         // We treat trivial structs like their underlying types for compatibility with the native ABI.
         CorInfoType primitiveType = GetPrimitiveTypeForTrivialWasmStruct(structHandle);
         if (primitiveType != CORINFO_TYPE_UNDEF)
@@ -121,9 +115,9 @@ Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
 
             unsigned lastOffset = 0;
             unsigned totalSize = 0;
-            std::vector<Type*> llvmFields = std::vector<Type*>();
-            unsigned prevElementSize = 0;
+            ArrayStack<Type*> llvmFields(_compiler->getAllocator(CMK_Codegen));
 
+            unsigned prevElementSize = 0;
             for (unsigned fieldIx = 0; fieldIx < fieldCount; fieldIx++)
             {
                 FieldDesc* fieldDesc = structDesc->getFieldDesc(fieldIx);
@@ -139,8 +133,8 @@ Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
                 CorInfoType fieldCorType = fieldDesc->getCorType();
 
                 unsigned fieldSize = getElementSize(fieldDesc->getClassHandle(), fieldCorType);
-
-                llvmFields.push_back(getLlvmTypeForCorInfoType(fieldCorType, fieldDesc->getClassHandle()));
+                Type* fieldLlvmType = getLlvmTypeForCorInfoType(fieldCorType, fieldDesc->getClassHandle());
+                llvmFields.Push(fieldLlvmType);
 
                 totalSize += fieldSize;
                 lastOffset = fieldDesc->getFieldOffset();
@@ -154,13 +148,13 @@ Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
                 addPaddingFields(structSize - totalSize, llvmFields);
             }
 
-            llvmStructType = llvm::StructType::get(m_context->Context, llvmFields, /* isPacked */ true);
+            llvmStructType = llvm::StructType::get(m_context->Context, AsRef(llvmFields), /* isPacked */ true);
         }
 
-        map.insert({structHandle, llvmStructType});
+        m_context->LlvmStructTypesMap.Set(structHandle, llvmStructType);
     }
 
-    return map.at(structHandle);
+    return llvmStructType;
 }
 
 Type* Llvm::getLlvmTypeForVarType(var_types type)
@@ -232,17 +226,17 @@ unsigned Llvm::getElementSize(CORINFO_CLASS_HANDLE classHandle, CorInfoType corI
     return genTypeSize(JITtype2varType(corInfoType));
 }
 
-void Llvm::addPaddingFields(unsigned paddingSize, std::vector<Type*>& llvmFields)
+void Llvm::addPaddingFields(unsigned paddingSize, ArrayStack<Type*>& llvmFields)
 {
     unsigned numInts = paddingSize / 4;
     unsigned numBytes = paddingSize - numInts * 4;
     for (unsigned i = 0; i < numInts; i++)
     {
-        llvmFields.push_back(Type::getInt32Ty(m_context->Context));
+        llvmFields.Push(Type::getInt32Ty(m_context->Context));
     }
     for (unsigned i = 0; i < numBytes; i++)
     {
-        llvmFields.push_back(Type::getInt8Ty(m_context->Context));
+        llvmFields.Push(Type::getInt8Ty(m_context->Context));
     }
 }
 

--- a/src/coreclr/jit/llvmtypes.cpp
+++ b/src/coreclr/jit/llvmtypes.cpp
@@ -117,7 +117,7 @@ Type* Llvm::getLlvmTypeForStruct(CORINFO_CLASS_HANDLE structHandle)
         else
         {
             StructDesc* structDesc = getStructDesc(structHandle);
-            unsigned fieldCount = structDesc->getFieldCount();
+            size_t fieldCount = structDesc->getFieldCount();
 
             unsigned lastOffset = 0;
             unsigned totalSize = 0;


### PR DESCRIPTION
The first commit fixes #2554.

The following few commits replace the usage of various `std` types, mostly `std::vector` with their JIT equivalents. This is for a couple reasons:
1) Jit types plug into the Jit allocator, which is both much faster and integrated into the Jit's memory usage diagnostics (`CMK_XYZ`).
2) We cannot really use the standard collections (see https://github.com/dotnet/runtime/pull/101088).
3) Consistency with the rest of the Jit.

The totality of the changes are zero-diff, except for the last commit, where I switched to `jitstd::sort` and some diffs were expected.

I will note that with regards to `2`, we are still not functionally correct, since LLVM code (and some of our own code) may still call standard library functions which may throw. The primary concern is OOM, since, fortunately, LLVM itself doesn't use exceptions, and there are a couple solutions which could be employed. Luckily, this is not a problem that needs to be solved here and now.