### PR TITLE
[NativeAOT-LLVM] Implement automatic finalization

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.SingleThreaded.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/__Finalizer.SingleThreaded.cs
@@ -12,7 +12,7 @@ namespace System.Runtime
 {
     internal static class __Finalizer
     {
-        [UnmanagedCallersOnly(EntryPoint = "RhpProcessFinalizersAndReturn", CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        [UnmanagedCallersOnly(EntryPoint = "RhpProcessFinalizersAndReturn")]
         private static unsafe void RhpProcessFinalizersAndReturn()
         {
             // Drain the queue of finalizable objects.

--- a/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
@@ -36,6 +36,10 @@ GPTR_DECL(MethodTable, g_pFreeObjectEEType);
 
 GPTR_IMPL(Thread, g_pFinalizerThread);
 
+#if defined(HOST_WASM) && !defined(FEATURE_WASM_THREADS)
+void FinalizeFinalizableObjects();
+#endif
+
 bool RhInitializeFinalization();
 
 // Perform any runtime-startup initialization needed by the GC, HandleTable or environmental code in gcenv.ee.
@@ -108,6 +112,10 @@ EXTERN_C void QCALLTYPE RhpCollect(uint32_t uGeneration, uint32_t uMode, UInt32_
     GCHeapUtilities::GetGCHeap()->GarbageCollect(uGeneration, lowMemoryP, uMode);
 
     pCurThread->EnablePreemptiveMode();
+
+#if defined(HOST_WASM) && !defined(FEATURE_WASM_THREADS)
+    FinalizeFinalizableObjects();
+#endif
 }
 
 EXTERN_C int64_t QCALLTYPE RhpGetGcTotalMemory()


### PR DESCRIPTION
Drain the finalizer queue on exit from allocation helpers on their slow path, as well as in `GC.Collect()`.

Fixes https://github.com/dotnet/runtimelab/issues/2240.