### PR TITLE
Added support for finding metadata accessors

### DIFF
--- a/src/Swift.Bindings/src/Demangler/IReduction.cs
+++ b/src/Swift.Bindings/src/Demangler/IReduction.cs
@@ -42,6 +42,20 @@ public class TypeSpecReduction : IReduction {
 }
 
 /// <summary>
+/// Represents a reduction for a metadata acessor function.
+/// </summary>
+public class MetadataAccessorReduction : IReduction {
+    /// <summary>
+    /// Returns a the mangled symbol associated with a reduction
+    /// </summary>
+    public required string Symbol { get; init; }
+    /// <summary>
+    /// Returns a NameTypeSpec for the type hosting the metadata
+    /// </summary>
+    public required NamedTypeSpec TypeSpec { get; init; }
+}
+
+/// <summary>
 /// Represents a reduction that reduces to a Swift function
 /// </summary>
 public class FunctionReduction : IReduction {

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -60,17 +60,6 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     }
 
     [Fact]
-    public void TestFailMetadataAccessor()
-    {
-        var symbol = "_$s20GenericTestFramework6ThingyCMa";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
-        var err = result as ReductionError;
-        Assert.NotNull(err);
-        Assert.Equal("No rule for node TypeMetadataAccessFunction", err.Message);
-    }
-
-    [Fact]
     public void TestNestedProtocolWitnessTable()
     {
         var symbol = "_$s20GenericTestFramework3FooC6ThingyCAA8IsItRealAAWP";
@@ -210,4 +199,27 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
         Assert.Equal ("Swift.Int", returnType.Name);
     }
 
+
+    [Fact]
+    public void TestMetadataAccessor()
+    {
+        var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassCMa";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var metadataAccessor = result as MetadataAccessorReduction;
+        Assert.NotNull (metadataAccessor);
+        Assert.Equal ("GeneralHackingNonsense.ThisIsAClass", metadataAccessor.TypeSpec.Name);
+    }
+
+
+    [Fact]
+    public void TestGenericMetadataAccessor()
+    {
+        var symbol = "_$s22GeneralHackingNonsense6DupletVMa";
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run ();
+        var metadataAccessor = result as MetadataAccessorReduction;
+        Assert.NotNull (metadataAccessor);
+        Assert.Equal ("GeneralHackingNonsense.Duplet", metadataAccessor.TypeSpec.Name);
+    }
 }


### PR DESCRIPTION
Metadata accessor functions are not exposed as actual functions in Swift which is odd on the face of it, but it makes sense when you realize that metadata accessors are effectively singletons and the knowledge of the calling conventions is defined by the type itself.

Calling conventions for the accessor is always this:
arg0: SwiftMetadataRequest
arg1-argn - only present if the type is generic, then there is a swift metadata object for each generic specialization.

The `SwiftMetadataRequest` is an enum, but in our usage it will probably always be the 0 value, `Complete`.

How to find metadata accessors from a collection of `IReduction`:
```csharp
    var accessor = reductions.OfType<MetadataAccessorReduction> ().Where (ma => ma.TypeSpec.Name == fullTypeName).FirstOrDefault ();
```
Although since we'll be getting the metadata accessor functions for each type we're binding, it will probably be best to separate out all the metadata accessors into a `Dictionary<string, string>` where the key is the full type name and the value is the mangled name for the accessor.