### PR TITLE
[NativeAOT-LLVM] Move thread stack top and bottom from thread locals to `thread` class

### DIFF
--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -35,29 +35,6 @@ static Thread* g_RuntimeInitializingThread;
 
 #endif //!DACCESS_COMPILE
 
-#ifdef HOST_WASM
-void* Thread::GetShadowStackBottom()
-{
-    return m_pShadowStackBottom;
-}
-
-void Thread::SetShadowStackBottom(void *pShadowStack)
-{
-    ASSERT(m_pShadowStackBottom == nullptr);
-    m_pShadowStackBottom = pShadowStack;
-}
-
-void* Thread::GetShadowStackTop()
-{
-    return m_pShadowStackTop;
-}
-
-void Thread::SetShadowStackTop(void* pShadowStack)
-{
-    m_pShadowStackTop = pShadowStack;
-}
-#endif
-
 PInvokeTransitionFrame* Thread::GetTransitionFrame()
 {
     if (ThreadStore::GetSuspendingThread() == this)
@@ -406,7 +383,7 @@ void Thread::Destroy()
 void Thread::GcScanWasmShadowStack(ScanFunc * pfnEnumCallback, ScanContext * pvCallbackData)
 {
     // Wasm does not permit iteration of stack frames so is uses a shadow stack instead
-    EnumGcRefsInRegionConservatively((PTR_OBJECTREF)GetShadowStackBottom(), (PTR_OBJECTREF)m_pShadowStackTop, pfnEnumCallback, pvCallbackData);
+    EnumGcRefsInRegionConservatively((PTR_OBJECTREF)m_pShadowStackBottom, (PTR_OBJECTREF)m_pShadowStackTop, pfnEnumCallback, pvCallbackData);
 
     // TODO-LLVM-Upstream: unify this method with the general "GcScanRootsWorker" below.
     for (GCFrameRegistration* pCurGCFrame = m_pGCFrameRegistrations; pCurGCFrame != NULL; pCurGCFrame = pCurGCFrame->m_pNext)

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -166,11 +166,6 @@ public:
                                                     // On Unix this is an optimization to not queue up more signals when one is
                                                     // still being processed.
     };
-#ifdef HOST_WASM
-    PTR_VOID GetShadowStackTop();
-    void SetShadowStackBottom(PTR_VOID pShadowStack);
-    void SetShadowStackTop(PTR_VOID pShadowStack);
-#endif
 private:
 
     void Construct();
@@ -205,7 +200,6 @@ private:
     PInvokeTransitionFrame* GetTransitionFrame();
 
 #ifdef HOST_WASM
-    PTR_VOID GetShadowStackBottom();
     void GcScanWasmShadowStack(ScanFunc* pfnEnumCallback, ScanContext* pvCallbackData);
 #endif
 
@@ -342,6 +336,12 @@ public:
 #ifdef TARGET_X86
     void                SetPendingRedirect(PCODE eip);
     bool                CheckPendingRedirect(PCODE eip);
+#endif
+
+#ifdef HOST_WASM
+    void* GetShadowStackTop();
+    void SetShadowStackBottom(void* pShadowStack);
+    void SetShadowStackTop(void* pShadowStack);
 #endif
 };
 

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -118,6 +118,10 @@ struct RuntimeThreadLocals
 #ifdef FEATURE_GC_STRESS
     uint32_t                m_uRand;                                // current per-thread random number
 #endif // FEATURE_GC_STRESS
+#ifdef HOST_WASM
+    void*                   m_pShadowStackBottom;
+    void*                   m_pShadowStackTop;
+#endif // HOST_WASM
 };
 
 struct ReversePInvokeFrame
@@ -162,6 +166,11 @@ public:
                                                     // On Unix this is an optimization to not queue up more signals when one is
                                                     // still being processed.
     };
+#ifdef HOST_WASM
+    PTR_VOID GetShadowStackTop();
+    void SetShadowStackBottom(PTR_VOID pShadowStack);
+    void SetShadowStackTop(PTR_VOID pShadowStack);
+#endif
 private:
 
     void Construct();
@@ -196,6 +205,7 @@ private:
     PInvokeTransitionFrame* GetTransitionFrame();
 
 #ifdef HOST_WASM
+    PTR_VOID GetShadowStackBottom();
     void GcScanWasmShadowStack(ScanFunc* pfnEnumCallback, ScanContext* pvCallbackData);
 #endif
 

--- a/src/coreclr/nativeaot/Runtime/thread.inl
+++ b/src/coreclr/nativeaot/Runtime/thread.inl
@@ -156,3 +156,21 @@ FORCEINLINE bool Thread::InlineTryFastReversePInvoke(ReversePInvokeFrame* pFrame
 
     return true;
 }
+
+#ifdef HOST_WASM
+FORCEINLINE void Thread::SetShadowStackBottom(void *pShadowStack)
+{
+    ASSERT(m_pShadowStackBottom == nullptr);
+    m_pShadowStackBottom = pShadowStack;
+}
+
+FORCEINLINE void* Thread::GetShadowStackTop()
+{
+    return m_pShadowStackTop;
+}
+
+FORCEINLINE void Thread::SetShadowStackTop(void* pShadowStack)
+{
+    m_pShadowStackTop = pShadowStack;
+}
+#endif

--- a/src/coreclr/nativeaot/Runtime/wasm/GcStress.cpp
+++ b/src/coreclr/nativeaot/Runtime/wasm/GcStress.cpp
@@ -16,8 +16,6 @@
 
 #include "wasm.h"
 
-void SetShadowStackTop(void* pShadowStack);
-
 FCIMPL2(void*, RhpGcStressOnce, void* obj, uint8_t* pFlag)
 {
     if (*pFlag)
@@ -44,7 +42,7 @@ FCIMPL2(void*, RhpGcStressOnce, void* obj, uint8_t* pFlag)
             pThread->PushGCFrameRegistration(&gc);
         }
 
-        SetShadowStackTop(pShadowStack);
+        pThread->SetShadowStackTop(pShadowStack);
         GCHeapUtilities::GetGCHeap()->GarbageCollect();
 
         if (obj != nullptr)


### PR DESCRIPTION
This PR removes the thread locals for the shadow stack top and bottom and replaces them with members in the `thread` class.  This opens the opportunity for one thread to initiate the scan of the shadow stack of all threads unblocking one thing to make NAOT-LLVM runtime for Wasm multi threaded.
