### PR TITLE
Disable PerfTracing

### DIFF
--- a/src/coreclr/clr.featuredefines.props
+++ b/src/coreclr/clr.featuredefines.props
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <FeatureCoreCLR>true</FeatureCoreCLR>
         <FeatureEventTrace>true</FeatureEventTrace>
-        <FeaturePerfTracing>true</FeaturePerfTracing>
+        <!-- <FeaturePerfTracing>true</FeaturePerfTracing> -->
         <FeatureTypeEquivalence>true</FeatureTypeEquivalence>
         <ProfilingSupportedBuild>true</ProfilingSupportedBuild>
     </PropertyGroup>

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -11024,8 +11024,8 @@ void Interpreter::DoGetMethodTable()
 
     MethodTable* pMT = obj->RawGetMethodTable();
 
-    OpStackSet<MethodTable*>(m_curStackHt, pMT);
-    OpStackTypeSet(m_curStackHt, InterpreterType(CORINFO_TYPE_NATIVEINT));
+    OpStackSet<MethodTable*>(ind, pMT);
+    OpStackTypeSet(ind, InterpreterType(CORINFO_TYPE_NATIVEINT));
 }
 
 bool Interpreter::DoInterlockedCompareExchange(CorInfoType retType)

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -9625,6 +9625,8 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
     {
         _ASSERTE(m_callThisArg == NULL);  // "m_callThisArg" non-null only for .ctor, which are not callvirts.
 
+        bool staticAbstract = false;
+
         // The constrained. prefix will be immediately followed by a ldftn, call or callvirt instruction.
         // See Ecma-335-Augments.md#iii21-constrained---prefix-invoke-a-member-on-a-value-of-a-variable-type-page-316 for more detail
         if (sigInfo.hasThis())
@@ -9637,7 +9639,8 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
         else
         {
             // If the constrained. prefix is applied to a call or ldftn instruction, method must be a virtual static method.
-            // TODO: Assert it is a virtual static method.
+            OPCODE opcode = (OPCODE)(*m_ILCodePtr);
+            staticAbstract = (opcode == CEE_CALL || opcode == CEE_LDFTN) && methToCall->IsStatic();
         }
 
         // We only cache for the CORINFO_NO_THIS_TRANSFORM case, so we may assume that if we have a cached call site,
@@ -9683,7 +9686,7 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
                 DWORD exactClassAttribs = m_interpCeeInfo.getClassAttribs(exactClass);
                 // If the constraint type is a value class, then it is the exact class (which will be the
                 // "owner type" in the MDCS below.)  If it is not, leave it as the (precise) interface method.
-                if (exactClassAttribs & CORINFO_FLG_VALUECLASS)
+                if (exactClassAttribs & CORINFO_FLG_VALUECLASS && !staticAbstract)
                 {
                     MethodTable* exactClassMT = GetMethodTableFromClsHnd(exactClass);
                     // Find the method on exactClass corresponding to methToCall.
@@ -9696,6 +9699,8 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
                 }
                 else
                 {
+                    if (staticAbstract)
+                        methToCall = reinterpret_cast<MethodDesc*>(callInfoPtr->hMethod);
                     exactClass = methTokPtr->hClass;
                 }
             }
@@ -10565,7 +10570,11 @@ void Interpreter::CallI()
             // change the GC mode.  (We'll only do this at the call if the calling convention turns out
             // to be a managed calling convention.)
             MethodDesc* pStubContextMD = reinterpret_cast<MethodDesc*>(m_stubContext);
-            bool transitionToPreemptive = (pStubContextMD != NULL && !pStubContextMD->IsIL());
+            bool transitionToPreemptive;
+            {
+                GCX_PREEMP();
+                transitionToPreemptive = (pStubContextMD != NULL && !pStubContextMD->IsIL() && !pStubContextMD->ShouldSuppressGCTransition());
+            }
             mdcs.CallTargetWorker(args, &retVal, sizeof(retVal), transitionToPreemptive);
         }
         // retVal is now vulnerable.

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -7704,6 +7704,7 @@ CEEInfo::getMethodInfo(
         getMethodInfoHelper(cxt, methInfo, context);
         result = true;
     }
+#ifndef FEATURE_INTERPRETER
     else if (ftn->IsIL() && ftn->GetRVA() == 0)
     {
         // We will either find or create transient method details.
@@ -7733,6 +7734,7 @@ CEEInfo::getMethodInfo(
 
         result = true;
     }
+#endif // !FEATURE_INTERPRETER
 
     if (result)
     {


### PR DESCRIPTION
Hack around an issue with Static Abstracts.
Fix stack bug in `DoGetMethodTable()`.
Disable Transient code-gen for `UnsafeAccessorAttribute`.

Basic C# `"Hello, World"` works!

/cc @janvorli @cshung 