### PR TITLE
[Swift Bindings] Added demangling support for protocol conformance descriptors and nested type names

### DIFF
--- a/src/Swift.Bindings/src/Demangler/IReduction.cs
+++ b/src/Swift.Bindings/src/Demangler/IReduction.cs
@@ -7,6 +7,9 @@ namespace BindingsGeneration.Demangling;
 /// Represents the result of reducing a Node or tree of nodes
 /// </summary>
 public interface IReduction {
+    /// <summary>
+    /// Returns a the mangled symbol associated with a reduction
+    /// </summary>
     string Symbol { get; init; }
 }
 
@@ -14,6 +17,9 @@ public interface IReduction {
 /// Represents an error in an attempted reduction
 /// </summary>
 public class ReductionError : IReduction {
+    /// <summary>
+    /// Returns a the mangled symbol associated with a reduction
+    /// </summary>
     public required string Symbol { get; init; }
     /// <summary>
     /// Returns an error message describing the error
@@ -25,6 +31,9 @@ public class ReductionError : IReduction {
 /// Represents a reduction that reduces to a single type
 /// </summary>
 public class TypeSpecReduction : IReduction {
+    /// <summary>
+    /// Returns a the mangled symbol associated with a reduction
+    /// </summary>
     public required string Symbol { get; init; }
     /// <summary>
     /// Returns a TypeSpec for the type that this node represents
@@ -36,6 +45,9 @@ public class TypeSpecReduction : IReduction {
 /// Represents a reduction that reduces to a Swift function
 /// </summary>
 public class FunctionReduction : IReduction {
+    /// <summary>
+    /// Returns a the mangled symbol associated with a reduction
+    /// </summary>
     public required string Symbol { get; init; }
     /// <summary>
     /// Returns a function that this type represents
@@ -43,8 +55,59 @@ public class FunctionReduction : IReduction {
     public required SwiftFunction Function { get; init; }
 }
 
+/// <summary>
+/// Represents a reduction to a protocol witness table
+/// </summary>
 public class ProtocolWitnessTableReduction : IReduction {
+    /// <summary>
+    /// Returns a the mangled symbol associated with a reduction
+    /// </summary>
     public required string Symbol { get; init; }
+    /// <summary>
+    /// Returns the TypeSpec of the type that implements the protocol
+    /// </summary>
     public required NamedTypeSpec ImplementingType { get; init; }
-    public required NamedTypeSpec ProtocolType { get; init;}
+    /// <summary>
+    /// Returns the TypeSpec of the protocol being implemented
+    /// </summary>
+    public required NamedTypeSpec ProtocolType { get; init; }
+}
+
+/// <summary>
+/// Represents a reduction to a protocol conformance descriptor
+/// </summary>
+public class ProtocolConformanceDescriptorReduction : ProtocolWitnessTableReduction {
+    public required string Module { get; init; }
+}
+
+/// <summary>
+/// Represents a reduction to a provenance
+/// </summary>
+public class ProvenanceReduction : IReduction {
+    /// <summary>
+    /// Returns a the mangled symbol associated with a reduction
+    /// </summary>
+    public required string Symbol { get; init; }
+    /// <summary>
+    /// Returns the Provenance of reduction
+    /// </summary>
+    public required Provenance Provenance { get; init; }
+    
+    /// <summary>
+    /// Factory method to construct a top-level provenance reduction
+    /// </summary>
+    public static ProvenanceReduction TopLevel(string symbol, string moduleName) =>
+        new ProvenanceReduction() { Symbol = symbol, Provenance = Provenance.TopLevel (moduleName) };
+    
+    /// <summary>
+    /// Factory method to construct an instance provenance reduction
+    /// </summary>
+    public static ProvenanceReduction Instance(string symbol, NamedTypeSpec instance) =>
+        new ProvenanceReduction() { Symbol = symbol, Provenance = Provenance.Instance (instance) };
+
+    /// <summary>
+    /// Factory method to construct an excetion provenance reduction
+    /// </summary>
+    public static ProvenanceReduction Extension(string symbol, NamedTypeSpec extensionOn) =>
+        new ProvenanceReduction() { Symbol = symbol, Provenance = Provenance.Extension (extensionOn) };
 }

--- a/src/Swift.Bindings/src/Demangler/IReduction.cs
+++ b/src/Swift.Bindings/src/Demangler/IReduction.cs
@@ -106,7 +106,7 @@ public class ProvenanceReduction : IReduction {
         new ProvenanceReduction() { Symbol = symbol, Provenance = Provenance.Instance (instance) };
 
     /// <summary>
-    /// Factory method to construct an excetion provenance reduction
+    /// Factory method to construct an extension provenance reduction
     /// </summary>
     public static ProvenanceReduction Extension(string symbol, NamedTypeSpec extensionOn) =>
         new ProvenanceReduction() { Symbol = symbol, Provenance = Provenance.Extension (extensionOn) };

--- a/src/Swift.Bindings/src/Demangler/MatchRule.cs
+++ b/src/Swift.Bindings/src/Demangler/MatchRule.cs
@@ -45,7 +45,7 @@ internal class MatchRule {
     /// <summary>
     /// If and how to match the content of the Node
     /// </summary>
-    public MatchNodeContentType MatchContentType { get; init; } = MatchNodeContentType.None;
+    public MatchNodeContentType MatchContentType { get; init; } = MatchNodeContentType.AlwaysMatch;
 
     /// <summary>
     /// Rules to apply to children node.

--- a/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
@@ -35,7 +35,7 @@ internal class Swift5Reducer {
             Name = "Global", NodeKind = NodeKind.Global, Reducer = ConvertFirstChild
         },
         new MatchRule() {
-            Name = "ProtocolConformance", NodeKindList = new List<NodeKind>() { NodeKind.ProtocolWitnessTable, NodeKind.ProtocolConformanceDescriptor, } , Reducer = ConvertProtocolWitnessTable
+            Name = "ProtocolConformance", NodeKindList = new List<NodeKind>() { NodeKind.ProtocolWitnessTable, NodeKind.ProtocolConformanceDescriptor, } , Reducer = ConvertProtocolConformance
         },
         new MatchRule() {
             Name = "Type", NodeKind = NodeKind.Type, Reducer = ConvertFirstChild
@@ -60,7 +60,7 @@ internal class Swift5Reducer {
     /// <summary>
     /// Given a ProtocolWitnessTable node, convert to a ProtocolWitnessTable reduction
     /// </summary>
-    IReduction ConvertProtocolWitnessTable (Node node, string? name)
+    IReduction ConvertProtocolConformance (Node node, string? name)
     {
         // What to expect here:
         // ProtocolConformance
@@ -146,10 +146,10 @@ internal class Swift5Reducer {
     {
         if (IsNominal(node.Children [0])) {
             GetNestedNominalName (node.Children [0], sb);
-            sb.Append('.').Append (FristChildIdentifierText (node));
+            sb.Append('.').Append (FirstChildIdentifierText (node));
         } else {
             var moduleName = node.Children [0].Text;
-            var typeName = FristChildIdentifierText (node);
+            var typeName = FirstChildIdentifierText (node);
             sb.Append (moduleName).Append ('.').Append (typeName);
         }
     }
@@ -157,7 +157,7 @@ internal class Swift5Reducer {
     /// <summary>
     /// Returns the text of the first child of a node if and only if that child is an Identifier, else throw
     /// </summary>
-    string FristChildIdentifierText (Node node)
+    string FirstChildIdentifierText (Node node)
     {
         if (node.Children [1].Kind != NodeKind.Identifier)
             throw new Exception (ExpectedButGot ("Identifier", node.Children [1].Kind.ToString()));

--- a/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
@@ -95,7 +95,7 @@ internal class Swift5Reducer {
             grandchild = Convert (child.Children [2]);
             if (grandchild is ProvenanceReduction prov) {
                 if (!prov.Provenance.IsTopLevel)
-                    return ReductionError (ExpectedButGot ("", prov.Provenance.ToString()));
+                    return ReductionError (ExpectedButGot ("A top-level module name", prov.Provenance.ToString()));
                 return new ProtocolConformanceDescriptorReduction() { Symbol = mangledName, ImplementingType = impNamed, ProtocolType = protoNamed, Module = prov.Provenance.Module};
             } else if (grandchild is ReductionError) {
                 return grandchild;

--- a/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
@@ -35,7 +35,7 @@ internal class Swift5Reducer {
             Name = "Global", NodeKind = NodeKind.Global, Reducer = ConvertFirstChild
         },
         new MatchRule() {
-            Name = "ProtocolWitnessTable", NodeKind = NodeKind.ProtocolWitnessTable, Reducer = ConvertProtocolWitnessTable
+            Name = "ProtocolConformance", NodeKindList = new List<NodeKind>() { NodeKind.ProtocolWitnessTable, NodeKind.ProtocolConformanceDescriptor, } , Reducer = ConvertProtocolWitnessTable
         },
         new MatchRule() {
             Name = "Type", NodeKind = NodeKind.Type, Reducer = ConvertFirstChild
@@ -43,9 +43,6 @@ internal class Swift5Reducer {
         new MatchRule() {
             Name = "Nominal", NodeKindList = new List<NodeKind>() { NodeKind.Class, NodeKind.Structure, NodeKind.Protocol, NodeKind.Enum },
             Reducer = ConvertNominal
-        },
-        new MatchRule() {
-            Name = "ProtocolConformanceDescriptor", NodeKind = NodeKind.ProtocolConformanceDescriptor, Reducer = ConvertProtocolWitnessTable
         },
         new MatchRule() {
             Name = "Module", NodeKind = NodeKind.Module, Reducer = (n, s) => ProvenanceReduction.TopLevel (mangledName, n.Text)

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -68,4 +68,29 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
         Assert.NotNull(err);
         Assert.Equal("No rule for node TypeMetadataAccessFunction", err.Message);
     }
+
+    [Fact]
+    public void TestNestedProtocolWitnessTable()
+    {
+        var symbol = "_$s20GenericTestFramework3FooC6ThingyCAA8IsItRealAAWP";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var protoWitnessReduction = result as ProtocolWitnessTableReduction;
+        Assert.NotNull(protoWitnessReduction);
+        Assert.Equal("GenericTestFramework.Foo.Thingy", protoWitnessReduction.ImplementingType.Name);
+        Assert.Equal("GenericTestFramework.IsItReal", protoWitnessReduction.ProtocolType.Name);
+    }
+
+    [Fact]
+    public void TestOtherProtocolConformanceDescriptor()
+    {
+        var symbol = "_$s10someclient14CSAgeableProxyCAA7AgeableAAMc";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var conf = result as ProtocolConformanceDescriptorReduction;
+        Assert.NotNull(conf);
+        Assert.Equal("someclient.CSAgeableProxy", conf.ImplementingType.Name);
+        Assert.Equal("someclient.Ageable", conf.ProtocolType.Name);
+        Assert.Equal("someclient", conf.Module);
+    }
 }


### PR DESCRIPTION
This PR makes protocol conformance descriptors available to the demangler.
Both protocol witness tables and protocol conformance descriptors share the same reduction rule because they are effectively the same in terms of the contents. Protocol conformance descriptors have one more child for the module.

Added a rule for the `Module` kind which will reduce to a `Provenance` reduction.

Refactored the `Type` reducer to include support for inner types.

Note on inner types in the tree: they are represented as a set of nodes that are built in a depth-first fashion. This lends itself to a recursive decoder.  For example, for the type `GenericTestFramework.Foo.Thingy`, the node structure looks like this:
```
      kind=Type
        kind=Class
          kind=Class
            kind=Module, text="GenericTestFramework"
            kind=Identifier, text="Foo"
          kind=Identifier, text="Thingy"
```

Set the default MatchContentType to `AlwaysMatch` since we don't have any nodes that require content matching (yet), so this seems like a better default and it was breaking the Module node reduction with the previous default.