### PR TITLE
[NativeAOT-LLVM] Add tracked SSA locals to the first basic block LiveIn set.

### DIFF
--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -985,11 +985,13 @@ private:
                     initValue->SetRegNum(REG_LLVM);
                     if (m_compiler->lvaInSsa(lclNum))
                     {
+                        // Fortunately for the implicit GC def logic, SSA always adds an implicit def for parameters.
+                        assert(varDsc->GetPerSsaData(SsaConfig::FIRST_SSA_NUM)->GetDefNode() == nullptr);
                         initValue->SetSsaNum(SsaConfig::FIRST_SSA_NUM);
-                        if (varDsc->lvTracked)
-                        {
-                            VarSetOps::AddElemD(m_compiler, m_compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex);
-                        }
+                    }
+                    if (varDsc->lvTracked)
+                    {
+                        VarSetOps::AddElemD(m_compiler, m_compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex);
                     }
                     InitializeLocalInProlog(lclNum, initValue);
                 }

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -986,6 +986,10 @@ private:
                     if (m_compiler->lvaInSsa(lclNum))
                     {
                         initValue->SetSsaNum(SsaConfig::FIRST_SSA_NUM);
+                        if (varDsc->lvTracked)
+                        {
+                            VarSetOps::AddElemD(m_compiler, m_compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex);
+                        }
                     }
                     InitializeLocalInProlog(lclNum, initValue);
                 }

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -433,6 +433,8 @@ internal unsafe partial class Program
 
         TestThreadStaticAlignment();
 
+        TestLiveInFirstBlockForTracked(new object());
+
         if (OperatingSystem.IsBrowser())
         {
             EventLoopTestClass.TestEventLoopIntegration();
@@ -4315,6 +4317,23 @@ internal unsafe partial class Program
         var ts2Addr = ThreadStaticAlignCheck2.returnArea.AddressOfReturnArea();
 
         EndTest((((nint)ts1Addr) % 8 == 0) && (((nint)ts2Addr) % 8 == 0));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void SafePoint()
+    {
+    }
+
+    static object TestLiveInFirstBlockForTracked(object a)
+    {
+        StartTest("Test live in populated for first block tracked variables");
+
+        SafePoint();
+        a = new object();
+        SafePoint(); // Force a to the shadow stack
+
+        EndTest(true);
+        return a;
     }
 
     static ushort ReadUInt16()


### PR DESCRIPTION
This PR adds tracked SSA variables to the Live In set for the first basic block, fixing an assert in release config.  

Fixes #2682 