### PR TITLE
[SwiftBindings] added basic function and tuple demangling

### DIFF
--- a/src/Swift.Bindings/src/Demangler/MatchRule.cs
+++ b/src/Swift.Bindings/src/Demangler/MatchRule.cs
@@ -60,7 +60,7 @@ internal class MatchRule {
     /// <summary>
     /// A reducer to apply if the node matches
     /// </summary>
-    public required Func<Node, string?, IReduction> Reducer { get; init; }
+    public required Func<Node, string?, IReduction> Reducer { get; init; } = (node, name) => new ReductionError () { Message = "Call of empty reduction rule", Symbol = name ?? "no symbol" };
 
     /// <summary>
     /// Returns true if and only if the given node matches this rule
@@ -128,6 +128,14 @@ internal class MatchRule {
         }
         return true;
     }
+
+    /// <summary>
+    /// Returns a reducer to serve as a placeholder for a reducer that shouldn't be run.
+    /// This is best used in ChildRules of match rules which get matched but don't run a reducer.
+    /// </summary>
+    public static Func<Node, string?, IReduction> ErrorReducer = (n, s) => {
+        return new ReductionError () { Message = $"Undefined reduction error for Node {n.Kind}", Symbol = s ?? "" };
+    };
 
     /// <summary>
     /// Creates a simple string representation of this rule

--- a/src/Swift.Bindings/src/Model/TypeSpec.cs
+++ b/src/Swift.Bindings/src/Model/TypeSpec.cs
@@ -92,6 +92,12 @@ public abstract class TypeSpec
 	public string? TypeLabel { get; set; }
 
 	/// <summary>
+	/// Returns true if and only if this TypeSpec is a variadic type. If so, then this will be a
+	/// NamedTypeSpec with the name Swift.Array and a bound generic type of the variadic type
+	/// </summary>
+	public bool IsVariadic { get; set; } = false;
+
+	/// <summary>
 	/// Returns true if the type is an array
 	/// </summary>
 	public bool IsArray
@@ -114,6 +120,8 @@ public abstract class TypeSpec
 			if (!ListEqual(GenericParameters, spec.GenericParameters, false))
 				return false;
 			if (IsInOut != spec.IsInOut)
+				return false;
+			if (IsVariadic != spec.IsVariadic)
 				return false;
 			// Don't compare IsAny - it's really not important (yet)
 			return LLEquals(spec, false);

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -93,4 +93,29 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
         Assert.Equal("someclient.Ageable", conf.ProtocolType.Name);
         Assert.Equal("someclient", conf.Module);
     }
+
+    [Fact]
+    public void TestFuncWithTuple()
+    {
+        var symbol = "_$s17unitHelpFrawework10ReturnsInt3arg1cS2u1a_Si1bt_SitF";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var func = result as FunctionReduction;
+        Assert.NotNull (func);
+        Assert.Equal ("ReturnsInt", func.Function.Name);
+        var returnType = func.Function.Return as NamedTypeSpec;
+        Assert.NotNull (returnType);
+        Assert.Equal ("Swift.UInt", returnType.Name);
+        var args = func.Function.ParameterList;
+        Assert.Equal (2, args.Elements.Count);
+        var firstarg = args.Elements [0] as TupleTypeSpec;
+        Assert.NotNull (firstarg);
+        Assert.Equal ("arg", firstarg.TypeLabel);
+        Assert.Equal (2, firstarg.Elements.Count);
+        Assert.Equal ("arg: (a: Swift.UInt, b: Swift.Int)", firstarg.ToString());
+        var secondarg = args.Elements [1] as NamedTypeSpec;
+        Assert.NotNull (secondarg);
+        Assert.Equal ("c", secondarg.TypeLabel);
+        Assert.Equal ("Swift.Int", secondarg.Name);
+    }
 }


### PR DESCRIPTION
This adds a couple of things to the demangler:

1. A default for the reducer that returns a `ReductionError` by default. This is used as a placeholder for Child rules. It should never get called because Child reductions don't get called. I went back and forth as to whether I should remove the `required` keyword. Ultimately, I think it's more important to be told you didn't set the property instead of forgetting to put in a reducer.
2. Added match rules for tuples and tuple elements
3. Added match rule for function
4. Added match rule for function types
5. Support for variadics

In the big picture, all of this is necessary in order to get detangling for dispatch thunks.
Why? Because a dispatch thunk is a special case of functions.

In terms of what you're seeing here, there are a few weird things.
A function consists of:
- Provenance
- Name
- Labels
- Type of the function

The weirdness is that the argument labels are kept in a separate list from the type of the function - essentially this isn't needed because tuples can already have labels in them, but for functions they get put into a separate list.

The test code tests for a function with this signature: 
```swift
unitHelpFrawework.ReturnsInt(arg: (a: Swift.UInt, b: Swift.Int), c: Swift.Int) -> Swift.UInt
```
When demangled, we get a tree of nodes that looks like this:
```
kind=Global
  kind=Function
    kind=Module, text="unitHelpFrawework"
    kind=Identifier, text="ReturnsInt"
    kind=LabelList
      kind=Identifier, text="arg"
      kind=Identifier, text="c"
    kind=Type
      kind=FunctionType
        kind=ArgumentTuple
          kind=Type
            kind=Tuple
              kind=TupleElement
                kind=Type
                  kind=Tuple
                    kind=TupleElement
                      kind=TupleElementName, text="a"
                      kind=Type
                        kind=Structure
                          kind=Module, text="Swift"
                          kind=Identifier, text="UInt"
                    kind=TupleElement
                      kind=TupleElementName, text="b"
                      kind=Type
                        kind=Structure
                          kind=Module, text="Swift"
                          kind=Identifier, text="Int"
              kind=TupleElement
                kind=Type
                  kind=Structure
                    kind=Module, text="Swift"
                    kind=Identifier, text="Int"
        kind=ReturnType
          kind=Type
            kind=Structure
              kind=Module, text="Swift"
              kind=Identifier, text="UInt"
```
Variadics are part of the tuple declarations, so I went ahead and did those. I automatically desugar these into `Swift.Array<T>` and mark them as variadic. This will make the distinction between `func f(a: Int ...) -> Int` and `func f(a: [Int]) -> Int` which are effectively different function types.

