### PR TITLE
[NativeAOT-LLVM] Add _requiresAlign8 to the compare method and name for GCStaticEETypeNode to avoid asserts when sorting.

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -44,6 +44,10 @@ namespace ILCompiler.DependencyAnalysis
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
             sb.Append("__GCStaticEEType_"u8).Append(_gcMap.ToString());
+            if (_requiresAlign8)
+            {
+                sb.Append("_align8");
+            }
         }
 
         int ISymbolDefinitionNode.Offset
@@ -107,7 +111,14 @@ namespace ILCompiler.DependencyAnalysis
 
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
-            return _gcMap.CompareTo(((GCStaticEETypeNode)other)._gcMap);
+            GCStaticEETypeNode otherGCStaticEETypeNode = (GCStaticEETypeNode)other;
+            int mapCompare = _gcMap.CompareTo(otherGCStaticEETypeNode._gcMap);
+            if (mapCompare == 0)
+            {
+                return _requiresAlign8.CompareTo(otherGCStaticEETypeNode._requiresAlign8);
+            }
+
+            return mapCompare;
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -46,7 +46,7 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append("__GCStaticEEType_"u8).Append(_gcMap.ToString());
             if (_requiresAlign8)
             {
-                sb.Append("_align8");
+                sb.Append("_align8"u8);
             }
         }
 

--- a/src/native/libs/configure.cmake
+++ b/src/native/libs/configure.cmake
@@ -1,4 +1,4 @@
-include(CheckCCompilerFlag)
+ include(CheckCCompilerFlag)
 include(CheckCSourceCompiles)
 include(CheckCSourceRuns)
 include(CheckIncludeFiles)
@@ -648,7 +648,7 @@ elseif (HAVE_PTHREAD_IN_LIBC)
 endif()
 
 if (NOT CLR_CMAKE_TARGET_WASI)
-    check_library_exists(${PTHREAD_LIBRARY} pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
+    check_library_exists(pthread pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
 endif()
 
 check_symbol_exists(
@@ -754,7 +754,7 @@ check_c_source_compiles(
 
     int main(void)
     {
-        return mkstemps(\"abc\", 3);
+        return mkstemps(\"XXXXXX\", 3);
     }
     "
     HAVE_MKSTEMPS)
@@ -767,7 +767,7 @@ check_c_source_compiles(
 
     int main(void)
     {
-        return mkstemp(\"abc\");
+        return mkstemp(\"XXXXXXX\");
     }
     "
     HAVE_MKSTEMP)

--- a/src/native/libs/configure.cmake
+++ b/src/native/libs/configure.cmake
@@ -1,4 +1,4 @@
- include(CheckCCompilerFlag)
+include(CheckCCompilerFlag)
 include(CheckCSourceCompiles)
 include(CheckCSourceRuns)
 include(CheckIncludeFiles)
@@ -648,7 +648,7 @@ elseif (HAVE_PTHREAD_IN_LIBC)
 endif()
 
 if (NOT CLR_CMAKE_TARGET_WASI)
-    check_library_exists(pthread pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
+    check_library_exists(${PTHREAD_LIBRARY} pthread_condattr_setclock "" HAVE_PTHREAD_CONDATTR_SETCLOCK)
 endif()
 
 check_symbol_exists(
@@ -754,7 +754,7 @@ check_c_source_compiles(
 
     int main(void)
     {
-        return mkstemps(\"XXXXXX\", 3);
+        return mkstemps(\"abc\", 3);
     }
     "
     HAVE_MKSTEMPS)
@@ -767,7 +767,7 @@ check_c_source_compiles(
 
     int main(void)
     {
-        return mkstemp(\"XXXXXXX\");
+        return mkstemp(\"abc\");
     }
     "
     HAVE_MKSTEMP)


### PR DESCRIPTION
This PR fixes an assert in `SortableDependencyNode` and an `InvalidOperationException` in `WasmObjectWriter` when we have 2 `GCStaticEETypeNode` with the same GC bit map but different align 8 requirements.