### PR TITLE
[NativeAOT-LLVM] Enable the official build for Linux

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -128,6 +128,7 @@
 
     <!-- If we're building clr.nativeaotlibs and not building the CLR runtime, compile libraries against NativeAOT CoreLib -->
     <UseNativeAotCoreLib Condition="'$(TestNativeAot)' == 'true' or ($(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+')) and !$(_subset.Contains('+clr.corelib+')))">true</UseNativeAotCoreLib>
+    <UseNativeAotCoreLib Condition="'$(UseNativeAotCoreLib)' == '' and $(_subset.Contains('+nativeaot.'))">true</UseNativeAotCoreLib>
   </PropertyGroup>
 
   <!-- Configure build properties for C++ runtime library references. -->

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -480,6 +480,7 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Browser WebAssembly Linux X64 for NAOT-LLVM
+# Use a different name to differentiate from upstream as we need the -sanitizer image to get build tools that are not present in the stock browser_wasm image.
 
 - ${{ if containsValue(parameters.platforms, 'Browser_wasm_linux_x64_naot_llvm') }}:
   - template: xplat-setup.yml
@@ -501,6 +502,7 @@ jobs:
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # WASI WebAssembly Linux X64 for NAOT-LLVM
+# Use a different name to differentiate from upstream as we need the -sanitizer image to get build tools that are not present in the stock wasi-wasm image.
 
 - ${{ if containsValue(parameters.platforms, 'wasi_wasm_linux_x64_naot_llvm') }}:
   - template: xplat-setup.yml

--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -36,14 +36,16 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: Release
           platforms:
-          - Browser_wasm_win
+          - browser_wasm_win
           - wasi_wasm_win
+          - Browser_wasm_linux_x64_naot_llvm
+          - wasi_wasm_linux_x64_naot_llvm
           jobParameters:
             templatePath: 'templates-official'
             timeoutInMinutes: 300
             isOfficialBuild: true
             testGroup: innerloop
-            buildArgs: -s clr.aot+libs+nativeaot.packages -c $(_BuildConfig)
+            buildArgs: -s clr.aot+libs -c $(_BuildConfig)
             postBuildSteps:
             - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
               parameters:

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -49,7 +49,6 @@ extends:
     stages:
     - stage: Build
       jobs:
-
         #
         # Build and test with Debug libraries and Debug runtime
         #
@@ -59,11 +58,9 @@ extends:
             helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
             buildConfig: debug
             platforms:
-            # - osx_x64 # Upstream break.
             - windows_x64
             - browser_wasm_win
             - wasi_wasm_win
-            # Use a different name to differentiate from upstream as we need the -sanitizer image to get build tools that are not present in the stock wasi-wasm image.
             - Browser_wasm_linux_x64_naot_llvm
             - wasi_wasm_linux_x64_naot_llvm
             jobParameters:
@@ -90,7 +87,6 @@ extends:
               postBuildSteps:
                 - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
                   parameters:
-                    uploadRuntimeTests: true
                     librariesConfiguration: Debug
 
         #
@@ -107,12 +103,11 @@ extends:
             - windows_x64
             - Browser_wasm_win
             - wasi_wasm_win
-            # Use a different name to differentiate from upstream as we need the -sanitizer image to get build tools that are not present in the stock wasi-wasm image.
             - wasi_wasm_linux_x64_naot_llvm
             - Browser_wasm_linux_x64_naot_llvm
             jobParameters:
               timeoutInMinutes: 300
-              buildArgs: -s clr.aot+libs -c $(_BuildConfig) /p:ArchiveTests=true
+              buildArgs: -s clr.aot+libs -c $(_BuildConfig)
               postBuildSteps:
                 - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
                   parameters:

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -61,14 +61,14 @@ extends:
             platforms:
             # - osx_x64 # Upstream break.
             - windows_x64
-            - Browser_wasm_win
+            - browser_wasm_win
             - wasi_wasm_win
             # Use a different name to differentiate from upstream as we need the -sanitizer image to get build tools that are not present in the stock wasi-wasm image.
             - Browser_wasm_linux_x64_naot_llvm
             - wasi_wasm_linux_x64_naot_llvm
             jobParameters:
               timeoutInMinutes: 300
-              buildArgs: -s clr.aot+libs+nativeaot.packages -c debug -rc $(_BuildConfig)
+              buildArgs: -s clr.aot+libs -c debug -rc $(_BuildConfig)
               postBuildSteps:
                 - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
                   parameters:
