### PR TITLE
Add official build pipeline for `dotnet-experimental` feed

### DIFF
--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -1,0 +1,74 @@
+parameters:
+  dependsOn: []
+  isOfficialBuild: false
+  logArtifactName: 'Logs-PrepareSignedArtifacts_Attempt$(System.JobAttempt)'
+
+jobs:
+- job: PrepareSignedArtifacts
+  displayName: Prepare Signed Artifacts
+  dependsOn: ${{ parameters.dependsOn }}
+  pool:
+    name: $(DncEngInternalBuildPool)
+    demands: ImageOverride -equals 1es-windows-2022
+  # Double the default timeout.
+  timeoutInMinutes: 240
+  workspace:
+    clean: all
+
+  variables:
+  - name: SignType
+    value: $[ coalesce(variables.OfficialSignType, 'real') ]
+
+  templateContext:
+    outputs:
+    - output: pipelineArtifact
+      displayName: 'Publish BuildLogs'
+      condition: succeededOrFailed()
+      targetPath: '$(Build.StagingDirectory)\BuildLogs'
+      artifactName: ${{ parameters.logArtifactName }}
+
+  steps:
+  - checkout: self
+    clean: true
+    fetchDepth: 20
+
+  - ${{ if eq(parameters.isOfficialBuild, true) }}:
+    - task: NuGetAuthenticate@1
+
+  - task: MicroBuildSigningPlugin@2
+    displayName: Install MicroBuild plugin for Signing
+    inputs:
+      signType: $(SignType)
+      zipSources: false
+      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+    continueOnError: false
+    condition: and(succeeded(),
+                in(variables['SignType'], 'real', 'test'))
+
+  - task: DownloadBuildArtifacts@0
+    displayName: Download IntermediateArtifacts
+    inputs:
+      artifactName: IntermediateArtifacts
+      downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
+      checkDownloadedFiles: true
+
+  - script: >-
+      build.cmd -ci
+      -publish
+      -configuration Release
+      /p:OfficialBuildId=$(Build.BuildNumber)
+      /p:SignType=$(SignType)
+      /p:DotNetSignType=$(SignType)
+      /p:DotNetPublishUsingPipelines=true
+      /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+    displayName: Prepare artifacts and upload to build
+  - task: CopyFiles@2
+    displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)'
+      Contents: |
+        **/*.log
+        **/*.binlog
+      TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
+    continueOnError: true
+    condition: succeededOrFailed()

--- a/eng/pipelines/common/templates/build-job.yml
+++ b/eng/pipelines/common/templates/build-job.yml
@@ -14,9 +14,6 @@ jobs:
     enableTelemetry: true
     helixRepo: dotnet/runtimelab
     pool: ${{ parameters.pool }}
-    enablePublishBuildArtifacts: true
-    enablePublishBuildAssets: true
-    enablePublishUsingPipelines: true
     enableMicrobuild: true
     graphFileGeneration:
       enabled: false
@@ -37,15 +34,8 @@ jobs:
         testResultsFormat: vstest
         testRunTitle: ${{ parameters.osGroup }}_${{ parameters.archType }}_$(_BuildConfig)
 
-      ${{ if ne(parameters.container, '') }}:
-        ${{ if eq(parameters.container.registry, 'mcr') }}:
-          container: ${{ format('{0}:{1}', 'mcr.microsoft.com/dotnet-buildtools/prereqs', parameters.container.image) }}
-        ${{ if ne(parameters.container.registry, 'mcr') }}:
-          container: ${{ format('{0}:{1}', parameters.container.registry, parameters.container.image) }}
-
       variables:
         - _buildScript: build.cmd
-
         - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
           - _buildScript: ./build.sh
         
@@ -53,25 +43,17 @@ jobs:
         - ${{ if eq(parameters.runTests, true) }}:
           - _testBuildArg: -test
 
-        - _officialBuildArgs: ''
-        - ${{ if eq(parameters.isOfficialBuild, true) }}:
-          - group: DotNet-Symbol-Server-Pats
-          - _SignType: real
-          - _officialBuildArgs: -sign
-                                -publish
-                                /p:DotNetSignType=$(_SignType)
-                                /p:TeamName=$(_TeamName)
-                                /p:OfficialBuildId=$(Build.BuildNumber)
-                                /p:DotNetPublishUsingPipelines=true
-                                /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-                                /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
-
       steps:
       - script: $(_buildScript)
                 -ci
                 -pack
                 -c $(_BuildConfig)
                 $(_testBuildArg)
-                $(_officialBuildArgs)
                 /p:TargetPlatform=${{ parameters.archType }}
         displayName: Build and Test
