### PR TITLE
Update official build to generate and upload NuGet packages to the feed

### DIFF
--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -1,74 +1,65 @@
 parameters:
-  dependsOn: []
+  PublishRidAgnosticPackagesFromPlatform: ''
   isOfficialBuild: false
   logArtifactName: 'Logs-PrepareSignedArtifacts_Attempt$(System.JobAttempt)'
 
 jobs:
-- job: PrepareSignedArtifacts
-  displayName: Prepare Signed Artifacts
-  dependsOn: ${{ parameters.dependsOn }}
-  pool:
-    name: $(DncEngInternalBuildPool)
-    demands: ImageOverride -equals 1es-windows-2022
-  # Double the default timeout.
-  timeoutInMinutes: 240
-  workspace:
-    clean: all
+- template: /eng/common/templates-official/job/job.yml
+  parameters:
+    name: 'PrepareSignedArtifacts'
+    displayName: 'Prepare Signed Artifacts'
 
-  variables:
-  - name: SignType
-    value: $[ coalesce(variables.OfficialSignType, 'real') ]
+    pool:
+      name: $(DncEngInternalBuildPool)
+      demands: ImageOverride -equals 1es-windows-2022
 
-  templateContext:
-    outputs:
-    - output: pipelineArtifact
-      displayName: 'Publish BuildLogs'
+    # Double the default timeout.
+    timeoutInMinutes: 240
+
+    workspace:
+      clean: all
+
+    enableMicrobuild: true
+
+    variables:
+      - name: '_SignType'
+        value: $[ coalesce(variables.OfficialSignType, 'real') ]
+      
+    templateContext:
+      inputs:
+      - input: checkout
+        repository: self
+        clean: true
+        fetchDepth: 20
+      - input: pipelineArtifact
+        artifactName: IntermediateArtifacts
+        targetPath: $(Build.SourcesDirectory)\artifacts\PackageDownload\IntermediateArtifacts
+      outputs:
+      - output: pipelineArtifact
+        displayName: 'Publish BuildLogs'
+        condition: succeededOrFailed()
+        targetPath: '$(Build.StagingDirectory)\BuildLogs'
+        artifactName: ${{ parameters.logArtifactName }}
+    
+    steps:
+    - script: >-
+        build.cmd -ci
+        -subset publish
+        -configuration Release
+        /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
+        /p:OfficialBuildId=$(Build.BuildNumber)
+        /p:SignType=$(_SignType)
+        /p:DotNetSignType=$(_SignType)
+        /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+      displayName: Prepare artifacts and upload to build
+    
+    - task: CopyFiles@2
+      displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)'
+        Contents: |
+          **/*.log
+          **/*.binlog
+        TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
+      continueOnError: true
       condition: succeededOrFailed()
-      targetPath: '$(Build.StagingDirectory)\BuildLogs'
-      artifactName: ${{ parameters.logArtifactName }}
-
-  steps:
-  - checkout: self
-    clean: true
-    fetchDepth: 20
-
-  - ${{ if eq(parameters.isOfficialBuild, true) }}:
-    - task: NuGetAuthenticate@1
-
-  - task: MicroBuildSigningPlugin@2
-    displayName: Install MicroBuild plugin for Signing
-    inputs:
-      signType: $(SignType)
-      zipSources: false
-      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-    continueOnError: false
-    condition: and(succeeded(),
-                in(variables['SignType'], 'real', 'test'))
-
-  - task: DownloadBuildArtifacts@0
-    displayName: Download IntermediateArtifacts
-    inputs:
-      artifactName: IntermediateArtifacts
-      downloadPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
-      checkDownloadedFiles: true
-
-  - script: >-
-      build.cmd -ci
-      -publish
-      -configuration Release
-      /p:OfficialBuildId=$(Build.BuildNumber)
-      /p:SignType=$(SignType)
-      /p:DotNetSignType=$(SignType)
-      /p:DotNetPublishUsingPipelines=true
-      /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
-    displayName: Prepare artifacts and upload to build
-  - task: CopyFiles@2
-    displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)'
-      Contents: |
-        **/*.log
-        **/*.binlog
-      TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
-    continueOnError: true
-    condition: succeededOrFailed()

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -44,12 +44,14 @@ jobs:
     steps:
     - script: >-
         build.cmd -ci
-        -subset publish
+        -publish
+        -pack
         -configuration Release
         /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
         /p:OfficialBuildId=$(Build.BuildNumber)
         /p:SignType=$(_SignType)
         /p:DotNetSignType=$(_SignType)
+        /p:DotNetPublishUsingPipelines=true
         /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
       displayName: Prepare artifacts and upload to build
     

--- a/eng/pipelines/common/templates/build-job.yml
+++ b/eng/pipelines/common/templates/build-job.yml
@@ -45,7 +45,6 @@ jobs:
 
       steps:
       - script: $(_buildScript)
-                -ci
                 -pack
                 -c $(_BuildConfig)
                 $(_testBuildArg)

--- a/eng/pipelines/common/templates/build-job.yml
+++ b/eng/pipelines/common/templates/build-job.yml
@@ -45,6 +45,7 @@ jobs:
 
       steps:
       - script: $(_buildScript)
+                -ci
                 -pack
                 -c $(_BuildConfig)
                 $(_testBuildArg)

--- a/eng/pipelines/common/templates/publish.yml
+++ b/eng/pipelines/common/templates/publish.yml
@@ -1,4 +1,5 @@
 parameters:
+  PublishRidAgnosticPackagesFromPlatform: windows_x64
   publishingInfraVersion: 3
   enableSigningValidation: false
   enableNugetValidation: false
@@ -13,6 +14,8 @@ stages:
   jobs:
   # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
   - template: /eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+    parameters:
+        PublishRidAgnosticPackagesFromPlatform: ${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
 
   # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
   - template: /eng/common/templates-official/job/publish-build-assets.yml


### PR DESCRIPTION
## Description

This PR updates the `prepare-signed-artifacts.yml` file to use Arcade's templates and modifies the publish script to generate and upload NuGet packages to the feed.

Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2463272&view=results