### PR TITLE
[NativeAOT-LLVM] Workaround to align thread statics to 8 byte boundary

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
@@ -138,7 +138,7 @@ namespace Internal.Runtime
             }
 
 #if TARGET_WASM
-            // TODO-LLVM: Remove when there is an upstream fix.  See https://github.com/dotnet/runtimelab/issues/2606
+            // TODO-LLVM: Remove when there is an upstream fix.  See https://github.com/dotnet/runtimelab/issues/2606 and https://github.com/dotnet/runtime/issues/103234
             // This is a fix for aligning to 8, thread static fields that should be aligned 8, we just conservatively align everything to 8.
             return InternalCalls.RhpNewFastAlign8((MethodTable*)gcDesc);
 #else

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
@@ -137,7 +137,13 @@ namespace Internal.Runtime
                 gcDesc = Internal.Runtime.Augments.RuntimeAugments.TypeLoaderCallbacks.GetThreadStaticGCDescForDynamicType(typeManager, typeTlsIndex);
             }
 
+#if TARGET_WASM
+            // TODO-LLVM: Remove when there is an upstream fix.  See https://github.com/dotnet/runtimelab/issues/2606
+            // This is a fix for aligning to 8, thread static fields that should be aligned 8, we just conservatively align everything to 8.
+            return InternalCalls.RhpNewFastAlign8((MethodTable*)gcDesc);
+#else
             return RuntimeImports.RhNewObject((MethodTable*)gcDesc);
+#endif
         }
     }
 }


### PR DESCRIPTION
This PR is a workaround to align all thread statics to 8 byte boundary to ensure those statics that do require 8 byte alignment are aligned.

Follows https://github.com/dotnet/runtimelab/issues/2606