### PR TITLE
Fix unwinding for StubLink

### DIFF
--- a/src/coreclr/vm/stublink.cpp
+++ b/src/coreclr/vm/stublink.cpp
@@ -1815,6 +1815,7 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
 
 #ifdef TARGET_AMD64
     // Publish Unwind info to ETW stack crawler
+    UnwindInfoTable::PublishUnwindInfo(false);
     UnwindInfoTable::AddToUnwindInfoTable(
         &pStubHeapSegment->pUnwindInfoTable, pCurFunction,
         (TADDR) pStubHeapSegment->pbBaseAddress,

--- a/src/coreclr/vm/stublink.cpp
+++ b/src/coreclr/vm/stublink.cpp
@@ -1815,7 +1815,9 @@ bool StubLinker::EmitUnwindInfo(Stub* pStubRX, Stub* pStubRW, int globalsize, Lo
 
 #ifdef TARGET_AMD64
     // Publish Unwind info to ETW stack crawler
+#ifdef FEATURE_INTERPRETER
     UnwindInfoTable::PublishUnwindInfo(false);
+#endif // FEATURE_INTERPRETER
     UnwindInfoTable::AddToUnwindInfoTable(
         &pStubHeapSegment->pUnwindInfoTable, pCurFunction,
         (TADDR) pStubHeapSegment->pbBaseAddress,


### PR DESCRIPTION
I have been looking into stack unwinding related issue, and I think I have found a culprit.
 
**Problem**: If we set a breakpoint on `Interpreter::ExecuteMethod`, we will fail to unwind the stack across the generate stub.
 
**Symptom**: The unwinder found the correct return address of the callee of the stub, and the unwinder fails to continue the unwinding because it can't find the module responsible for the address [here](https://github.com/dotnet/runtime/blob/eed9c19ee6125f58340f8f3d6530c797c7d53cc7/src/coreclr/unwinder/amd64/unwinder.cpp#L242)

**Cause**: It looks like the work of registering the unwind info is skipped because of `s_publishingActive` is false [here](https://github.com/dotnet/runtime/blob/cfc7c204c2317b5b4471c841ce4304fd74610822/src/coreclr/vm/codeman.cpp#L241) while we are trying to `StubLinker::EmitUnwindInfo` by `UnwindInfoTable::AddToUnwindInfoTable` [here](https://github.com/dotnet/runtime/blob/cfc7c204c2317b5b4471c841ce4304fd74610822/src/coreclr/vm/stublink.cpp#L1818)