### PR TITLE
[NativeAOT-LLVM] Don't always build the runtime and fix static graph restore for BuildIntegration.proj

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -268,7 +268,7 @@
     <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrILToolsSubset=true</ClrRuntimeBuildSubsets>
   </PropertyGroup>
 
-  <PropertyGroup Condition="($(_subset.Contains('+clr.nativeaotruntime+')) and '$(NativeAotSupported)' == 'true') or '$(TargetArchitecture)' == 'wasm'">
+  <PropertyGroup Condition="$(_subset.Contains('+clr.nativeaotruntime+')) and ('$(NativeAotSupported)' == 'true' or '$(TargetsWasm)' == 'true')">
     <ClrRuntimeBuildSubsets>$(ClrRuntimeBuildSubsets);ClrNativeAotSubset=true</ClrRuntimeBuildSubsets>
   </PropertyGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.Build.Traversal">
+  <!-- TODO-LLVM-Upstream: https://github.com/dotnet/runtimelab/issues/2576 -->
   <PropertyGroup>
-    <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
+    <IsNativeAotProject>false</IsNativeAotProject>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The subset condition as written leads to always invoking runtime build, which is undesirable.

Also change the workaround for static graph restore in `BuildIntegration.proj` to a better working option.

