### PR TITLE
Integrate TypeSpec into TypeDecls and ABI parsing.

### DIFF
--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/ModuleHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/ModuleHandler.cs
@@ -83,7 +83,7 @@ namespace BindingsGeneration
                 foreach(FieldDecl fieldDecl in moduleDecl.Fields)
                 {
                     string accessModifier = fieldDecl.Visibility == Visibility.Public ? "public" : "private";
-                    writer.WriteLine($"{accessModifier} {fieldDecl.TypeIdentifier.Name} {fieldDecl.Name};");
+                    writer.WriteLine($"{accessModifier} {fieldDecl.CSTypeIdentifier.Name} {fieldDecl.Name};");
                 }
                 writer.WriteLine();
                 foreach(MethodDecl methodDecl in moduleDecl.Methods)

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/TypeHandler.cs
@@ -79,7 +79,7 @@ namespace BindingsGeneration
             foreach (var fieldDecl in structDecl.Fields)
             {
                 string accessModifier = fieldDecl.Visibility == Visibility.Public ? "public" : "private";
-                writer.WriteLine($"{accessModifier} {fieldDecl.TypeIdentifier.Name} {fieldDecl.Name};");
+                writer.WriteLine($"{accessModifier} {fieldDecl.CSTypeIdentifier.Name} {fieldDecl.Name};");
 
                 // TODO: Fix memory access violation
                 // // Verify field against Swift type information

--- a/src/Swift.Bindings/src/Model/ArgumentDecl.cs
+++ b/src/Swift.Bindings/src/Model/ArgumentDecl.cs
@@ -11,7 +11,12 @@ namespace BindingsGeneration
         /// <summary>
         /// Type of the argument.
         /// </summary>
-        public required TypeDecl TypeIdentifier { get; set; }
+        public required TypeDecl CSTypeIdentifier { get; set; }
+
+        /// <summary>
+        /// Type of the argument
+        ///
+        public required TypeSpec SwiftTypeSpec { get; set; }
         
         /// <summary>
         /// The private name of the argument.

--- a/src/Swift.Bindings/src/Model/FieldDecl.cs
+++ b/src/Swift.Bindings/src/Model/FieldDecl.cs
@@ -11,7 +11,12 @@ namespace BindingsGeneration
         /// <summary>
         /// Type name.
         /// </summary>
-        public required TypeDecl TypeIdentifier { get; set; }
+        public required TypeDecl CSTypeIdentifier { get; set; }
+
+        /// <summary>
+        /// The TypeSpec of the declaration
+        ///
+        public required TypeSpec SwiftTypeSpec {get; set; }
 
         /// <summary>
         /// Indicates the visibility of the declaration.

--- a/src/Swift.Bindings/src/Model/MethodDecl.cs
+++ b/src/Swift.Bindings/src/Model/MethodDecl.cs
@@ -28,8 +28,6 @@ namespace BindingsGeneration
         /// Signature of the method.
         /// </summary>
         public required List<ArgumentDecl> CSSignature { get; set; }
-
-        public required List<TypeSpec> SwiftSignature { get; set; }
     }
 
     /// <summary>

--- a/src/Swift.Bindings/src/Model/MethodDecl.cs
+++ b/src/Swift.Bindings/src/Model/MethodDecl.cs
@@ -27,7 +27,9 @@ namespace BindingsGeneration
         /// <summary>
         /// Signature of the method.
         /// </summary>
-        public required List<ArgumentDecl> Signature { get; set; }
+        public required List<ArgumentDecl> CSSignature { get; set; }
+
+        public required List<TypeSpec> SwiftSignature { get; set; }
     }
 
     /// <summary>

