### PR TITLE
[SwiftBindings] Add DispatchThunk support, fix issues in functions

### DIFF
--- a/src/Swift.Bindings/src/Demangler/IReduction.cs
+++ b/src/Swift.Bindings/src/Demangler/IReduction.cs
@@ -56,6 +56,23 @@ public class FunctionReduction : IReduction {
 }
 
 /// <summary>
+/// Represents a dispatch thunk for a function.
+/// While they are identical in terms of content, having this as a separate type will make it easy to locate
+/// dispatch thunks.
+/// </summary>
+public class DispatchThunkFunctionReduction : FunctionReduction {
+    /// <summary>
+    /// Factory method to create a DispatchThunkFunctionReduction from a FunctionReduction
+    /// </summary>
+    /// <param name="reduction">The FunctionReduction to copy</param>
+    /// <returns>A DispatchThunkFunctionReduction that matches the give FunctionReduction</returns>
+    public static DispatchThunkFunctionReduction FromFunctionReduction (FunctionReduction reduction)
+    {
+        return new DispatchThunkFunctionReduction() { Symbol = reduction.Symbol, Function = reduction.Function };
+    }
+}
+
+/// <summary>
 /// Represents a reduction to a protocol witness table
 /// </summary>
 public class ProtocolWitnessTableReduction : IReduction {

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using BindingsGeneration.Demangling;
 using Xunit;
 
@@ -118,4 +119,95 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
         Assert.Equal ("c", secondarg.TypeLabel);
         Assert.Equal ("Swift.Int", secondarg.Name);
     }
+
+    [Fact]
+    public void TestDispatchThunkFunc()
+    {
+        var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassC12identityFunc1aS2i_tFTj";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var thunk = result as DispatchThunkFunctionReduction;
+        Assert.NotNull (thunk);
+        var provenance = thunk.Function.Provenance;
+        Assert.True (provenance.IsInstance);
+        Assert.Equal ("GeneralHackingNonsense.ThisIsAClass", provenance.InstanceType!.Name);
+        Assert.Equal ("identityFunc", thunk.Function.Name);
+        Assert.Single (thunk.Function.ParameterList.Elements);
+        var parameter = thunk.Function.ParameterList.Elements [0];
+        Assert.Equal ("a: Swift.Int", parameter.ToString ());
+        Assert.Equal ("Swift.Int", thunk.Function.Return.ToString ());
+    }
+
+    [Fact]
+    public void TestDispatchThunkFuncAllocator()
+    {
+        var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassCACycfCTj";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var thunk = result as DispatchThunkFunctionReduction;
+        Assert.NotNull (thunk);
+        var provenance = thunk.Function.Provenance;
+        Assert.True (provenance.IsInstance);
+        Assert.Equal ("GeneralHackingNonsense.ThisIsAClass", provenance.InstanceType!.Name);
+        Assert.Equal ("__allocating_init", thunk.Function.Name);
+        Assert.Empty (thunk.Function.ParameterList.Elements);
+        var returnType = thunk.Function.Return as NamedTypeSpec;
+        Assert.NotNull (returnType);
+        Assert.Equal ("GeneralHackingNonsense.ThisIsAClass", returnType.Name);
+    }
+
+    [Fact]
+    public void TestFuncNoArgs()
+    {
+        var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassC11returnSevenSiyF";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var func = result as FunctionReduction;
+        Assert.NotNull (func);
+        var provenance = func.Function.Provenance;
+        Assert.True (provenance.IsInstance);
+        Assert.Equal ("GeneralHackingNonsense.ThisIsAClass", provenance.InstanceType!.Name);
+        Assert.Empty (func.Function.ParameterList.Elements);
+        var returnType = func.Function.Return as NamedTypeSpec;
+        Assert.NotNull (returnType);
+        Assert.Equal ("Swift.Int", returnType.Name);
+    }
+
+    [Fact]
+    public void TestFuncNoLabels()
+    {
+        var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassC22noPublicParameterNamesyS2i_SitF";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var func = result as FunctionReduction;
+        Assert.NotNull (func);
+        var provenance = func.Function.Provenance;
+        Assert.True (provenance.IsInstance);
+        Assert.Equal ("GeneralHackingNonsense.ThisIsAClass", provenance.InstanceType!.Name);
+        Assert.Equal (2, func.Function.ParameterList.Elements.Count);
+        Assert.Equal ("(Swift.Int, Swift.Int)", func.Function.ParameterList.ToString ());
+        var returnType = func.Function.Return as NamedTypeSpec;
+        Assert.NotNull (returnType);
+        Assert.Equal ("Swift.Int", returnType.Name);
+    }
+
+
+    [Fact]
+    public void TestFuncFewLabels()
+    {
+        var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassC23fewPublicParameterNames_1b_S2i_S2itF";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var func = result as FunctionReduction;
+        Assert.NotNull (func);
+        var provenance = func.Function.Provenance;
+        Assert.True (provenance.IsInstance);
+        Assert.Equal ("GeneralHackingNonsense.ThisIsAClass", provenance.InstanceType!.Name);
+        Assert.Equal (3, func.Function.ParameterList.Elements.Count);
+        Assert.Equal ("(Swift.Int, b: Swift.Int, Swift.Int)", func.Function.ParameterList.ToString ());
+        var returnType = func.Function.Return as NamedTypeSpec;
+        Assert.NotNull (returnType);
+        Assert.Equal ("Swift.Int", returnType.Name);
+    }
+
 }


### PR DESCRIPTION
This adds support for Dispatch Thunk demangling.

A dispatch thunk node consists of a child which is some flavor of function.

Since a dispatch thunk is really a function with a special name, it made sense for the reduction class to be a subclass of the function reduction and no added members.

In this way, if you're looking for a dispatch thunk that matches a given function, you should be able to do something like:
```
var thunk = alldemangled.OfType<DispatchThunkFunctionReduction>.Where (th => th.Function.Equals (candidate)).FirstOrDefault ();
```
Of course, we wouldn't want to do that every time - it would make more sense to silo the reduction types into their own collections to factor out the filtering every time you want find a thunk.

Other details:
- Saw a dispatch thunk for allocators, so I added support for that.
- It occurred to me that the `LabelList` would be different when you didn't have labels for each arg, so I handled that as well.
- Added code to handle instance provenances
- Tests for all these cases