### PR TITLE
[NativeAOT-LLVM] Export symbols passed to ILC on the command line on WASI

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
@@ -50,6 +50,8 @@ namespace ILCompiler
                 }
                 else if (_context.Target.OperatingSystem == TargetOS.Wasi)
                 {
+                    foreach (string symbol in _exportSymbols)
+                        streamWriter.WriteLine(symbol);
                     foreach (var method in _methods)
                         streamWriter.WriteLine(method.GetUnmanagedCallersOnlyExportName());
                 }


### PR DESCRIPTION
A small bug I've noticed looking at this code.