--- a/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecParser.cs
+++ b/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecParser.cs
@@ -283,7 +283,7 @@ public class TypeSpecParser {
     /// Given an existing TypeSpec type, create a new NamedTypeSpec with name
     /// and type as the generic parameter, e.g. name&lt;type&rt;
     /// </summary>
-    TypeSpec WrapAsBoundGeneric(TypeSpec type, string name)
+    NamedTypeSpec WrapAsBoundGeneric(TypeSpec type, string name)
     {
         var result = new NamedTypeSpec(name);
         result.GenericParameters.Add(type);

--- a/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecParser.cs
+++ b/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecParser.cs
@@ -1,0 +1,358 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// A class to parse swift type specifications into the TypeSpec type
+/// The TypeSpec language is a little language to represent a swift type.
+/// It will lool like:
+/// typespec: [attribute]*[inout][any][typelable]typespec[generic-clause]['?']
+/// typespec: tuple-typespec|named-typespec|func-typespec|protocol-list-type-spec
+/// tuple-typespec:'('typespec-list')'
+/// named-typespec: name
+/// func-type-spec: ypespec [async][throws]t '->' typespec
+/// protocol-list-type-spec: named-typespec &amp; named-typespec [&amp; named-type-spec]*
+/// generic-clause: '<' typespec-list '>'
+/// typespeclist: typespec [',' typespec]*
+/// attribute @name['(' parameters ')']
+/// </summary>
+public class TypeSpecParser {
+    TextReader reader;
+    TypeSpecTokenizer tokenizer;
+
+    /// <summary>
+    /// Private constructor for a TypeSpecParser using the supplied TextReader as a source
+    /// </summary>
+    TypeSpecParser(TextReader reader)
+    {
+        this.reader = reader;
+        tokenizer = new TypeSpecTokenizer(reader);
+    }
+
+    /// <summary>
+    /// Private utility method to parse and return a TypeSpec
+    /// </summary>
+    TypeSpec? Parse()
+    {
+        // This is a very simple recursive descent parser with 1 token look-ahead
+        // The typespec language is very simple and doesn't need anything more
+        var token = tokenizer.Peek();
+        TypeSpec? type = null;
+        List<TypeSpecAttribute> attrs = new ();
+        var inout = false;
+        var isAny = false;
+        string? typeLabel = null;
+        var throwsClosure = false;
+        var asyncClosure = false;
+        var expectClosure = false;
+
+        // Prefix
+
+        // parse any attributes
+        if (token.Kind == TypeTokenKind.At) {
+            attrs = ParseAttributes();
+            token = tokenizer.Peek();
+        }
+
+        // looks like it's inout, consume and continue
+        if (token.Kind == TypeTokenKind.TypeName && token.Value == "inout") {
+            inout = true;
+            tokenizer.Next ();
+            token = tokenizer.Peek ();
+        }
+
+        // any, consume and continute
+        if (token.Kind == TypeTokenKind.TypeName && token.Value == "any") {
+            isAny = true;
+            tokenizer.Next ();
+            token = tokenizer.Peek ();
+        }
+
+        // label, consume and continue
+        if (token.Kind == TypeTokenKind.TypeLabel) {
+            typeLabel = token.Value;
+            tokenizer.Next ();
+            token = tokenizer.Peek ();
+        }
+
+        // meat of the type
+
+        if (token.Kind == TypeTokenKind.LeftParenthesis) { // tuple
+            tokenizer.Next ();
+            TupleTypeSpec tuple = ParseTuple ();
+            type = tuple.Elements.Count == 1 ? tuple.Elements [0] : tuple;
+            typeLabel = type.TypeLabel;
+            type.TypeLabel = null;
+        } else if (token.Kind == TypeTokenKind.TypeName) { // name
+            tokenizer.Next ();
+            var tokenValue = token.Value.StartsWith ("ObjectiveC.", StringComparison.Ordinal) ?
+                            "Foundation" + token.Value.Substring ("ObjectiveC".Length) : token.Value;
+            if (tokenValue == "Swift.Void")
+                type = TupleTypeSpec.Empty;
+            else
+                type = new NamedTypeSpec(tokenValue);
+        } else if (token.Kind == TypeTokenKind.LeftBracket) { // array
+            tokenizer.Next ();
+            type = ParseArrayOrDictionary ();
+        } else { // illegal
+            throw new Exception($"Unexpected token {token.Value}.");
+        }
+
+        if (tokenizer.NextIs("async")) {
+            tokenizer.Next();
+            asyncClosure = true;
+            expectClosure = true;
+        }
+
+        if (tokenizer.NextIs("throws")) {
+            tokenizer.Next();
+            throwsClosure = true;
+            expectClosure = true;
+        }
+
+        if (tokenizer.Peek().Kind == TypeTokenKind.Arrow) {
+            tokenizer.Next();
+            type = ParseClosure(type, throwsClosure, asyncClosure);
+            expectClosure = false;
+            throwsClosure = false;
+            asyncClosure = false;
+        } else if (expectClosure) {
+            var errorCase = asyncClosure && throwsClosure ? "'async throws'" : asyncClosure ? "'async'" : "'throws'";
+            throw new Exception($"Unexpected token {tokenizer.Peek ().Value} after {errorCase} in a closure.");
+        } else if (tokenizer.Peek().Kind == TypeTokenKind.LeftAngle) {
+            tokenizer.Next();
+            type = Genericize (type);
+        }
+
+        if (tokenizer.Peek().Kind == TypeTokenKind.Period) {
+            tokenizer.Next();
+            var currType = type as NamedTypeSpec;
+            if (currType is null)
+                throw new Exception($"In parsing an inner type (type.type), first element is a {type.Kind} instead of a NamedTypeSpec.");
+            var nextType = Parse() as NamedTypeSpec;
+            if (nextType is null)
+                throw new Exception($"In parsing an inner type (type.type), the second element is a {type.Kind} instead of a NamedTypeSpec");
+            currType.InnerType = nextType;
+        }
+
+        // Postfix
+
+        if (tokenizer.Peek ().Kind == TypeTokenKind.Ampersand) {
+            if (type is NamedTypeSpec ns) {
+                type = ParseProtocolList (ns);
+            } else {
+                throw new Exception($"In parsing a protocol list type, expected a NamedTypeSpec but got a {type.GetType().Name}");
+            }
+        }
+
+        // this handles arbitrary nested optionals (eg, Int?????????)
+        while (tokenizer.Peek ().Kind == TypeTokenKind.QuestionMark) {
+            tokenizer.Next ();
+            type = WrapAsBoundGeneric (type, "Swift.Optional");
+        }
+
+        if (tokenizer.Peek ().Kind == TypeTokenKind.ExclamationPoint) {
+            tokenizer.Next ();
+            type = WrapAsBoundGeneric (type, "Swift.ImplicitlyUnwrappedOptional");
+        }
+
+        type.IsInOut = inout;
+        type.IsAny = isAny;
+        type.TypeLabel = typeLabel;
+
+        if (type != null && attrs != null) {
+            type.Attributes.AddRange (attrs);
+        }
+
+        return type;
+    }
+
+    /// <summary>
+    /// Parse the attributes that might be present in a TypeSpec
+    /// </summary>
+    List<TypeSpecAttribute> ParseAttributes()
+    {
+        // An attribute is
+        // @name
+        // or
+        // @name [ parameters ]
+        // The spec says that it could be ( parameters ), [ parameters ], or { parameters }
+        // but the reflection code should make certain that it's [ parameters ].
+        List<TypeSpecAttribute> attrs = new List<TypeSpecAttribute>();
+        while (true) {
+            if (tokenizer.Peek().Kind != TypeTokenKind.At) {
+                return attrs;
+            }
+            tokenizer.Next();
+            if (tokenizer.Peek().Kind != TypeTokenKind.TypeName) {
+                throw new Exception($"Unexpected token {tokenizer.Peek().Value}, expected a name while parsing an attribute.");
+            }
+            string name = tokenizer.Next ().Value;
+            TypeSpecAttribute attr = new TypeSpecAttribute(name);
+            if (tokenizer.Peek().Kind == TypeTokenKind.LeftBracket) {
+                tokenizer.Next();
+                ParseAttributeParameters(attr.Parameters);
+            }
+            attrs.Add(attr);
+        }
+    }
+
+    /// <summary>
+    /// Parses a comma separated list of parameters ending with a right bracket
+    /// </summary>
+    void ParseAttributeParameters (List<string> parameters)
+    {
+        // Attribute parameters are funny
+        // The contents between the brackets vary.
+        // They may be comma separated. They may not.
+        // Therefore this code is likely to break, but since I'm responsible for
+        // generating the text of the attributes parsed here, I can try to ensure
+        // that it will always fit the pattern.
+        while (true) {
+            if (tokenizer.Peek().Kind == TypeTokenKind.RightBracket) {
+                tokenizer.Next();
+                return;
+            }
+            var value = tokenizer.Next();
+            if (value.Kind != TypeTokenKind.TypeName) {
+                throw new Exception($"Unexpected token {value.Value} while parsing attribute parameter.");
+            }
+            parameters.Add(value.Value);
+            if (tokenizer.Peek().Kind == TypeTokenKind.Comma) {
+                tokenizer.Next();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parse a protocol list of the form name &amp; name [&amp; name]*
+    /// <summary>
+    TypeSpec ParseProtocolList(NamedTypeSpec first)
+    {
+        var protocols = new List<NamedTypeSpec> ();
+        protocols.Add(first);
+        while (true) {
+            if (tokenizer.Peek().Kind != TypeTokenKind.Ampersand)
+                break;
+            tokenizer.Next();
+            var nextName = tokenizer.Next();
+            if (nextName.Kind != TypeTokenKind.TypeName)
+                throw new Exception($"Unexpected token '{nextName.Value}' with kind {nextName.Kind} while parsing a protocol list");
+            protocols.Add(new NamedTypeSpec(nextName.Value));
+        }
+        return new ProtocolListTypeSpec (protocols);
+    }
+
+    /// <summary>
+    /// Parses a comman separated list of tokens with the specified terminating token.
+    /// Used for parsing generics and tuples.
+    /// </summary>
+    void ConsumeList (List<TypeSpec> elements, TypeTokenKind terminator, string typeImParsing)
+    {
+        while (true) {
+            if (tokenizer.Peek().Kind == terminator) {
+                tokenizer.Next();
+                return;
+            }
+            var next = Parse ();
+            if (next is null)
+                throw new Exception($"Unexpected end while parsing a {typeImParsing}");
+            elements.Add(next);
+            if (tokenizer.Peek().Kind == TypeTokenKind.Comma) {
+                tokenizer.Next();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Given an existing TypeSpec, add generic parameters to it
+    /// </summary>
+    TypeSpec Genericize(TypeSpec type)
+    {
+        ConsumeList (type.GenericParameters, TypeTokenKind.RightAngle, "generic parameter list");
+        return type;
+    }
+
+    /// <summary>
+    /// Given an existing TypeSpec type, create a new NamedTypeSpec with name
+    /// and type as the generic parameter, e.g. name&lt;type&rt;
+    /// </summary>
+    TypeSpec WrapAsBoundGeneric(TypeSpec type, string name)
+    {
+        var result = new NamedTypeSpec(name);
+        result.GenericParameters.Add(type);
+        return result;
+    }
+
+    /// <summary>
+    /// Parse a tuple and return it
+    /// </summary>
+    TupleTypeSpec ParseTuple()
+    {
+        TupleTypeSpec tuple = new TupleTypeSpec ();
+        ConsumeList(tuple.Elements, TypeTokenKind.RightParenthesis, "tuple");
+        return tuple;
+    }
+
+    /// <summary>
+    /// Parse an array or dictionary.
+    /// An array is in the form [ TypeSpec ] and a dictionary is in the form [ TypeSpec : TypeSpec ]
+    /// </summary>
+    NamedTypeSpec ParseArrayOrDictionary()
+    {
+        var keyType = Parse ();
+        TypeSpec? valueType = null;
+        if (keyType is null)
+            throw new Exception("Unexpected end while parsing an array or dictionary.");
+        if (tokenizer.Peek().Kind == TypeTokenKind.Colon) {
+            tokenizer.Next();
+            valueType = Parse();
+            if (valueType is null)
+                throw new Exception("Unexpected end while parsing a dictionary value type.");
+        } else if (tokenizer.Peek().Kind != TypeTokenKind.RightBracket)
+            throw new Exception("Expected a right bracket after an array or dictionary.");
+
+        tokenizer.Next();
+
+        if (valueType is null) {
+            return WrapAsBoundGeneric(keyType, "Swift.Array");
+        } else {
+            var dictionary = new NamedTypeSpec("Swift.Dictionary");
+            dictionary.GenericParameters.Add(keyType);
+            dictionary.GenericParameters.Add(valueType);
+            return dictionary;
+        }
+    }
+
+    /// <summary>
+    /// Parses a closure with the argument list and arrow already consumed already parsed.
+    /// </summary>
+    ClosureTypeSpec ParseClosure(TypeSpec arg, bool throws, bool isAsync)
+    {
+        var returnType = Parse();
+        if (returnType is null)
+            throw new Exception("Unexpected end while parsing a closure.");
+        var closure = new ClosureTypeSpec ();
+        closure.Arguments = arg;
+        closure.ReturnType = returnType;
+        closure.Throws = throws;
+        closure.IsAsync = isAsync;
+        return closure;
+    }
+
+    /// <summary>
+    /// Parse a string representing a Swift type specification into a TypeSpec.
+    /// Returns null on empty string and throws on a parse error.
+    /// </summary>
+    public static TypeSpec? Parse (string typeName)
+    {
+        TypeSpecParser parser = new TypeSpecParser (new StringReader (typeName));
+        return parser.Parse ();
+    }
+}

--- a/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecToken.cs
+++ b/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecToken.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// Represents the type of token from the tokenizer
+/// </summary>
+public enum TypeTokenKind {
+    /// <summary>
+    /// The token is a nominal swift type, e.g., Foo.Bar.Baz
+    /// </summary>
+    TypeName,
+    /// <summary>
+    /// The token is a comma
+    /// </summary>
+    Comma,
+    /// <summary>
+    /// The token is a left parenthesis, e.g. '('
+    /// </summary>
+    LeftParenthesis,
+    /// <summary>
+    /// The token is a right parenthesis, e.g. ')'
+    /// </summary>
+    RightParenthesis,
+    /// <summary>
+    /// The token is a left angle
+    /// </summary>
+    LeftAngle,
+    /// <summary>
+    /// The token is a right angle
+    /// </summary>
+    RightAngle,
+    /// <summary>
+    /// The token is a left bracket
+    /// </summary>
+    LeftBracket,
+    /// <summary>
+    /// The token is a right bracket
+    /// </summary>
+    RightBracket,
+    /// <summary>
+    /// The token is an arrow, e.g., '->'
+    /// </summary>
+    Arrow,
+    /// <summary>
+    /// The token is an at sign
+    /// </summary>
+    At,
+    /// <summary>
+    /// The token is a question mark
+    /// </summary>
+    QuestionMark,
+    /// <summary>
+    /// The token is a type label, e.g., 'someLabel:'
+    /// </summary>
+    TypeLabel,
+    /// <summary>
+    /// The token is a colon
+    /// </summary>
+    Colon,
+    /// <summary>
+    /// The token is an exclamation point
+    /// </summary>
+    ExclamationPoint,
+    /// <summary>
+    /// The token is a period
+    /// </summary>
+    Period,
+    /// <summary>
+    /// The token is an ampersand
+    /// </summary>
+    Ampersand,
+    /// <summary>
+    /// This is a special token representing the end of the stream.
+    /// </summary>
+    Done,
+}
+
+/// <summary>
+/// Represents a token for parsing a TypeSpec
+/// </summary>
+public class TypeSpecToken {
+    TypeSpecToken(TypeTokenKind kind, string value)
+    {
+        Kind = kind;
+        Value = value;
+    }
+
+    /// <summary>
+    /// The kind of this token
+    /// </summary>
+    public TypeTokenKind Kind { get; private set; }
+
+    /// <summary>
+    /// The string value of the token
+    /// </summary>
+    public string Value { get; private set; }
+
+    /// <summary>
+    /// Returns the Value of the token
+    /// </summary>
+    public override string ToString() => Value;
+    
+    /// <summary>
+    /// Returns a label token from the given string
+    /// </summary>
+    public static TypeSpecToken LabelFromString(string value) => new(TypeTokenKind.TypeLabel, value);
+
+    /// <summary>
+    /// Returns a name token from the given string
+    /// </summary>
+    public static TypeSpecToken FromString(string value) => new(TypeTokenKind.TypeName, value);
+
+    /// <summary>
+    /// A singleton for the left parenthesis token
+    /// </summary>
+    public static TypeSpecToken LeftParenthesis { get; } = new (TypeTokenKind.LeftParenthesis, "(");
+     /// <summary>
+    /// A singleton for the right parenthesis token
+    /// </summary>
+   public static TypeSpecToken RightParenthesis { get; } = new (TypeTokenKind.RightParenthesis, ")");
+
+    /// <summary>
+    /// A singleton for the left angle token
+    /// </summary>
+    public static TypeSpecToken LeftAngle { get; } = new (TypeTokenKind.LeftAngle, "<");
+    /// <summary>
+    /// A singleton for the right angle token
+    /// </summary>
+    public static TypeSpecToken RightAngle { get; } = new (TypeTokenKind.RightAngle, ">");
+
+    /// <summary>
+    /// A singleton for the left bracket token
+    /// </summary>
+    public static TypeSpecToken LeftBracket { get;} = new (TypeTokenKind.LeftBracket, "[");
+    /// <summary>
+    /// A singleton for the right bracket token
+    /// </summary>
+    public static TypeSpecToken RightBracket { get;} = new (TypeTokenKind.RightBracket, "]");
+
+    /// <summary>
+    /// A singleton for the comma token
+    /// </summary>
+    public static TypeSpecToken Comma { get; } = new (TypeTokenKind.Comma, ",");
+    /// <summary>
+    /// A singleton for the arrow token
+    /// </summary>
+    public static TypeSpecToken Arrow { get; } = new (TypeTokenKind.Arrow, "->");
+    /// <summary>
+    /// A singleton for the at sign token
+    /// </summary>
+    public static TypeSpecToken At { get; } = new (TypeTokenKind.At, "@");
+    /// <summary>
+    /// A singleton for the question mark token
+    /// </summary>
+    public static TypeSpecToken QuestionMark { get; } = new (TypeTokenKind.QuestionMark, "?");
+    /// <summary>
+    /// A singleton for the exclamation point token
+    /// </summary>
+    public static TypeSpecToken ExclamationPoint { get; } = new (TypeTokenKind.ExclamationPoint, "!");
+    /// <summary>
+    /// A singleton for the done token
+    /// </summary>
+    public static TypeSpecToken Done { get; } = new (TypeTokenKind.Done, "");
+    /// <summary>
+    /// A singleton for the colon token
+    /// </summary>
+    public static TypeSpecToken Colon { get; } = new (TypeTokenKind.Colon, ":");
+    /// <summary>
+    /// A singleton for the period token
+    /// </summary>
+    public static TypeSpecToken Period { get; } = new (TypeTokenKind.Period, ".");
+    /// <summary>
+    /// A singleton for the ampersand token
+    /// </summary>
+    public static TypeSpecToken Ampersand { get; } = new(TypeTokenKind.Ampersand, "&");
+}

--- a/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecTokenizer.cs
+++ b/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecTokenizer.cs
@@ -20,7 +20,7 @@ public class TypeSpecTokenizer {
     State state;
     StringBuilder buffer;
     TextReader reader;
-    static string invalidNameChars;
+    static HashSet<char> invalidNameChars = new();
 
     /// <summary>
     /// Builds a set of characters that are illegal for names
@@ -30,22 +30,20 @@ public class TypeSpecTokenizer {
         // Since identifiers in Swift can be nearly any unicode, including emoji, we
         // can't just ask "IsLetterOrNumber". Instead, I build the set of characters that are specifically
         // forbidden.
-        var sb = new StringBuilder();
         for (char c = (char)0; c < '.'; c++) {
-            sb.Append (c);
+            invalidNameChars.Add(c);
         }
-        sb.Append ('/');
+        invalidNameChars.Add('/');
         for (char c = ':'; c < 'A'; c++) {
-            sb.Append (c);
+            invalidNameChars.Add(c);
         }
         for (char c = '['; c < '_'; c++) {
-            sb.Append (c);
+            invalidNameChars.Add (c);
         }
-        sb.Append ('`');
+        invalidNameChars.Add('`');
         for (char c = '{'; c <= (char)127; c++) {
-            sb.Append (c);
+            invalidNameChars.Add(c);
         }
-        invalidNameChars = sb.ToString();
     }
 
     /// <summary>
@@ -116,7 +114,7 @@ public class TypeSpecTokenizer {
     {
         // parses a name until we hit an invalid character for a name
         int curr = reader.Peek();
-        if (curr < 0 || InvalidNameCharacter((char)curr)) {
+        if (curr < 0 || IsInvalidNameCharacter((char)curr)) {
             // if the invalid character is a ':', this is a label, otherwise it's a name
             if (curr == ':') {
                 reader.Read(); // drop the colon
@@ -220,7 +218,7 @@ public class TypeSpecTokenizer {
                 reader.Read ();
                 return null;
             }
-            if (InvalidNameCharacter (c)) {
+            if (IsInvalidNameCharacter (c)) {
                 throw new Exception($"Unexpected/illegal char {c}");
             }
             state = State.InName;
@@ -231,8 +229,8 @@ public class TypeSpecTokenizer {
     /// <summary>
     /// Return true if and only if c is invalid for a name
     /// <summary>
-    static bool InvalidNameCharacter (char c)
+    static bool IsInvalidNameCharacter (char c)
     {
-        return invalidNameChars.IndexOf (c) >= 0;
+        return invalidNameChars.Contains(c);
     }
 }

--- a/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecTokenizer.cs
+++ b/src/Swift.Bindings/src/Model/TypeSpecParsing/TypeSpecTokenizer.cs
@@ -1,0 +1,238 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using System.IO;
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// a simple 1 char look-ahead state machine to tokenize the language of type specs
+/// </summary>
+public class TypeSpecTokenizer {
+    enum State {
+        Start,
+        InName,
+        InArrow,
+    };
+
+    State state;
+    StringBuilder buffer;
+    TextReader reader;
+    static string invalidNameChars;
+
+    /// <summary>
+    /// Builds a set of characters that are illegal for names
+    /// </summary>
+    static TypeSpecTokenizer()
+    {
+        // Since identifiers in Swift can be nearly any unicode, including emoji, we
+        // can't just ask "IsLetterOrNumber". Instead, I build the set of characters that are specifically
+        // forbidden.
+        var sb = new StringBuilder();
+        for (char c = (char)0; c < '.'; c++) {
+            sb.Append (c);
+        }
+        sb.Append ('/');
+        for (char c = ':'; c < 'A'; c++) {
+            sb.Append (c);
+        }
+        for (char c = '['; c < '_'; c++) {
+            sb.Append (c);
+        }
+        sb.Append ('`');
+        for (char c = '{'; c <= (char)127; c++) {
+            sb.Append (c);
+        }
+        invalidNameChars = sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds a tokenizer that will build tokens from the given reader
+    /// <summary>
+    public TypeSpecTokenizer(TextReader reader)
+    {
+        this.reader = reader;
+        buffer = new ();
+        state = State.Start;
+    }
+
+    TypeSpecToken? curr = null;
+
+    /// <summary>
+    /// Return the next token without consuming it.
+    /// </summary>
+    public TypeSpecToken Peek()
+    {
+        if (curr is null) {
+            curr = Next();
+        }
+        return curr;
+    }
+
+    /// <summary>
+    /// Return the next token consuming it
+    /// </summary>
+    public TypeSpecToken Next()
+    {
+        // this is based on a simple state machine that switches between
+        // 3 states: Start, InName, and InArrow. Each of the sub handlers will return
+        // either null (more work to do) or a finished token.
+        if (curr is not null) {
+            var retval = curr;
+            curr = null;
+            return retval;
+        }
+        TypeSpecToken? token = null;
+        do {
+            switch (state) {
+                case State.InName:
+                    token = DoName();
+                    break;
+                case State.InArrow:
+                    token = DoArrow();
+                    break;
+                case State.Start:
+                    token = DoStart();
+                    break;
+            }            
+        } while (token is null);
+        return token;
+    }
+
+    /// <summary>
+    /// Return true if and only if the next token is a name and is equal to the supplied string
+    /// </summary>
+    public bool NextIs(string name)
+    {
+        return Peek().Kind == TypeTokenKind.TypeName && Peek().Value == name;
+    }
+
+    /// <summary>
+    /// Scans in a name or label token
+    /// </summary>
+    TypeSpecToken? DoName()
+    {
+        // parses a name until we hit an invalid character for a name
+        int curr = reader.Peek();
+        if (curr < 0 || InvalidNameCharacter((char)curr)) {
+            // if the invalid character is a ':', this is a label, otherwise it's a name
+            if (curr == ':') {
+                reader.Read(); // drop the colon
+                state = State.Start;
+                var token = TypeSpecToken.LabelFromString(buffer.ToString());
+                buffer.Clear();
+                return token;
+            } else {
+                state = State.Start;
+                var token = TypeSpecToken.FromString(buffer.ToString());
+                buffer.Clear();
+                return token;
+            }
+        } else {
+            buffer.Append((char)reader.Read());
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// parses an arrow (->)
+    /// </summary>
+    TypeSpecToken? DoArrow()
+    {
+        if (buffer.Length == 0) {
+            if (reader.Peek() == (int)'-') {
+                buffer.Append((char)reader.Read());
+                return null;
+            } 
+        } else {
+            if (reader.Peek() == (int)'>') {
+                reader.Read();
+                buffer.Clear();
+                state = State.Start;
+                return TypeSpecToken.Arrow;
+            }
+        }
+        throw new Exception($"Unexpected character in arrow token: {(char)reader.Peek()}");
+    }
+
+    /// <summary>
+    /// Handle the start state condition
+    /// </summary>
+    TypeSpecToken? DoStart ()
+    {
+        // in the start state. If it's a known single character token, return that.
+        // If it's a '-' switch to InArrow state
+        // If it's whitespace, consume it
+        // If it's a legal name character, switch to InName state
+        // If it's end of stream, return Done
+        // If its anything else, throw
+        int currentChar = reader.Peek ();
+        if (currentChar < 0)
+            return TypeSpecToken.Done;
+        char c = (char)currentChar;
+        switch (c) {
+        case '(':
+            reader.Read ();
+            return TypeSpecToken.LeftParenthesis;
+        case ')':
+            reader.Read ();
+            return TypeSpecToken.RightParenthesis;
+        case '<':
+            reader.Read ();
+            return TypeSpecToken.LeftAngle;
+        case '>':
+            reader.Read ();
+            return TypeSpecToken.RightAngle;
+        case ',':
+            reader.Read ();
+            return TypeSpecToken.Comma;
+        case '@':
+            reader.Read ();
+            return TypeSpecToken.At;
+        case '?':
+            reader.Read ();
+            return TypeSpecToken.QuestionMark;
+        case '!':
+            reader.Read ();
+            return TypeSpecToken.ExclamationPoint;
+        case '-':
+            state = State.InArrow;
+            return null;
+        case '[':
+            reader.Read ();
+            return TypeSpecToken.LeftBracket;
+        case ']':
+            reader.Read ();
+            return TypeSpecToken.RightBracket;
+        case ':':
+            reader.Read ();
+            return TypeSpecToken.Colon;
+        case '.':
+            reader.Read ();
+            return TypeSpecToken.Period;
+        case '&':
+            reader.Read ();
+            return TypeSpecToken.Ampersand;
+        default:
+            if (Char.IsWhiteSpace (c)) {
+                reader.Read ();
+                return null;
+            }
+            if (InvalidNameCharacter (c)) {
+                throw new Exception($"Unexpected/illegal char {c}");
+            }
+            state = State.InName;
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Return true if and only if c is invalid for a name
+    /// <summary>
+    static bool InvalidNameCharacter (char c)
+    {
+        return invalidNameChars.IndexOf (c) >= 0;
+    }
+}

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -378,7 +378,6 @@ namespace BindingsGeneration
                 MethodType = node.@static ?? false ? MethodType.Static : MethodType.Instance,
                 IsConstructor = node.Kind == "Constructor",
                 CSSignature = new List<ArgumentDecl>(),
-                SwiftSignature = new List<TypeSpec>(),
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl
             };

--- a/src/Swift.Bindings/tests/TypeSpecTests/TypeSpecParserTests.cs
+++ b/src/Swift.Bindings/tests/TypeSpecTests/TypeSpecParserTests.cs
@@ -333,4 +333,63 @@ public class TypeSpecParserTests : IClassFixture<TypeSpecParserTests.TestFixture
         Assert.True (inType.Throws);
     }
 
+    [Fact]
+    public static void TestThrowBadArrow()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("(Swift.Int)-=>(Swift.Int)"); });
+    }
+
+    [Fact]
+    public static void TestIllegalNameChar()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("Swift#Int"); });
+    }
+
+    [Fact]
+    public static void TestBadStartToken()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse(")"); });
+    }
+
+    [Fact]
+    public static void TestBadClosureToken()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("() throws ? -> )"); });
+    }
+
+    [Fact]
+    public static void TestInnerClass1()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("().Foo"); });
+    }
+    
+    [Fact]
+    public static void TestProtoListFail()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("Foo & ()"); });
+    }
+    
+    [Fact]
+    public static void TestAttributeFail()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("@&Foo"); });
+    }
+    
+    [Fact]
+    public static void TestListFail()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("Swift.Foo<A, &>"); });
+    }
+    
+    [Fact]
+    public static void TestArrayFail1()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("[&]"); });
+    }
+    
+    [Fact]
+    public static void TestArrayFail2()
+    {
+        Assert.Throws<Exception>(() => { TypeSpecParser.Parse("[Swift.Int : ?]"); });
+    }
 }

