### PR TITLE
[NativeAOT-LLVM] Don't use the `emcc` wrapper for bitcode compilation

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -127,6 +127,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(OptimizationPreference) != 'Size' and '$(_targetOS)' == 'wasi'">-O2</WasmOptimizationSetting>
     <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(OptimizationPreference) == 'Size'">-Oz</WasmOptimizationSetting>
 
+    <IlcLlvmTarget Condition="'$(_targetOS)' == 'browser'">wasm32-unknown-emscripten</IlcLlvmTarget>
     <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi'">wasm32-unknown-wasi</IlcLlvmTarget>
     <IlcWasmStackSize>1048576</IlcWasmStackSize> <!-- 1MB -->
     <IlcWasmStackSize Condition="'$(EmccStackSize)' != ''">$(EmccStackSize)</IlcWasmStackSize>
@@ -387,10 +388,11 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Target>
 
   <Target Name="CheckWasmSdks">
-    <!-- The EMSDK is typically set by user and points to a standard emscripten layout -->
-    <!-- The EmscriptenUpstreamEmscriptenPath comes from upstream mono workload and points to an upstream folder of emscripten. The EmscriptenUpstreamBinPath points to bin folder -->
-    <Error Text="Emscripten not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Emscripten and ensure the EMSDK environment variable points to the directory containing upstream/emscripten/emcc.bat"
-           Condition="'$(EMSDK)' == '' and '$(EmscriptenUpstreamEmscriptenPath)' == '' and '$(_targetOS)' == 'browser'" />
+    <!-- $(EMSDK) is typically set by the user and points to a standard emscripten layout. -->
+    <!-- $(EmscriptenSdkToolsPath) comes from upstream mono workload and points to the dotnet/emsdk-style SDK layout. -->
+    <!-- See https://github.com/dotnet/runtime/blob/main/src/mono/browser/build/EmSdkRepo.Defaults.props. -->
+    <Error Text="Emscripten not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Emscripten and ensure the EMSDK environment variable points to the directory containing emsdk.bat"
+           Condition="'$(EMSDK)' == '' and '$(EmscriptenSdkToolsPath)' == '' and '$(_targetOS)' == 'browser'" />
     <Error Text="Wasi SDK not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Wasi SDK and ensure the WASI_SDK_PATH environment variable points to the directory containing share/wasi-sysroot"
            Condition="'$(WASI_SDK_PATH)' == '' and '$(_targetOS)' == 'wasi'" />
     <Warning Text="The WASI SDK version is too low. Please use WASI SDK 22 or newer with a 64 bit Clang."
@@ -406,26 +408,25 @@ The .NET Foundation licenses this file to you under the MIT license.
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeBinary)))" />
 
     <PropertyGroup>
-      <CompileWasmArgs>-c $(WasmOptimizationSetting)</CompileWasmArgs>
+      <CompileWasmArgs>-mllvm -combiner-global-alias-analysis=false -mllvm -disable-lsr</CompileWasmArgs> <!-- CQ workarounds. -->
+      <CompileWasmArgs>$(CompileWasmArgs) -target $(IlcLlvmTarget) -c $(WasmOptimizationSetting)</CompileWasmArgs>
       <CompileWasmArgs Condition="'$(NativeDebugSymbols)' == 'true'">$(CompileWasmArgs) -g3</CompileWasmArgs>
       <CompileWasmArgs Condition="'$(WasmEnableNonTrappingFloatToIntConversions)' == 'true'">$(CompileWasmArgs) -mnontrapping-fptoint</CompileWasmArgs>
       <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'wasm'">$(CompileWasmArgs) -fwasm-exceptions</CompileWasmArgs>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(_targetOS)' == 'browser'">
-      <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'">$(CompileWasmArgs) -s DISABLE_EXCEPTION_CATCHING=0</CompileWasmArgs>
+      <CompileWasmArgs Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'">$(CompileWasmArgs) -mllvm -enable-emscripten-cxx-exceptions</CompileWasmArgs>
 
       <ScriptExt Condition="'$(OS)' == 'Windows_NT'">.bat</ScriptExt>
-      <WasmCompilerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/emscripten/emcc$(ScriptExt)&quot;</WasmCompilerPath>
-      <WasmCompilerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenUpstreamEmscriptenPath)emcc$(ScriptExt)&quot;</WasmCompilerPath>
-      <WasmLinkerPath>$(WasmCompilerPath)</WasmLinkerPath>
+      <WasmCompilerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/bin/clang++&quot;</WasmCompilerPath>
+      <WasmCompilerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)bin/clang++&quot;</WasmCompilerPath>
+      <WasmLinkerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/emscripten/emcc$(ScriptExt)&quot;</WasmLinkerPath>
+      <WasmLinkerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)emscripten/emcc$(ScriptExt)&quot;</WasmLinkerPath>
     </PropertyGroup>
 
    <PropertyGroup Condition="'$(_targetOS)' == 'wasi'">
-      <CompileWasmArgs>$(CompileWasmArgs) -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -disable-lsr --sysroot=&quot;$(WASI_SDK_PATH)/share/wasi-sysroot&quot; -target $(IlcLlvmTarget)</CompileWasmArgs>
-
-      <ExeExt Condition="'$(OS)' == 'Windows_NT'">.exe</ExeExt>
-      <WasmCompilerPath>&quot;$(WASI_SDK_PATH)/bin/clang++$(ExeExt)&quot;</WasmCompilerPath>
+      <WasmCompilerPath>&quot;$(WASI_SDK_PATH)/bin/clang++&quot;</WasmCompilerPath>
       <WasmLinkerPath>&quot;$(WASI_SDK_PATH)/bin/clang&quot;</WasmLinkerPath>
     </PropertyGroup>
 

--- a/src/coreclr/nativeaot/Runtime/regdisplay.h
+++ b/src/coreclr/nativeaot/Runtime/regdisplay.h
@@ -173,12 +173,10 @@ struct REGDISPLAY
 
 struct REGDISPLAY
 {
-    // TODO: WebAssembly doesn't really have registers. What exactly do we need here?
-
     uintptr_t   SP;
     PCODE        IP;
 
-    inline PCODE GetIP() { return NULL; }
+    inline PCODE GetIP() { return IP; }
     inline uintptr_t GetSP() { return 0; }
     inline uintptr_t GetFP() { return 0; }
 


### PR DESCRIPTION
The wrapper just adds overhead.

Also remove unnecessary clang arguments. Also fix a warning.

Fixes #2603.