### PR TITLE
[SwiftBinding] Made the node reducer completely static

### DIFF
--- a/src/Swift.Bindings/src/Demangler/MatchRule.cs
+++ b/src/Swift.Bindings/src/Demangler/MatchRule.cs
@@ -60,7 +60,7 @@ internal class MatchRule {
     /// <summary>
     /// A reducer to apply if the node matches
     /// </summary>
-    public required Func<Node, string?, IReduction> Reducer { get; init; } = (node, name) => new ReductionError () { Message = "Call of empty reduction rule", Symbol = name ?? "no symbol" };
+    public required Func<Node, string, IReduction> Reducer { get; init; } = (node, mangledName) => new ReductionError () { Message = "Call of empty reduction rule", Symbol = mangledName };
 
     /// <summary>
     /// Returns true if and only if the given node matches this rule

--- a/src/Swift.Bindings/src/Demangler/RuleRunner.cs
+++ b/src/Swift.Bindings/src/Demangler/RuleRunner.cs
@@ -7,16 +7,14 @@ namespace BindingsGeneration.Demangling;
 /// RuleRunner contains a a collection of rules that get run to reduce nodes
 /// </summary>
 internal class RuleRunner {
-    string mangledName;
     List<MatchRule> rules = new List<MatchRule>();
 
     /// <summary>
     /// Constructs a new rules runner initialized with the give rule set
     /// </summary>
     /// <param name="rules">Rules to test against a node</param>
-    public RuleRunner(IEnumerable<MatchRule> rules, string mangledName)
+    public RuleRunner(IEnumerable<MatchRule> rules)
     {
-        this.mangledName = mangledName;
         this.rules.AddRange(rules);
     }
 
@@ -25,14 +23,14 @@ internal class RuleRunner {
     /// or there was an error, this will return a IReduction of type ReductionError
     /// </summary>
     /// <param name="node">A node to attempt to match</param>
-    /// <param name="name">A name used for the reduction</param>
+    /// <param name="mangledName">A mangled symbol name that generated the node</param>
     /// <returns></returns>
-    public IReduction RunRules(Node node, string? name)
+    public IReduction RunRules(Node node, string mangledName)
     {
         var rule = rules.FirstOrDefault (r => r.Matches(node));
         
         if (rule is null)
             return new ReductionError() { Symbol = mangledName, Message = $"No rule for node {node.Kind}" };
-        return rule.Reducer(node, name);
+        return rule.Reducer(node, mangledName);
     }
 }

--- a/src/Swift.Bindings/src/Demangler/Swift5Demangler.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Demangler.cs
@@ -52,8 +52,7 @@ namespace BindingsGeneration.Demangling {
 				}
 				return nextReduction;
 			} else if (topLevelNode is not null) {
-				var reducer = new Swift5Reducer (originalIdentifier);
-				return reducer.Convert (topLevelNode);
+				return Swift5Reducer.Convert (topLevelNode, originalIdentifier);
 			} else {
 				return new ReductionError () {Symbol = originalIdentifier,  Message = $"Unable to demangle {originalIdentifier}" };
 			}


### PR DESCRIPTION
The original version was non-static which meant that for every symbol, it would new up a list of MatchRule that would get thrown away after reduction.

A side effect of doing this is that the mangled name needs to get passed through each rule. This is fine since the previous version had a `string?` argument that wasn't really getting used.

This addresses [this issue](https://github.com/dotnet/runtimelab/issues/2691)