@@ -86,7 +86,7 @@ extends:
             - windows_x64
             jobParameters:
               timeoutInMinutes: 300
-              buildArgs: -s clr.aot+libs+nativeaot.packages -c debug -rc $(_BuildConfig)
+              buildArgs: -s clr.aot+libs -c debug -rc $(_BuildConfig)
               postBuildSteps:
                 - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
                   parameters:
@@ -112,7 +112,7 @@ extends:
             - Browser_wasm_linux_x64_naot_llvm
             jobParameters:
               timeoutInMinutes: 300
-              buildArgs: -s clr.aot+libs+nativeaot.packages -c $(_BuildConfig) /p:ArchiveTests=true
+              buildArgs: -s clr.aot+libs -c $(_BuildConfig) /p:ArchiveTests=true
               postBuildSteps:
                 - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
                   parameters:

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -5,18 +5,13 @@ parameters:
   osSubgroup: ''
   platform: ''
   runtimeVariant: ''
-  uploadTests: false
   testFilter: tree nativeaot
-  runSingleFileTests: true
   isOfficialBuild: false
   librariesConfiguration: Debug
 
 steps:
-- ${{ if and(ne(parameters.archType, 'arm'), ne(parameters.archType, 'arm64')) }}:
-
   # For NativeAOT-LLVM, we have just built the Wasm-targeting native artifacts (the runtime and libraries).
   # Now we need to build the cross-targeting compilers, RyuJit and ILC. Likewise with packages.
-
   - ${{ if eq(parameters.archType, 'wasm') }}:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.wasmjit+clr.aot -c $(buildConfigUpper) $(_officialBuildParameter) -ci -cross
       displayName: Build the ILC and RyuJit cross-compilers
@@ -59,26 +54,25 @@ steps:
       - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} 'tree nativeaot' /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
         displayName: Build tests
 
-    - ${{ if eq(parameters.runSingleFileTests, true) }}:
-      - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:
-        - script: |
-            call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-            $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
-          displayName: Run WebAssembly tests in single file mode
-      - ${{ elseif eq(parameters.osGroup, 'windows') }}:
-        - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
-          displayName: Run tests in single file mode
-      - ${{ else }}:
-        - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) --runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
-          displayName: Run tests in single file mode
+    - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:
+      - script: |
+          call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
+          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
+        displayName: Run WebAssembly tests in single file mode
+    - ${{ elseif eq(parameters.osGroup, 'windows') }}:
+      - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
+        displayName: Run tests in single file mode
+    - ${{ else }}:
+      - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) --runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
+        displayName: Run tests in single file mode
 
     - ${{ if eq(parameters.archType, 'wasm') }}:
       - script: |
             $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -test -a ${{ parameters.archType }} -os ${{ parameters.osGroup }} -lc ${{ parameters.librariesConfiguration }} -rc $(buildConfigUpper) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true
         displayName: Build and run WebAssembly libraries tests
 
-# Upload unsigned artifacts
-- ${{ if eq(parameters.uploadIntermediateArtifacts, true) }}:
-  - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-    parameters:
-      name: ${{ parameters.platform }}${{ parameters.nameSuffix }}
+  # Upload unsigned artifacts
+  - ${{ if eq(parameters.uploadIntermediateArtifacts, true) }}:
+    - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+      parameters:
+        name: ${{ parameters.platform }}${{ parameters.nameSuffix }}

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -21,8 +21,14 @@ steps:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.wasmjit+clr.aot -c $(buildConfigUpper) $(_officialBuildParameter) -ci -cross
       displayName: Build the ILC and RyuJit cross-compilers
 
-    - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.platform, 'browser_wasm_win')) }}:
-      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) $(_officialBuildParameter) -ci
+    # Build target packages when the host OS is Windows (note: target libs already built).
+    - ${{ if contains(parameters.platform, 'win') }}:
+      - script: $(Build.SourcesDirectory)/build$(scriptExt) nativeaot.packages -a wasm -os ${{ parameters.osGroup }} -c $(buildConfigUpper) $(_officialBuildParameter) -ci
+        displayName: Build target packages
+
+    # Build host packages when the target OS is Browser.
+    - ${{ if eq(parameters.osGroup, 'browser') }}:
+      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) $(_officialBuildParameter) -ci -cross
         displayName: Build host packages
 
   # Build coreclr native test output outside of official build


### PR DESCRIPTION
This requires reconfiguring how we build packages a little. See the first commit.

Also, a little bit of YAML cleanup has been snuck in.