### PR TITLE
[Swift] Add first piece of rule reduction

### DIFF
--- a/src/Swift.Bindings/src/Demangler/IReduction.cs
+++ b/src/Swift.Bindings/src/Demangler/IReduction.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration.Demangling;
+
+/// <summary>
+/// Represents the result of reducing a Node or tree of nodes
+/// </summary>
+public interface IReduction {
+    string Symbol { get; init; }
+}
+
+/// <summary>
+/// Represents an error in an attempted reduction
+/// </summary>
+public class ReductionError : IReduction {
+    public required string Symbol { get; init; }
+    /// <summary>
+    /// Returns an error message describing the error
+    /// </summary>
+    public required string Message { get; init; }
+}
+
+/// <summary>
+/// Represents a reduction that reduces to a single type
+/// </summary>
+public class TypeSpecReduction : IReduction {
+    public required string Symbol { get; init; }
+    /// <summary>
+    /// Returns a TypeSpec for the type that this node represents
+    /// </summary>
+    public required TypeSpec TypeSpec { get; init; }
+}
+
+/// <summary>
+/// Represents a reduction that reduces to a Swift function
+/// </summary>
+public class FunctionReduction : IReduction {
+    public required string Symbol { get; init; }
+    /// <summary>
+    /// Returns a function that this type represents
+    /// </summary>
+    public required SwiftFunction Function { get; init; }
+}
+
+public class ProtocolWitnessTableReduction : IReduction {
+    public required string Symbol { get; init; }
+    public required NamedTypeSpec ImplementingType { get; init; }
+    public required NamedTypeSpec ProtocolType { get; init;}
+}

