### PR TITLE
[NativeAOT-LLVM] Set the runtime flavor for 'nativeaot' subsets to CoreCLR

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -56,7 +56,7 @@
 
   <PropertyGroup>
     <RuntimeFlavor Condition="'$(TargetsMobile)' == 'true' and !$(_subset.Contains('+clr.nativeaotlibs+'))">Mono</RuntimeFlavor>
-    <RuntimeFlavor Condition="('$(TargetsMobile)' == 'true' or '$(TargetsLinuxBionic)' == 'true') and ($(_subset.Contains('+clr.')) or '$(TestNativeAot)' == 'true')">CoreCLR</RuntimeFlavor>
+    <RuntimeFlavor Condition="('$(TargetsMobile)' == 'true' or '$(TargetsLinuxBionic)' == 'true') and ($(_subset.Contains('+clr.')) or $(_subset.Contains('+nativeaot.')) or '$(TestNativeAot)' == 'true')">CoreCLR</RuntimeFlavor>
     <RuntimeFlavor Condition="'$(RuntimeFlavor)' == '' and ($(_subset.Contains('+mono+')) or $(_subset.Contains('+mono.runtime+'))) and (!$(_subset.Contains('+clr+')) and !$(_subset.Contains('+clr.runtime+')))">Mono</RuntimeFlavor>
     <RuntimeFlavor Condition="'$(RuntimeFlavor)' == ''">$(PrimaryRuntimeFlavor)</RuntimeFlavor>
   </PropertyGroup>


### PR DESCRIPTION
The before-last merge introduced a problem that @dicej reported a while ago, where things like `./build nativeaot.build` would pick Mono as the default runtime flavor for `$(TargetsMobile) == true`. This change fixes it.