### PR TITLE
[NativeAOT-LLVM] Cleanup dotnet.js API integration with ExportsFile

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
@@ -5,14 +5,12 @@
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints><!-- For JSExports -->
   </PropertyGroup>
   <ItemGroup>
-    <EmccNativeExportedFunction Include="free" />
-    <EmccNativeExportedFunction Include="htons" />
-    <EmccNativeExportedFunction Include="main" />
-    <EmccNativeExportedFunction Include="malloc" />
-    <EmccNativeExportedFunction Include="memalign" />
-    <EmccNativeExportedFunction Include="memset" />
-    <EmccNativeExportedFunction Include="ntohs" />
-    <EmccExportedFunction Include="_%(EmccNativeExportedFunction)" />
+    <EmccExportedFunction Include="_free" />
+    <EmccExportedFunction Include="_htons" />
+    <EmccExportedFunction Include="_malloc" />
+    <EmccExportedFunction Include="_memalign" />
+    <EmccExportedFunction Include="_memset" />
+    <EmccExportedFunction Include="_ntohs" />
     <EmccExportedFunction Include="stackAlloc" />
     <EmccExportedFunction Include="stackRestore" />
     <EmccExportedFunction Include="stackSave" />
@@ -38,14 +36,7 @@
 
     <!-- Pseudo-namespace for the JS interop symbols. -->
     <DirectPInvoke Include="System.Runtime.InteropServices.JavaScript" />
-    <UnmanagedEntryPointsAssembly Include="System.Runtime.InteropServices.JavaScript" />
   </ItemGroup>
-
-  <Target Name="PrepareDotNetJsApiForIlcRspFile" BeforeTargets="WriteIlcRspFileForCompilation">
-    <ItemGroup>
-      <IlcArg Include="--export-dynamic-symbol:%(EmccNativeExportedFunction.Identity)" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="PrepareDotNetJsApiForLinking">
     <PropertyGroup>
@@ -91,6 +82,14 @@
     <ItemGroup>
       <CustomLinkerArg Include="@(_DotNetJsLinkerFlag)" />
     </ItemGroup>
+    <ReadLinesFromFile File="$(ExportsFile)" Condition="'$(ExportsFile)' != ''">
+      <Output TaskParameter="Lines" ItemName="_ExistingExports" />
+    </ReadLinesFromFile>
+    <ItemGroup Condition="'$(ExportsFile)' != ''">
+      <_ExportsToAddToExportsFile Include="@(EmccExportedFunction)" />
+      <_ExportsToAddToExportsFile Remove="@(_ExistingExports)" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(ExportsFile)" Lines="@(_ExportsToAddToExportsFile)" Overwrite="false" Encoding="utf-8" Condition="'@(_ExportsToAddToExportsFile->Count())' != '0'" />
   </Target>
   <Target Name="CopyDotnetJsAfterLinking" AfterTargets="LinkNativeLlvm">
     <ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
@@ -5,12 +5,14 @@
     <IlcExportUnmanagedEntrypoints>true</IlcExportUnmanagedEntrypoints><!-- For JSExports -->
   </PropertyGroup>
   <ItemGroup>
-    <EmccExportedFunction Include="_free" />
-    <EmccExportedFunction Include="_htons" />
-    <EmccExportedFunction Include="_malloc" />
-    <EmccExportedFunction Include="_memalign" />
-    <EmccExportedFunction Include="_memset" />
-    <EmccExportedFunction Include="_ntohs" />
+    <EmccNativeExportedFunction Include="free" />
+    <EmccNativeExportedFunction Include="htons" />
+    <EmccNativeExportedFunction Include="main" />
+    <EmccNativeExportedFunction Include="malloc" />
+    <EmccNativeExportedFunction Include="memalign" />
+    <EmccNativeExportedFunction Include="memset" />
+    <EmccNativeExportedFunction Include="ntohs" />
+    <EmccExportedFunction Include="_%(EmccNativeExportedFunction)" />
     <EmccExportedFunction Include="stackAlloc" />
     <EmccExportedFunction Include="stackRestore" />
     <EmccExportedFunction Include="stackSave" />
@@ -36,7 +38,14 @@
 
     <!-- Pseudo-namespace for the JS interop symbols. -->
     <DirectPInvoke Include="System.Runtime.InteropServices.JavaScript" />
+    <UnmanagedEntryPointsAssembly Include="System.Runtime.InteropServices.JavaScript" />
   </ItemGroup>