+
+      - ${{ if eq(parameters.isOfficialBuild, true) }}:
+        - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+          parameters:
+            name: ${{ parameters.osGroup }}${{ parameters.archType }}
+            isOfficialBuild: ${{ parameters.isOfficialBuild }}

--- a/eng/pipelines/common/templates/publish.yml
+++ b/eng/pipelines/common/templates/publish.yml
@@ -1,0 +1,59 @@
+parameters:
+  publishingInfraVersion: 3
+  enableSigningValidation: false
+  enableNugetValidation: false
+  enableSourceLinkValidation: false
+
+stages:
+
+- stage: PrepareForPublish
+  displayName: Prepare for Publish
+  variables:
+  - template: /eng/common/templates-official/variables/pool-providers.yml
+  jobs:
+  # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
+  - template: /eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+
+  # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
+  - template: /eng/common/templates-official/job/publish-build-assets.yml
+    parameters:
+      publishUsingPipelines: true
+      publishAssetsImmediately: true
+      dependsOn: PrepareSignedArtifacts
+      pool:
+        name: $(DncEngInternalBuildPool)
+        demands: ImageOverride -equals 1es-windows-2022
+      symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
+
+# Stages-based publishing entry point
+- template: /eng/common/templates-official/post-build/post-build.yml
+  parameters:
+    publishingInfraVersion: ${{ parameters.publishingInfraVersion }}
+    validateDependsOn:
+    - PrepareForPublish
+    # The following checks are run after the build in the validation and release pipelines
+    # And thus are not enabled here. They can be enabled for dev builds for spot testing if desired
+    enableSymbolValidation: false
+    enableSigningValidation: ${{ parameters.enableSigningValidation }}
+    enableNugetValidation: ${{ parameters.enableNugetValidation }}
+    enableSourceLinkValidation: ${{ parameters.enableSourceLinkValidation }}
+    publishAssetsImmediately: true
+    SDLValidationParameters:
+      enable: false
+      artifactNames:
+      - PackageArtifacts
+      - BlobArtifacts
+      params: >-
+        -SourceToolsList @("policheck","credscan")
+        -TsaInstanceURL "$(TsaInstanceURL)"
+        -TsaProjectName "$(TsaProjectName)"
+        -TsaNotificationEmail "$(TsaNotificationEmail)"
+        -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
+        -TsaBugAreaPath "$(TsaBugAreaPath)"
+        -TsaIterationPath "$(TsaIterationPath)"
+        -TsaRepositoryName "$(TsaRepositoryName)"
+        -TsaCodebaseName "$(TsaCodebaseName)"
+        -TsaPublish $True
+    symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
+    # Publish to blob storage.
+    publishInstallersAndChecksums: true

--- a/eng/pipelines/common/templates/template1es.yml
+++ b/eng/pipelines/common/templates/template1es.yml
@@ -1,0 +1,24 @@
+parameters:
+  - name: templatePath
+    type: string
+    default: 'templates-official'
+  - name: stages
+    type: stageList
+
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: 1es-windows-2022
+      os: windows
+
+    stages: ${{ parameters.stages }}

