### PR TITLE
[NativeAOT-LLVM] Improve the shadow tail-calling code 

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -493,7 +493,7 @@ private:
 
     unsigned getShadowFrameSize(unsigned funcIdx) const;
     unsigned getCalleeShadowStackOffset(unsigned funcIdx, bool isTailCall) const;
-    bool canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter) const;
+    bool canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter DEBUGARG(const char** pReasonWhyNot)) const;
     bool isPotentialGcSafePoint(GenTree* node) const;
     bool isShadowFrameLocal(LclVarDsc* varDsc) const;
     bool isShadowStackLocal(unsigned lclNum) const;

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2615,9 +2615,10 @@ bool Llvm::canEmitHelperCallAsShadowTailCall(CorInfoHelpFunc helperFunc)
     assert(helperCallHasShadowStackArg(helperFunc));
 
     // Right now the check on whether the call is in a "tail" position is simply that it won't return.
+    INDEBUG(const char* reasonWhyNot);
     if (Compiler::s_helperCallProperties.AlwaysThrow(helperFunc) &&
         canEmitCallAsShadowTailCall(getCurrentProtectedRegionIndex() != EHblkDsc::NO_ENCLOSING_INDEX,
-                                    isCurrentContextInFilter()))
+                                    isCurrentContextInFilter() DEBUGARG(&reasonWhyNot)))
     {
         return true;
     }


### PR DESCRIPTION
I've noticed that in some cases our shadow tail-calling ability gets hampered by the `IL_OFFSET` nodes. This change fixes that. Diffs:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3039666
Total bytes of diff: 3039208
Total bytes of delta: -458 (-0.02% % of base)
Average relative delta: -2.47%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
           2 ( 4.35% of base) : 1056.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilder__BuildMethod
           2 ( 4.35% of base) : 1037.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeBuilder__BuildType
           2 ( 2.13% of base) : 1074.dasm - S_P_TypeLoader_Internal_TypeSystem_ExceptionTypeNameFormatter__AppendName_0
           2 ( 1.67% of base) : 1077.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeSystemContextFactory__Recycle
           2 ( 1.56% of base) : 1024.dasm - S_P_CoreLib_System_Threading_Tasks_Task__ExecuteFromThreadPool
           2 ( 1.56% of base) : 1034.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_CustomAttribute___ctor
           2 ( 1.55% of base) : 1019.dasm - S_P_CoreLib_System_Threading_Tasks_Task__ExecuteEntryUnsafe
           5 ( 0.65% of base) : 1078.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_TypeDefinition___ctor

Top method improvements (percentages):
         -57 (-20.28% of base) : 1021.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_FieldAccessors_ValueTypeFieldAccessorForStaticFields__UncheckedSetFieldBypassCctor
         -12 (-11.54% of base) : 1023.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_FieldAccessors_PointerTypeFieldAccessorForInstanceFields__UncheckedSetField
          -4 (-11.11% of base) : 1062.dasm - HelloWasm_System_Runtime_JitTesting_LSSATests__Optimized_LastUses_OutOfOrder
          -4 (-11.11% of base) : 1061.dasm - HelloWasm_System_Runtime_JitTesting_LSSATests__Optimized_LastUses_UseLocation
         -30 (-10.75% of base) : 1020.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_FieldAccessors_ReferenceTypeFieldAccessorForStaticFields__UncheckedSetFieldBypassCctor
         -24 (-6.65% of base) : 1022.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_FieldAccessors_PointerTypeFieldAccessorForStaticFields__UncheckedSetFieldBypassCctor
         -26 (-6.42% of base) : 1087.dasm - S_P_CoreLib_System_Diagnostics_StackFrame__InitializeForEip
          -3 (-6.38% of base) : 1060.dasm - HelloWasm_System_Runtime_JitTesting_LSSATests__Optimized_LastUses_ForkedFlowExposed
          -4 (-6.06% of base) : 1003.dasm - S_P_CoreLib_System_Diagnostics_StackTrace___ctor_3
          -2 (-5.88% of base) : 1059.dasm - HelloWasm_System_Runtime_JitTesting_LSSATests__Optimized_ParameterExposed
          -4 (-5.80% of base) : 1076.dasm - S_P_TypeLoader_Internal_TypeSystem_ExceptionTypeNameFormatter__AppendName
          -4 (-5.80% of base) : 1030.dasm - S_P_CoreLib_System_Collections_Hashtable__expand
          -2 (-5.56% of base) : 1064.dasm - HelloWasm_System_Runtime_JitTesting_LSSATests__Optimized_AlreadySpilled
          -4 (-5.19% of base) : 1075.dasm - S_P_TypeLoader_Internal_TypeSystem_ExceptionTypeNameFormatter__AppendName_4
          -4 (-4.40% of base) : 1014.dasm - S_P_CoreLib_System_AggregateException___ctor_5
          -4 (-4.30% of base) : 1047.dasm - S_P_CoreLib_System_AggregateException___ctor_2
          -4 (-4.30% of base) : 1106.dasm - S_P_CoreLib_System_AggregateException___ctor_3
          -6 (-4.00% of base) : 1053.dasm - S_P_CoreLib_System_Threading_WaitSubsystem_WaitableObject__SignalEvent
         -12 (-3.99% of base) : 1096.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_PropertySignature___ctor
          -4 (-3.74% of base) : 1044.dasm - S_P_CoreLib_System_Collections_ObjectModel_ReadOnlyCollection_1<System___Canon>__CopyTo

115 total methods with Code Size differences (107 improved, 8 regressed)
```
The few regressions are cases where tail-calling leads to LLVM needing to introduce another local instead of redefining the shadow stack via `local.tee`, since we could have, e. g., 3 calls that all used the same (callee's) shadow stack value, and now one of them gets tailcalled and uses the caller's.

I've also added a little bit of logging so that tail-calling decisions get recorded in the dump.