### PR TITLE
[NativeAOT-LLVM] Remove WASI Linux from the official build matrix

### DIFF
--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -39,7 +39,6 @@ extends:
           - browser_wasm_win
           - wasi_wasm_win
           - Browser_wasm_linux_x64_naot_llvm
-          - wasi_wasm_linux_x64_naot_llvm
           jobParameters:
             templatePath: 'templates-official'
             timeoutInMinutes: 300


### PR DESCRIPTION
This platform does not produce packages, and "upload intermediate artifacts" step cannot handle the missing artifacts directory.

This should hopefully fix the official build.

@dotnet/nativeaot-llvm 