### PR TITLE
[NativeAOT-LLVM] disable SocketsHttpHandler support for WASI

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -36,7 +36,7 @@ namespace System.Net.Http
         /// Gets a value that indicates whether the handler is supported on the current platform.
         /// </summary>
         [UnsupportedOSPlatformGuard("browser")]
-        public static bool IsSupported => !OperatingSystem.IsBrowser();
+        public static bool IsSupported => !(OperatingSystem.IsBrowser() || OperatingSystem.IsWasi());
 
         public bool UseCookies
         {


### PR DESCRIPTION
Disabling this until `System.Net.Sockets` support comes to WASI via [wasi-sockets](https://github.com/WebAssembly/wasi-sockets). Many libraries (such as [grpc-dotnet](https://github.com/grpc/grpc-dotnet)) check the value of `SocketsHttpHandler.IsSupported` to see if it [needs to fall back](https://github.com/grpc/grpc-dotnet/blob/e9cc7e15796d39f1d2656178f56a45c09147d0fe/src/Shared/HttpHandlerFactory.cs#L32) from a sockets-based handler to a basic HTTP handler.

If this is not the correct location to update, let me know and I'd be happy to amend the PR.