### PR TITLE
[NativeAOT-LLVM] Support using emscripten from Mono workload

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -387,12 +387,12 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Target>
 
   <Target Name="CheckWasmSdks">
+    <!-- The EMSDK is typically set by user and points to a standard emscripten layout -->
+    <!-- The EmscriptenUpstreamEmscriptenPath comes from upstream mono workload and points to an upstream folder of emscripten. The EmscriptenUpstreamBinPath points to bin folder -->
     <Error Text="Emscripten not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Emscripten and ensure the EMSDK environment variable points to the directory containing upstream/emscripten/emcc.bat"
-           Condition="'$(EMSDK)' == '' and '$(_targetOS)' == 'browser'" />
+           Condition="'$(EMSDK)' == '' and '$(EmscriptenUpstreamEmscriptenPath)' == '' and '$(_targetOS)' == 'browser'" />
     <Error Text="Wasi SDK not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Wasi SDK and ensure the WASI_SDK_PATH environment variable points to the directory containing share/wasi-sysroot"
            Condition="'$(WASI_SDK_PATH)' == '' and '$(_targetOS)' == 'wasi'" />
-    <Warning Text="The WASI SDK version is too low. Please use WASI SDK 22 or newer with a 64 bit Clang."
-             Condition="!Exists('$(WASI_SDK_PATH)/VERSION') and '$(_targetOS)' == 'wasi'" />
   </Target>
 
   <Target Name="CompileWasmObjects"
@@ -414,7 +414,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'">$(CompileWasmArgs) -s DISABLE_EXCEPTION_CATCHING=0</CompileWasmArgs>
 
       <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.bat</ScriptExt>
-      <WasmCompilerPath Condition="'$(WasmCompilerPath)' == ''">&quot;$(EMSDK)/upstream/emscripten/emcc$(ScriptExt)&quot;</WasmCompilerPath>
+      <WasmCompilerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/emscripten/emcc$(ScriptExt)&quot;</WasmCompilerPath>
+      <WasmCompilerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenUpstreamEmscriptenPath)emcc$(ScriptExt)&quot;</WasmCompilerPath>
       <WasmLinkerPath>$(WasmCompilerPath)</WasmLinkerPath>
     </PropertyGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -393,6 +393,8 @@ The .NET Foundation licenses this file to you under the MIT license.
            Condition="'$(EMSDK)' == '' and '$(EmscriptenUpstreamEmscriptenPath)' == '' and '$(_targetOS)' == 'browser'" />
     <Error Text="Wasi SDK not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Wasi SDK and ensure the WASI_SDK_PATH environment variable points to the directory containing share/wasi-sysroot"
            Condition="'$(WASI_SDK_PATH)' == '' and '$(_targetOS)' == 'wasi'" />
+    <Warning Text="The WASI SDK version is too low. Please use WASI SDK 22 or newer with a 64 bit Clang."
+             Condition="!Exists('$(WASI_SDK_PATH)/VERSION') and '$(_targetOS)' == 'wasi'" />
   </Target>
 
   <Target Name="CompileWasmObjects"

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -414,7 +414,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'">$(CompileWasmArgs) -s DISABLE_EXCEPTION_CATCHING=0</CompileWasmArgs>
 
       <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.bat</ScriptExt>
-      <WasmCompilerPath>&quot;$(EMSDK)/upstream/emscripten/emcc$(ScriptExt)&quot;</WasmCompilerPath>
+      <WasmCompilerPath Condition="'$(WasmCompilerPath)' == ''">&quot;$(EMSDK)/upstream/emscripten/emcc$(ScriptExt)&quot;</WasmCompilerPath>
       <WasmLinkerPath>$(WasmCompilerPath)</WasmLinkerPath>
     </PropertyGroup>
 
@@ -439,7 +439,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Target>
 
   <Target Name="CompileSingleWasmObject">
-    <Exec Command="$(ExecCommand)" />
+    <Exec Command="$(ExecCommand)" EnvironmentVariables="@(EmscriptenEnvVars)" />
   </Target>
 
   <Target Name="LinkNativeSingle" Condition="'$(_targetOS)' != 'browser' and '$(_targetOS)' != 'wasi'"


### PR DESCRIPTION
Soon version of emscripten that uses NativeAOT-LLVM and mono will align. These changes allows to use emscripten from mono workload. For the moment it unblocks smoke tests on runtime repo.

- Allow to override `WasmCompilerPath` for browser
- Pass `EmscriptenEnvVars` when running the emscripten compiler

Preview of upstream integration bits
```xml
<Target Name="SetupEmscriptenEnvVars" BeforeTargets="CompileSingleWasmObject;LinkNativeLlvm">
  <!-- Environment variables required for running emsdk commands like `emcc` -->
  <ItemGroup Condition="'$(EMSDK)' == '$(EmscriptenUpstreamEmscriptenPath)'">
    <EmscriptenEnvVars Include="EMSDK_PYTHON=$(EmscriptenPythonToolsPath)python.exe" Condition="'$(OS)' == 'Windows_NT'" />
    <EmscriptenEnvVars Include="PYTHONPATH=$(EmscriptenPythonToolsPath)" Condition="'$(OS)' == 'Windows_NT'" />
    <EmscriptenEnvVars Include="PYTHONHOME=" Condition="'$(OS)' == 'Windows_NT'" />
    <EmscriptenEnvVars Include="DOTNET_EMSCRIPTEN_LLVM_ROOT=$(EmscriptenSdkToolsPath)bin" />
    <EmscriptenEnvVars Include="DOTNET_EMSCRIPTEN_BINARYEN_ROOT=$(EmscriptenSdkToolsPath)" />
    <EmscriptenEnvVars Include="DOTNET_EMSCRIPTEN_NODE_JS=$([MSBuild]::NormalizePath($(EmscriptenNodeToolsPath), 'bin', 'node$(_ExeExt)'))" />
    <EmscriptenEnvVars Include="EM_CACHE=$(WasmCachePath)" Condition="'$(WasmCachePath)' != ''" />
    <EmscriptenEnvVars Include="EM_FROZEN_CACHE=True" Condition="'$(WasmCachePath)' == '$(EmscriptenCacheSdkCacheDir)'" />
  </ItemGroup>
</Target>
```