--- a/eng/pipelines/common/upload-intermediate-artifacts-step.yml
+++ b/eng/pipelines/common/upload-intermediate-artifacts-step.yml
@@ -1,0 +1,33 @@
+parameters:
+  name: ''
+  publishPackagesCondition: always()
+  publishVSSetupCondition: false
+  isOfficialBuild: true
+
+steps:
+- task: CopyFiles@2
+  displayName: Prepare job-specific intermediate artifacts subdirectory
+  condition: and(succeeded(), ${{ parameters.publishPackagesCondition }})
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)'
+    Contents: |
+      Shipping/**/*
+      NonShipping/**/*
+    TargetFolder: '$(Build.StagingDirectory)/IntermediateArtifacts/${{ parameters.name }}'
+    CleanTargetFolder: true
+
+- task: CopyFiles@2
+  displayName: Prepare job-specific intermediate artifacts subdirectory
+  condition: and(succeeded(), ${{ parameters.publishVSSetupCondition }})
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)'
+    Contents: |
+      Insertion/**/*
+    TargetFolder: '$(Build.StagingDirectory)/IntermediateArtifacts/${{ parameters.name }}'
+    CleanTargetFolder: true
+
+- template: /eng/common/templates-official/steps/publish-build-artifacts.yml
+  parameters:
+    displayName: Publish intermediate artifacts
+    PathtoPublish: '$(Build.StagingDirectory)/IntermediateArtifacts'
+    ArtifactName: IntermediateArtifacts

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,0 +1,24 @@
+parameters:
+  - name: templatePath
+    type: string
+    default: 'templates'
+
+variables:
+
+# These values enable longer delays, configurable number of retries, and special understanding of TCP hang-up
+# See https://github.com/NuGet/Home/issues/11027 for details
+- name: NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY
+  value: true
+- name: NUGET_EXPERIMENTAL_MAX_NETWORK_TRY_COUNT
+  value: 6
+- name: NUGET_EXPERIMENTAL_NETWORK_RETRY_DELAY_MILLISECONDS
+  value: 1000
+
+# disable CodeQL if we're not in the dedicated pipeline for it
+- name: Codeql.Enabled
+  value: ${{ eq(variables['Build.DefinitionName'], 'dotnet-runtime-codeql') }}
+
+- name: isOfficialBuild
+  value: ${{ and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}
+
+- template: /eng/common/${{ parameters.templatePath }}/variables/pool-providers.yml

--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -49,24 +49,22 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/pipelines/templates/build-job.yml
       parameters:
         osGroup: Windows_NT
         archType: x64
+        isOfficialBuild: true
+        runTests: false
         pool:
-          vmImage: 'windows-latest'
+          name: NetCore1ESPool-Internal
+          demands: ImageOverride -equals windows.vs2022preview.amd64
 
-    - template: /eng/pipelines/templates/build-job.yml
-      parameters:
-        osGroup: OSX
-        archType: x64
-        pool:
-          vmImage: 'macOS-latest'
-
-    - template: /eng/pipelines/templates/build-job.yml
-      parameters:
-        osGroup: Linux
-        archType: x64
-        pool:
-          vmImage: 'ubuntu-latest'
+# Publish and validation steps. Only run in official builds
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: \eng\common\templates\post-build\post-build.yml
+    parameters:
+      publishingInfraVersion: 3
+      validateDependsOn:
+        - build
+      enableSourceLinkValidation: true

--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -22,49 +22,33 @@ trigger:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
 
-pr:
-  branches:
-    include:
-    - feature/*
-    - standalone-template
-  paths:
-    include:
-    - '*'
-    exclude:
-    - eng/Version.Details.xml
-    - .github/*
-    - docs/*
-    - CODE-OF-CONDUCT.md
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - README.md
-    - SECURITY.md
-    - THIRD-PARTY-NOTICES.TXT
-
 variables:
-  - name: _TeamName
+- template: /eng/pipelines/common/variables.yml@self
+  parameters:
+    templatePath: 'templates-official'
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - name: TeamName
     value: dotnet-core
+extends:
+  template: /eng/pipelines/common/templates/template1es.yml@self
+  parameters:
+    stages:
+    - stage: Build
+      jobs:
+      - template: /eng/pipelines/common/templates/build-job.yml
+        parameters:
+          osGroup: Windows_NT
+          archType: x64
+          isOfficialBuild: true
+          runTests: false
+          pool:
+            name: $(DncEngInternalBuildPool)
+            image: 1es-windows-2022
+            os: windows
 
-stages:
-- stage: build
-  displayName: Build
-  jobs:
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/pipelines/templates/build-job.yml
-      parameters:
-        osGroup: Windows_NT
-        archType: x64
-        isOfficialBuild: true
-        runTests: false
-        pool:
-          name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals windows.vs2022preview.amd64
-
-# Publish and validation steps. Only run in official builds
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: \eng\common\templates\post-build\post-build.yml
-    parameters:
-      publishingInfraVersion: 3
-      validateDependsOn:
-        - build
-      enableSourceLinkValidation: true
+    - ${{ if eq(variables.isOfficialBuild, true) }}:
+      - template: /eng/pipelines/common/templates/publish.yml
+        parameters:
+          isOfficialBuild: true
+          enableSourceLinkValidation: true

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -44,27 +44,26 @@ pr:
 variables:
   - name: _TeamName
     value: dotnet-core
-
 stages:
 - stage: build
   displayName: Build
   jobs:
   - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/pipelines/templates/build-job.yml
+    - template: /eng/pipelines/common/templates/build-job.yml
       parameters:
         osGroup: Windows_NT
         archType: x64
         pool:
           vmImage: 'windows-latest'
 
-    - template: /eng/pipelines/templates/build-job.yml
+    - template: /eng/pipelines/common/templates/build-job.yml
       parameters:
         osGroup: OSX
         archType: x64
         pool:
           vmImage: 'macOS-latest'
 
-    - template: /eng/pipelines/templates/build-job.yml
+    - template: /eng/pipelines/common/templates/build-job.yml
       parameters:
         osGroup: Linux
         archType: x64


### PR DESCRIPTION
## Description

This PR introduces `runtimelab-official.yml` file in the standalone template for `dotnet-experimental` feed. The change in AzDo has been introduced with https://github.com/dotnet/runtimelab/pull/2563.