--- a/src/Swift.Bindings/tests/TypeSpecTests/TypeSpecParserTests.cs
+++ b/src/Swift.Bindings/tests/TypeSpecTests/TypeSpecParserTests.cs
@@ -1,0 +1,336 @@
+using Xunit;
+
+namespace BindingsGeneration.Tests;
+
+public class TypeSpecParserTests : IClassFixture<TypeSpecParserTests.TestFixture>
+{
+    private readonly TestFixture _fixture;
+
+    public TypeSpecParserTests(TestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public class TestFixture
+    {
+        static TestFixture()
+        {
+        }
+
+        private static void InitializeResources()
+        {
+        }
+    }
+
+    [Fact]
+    public static void TestNamedBasicName()
+    {
+        var ts = TypeSpecParser.Parse("thisIsAName");
+        var ns = ts as NamedTypeSpec;
+        Assert.NotNull(ns);
+        Assert.Equal("thisIsAName", ns.Name);
+    }
+
+    [Fact]
+    public static void TestNamedGeneric()
+    {
+        var ts = TypeSpecParser.Parse("thisIsAName<a, b, c>");
+        var ns = ts as NamedTypeSpec;
+        Assert.NotNull(ns);
+        Assert.Equal("thisIsAName", ns.Name);
+        Assert.Equal(3, ns.GenericParameters.Count);
+        var ns1 = ns.GenericParameters[0] as NamedTypeSpec;
+        Assert.NotNull(ns1);
+        Assert.Equal("a", ns1.Name);
+        ns1 = ns.GenericParameters[1] as NamedTypeSpec;
+        Assert.NotNull(ns1);
+        Assert.Equal("b", ns1.Name);
+        ns1 = ns.GenericParameters[2] as NamedTypeSpec;
+        Assert.NotNull(ns1);
+        Assert.Equal("c", ns1.Name);
+    }
+
+    [Fact]
+    public static void TestEmptyTuple()
+    {
+        var tuple = TypeSpecParser.Parse("()") as TupleTypeSpec;
+        Assert.NotNull(tuple);
+        Assert.Empty(tuple.Elements);
+    }
+
+    [Fact]
+    public static void TestSingleTuple()
+    {
+        var ns = TypeSpecParser.Parse("Swift.Int") as NamedTypeSpec;
+        Assert.NotNull(ns);
+        Assert.Equal("Swift.Int", ns.Name);
+    }
+
+    [Fact]
+    public static void TestDoubleTuple()
+    {
+        var tuple = TypeSpecParser.Parse("(Swift.Int, Swift.Float)") as TupleTypeSpec;
+        Assert.NotNull(tuple);
+        Assert.Equal(2, tuple.Elements.Count);
+        var ns = tuple.Elements[0] as NamedTypeSpec;
+        Assert.NotNull(ns);
+        Assert.Equal("Swift.Int", ns.Name);
+        ns = tuple.Elements[1] as NamedTypeSpec;
+        Assert.NotNull(ns);
+        Assert.Equal("Swift.Float", ns.Name);
+    }
+
+    [Fact]
+    public static void TestNestedTuple()
+    {
+        var tuple = TypeSpecParser.Parse("(Swift.Int, (Swift.Int, Swift.Int))") as TupleTypeSpec;
+        Assert.NotNull(tuple);
+        Assert.Equal(2, tuple.Elements.Count);
+        var ns = tuple.Elements[0] as NamedTypeSpec;
+        Assert.NotNull(ns);
+        Assert.Equal("Swift.Int", ns.Name);
+        tuple = tuple.Elements[1] as TupleTypeSpec;
+        Assert.NotNull(tuple);
+        Assert.Equal(2, tuple.Elements.Count);
+        ns = tuple.Elements[0] as NamedTypeSpec;
+        Assert.NotNull(ns);
+        Assert.Equal("Swift.Int", ns.Name);
+        ns = tuple.Elements[1] as NamedTypeSpec;
+        Assert.NotNull(ns);
+        Assert.Equal("Swift.Int", ns.Name);
+    }
+
+    [Fact]
+    public static void TestFuncIntInt()
+    {
+        var close = TypeSpecParser.Parse ("Swift.Int -> Swift.Int") as ClosureTypeSpec;
+        Assert.NotNull (close);
+        var ns = close.Arguments as NamedTypeSpec;
+        Assert.NotNull (ns);
+        Assert.Equal ("Swift.Int", ns.Name);
+        ns = close.ReturnType as NamedTypeSpec;
+        Assert.NotNull (ns);
+        Assert.Equal ("Swift.Int", ns.Name);
+    }
+
+
+    [Fact]
+    public static void TestFuncVoidVoid()
+    {
+        var close = TypeSpecParser.Parse ("() -> ()") as ClosureTypeSpec;
+        Assert.NotNull (close);
+        var ts = close.Arguments as TupleTypeSpec;
+        Assert.NotNull (ts);
+        Assert.Empty (ts.Elements);
+        ts = close.ReturnType as TupleTypeSpec;
+        Assert.NotNull (ts);
+        Assert.Empty (ts.Elements);
+    }
+
+    [Fact]
+    public static void TestArrayOfInt()
+    {
+        var ns = TypeSpecParser.Parse ("Swift.Array<Swift.Int>") as NamedTypeSpec;
+        Assert.NotNull (ns);
+        Assert.Equal ("Swift.Array", ns.Name);
+        Assert.True (ns.ContainsGenericParameters);
+        Assert.Single (ns.GenericParameters);
+        ns = ns.GenericParameters [0] as NamedTypeSpec;
+        Assert.NotNull (ns);
+        Assert.Equal ("Swift.Int", ns.Name);
+    }
+
+    [Fact]
+    public static void TestDictionaryOfIntString()
+    {
+        var ns = TypeSpecParser.Parse ("Swift.Dictionary<Swift.Int, Swift.String>") as NamedTypeSpec;
+        Assert.NotNull (ns);
+        Assert.Equal ("Swift.Dictionary", ns.Name);
+        Assert.True (ns.ContainsGenericParameters);
+        Assert.Equal (2, ns.GenericParameters.Count);
+        var ns1 = ns.GenericParameters [0] as NamedTypeSpec;
+        Assert.NotNull (ns1);
+        Assert.Equal ("Swift.Int", ns1.Name);
+        ns1 = ns.GenericParameters [1] as NamedTypeSpec;
+        Assert.NotNull (ns1);
+        Assert.Equal ("Swift.String", ns1.Name);
+    }
+
+    [Fact]
+    public static void TestWithAttributes ()
+    {
+        var tupled = TypeSpecParser.Parse ("(Builtin.RawPointer, (@convention[thin] (Builtin.RawPointer, inout Builtin.UnsafeValueBuffer, inout SomeModule.Foo, @thick SomeModule.Foo.Type) -> ())?)")
+            as TupleTypeSpec;
+        Assert.NotNull (tupled);
+        var ns = tupled.Elements [1] as NamedTypeSpec;
+        Assert.True (ns.ContainsGenericParameters);
+        Assert.Equal ("Swift.Optional", ns.Name);
+        var close = ns.GenericParameters[0] as ClosureTypeSpec;
+        Assert.Single (close.Attributes);
+    }
+
+    [Fact]
+    public static void TestEmbeddedClass()
+    {
+        var ns = TypeSpecParser.Parse ("Swift.Dictionary<Swift.String, T>.Index") as NamedTypeSpec;
+        Assert.NotNull (ns);
+        Assert.NotNull (ns.InnerType);
+        Assert.Equal ("Index", ns.InnerType.Name);
+        Assert.Equal ("Swift.Dictionary<Swift.String, T>.Index", ns.ToString ());
+    }
+
+    [Fact]
+    public static void TestProtocolListAlphabetical ()
+    {
+        var specs = new NamedTypeSpec [] {
+            new NamedTypeSpec ("Cfoo"),
+            new NamedTypeSpec ("Afoo"),
+            new NamedTypeSpec ("Dfoo"),
+            new NamedTypeSpec ("Bfoo")
+        };
+
+        var protos = new ProtocolListTypeSpec (specs);
+        Assert.Equal ("Afoo & Bfoo & Cfoo & Dfoo", protos.ToString ());
+    }
+
+    [Fact]
+    public static void TestProtocolListParseSimple ()
+    {
+        var protocolListType = TypeSpecParser.Parse ("c & b & a") as ProtocolListTypeSpec;
+        Assert.NotNull (protocolListType);
+        Assert.Equal (3, protocolListType.Protocols.Count);
+        Assert.Equal ("a & b & c", protocolListType.ToString ());
+    }
+
+    [Fact]
+    public static void TestProtocolListParseNoSpacesBecauseWhyNot ()
+    {
+        var protocolListType = TypeSpecParser.Parse ("c&b&a") as ProtocolListTypeSpec;
+        Assert.NotNull (protocolListType);
+        Assert.Equal (3, protocolListType.Protocols.Count);
+        Assert.Equal ("a & b & c", protocolListType.ToString ());
+    }
+
+    [Fact]
+    public static void TestReplaceInNameSuccess ()
+    {
+        var inType = TypeSpecParser.Parse ("Foo.Bar");
+        var replaced = inType.ReplaceName ("Foo.Bar", "Slarty.Bartfast") as NamedTypeSpec;
+        Assert.NotNull (replaced);
+        Assert.Equal ("Slarty.Bartfast", replaced.Name);
+    }
+
+    [Fact]
+    public static void TestReplaceInNameFail ()
+    {
+        var inType = TypeSpecParser.Parse ("Foo.Bar");
+        var same = inType.ReplaceName ("Blah", "Slarty.Bartfast") as NamedTypeSpec;
+        Assert.Equal (same, inType);
+    }
+
+    [Fact]
+    public static void TestReplaceInTupleSuccess ()
+    {
+        var inType = TypeSpecParser.Parse ("(Swift.Int, Foo.Bar, Foo.Bar)");
+        var replaced = inType.ReplaceName ("Foo.Bar", "Slarty.Bartfast") as TupleTypeSpec;
+        Assert.NotNull (replaced);
+        var name = replaced.Elements [1] as NamedTypeSpec;
+        Assert.NotNull (name);
+        Assert.Equal ("Slarty.Bartfast", name.Name);
+        name = replaced.Elements [2] as NamedTypeSpec;
+        Assert.NotNull (name);
+        Assert.Equal ("Slarty.Bartfast", name.Name);
+    }
+
+    [Fact]
+    public static void TestReplaceInTupleFail ()
+    {
+        var inType = TypeSpecParser.Parse ("(Swift.Int, Foo.Bar, Foo.Bar)");
+        var same = inType.ReplaceName ("Blah", "Slarty.Bartfast") as TupleTypeSpec;
+        Assert.Equal (same, inType);
+    }
+
+
+    [Fact]
+    public static void TestReplaceInClosureSuccess ()
+    {
+        var inType = TypeSpecParser.Parse ("(Swift.Int, Foo.Bar) -> Foo.Bar");
+        var replaced = inType.ReplaceName ("Foo.Bar", "Slarty.Bartfast") as ClosureTypeSpec;
+        Assert.NotNull (replaced);
+        var args = replaced.Arguments as TupleTypeSpec;
+        Assert.NotNull (args);
+        Assert.Equal (2, args.Elements.Count);
+        var name = args.Elements [1] as NamedTypeSpec;
+        Assert.Equal ("Slarty.Bartfast", name.Name);
+        name = replaced.ReturnType as NamedTypeSpec;
+        Assert.Equal ("Slarty.Bartfast", name.Name);
+    }
+
+    [Fact]
+    public static void TestReplaceInClosureFail ()
+    {
+        var inType = TypeSpecParser.Parse ("(Swift.Int, Foo.Bar) -> Foo.Bar");
+        var same = inType.ReplaceName ("Blah", "Slarty.Bartfast") as ClosureTypeSpec;
+        Assert.NotNull (same);
+        Assert.Equal (same, inType);
+    }
+
+    [Fact]
+    public static void TestReplaceInProtoListSuccess ()
+    {
+        var inType = TypeSpecParser.Parse ("Swift.Equatable & Foo.Bar");
+        var replaced = inType.ReplaceName ("Foo.Bar", "Slarty.Bartfast") as ProtocolListTypeSpec;
+        Assert.NotNull (replaced);
+        var name = replaced.Protocols.Keys.FirstOrDefault (n => n.Name == "Slarty.Bartfast");
+        Assert.NotNull (name);
+    }
+
+    [Fact]
+    public static void TestReplaceInProtoListFail ()
+    {
+        var inType = TypeSpecParser.Parse ("Swift.Equatable & Foo.Bar");
+        var same = inType.ReplaceName ("Blah", "Slarty.Bartfast") as ProtocolListTypeSpec;
+        Assert.Equal (same, inType);
+    }
+
+    [Fact]
+    public static void TestWeirdClosureIssue ()
+    {
+        var inType = TypeSpecParser.Parse ("@escaping[] (_onAnimation:Swift.Bool)->Swift.Void");
+        Assert.True (inType is ClosureTypeSpec);
+        var closSpec = inType as ClosureTypeSpec;
+        Assert.True (closSpec.IsEscaping);
+        var textRep = closSpec.ToString ();
+        var firstIndex = textRep.IndexOf ("_onAnimation");
+        var lastIndex = textRep.LastIndexOf ("_onAnimation");
+        Assert.True (firstIndex == lastIndex);
+    }
+
+    [Fact]
+    public static void TestAsyncClosure ()
+    {
+        var inType = TypeSpecParser.Parse ("() async -> ()") as ClosureTypeSpec;
+        Assert.NotNull (inType);
+        Assert.True (inType.IsAsync);
+        Assert.False (inType.Throws);
+    }
+
+    [Fact]
+    public static void TestAsyncThrowsClosure ()
+    {
+        var inType = TypeSpecParser.Parse ("() async throws -> ()") as ClosureTypeSpec;
+        Assert.NotNull (inType);
+        Assert.True (inType.IsAsync);
+        Assert.True (inType.Throws);
+    }
+
+    [Fact]
+    public static void TestThrowsClosure ()
+    {
+        var inType = TypeSpecParser.Parse ("() throws -> ()") as ClosureTypeSpec;
+        Assert.NotNull (inType);
+        Assert.False (inType.IsAsync);
+        Assert.True (inType.Throws);
+    }
+
+}

--- a/src/Swift.Bindings/tests/TypeSpecTests/TypeSpecTests.cs
+++ b/src/Swift.Bindings/tests/TypeSpecTests/TypeSpecTests.cs
@@ -171,4 +171,87 @@ public class TypeSpecTests : IClassFixture<TypeSpecTests.TestFixture>
         ns.GenericParameters.Add(new TupleTypeSpec(GetSomeVariedTypes()));
         Assert.Equal("Foo.Bar<(Swift.Int, () -> (), a & b & c)>", ns.ToString());
     }