+
+  <Target Name="PrepareDotNetJsApiForIlcRspFile" BeforeTargets="WriteIlcRspFileForCompilation">
+    <ItemGroup>
+      <IlcArg Include="--export-dynamic-symbol:%(EmccNativeExportedFunction.Identity)" />
+    </ItemGroup>
+  </Target>
 
   <Target Name="PrepareDotNetJsApiForLinking">
     <PropertyGroup>
@@ -82,14 +91,6 @@
     <ItemGroup>
       <CustomLinkerArg Include="@(_DotNetJsLinkerFlag)" />
     </ItemGroup>
-    <ReadLinesFromFile File="$(ExportsFile)" Condition="'$(ExportsFile)' != ''">
-      <Output TaskParameter="Lines" ItemName="_ExistingExports" />
-    </ReadLinesFromFile>
-    <ItemGroup Condition="'$(ExportsFile)' != ''">
-      <_ExportsToAddToExportsFile Include="@(EmccExportedFunction)" />
-      <_ExportsToAddToExportsFile Remove="@(_ExistingExports)" />
-    </ItemGroup>
-    <WriteLinesToFile File="$(ExportsFile)" Lines="@(_ExportsToAddToExportsFile)" Overwrite="false" Encoding="utf-8" Condition="'@(_ExportsToAddToExportsFile->Count())' != '0'" />
   </Target>
   <Target Name="CopyDotnetJsAfterLinking" AfterTargets="LinkNativeLlvm">
     <ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
@@ -76,16 +76,15 @@
       <!-- Exported functions required by user or runtime API -->
       <_DotNetJsLinkerFlag Include="-s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$(_EmccExportedLibraryFunction)" Condition="'$(_EmccExportedLibraryFunction)' != ''" />
       <_DotNetJsLinkerFlag Include="-s EXPORTED_RUNTIME_METHODS=$(_EmccExportedRuntimeMethods)" />
-      <_DotNetJsLinkerFlag Include="-s EXPORTED_FUNCTIONS=$(_EmccExportedFunctions)" Condition="'$(ExportsFile)' == ''" /><!-- Multiple args in the same rsp file is not support, add functions to app exports -->
       <_DotNetJsLinkerFlag Include="$(EmccExtraLDFlags)" />
     </ItemGroup>
     <ItemGroup>
       <CustomLinkerArg Include="@(_DotNetJsLinkerFlag)" />
     </ItemGroup>
-    <ReadLinesFromFile File="$(ExportsFile)" Condition="'$(ExportsFile)' != ''">
+    <ReadLinesFromFile File="$(ExportsFile)">
       <Output TaskParameter="Lines" ItemName="_ExistingExports" />
     </ReadLinesFromFile>
-    <ItemGroup Condition="'$(ExportsFile)' != ''">
+    <ItemGroup>
       <_ExportsToAddToExportsFile Include="@(EmccExportedFunction)" />
       <_ExportsToAddToExportsFile Remove="@(_ExistingExports)" />
     </ItemGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
@@ -42,7 +42,6 @@
     <PropertyGroup>
       <_EmccExportedLibraryFunction>&quot;[@(EmccExportedLibraryFunction -> '%27%(Identity)%27', ',')]&quot;</_EmccExportedLibraryFunction>
       <_EmccExportedRuntimeMethods>&quot;[@(EmccExportedRuntimeMethod -> '%27%(Identity)%27', ',')]&quot;</_EmccExportedRuntimeMethods>
-      <_EmccExportedFunctions>@(EmccExportedFunction -> '%(Identity)',',')</_EmccExportedFunctions>
     </PropertyGroup>
     <ItemGroup>
       <!-- Default values for flags passed from emscripten to dotnet/runtime.js. Left here only to minimize changes to typescript -->

--- a/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
@@ -88,7 +88,7 @@
       <_ExportsToAddToExportsFile Include="@(EmccExportedFunction)" />
       <_ExportsToAddToExportsFile Remove="@(_ExistingExports)" />
     </ItemGroup>
-    <WriteLinesToFile File="$(ExportsFile)" Lines="@(_ExportsToAddToExportsFile)" Overwrite="false" Encoding="utf-8" Condition="'@(_ExportsToAddToExportsFile->Count())' != '0'" />
+    <WriteLinesToFile File="$(ExportsFile)" Lines="@(_ExportsToAddToExportsFile)" Overwrite="false" Condition="'@(_ExportsToAddToExportsFile->Count())' != '0'" />
   </Target>
   <Target Name="CopyDotnetJsAfterLinking" AfterTargets="LinkNativeLlvm">
     <ItemGroup>


### PR DESCRIPTION
- `ExportsFile` is always set
- Use UTF8 without BOM when overriding exports file