### PR TITLE
[NativeAOT-LLVM] Remove the Align8 workaround

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/ThreadStatics.cs
@@ -137,13 +137,7 @@ namespace Internal.Runtime
                 gcDesc = Internal.Runtime.Augments.RuntimeAugments.TypeLoaderCallbacks.GetThreadStaticGCDescForDynamicType(typeManager, typeTlsIndex);
             }
 
-#if TARGET_WASM
-            // TODO-LLVM: Remove when there is an upstream fix.  See https://github.com/dotnet/runtimelab/issues/2606 and https://github.com/dotnet/runtime/issues/103234
-            // This is a fix for aligning to 8, thread static fields that should be aligned 8, we just conservatively align everything to 8.
-            return InternalCalls.RhpNewFastAlign8((MethodTable*)gcDesc);
-#else
             return RuntimeImports.RhNewObject((MethodTable*)gcDesc);
-#endif
         }
     }
 }


### PR DESCRIPTION
Fixes #2606.

Upstream fix: https://github.com/dotnet/runtime/pull/105931.