+
+    [Fact]
+    public static void TestProtocolListAlphabetical1 ()
+    {
+        var specs = new NamedTypeSpec [] {
+            new NamedTypeSpec ("🤡Foo"),
+            new NamedTypeSpec ("💩Foo"),
+        };
+
+        var protos = new ProtocolListTypeSpec (specs);
+        Assert.Equal ("💩Foo & 🤡Foo", protos.ToString ());
+    }
+
+    [Fact]
+    public static void TestProtocolListMatch ()
+    {
+        var specs1 = new NamedTypeSpec [] {
+            new NamedTypeSpec ("Cfoo"),
+            new NamedTypeSpec ("Afoo"),
+            new NamedTypeSpec ("Dfoo"),
+            new NamedTypeSpec ("Bfoo")
+        };
+
+        var specs2 = new NamedTypeSpec [] {
+            new NamedTypeSpec ("Afoo"),
+            new NamedTypeSpec ("Dfoo"),
+            new NamedTypeSpec ("Cfoo"),
+            new NamedTypeSpec ("Bfoo")
+        };
+
+        var protos1 = new ProtocolListTypeSpec (specs1);
+        var protos2 = new ProtocolListTypeSpec (specs2);
+
+        Assert.True (protos1.Equals (protos2));
+    }
+
+    [Fact]
+    public static void TestProtocolListNotMatch ()
+    {
+        var specs1 = new NamedTypeSpec [] {
+            new NamedTypeSpec ("Cfoo"),
+            new NamedTypeSpec ("Afoo"),
+            new NamedTypeSpec ("Dfoo"),
+            new NamedTypeSpec ("Bfoo")
+        };
+
+        var specs2 = new NamedTypeSpec [] {
+            new NamedTypeSpec ("Afoo"),
+            new NamedTypeSpec ("Efoo"),
+            new NamedTypeSpec ("Cfoo"),
+            new NamedTypeSpec ("Bfoo")
+        };
+
+        var protos1 = new ProtocolListTypeSpec (specs1);
+        var protos2 = new ProtocolListTypeSpec (specs2);
+
+        Assert.False (protos1.Equals (protos2));
+    }
+
+    [Fact]
+    public static void TestProtocolListNotMatchLength ()
+    {
+        var specs1 = new NamedTypeSpec [] {
+            new NamedTypeSpec ("Cfoo"),
+            new NamedTypeSpec ("Afoo"),
+            new NamedTypeSpec ("Dfoo"),
+            new NamedTypeSpec ("Bfoo")
+        };
+
+        var specs2 = new NamedTypeSpec [] {
+            new NamedTypeSpec ("Afoo"),
+            new NamedTypeSpec ("Dfoo"),
+            new NamedTypeSpec ("Cfoo"),
+            new NamedTypeSpec ("Efoo"),
+            new NamedTypeSpec ("Bfoo")
+        };
+
+        var protos1 = new ProtocolListTypeSpec (specs1);
+        var protos2 = new ProtocolListTypeSpec (specs2);
+
+        Assert.False (protos1.Equals (protos2));
+    }
+
 }

--- a/src/Swift.Bindings/tests/TypeSpecTests/TypeSpecTests.cs
+++ b/src/Swift.Bindings/tests/TypeSpecTests/TypeSpecTests.cs
@@ -251,7 +251,7 @@ public class TypeSpecTests : IClassFixture<TypeSpecTests.TestFixture>
         var protos1 = new ProtocolListTypeSpec (specs1);
         var protos2 = new ProtocolListTypeSpec (specs2);
 
-        Assert.False (protos1.Equals (protos2));
+        Assert.NotEqual (protos1, protos2);
     }
 
 }


### PR DESCRIPTION
Added the TypeSpecParser and associated support to the code to be able to parse in Swift type names.

Renamed members that are in C# space to have a `CS` prefix.
Named members that are in Swift space to have a `Swift` prefix.
Added a ton of unit tests.