### PR TITLE
[NativeAOT-LLVM] Update llvm to 18.1.3 and emscripten to 3.1.54

### DIFF
--- a/eng/pipelines/runtimelab/install-emscripten.ps1
+++ b/eng/pipelines/runtimelab/install-emscripten.ps1
@@ -13,11 +13,11 @@ git clone https://github.com/emscripten-core/emsdk.git
 Set-Location -Path emsdk
 
 # Checkout a specific commit to avoid unexpected issues
-git checkout 37b85e9
+git checkout c18280c
 
-./emsdk install 3.1.47
+./emsdk install 3.1.54
 
-./emsdk activate 3.1.47
+./emsdk activate 3.1.54
 
 # Set a variable for later use (used in common/build.ps1)
 Write-Host "##vso[task.setvariable variable=NATIVEAOT_CI_WASM_BUILD_EMSDK_PATH]$PWD"

--- a/eng/pipelines/runtimelab/install-llvm.ps1
+++ b/eng/pipelines/runtimelab/install-llvm.ps1
@@ -32,7 +32,7 @@ if (!(gcm cmake -ErrorAction SilentlyContinue))
 
 if (!$NoClone)
 {
-    $LlvmProjectTag = "llvmorg-17.0.4"
+    $LlvmProjectTag = "llvmorg-18.1.3"
     $DepthOption = if ($CI) {"--depth","1"} else {}
     git clone https://github.com/llvm/llvm-project --branch $LlvmProjectTag $DepthOption
 }


### PR DESCRIPTION
Updates the version of LLVM and emscripten.

depends #2591 

Moving emscripten later than 3.1.54 causes C/C++ version standard problems, i.e. need to go from gnu99 to c11:

E.g.
```
C:/github/runtimelab/src/native/libs/System.Native/pal_networking.c(171,1): error GB0A439F3: '_Static_assert' is incompatible with C standards before C11 [-Wer
ror,-Wpre-c11-compat] [C:\github\runtimelab\src\native\libs\build-native.proj]
```