--- a/src/Swift.Bindings/src/Demangler/MatchRule.cs
+++ b/src/Swift.Bindings/src/Demangler/MatchRule.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration.Demangling;
+/// <summary>
+/// MatchRule represents a tree reducing rule for a demangled Swift symbol.
+/// Given a tree of nodes, a match rule contains conditions for the match,
+/// which include:
+/// - If and how the node content should be matched
+/// - If the number of children should match
+/// - Rules to run on the children
+/// - One or more NodeKinds to match
+/// If a match occurs, a reducer function can be run on the node.
+/// </summary>
+internal class MatchRule {
+    /// <summary>
+    /// The name of this rule - usefule for debugging
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// A list of node kinds to match. 
+    /// </summary>
+    public List<NodeKind> NodeKindList { get; set; } = new List<NodeKind>();
+
+    /// <summary>
+    /// A convenience accessor to match on a single NodeKind
+    /// </summary>
+    public NodeKind NodeKind {
+        get {
+            if (NodeKindList.Count != 1) {
+                throw new InvalidOperationException($"NodeKind is invalid when NodeKindList has {NodeKindList.Count} entries.");
+            }
+            return NodeKindList[0];
+        }
+        set {
+            NodeKindList = new List<NodeKind> { value };
+        }
+    }
+
+    /// <summary>
+    /// If and how to match the content of the Node
+    /// </summary>
+    public MatchNodeContentType MatchContent { get; init; } = MatchNodeContentType.None;
+
+    /// <summary>
+    /// Rules to apply to children node.
+    /// </summary>
+    public List<MatchRule> ChildRules { get; init; } = new List<MatchRule>();
+
+    /// <summary>
+    /// Whether or not the total number of children should match
+    /// </summary>
+    public bool MatchChildCount { get; init; } = false;
+
+    /// <summary>
+    /// A reducer to apply if the node matches
+    /// </summary>
+    public required Func<Node, string?, IReduction> Reducer { get; init; }
+
+    /// <summary>
+    /// Returns true if and only if the given node matches this rule
+    /// </summary>
+    /// <param name="n">a node to match on</param>
+    /// <returns></returns>
+    public bool Matches(Node n)
+    {
+        return NodeKindMatches(n) && ContentMatches(n) && ChildrenMatches(n);
+    }
+
+    /// <summary>
+    /// Returns true if and only if the NodeKind matches
+    /// </summary>
+    /// <param name="n">a node to match on</param>
+    /// <returns></returns>
+    bool NodeKindMatches(Node n)
+    {
+        return NodeKindList.Contains(n.Kind);
+    }
+
+    /// <summary>
+    /// Returns true if and only if the content of the given node matches
+    /// </summary>
+    /// <param name="n">a node to match on</param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    bool ContentMatches(Node n)
+    {
+        // Only care about the content type not its value
+        switch (MatchContent)
+        {
+        case MatchNodeContentType.AlwaysMatch:
+            return true;
+        case MatchNodeContentType.Index:
+            return n.HasIndex;
+        case MatchNodeContentType.Text:
+            return n.HasText;
+        case MatchNodeContentType.None:
+            return !n.HasIndex && !n.HasText;
+        default:
+            throw new InvalidOperationException ($"Unknown match instruction {MatchContent} in match rule.");
+        }
+    }
+
+    /// <summary>
+    /// Returns true if and only if the children rules matches the given node's children
+    /// </summary>
+    /// <param name="n"></param>
+    /// <returns></returns>
+    bool ChildrenMatches (Node n)
+    {
+        // if the rule says the child count matters, apply
+        if (MatchChildCount && n.Children.Count != ChildRules.Count)
+            return false;
+
+        // match up to the minimum of each list
+        // if MatchChileCount is true, min is the size of both lists
+        int minimumChildCount = Math.Min (n.Children.Count, ChildRules.Count);
+        for (var i = 0; i < minimumChildCount; i++) {
+            var childRule = ChildRules [i];
+            // recurse
+            if (!childRule.Matches (n.Children [i]))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Creates a simple string representation of this rule
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString() => Name;
+}

--- a/src/Swift.Bindings/src/Demangler/MatchRule.cs
+++ b/src/Swift.Bindings/src/Demangler/MatchRule.cs
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
+
 namespace BindingsGeneration.Demangling;
+
 /// <summary>
 /// MatchRule represents a tree reducing rule for a demangled Swift symbol.
 /// Given a tree of nodes, a match rule contains conditions for the match,
@@ -12,9 +15,10 @@ namespace BindingsGeneration.Demangling;
 /// - One or more NodeKinds to match
 /// If a match occurs, a reducer function can be run on the node.
 /// </summary>
+[DebuggerDisplay("{ToString()}")]
 internal class MatchRule {
     /// <summary>
-    /// The name of this rule - usefule for debugging
+    /// The name of this rule - useful for debugging
     /// </summary>
     public required string Name { get; init; }
 
@@ -41,7 +45,7 @@ internal class MatchRule {
     /// <summary>
     /// If and how to match the content of the Node
     /// </summary>
-    public MatchNodeContentType MatchContent { get; init; } = MatchNodeContentType.None;
+    public MatchNodeContentType MatchContentType { get; init; } = MatchNodeContentType.None;
 
     /// <summary>
     /// Rules to apply to children node.
@@ -65,7 +69,7 @@ internal class MatchRule {
     /// <returns></returns>
     public bool Matches(Node n)
     {
-        return NodeKindMatches(n) && ContentMatches(n) && ChildrenMatches(n);
+        return NodeKindMatches(n) && ContentTypeMatches(n) && ChildrenMatches(n);
     }
 
     /// <summary>
@@ -84,10 +88,10 @@ internal class MatchRule {
     /// <param name="n">a node to match on</param>
     /// <returns></returns>
     /// <exception cref="InvalidOperationException"></exception>
-    bool ContentMatches(Node n)
+    bool ContentTypeMatches(Node n)
     {
         // Only care about the content type not its value
-        switch (MatchContent)
+        switch (MatchContentType)
         {
         case MatchNodeContentType.AlwaysMatch:
             return true;
@@ -98,7 +102,7 @@ internal class MatchRule {
         case MatchNodeContentType.None:
             return !n.HasIndex && !n.HasText;
         default:
-            throw new InvalidOperationException ($"Unknown match instruction {MatchContent} in match rule.");
+            throw new InvalidOperationException ($"Unknown match instruction {MatchContentType} in match rule.");
         }
     }
 
@@ -128,6 +132,6 @@ internal class MatchRule {
     /// <summary>
     /// Creates a simple string representation of this rule
     /// </summary>
-    /// <returns></returns>
+    /// <returns>a string representation of the rule</returns>
     public override string ToString() => Name;
 }

--- a/src/Swift.Bindings/src/Demangler/RuleRunner.cs
+++ b/src/Swift.Bindings/src/Demangler/RuleRunner.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration.Demangling;
+
+/// <summary>
+/// RuleRunner contains a a collection of rules that get run to reduce nodes
+/// </summary>
+internal class RuleRunner {
+    string mangledName;
+    List<MatchRule> rules = new List<MatchRule>();
+
+    /// <summary>
+    /// Constructs a new rules runner initialized with the give rule set
+    /// </summary>
+    /// <param name="rules">Rules to test against a node</param>
+    public RuleRunner(IEnumerable<MatchRule> rules, string mangledName)
+    {
+        this.mangledName = mangledName;
+        this.rules.AddRange(rules);
+    }
+
+    /// <summary>
+    /// Run a set of rules on the given node and return a reduction on that node. If there was no match
+    /// or there was an error, this will return a IReduction of type ReductionError
+    /// </summary>
+    /// <param name="node">A node to attempt to match</param>
+    /// <param name="name">A name used for the reduction</param>
+    /// <returns></returns>
+    public IReduction RunRules(Node node, string? name)
+    {
+        var rule = rules.FirstOrDefault (r => r.Matches(node));
+        
+        if (rule is null)
+            return new ReductionError() { Symbol = mangledName, Message = $"No rule for node {node.Kind}" };
+        return rule.Reducer(node, name);
+    }
+}

--- a/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net.Sockets;
+
+namespace BindingsGeneration.Demangling;
+
+/// <summary>
+/// Swift5Reducer takes a tree of Node and attempts to reduce it completely to an easier to
+/// to manipulate data structure. It does this by matching patterns in the tree and on match
+/// applying a reduction function on the matched Node.
+/// </summary>
+internal class Swift5Reducer {
+    string mangledName;
+    RuleRunner ruleRunner;
+    List<MatchRule> rules;
+
+    /// <summary>
+    /// Construct Swift5Reducer to operate on a tree of nodes build from the given mangled name
+    /// </summary>
+    public Swift5Reducer (string mangledName)
+    {
+        this.mangledName = mangledName;
+        rules = BuildMatchRules ();
+        ruleRunner = new RuleRunner (rules, mangledName);
+    }
+
+    /// <summary>
+    /// Build a set of match rules for Node reduction
+    /// </summary>
+    List<MatchRule> BuildMatchRules () =>
+    new List<MatchRule>() {
+        new MatchRule() {
+            Name = "Global", NodeKind = NodeKind.Global, Reducer = ConvertFirstChild
+        },
+        new MatchRule() {
+            Name = "ProtocolWitnessTable", NodeKind = NodeKind.ProtocolWitnessTable, Reducer = ConvertProtocolWitnessTable
+        },
+        new MatchRule() {
+            Name = "Type", NodeKind = NodeKind.Type, Reducer = ConvertFirstChild
+        },
+        new MatchRule() {
+            Name = "Nominal", NodeKindList = new List<NodeKind>() { NodeKind.Class, NodeKind.Structure, NodeKind.Protocol, NodeKind.Enum },
+            Reducer = ConvertNominal
+        }
+    };
+
+    /// <summary>
+    /// Convert a Node into an IReduction. On failure, the IReduction will be type ReductionError
+    /// </summary>
+    public IReduction Convert (Node node)
+    {
+        return ruleRunner.RunRules (node, null);
+    }
+
+    /// <summary>
+    /// Given a ProtocolWitnessTable node, convert to a ProtocolWitnessTable reduction
+    /// </summary>
+    IReduction ConvertProtocolWitnessTable (Node node, string? name)
+    {
+        // What to expect here:
+        // ProtocolConformance
+        //     Type
+        //     Type
+        var child = node.Children [0];
+        if (child.Kind != NodeKind.ProtocolConformance) {
+            return ReductionError (ExpectedButGot ("ProtocolConformance", node.Kind.ToString ()));
+        }
+        var grandchild = Convert (child.Children [0]);
+        if (grandchild is ReductionError) return grandchild;
+        var implementingType = grandchild as TypeSpecReduction;
+        if (implementingType is null) {
+            return ReductionError (ExpectedButGot ("Nominal type implementing protocol", grandchild.GetType().Name));
+        }
+
+        grandchild = Convert (child.Children [1]);
+        if (grandchild is ReductionError) return grandchild;
+        var protocolType = grandchild as TypeSpecReduction;
+        if (protocolType is null) {
+            return ReductionError (ExpectedButGot ("Nominal type protocol", grandchild.GetType().Name));
+        }
+
+        var impNamed = (NamedTypeSpec)implementingType.TypeSpec;
+        var protoNamed = (NamedTypeSpec)protocolType.TypeSpec;
+
+        return new ProtocolWitnessTableReduction() { Symbol = mangledName, ImplementingType = impNamed, ProtocolType = protoNamed };
+    }
+
+    /// <summary>
+    /// Convert a nominal node into TypeSpecReduction
+    /// </summary>
+    IReduction ConvertNominal (Node node, string? name)
+    {
+        // What to expect here:
+        // Class/Structure/Protocol/Enum
+        //    Module Name
+        //    Identifier Name
+        var kind = node.Kind;
+        if (kind == NodeKind.Class || kind == NodeKind.Structure || kind == NodeKind.Enum || kind == NodeKind.Protocol) {
+            var moduleName = node.Children [0].Text;
+            if (node.Children[1].Kind != NodeKind.Identifier)
+                return ReductionError(ExpectedButGot("Identifier", node.Children[1].Kind.ToString()));
+            var typeName = node.Children [1].Text;    
+            return new TypeSpecReduction() { Symbol = mangledName, TypeSpec = new NamedTypeSpec ($"{moduleName}.{typeName}")};
+        }
+        return ReductionError(ExpectedButGot("Class/Struct/Enum/Protocol", kind.ToString()));
+    }
+
+    /// <summary>
+    /// Recurce on Convert with the first child
+    /// </summary>
+    IReduction ConvertFirstChild (Node node, string? name)
+    {
+        return Convert (node.Children [0]);
+    }
+
+    /// <summary>
+    /// Return a string in the form mangledName: expected xxxx but got yyyy
+    /// </summary>
+    string ExpectedButGot (string expected, string butGot)
+    {
+        return $"Demangling {mangledName}: expected {expected} but got {butGot}";
+    }
+
+    /// <summary>
+    /// Convenience factory for reduction errors
+    /// </summary>
+    ReductionError ReductionError (string message)
+    {
+        return new ReductionError() { Symbol = mangledName, Message = message };
+    }
+}

--- a/src/Swift.Bindings/src/Model/Provenance.cs
+++ b/src/Swift.Bindings/src/Model/Provenance.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// Represents the origin of a particular function
+/// </summary>
+public class Provenance {
+    private Provenance() { }
+
+    /// <summary>
+    /// If the provenance is in instance, return the type
+    /// </summary>
+    public NamedTypeSpec? InstanceType { get; private set; }
+
+    /// <summary>
+    /// If the provenance is an extension, return type it is an extension on
+    /// </summary>
+    public NamedTypeSpec? ExtensionOn { get; private set; }
+
+    /// <summary>
+    /// If the provenance is top level, return the module
+    /// </summary>
+    public string? Module {get; private set; }
+
+    /// <summary>
+    /// Construct a new instance provenance from the given NamedTypeSpec
+    /// </summary>
+    /// <param name="ns"></param>
+    /// <returns></returns>
+    public static Provenance Instance (NamedTypeSpec ns) {
+        return new Provenance () { InstanceType = ns };
+    }
+
+    /// <summary>
+    /// Construct a new extension provenance from the given NamedTypeSpec
+    /// </summary>
+    /// <param name="ns"></param>
+    /// <returns></returns>
+    public static Provenance Extension (NamedTypeSpec ns) {
+        return new Provenance () { ExtensionOn = ns };
+    }
+
+    /// <summary>
+    /// Construct a new top-level provenance from the given module name
+    /// </summary>
+    /// <param name="module"></param>
+    /// <returns></returns>
+    public static Provenance TopLevel (string module) {
+        return new Provenance () { Module = module };;
+    }
+
+    /// <summary>
+    /// Returns true if and only if the provenance is an instance
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(InstanceType))]
+    public bool IsInstance => InstanceType is not null;
+
+    /// <summary>
+    /// Returns true if and only if the provenance is an extension
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(ExtensionOn))]
+    public bool IsExtension => ExtensionOn is not null;
+
+    /// <summary>
+    /// Returns true if and only if the provenance is top level
+    /// </summary>
+    [MemberNotNullWhen(true, nameof(Module))]
+    public bool IsTopLevel => Module is not null;
+
+    /// <summary>
+    /// Returns true if o is a Provenance and equals this one
+    /// </summary>
+    /// <param name="o"></param>
+    /// <returns></returns>
+    public override bool Equals(object? o)
+    {
+        if (o is Provenance other) {
+            return (IsInstance && InstanceType.Equals (other.InstanceType)) ||
+                (IsExtension && ExtensionOn.Equals (other.ExtensionOn)) ||
+                (IsTopLevel && Module == other.Module);
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Returns a hashcode for this object
+    /// </summary>
+    /// <returns></returns>
+    public override int GetHashCode () => ToString ().GetHashCode ();
+
+    /// <summary>
+    /// Returns a string representation of the provenance
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    public override string ToString()
+    {
+        if (IsInstance) {
+            return InstanceType.ToString ();
+        } else if (IsExtension) {
+            return ExtensionOn.ToString ();
+        } else if (IsTopLevel) {
+            return Module.ToString ();
+        }
+        throw new NotImplementedException("Unknown provenance");
+    }
+}

--- a/src/Swift.Bindings/src/Model/SwiftFunction.cs
+++ b/src/Swift.Bindings/src/Model/SwiftFunction.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// Represents a Swift function signature and its provenance.
+/// </summary>
+public class SwiftFunction {
+    /// <summary>
+    /// Gets the name of the function
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the provenance of the function
+    /// </summary>
+    public required Provenance Provenance { get; init; }
+
+    /// <summary>
+    /// Gets the parameter list of the function as a tuple
+    /// </summary>
+    public required TupleTypeSpec ParameterList { get; init; }
+
+    /// <summary>
+    /// Gets the return type of the function
+    /// </summary>
+    public required TypeSpec Return { get; init; }
+
+    /// <summary>
+    /// Returns true if the give object is a SwiftFunction and matches this
+    /// </summary>
+    /// <param name="o"></param>
+    /// <returns></returns>
+    public override bool Equals(object? o)
+    {
+        if (o is SwiftFunction other) {
+            return Name == other.Name && Provenance.Equals (other.Provenance) &&
+                ParameterList.Equals (other.ParameterList) && Return.Equals (other.Return);
+        } else {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Returns a hashcode for the function
+    /// </summary>
+    /// <returns></returns>
+    public override int GetHashCode() => ToString ().GetHashCode ();
+
+    /// <summary>
+    /// Returns a string representation of the function
+    /// </summary>
+    /// <returns></returns>
+    public override string ToString () => $"{Provenance}.{Name}{ParameterList} -> {Return}";
+}

--- a/src/Swift.Bindings/src/Model/SwiftFunction.cs
+++ b/src/Swift.Bindings/src/Model/SwiftFunction.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
+
 namespace BindingsGeneration;
 
 /// <summary>
 /// Represents a Swift function signature and its provenance.
 /// </summary>
+[DebuggerDisplay("{ToString()}")]
 public class SwiftFunction {
     /// <summary>
     /// Gets the name of the function
@@ -31,7 +34,7 @@ public class SwiftFunction {
     /// Returns true if the give object is a SwiftFunction and matches this
     /// </summary>
     /// <param name="o"></param>
-    /// <returns></returns>
+    /// <returns>true if this equals the supplied object</returns>
     public override bool Equals(object? o)
     {
         if (o is SwiftFunction other) {
@@ -51,6 +54,6 @@ public class SwiftFunction {
     /// <summary>
     /// Returns a string representation of the function
     /// </summary>
-    /// <returns></returns>
+    /// <returns>a string representation of the function</returns>
     public override string ToString () => $"{Provenance}.{Name}{ParameterList} -> {Return}";
 }

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -1,0 +1,71 @@
+using BindingsGeneration.Demangling;
+using Xunit;
+
+namespace BindingsGeneration.Tests;
+
+public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixture>
+{
+    private readonly TestFixture _fixture;
+
+    public BasicDemanglingTests(TestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public class TestFixture
+    {
+        static TestFixture()
+        {
+        }
+
+        private static void InitializeResources()
+        {
+        }
+    }
+
+    [Fact]
+    public void TestProtocolWitnessTable()
+    {
+        var symbol = "_$s20GenericTestFramework6ThingyCAA7StanleyAAWP";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var protoWitnessReduction = result as ProtocolWitnessTableReduction;
+        Assert.NotNull(protoWitnessReduction);
+        Assert.Equal("GenericTestFramework.Thingy", protoWitnessReduction.ImplementingType.Name);
+        Assert.Equal("GenericTestFramework.Stanley", protoWitnessReduction.ProtocolType.Name);
+    }
+
+    [Fact]
+    public void TestOtherProtocolWitnessTable()
+    {
+        var symbol = "_$s20GenericTestFramework6ThingyCAA8IsItRealAAWP";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var protoWitnessReduction = result as ProtocolWitnessTableReduction;
+        Assert.NotNull(protoWitnessReduction);
+        Assert.Equal("GenericTestFramework.Thingy", protoWitnessReduction.ImplementingType.Name);
+        Assert.Equal("GenericTestFramework.IsItReal", protoWitnessReduction.ProtocolType.Name);
+    }
+
+    [Fact]
+    public void TestFailDemangleNonsense()
+    {
+        var symbol = "_$ThisIsJustGarbage";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var err = result as ReductionError;
+        Assert.NotNull(err);
+        Assert.Equal("No rule for node FirstElementMarker", err.Message);
+    }
+
+    [Fact]
+    public void TestFailMetadataAccessor()
+    {
+        var symbol = "_$s20GenericTestFramework6ThingyCMa";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var err = result as ReductionError;
+        Assert.NotNull(err);
+        Assert.Equal("No rule for node TypeMetadataAccessFunction", err.Message);
+    }
+}


### PR DESCRIPTION
This PR adds demangling tree reduction to the project.
What does this mean?
When a symbol is demangled there is an intermediate state where there is a tree of Node which represent the semantic meaning of the symbol. In order for this to be useful to us, we need to reduce a tree of Node to a more directly accessible set of types.

To do this, there are 3 main pieces:
1. a way to determine if a Node (and possibly subnodes) match a given pattern. This is `MatchRule`
2. a way to uniformly apply rules (RulesRunner)
3. a way, given a matched node, to reduce it to a more easily consumable data structure

This PR partially addresses issue [2664](https://github.com/dotnet/runtimelab/issues/2664).

What happens: given a `Swift5Demangler` instance, calling `Run` with a symbol returns an `IReduction` that represents the result of the reduction. Right now, we're only ever instantiating either a `ProtocolWitnessTableReduction`, `TypeSpec` or a `ReductionError`, but I created placeholder for functions which will help enable dispatch thunks later.

Inner types will not work yet - issue opened [here](https://github.com/dotnet/runtimelab/issues/2690).

The reduction rules are non-static and the collection gets rebuilt for every symbol. This is [known](https://github.com/dotnet/runtimelab/issues/2691).

There is a name argument in the rule which is not used (yet). I'm trying to decide still if we're going to need it.

MatchRule is very flexible - it can do the simplest matching on a single `Node.Kind` but it can also match on multiples as well. It can match on child nodes too. Overall, this is a simplified version of a regular expression in a way. Nothing in the current code requires it, but we will need it for more complicated reductions later (thunks, for example).

Where this is going: we should be able to get all the protocol witness table symbols from a file with a single expression:
```
var protoWitnesses = machoFiies.AllPublicSymbols().Select(nle => new Swift5Demangler(nle.str).Run()).OfType(ProtocolWitnessTableReduction);
```
Similar expressions could be used to get all the dispatch thunks etc.