### PR TITLE
[SwiftBindings] Better demangle errors

### DIFF
--- a/src/Swift.Bindings/src/Demangler/Enums.cs
+++ b/src/Swift.Bindings/src/Demangler/Enums.cs
@@ -380,3 +380,17 @@ internal enum MatchNodeContentType {
 public enum SymbolicReferenceKind {
 	Context,
 }
+
+/// <summary>
+/// Represents the severity of a reduction error
+/// </summary>
+public enum ReductErrorSeverity {
+	/// <summary>
+	/// A low severity error that can be ignored
+	/// </summary>
+	Low = 0,
+	/// <summary>
+	/// A high severity error that should not be ignored
+	/// </summary>
+	High,
+}

--- a/src/Swift.Bindings/src/Demangler/IReduction.cs
+++ b/src/Swift.Bindings/src/Demangler/IReduction.cs
@@ -25,6 +25,11 @@ public class ReductionError : IReduction {
     /// Returns an error message describing the error
     /// </summary>
     public required string Message { get; init; }
+
+    /// <summary>
+    /// Returns the severity of the error
+    /// </summary>
+    public ReductErrorSeverity Severity { get; set; } = ReductErrorSeverity.Low;
 }
 
 /// <summary>

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -222,4 +222,15 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
         Assert.NotNull (metadataAccessor);
         Assert.Equal ("GeneralHackingNonsense.Duplet", metadataAccessor.TypeSpec.Name);
     }
+
+    [Fact]
+    public void TestUnknownEntry()
+    {
+        var symbol = "_$ss5print_9separator10terminatoryypd_S2StFfA0_"; // default argument initializer
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run();
+        var error = result as ReductionError;
+        Assert.NotNull (error);
+        Assert.Equal (ReductErrorSeverity.Low, error.Severity);
+    }
 }

--- a/src/docs/runtime-existential-containers.md
+++ b/src/docs/runtime-existential-containers.md
@@ -2,13 +2,13 @@
 
 In Swift when a protocol *without associated types* or a composition of protocols is passed as an argument into or returned from a function, the value gets passed in an Existential Container. This is a value type which serves as a box for any type that adopts the protocol or protocols needed. It is a [variable length struct](https://github.com/swiftlang/swift/blob/main/docs/ABI/TypeLayout.rst#existential-container-layout) of the form:
 
-| Index | Contents | Size in Machine Words |
-|-------|----------|-----------------------|
-|   0   | Payload  | 3                     |
-|   3   | Metadata | 1 |
-|   4   | Witness Tables | variable: 0 or more |
+| Index | Contents       | Size in Machine Words |
+|-------|----------------|-----------------------|
+|   0   | Payload        | 3                     |
+|   3   | Metadata       | 1                     |
+|   4   | Witness Tables | variable: 0 or more   |
 
-The start of the box includes 3 machine words which serve as a payload for the existential container. If the payload is 3 machine words or less, it will be copied into the existential container. If the payload is larger than 3 machine words, a copy will be allocated from the heap and it will be passed by reference.
+The start of the box includes 3 machine words which serve as a payload for the existential container. If the payload is 3 machine words or less, it will be copied into the existential container. If the payload is larger than 3 machine words, a copy will be allocated from the heap and the pointer to that copy will live in the payload.
 
 After the payload is the type metadata of the entity in the payload.
 
@@ -23,7 +23,7 @@ public interface IExistentialContainer {
     IntPtr Data1 { get; set; }
     IntPtr Data2 { get; set; }
     SwiftTypeMetadata ObjectMetadata { get; set; }
-    NativeHandle this [int index] { get; set; } // this and count could just as easily by IEnumerable<NativeHandle>
+    NativeHandle this [int index] { get; set; } // this[] and Count could just as easily be IEnumerable<NativeHandle>
     int Count { get; }
     int Sizeof { get; }
     unsafe IntPtr CopyTo (IntPtr memory);
@@ -39,9 +39,11 @@ Since most of the code is boiler plate, I made static internal utility functions
 I also created methods to unbox payloads from existential containers and to box into a 0 witness table container i.e. `Any`.
 
 There is also a second flavor of existential container which is a special case reserved for types constrained to `AnyObject` which has the following layout:
-| Index | Contents | Size in Machine Words |
-|   0   | Payload  | 1 |
-|   1   | Witness Tables | variable: 0 or more |
+
+| Index | Contents       | Size in Machine Words |
+|-------|----------------|-----------------------|
+|   0   | Payload        | 1                     |
+|   1   | Witness Tables | variable: 0 or more   |
 
 This is noted in [Apple's documentation](https://github.com/swiftlang/swift/blob/main/docs/ABI/TypeLayout.rst#class-existential-containers). I have never encountered this in Apple's code nor in the wild. This is mostly due to Apple encouraging Swift to be a value type based language.
 

--- a/src/docs/runtime-existential-containers.md
+++ b/src/docs/runtime-existential-containers.md
@@ -19,14 +19,23 @@ Because of the memory issues, existential containers need to be handled with att
 To start, we want to be able to operate on existential containers in the abstract. Therefore all existential containers should implement a common interface:
 ```csharp
 public interface IExistentialContainer {
-    IntPtr Data0 { get; set; }
-    IntPtr Data1 { get; set; }
-    IntPtr Data2 { get; set; }
-    SwiftTypeMetadata ObjectMetadata { get; set; }
+    // These 3 elements hold the payload of the existential type
+    IntPtr Payload0 { get; set; }
+    IntPtr Payload1 { get; set; }
+    IntPtr Payload2 { get; set; }
+    // This is the type metadata of the object in the payload. The type metadata will determine
+    // whether or not the payload contains the actual object or a heap-allocated copy. This is done by
+    // looking at the value witness table, if it's a value type, which has a field for the type's size
+    TypeMetadata ObjectMetadata { get; set; }
+    // an indexer into each of the value witness tables
     NativeHandle this [int index] { get; set; } // this[] and Count could just as easily be IEnumerable<NativeHandle>
+    // the number of value witness tables
     int Count { get; }
-    int Sizeof { get; }
+    // the size of this in MACHINE WORDS not bytes
+    int SizeOf { get; }
+    // Copy the existential container into memory, returns memory
     IntPtr CopyTo (IntPtr memory);
+    // Copy the contents of this into the supplied container. Throws if container doesn't match the size of this
     void CopyTo <T>(ref T container) where T : IExistentialContainer;
 }
 ```

--- a/src/docs/runtime-existential-containers.md
+++ b/src/docs/runtime-existential-containers.md
@@ -31,7 +31,7 @@ public interface IExistentialContainer {
     NativeHandle this [int index] { get; set; } // this[] and Count could just as easily be IEnumerable<NativeHandle>
     // the number of value witness tables
     int Count { get; }
-    // the size of this in MACHINE WORDS not bytes
+    // the size of this in bytes
     int SizeOf { get; }
     // Copy the existential container into memory, returns memory
     IntPtr CopyTo (IntPtr memory);

--- a/src/docs/runtime-existential-containers.md
+++ b/src/docs/runtime-existential-containers.md
@@ -1,0 +1,58 @@
+# Existential Containers
+
+In Swift when a protocol *without associated types* or a composition of protocols is passed as an argument into or returned from a function, the value gets passed in an Existential Container. This is a value type which serves as a box for any type that adopts the protocol or protocols needed. It is a [variable length struct](https://github.com/swiftlang/swift/blob/main/docs/ABI/TypeLayout.rst#existential-container-layout) of the form:
+
+| Index | Contents | Size in Machine Words |
+|-------|----------|-----------------------|
+|   0   | Payload  | 3                     |
+|   3   | Metadata | 1 |
+|   4   | Witness Tables | variable: 0 or more |
+
+The start of the box includes 3 machine words which serve as a payload for the existential container. If the payload is 3 machine words or less, it will be copied into the existential container. If the payload is larger than 3 machine words, a copy will be allocated from the heap and it will be passed by reference.
+
+After the payload is the type metadata of the entity in the payload.
+
+Finally, there is an inline list of pointers to protocol witness tables. This list can be 0 elements in length as in the case of the special `Any` protocol or it can be n elements in length as in the case of a protocol composition type (`P1 & P2 & ... Pn`). In the case of an existential container with more than 1 protocol witness table, they are ordered alphabetically by the protocol name (note, this is from the source code - Apple has not documented this).
+
+Because of the memory issues, existential containers need to be handled with attention paid to reference counting, but this can be managed by avoiding exposing the existential containers to the public API. This is straight-forward since in order to present protocols back and forth to each language will require dual proxies. This is detailed [here](binding-protocols.md).
+
+To start, we want to be able to operate on existential containers in the abstract. Therefore all existential containers should implement a common interface:
+```csharp
+public interface IExistentialContainer {
+    IntPtr Data0 { get; set; }
+    IntPtr Data1 { get; set; }
+    IntPtr Data2 { get; set; }
+    SwiftTypeMetadata ObjectMetadata { get; set; }
+    NativeHandle this [int index] { get; set; } // this and count could just as easily by IEnumerable<NativeHandle>
+    int Count { get; }
+    int Sizeof { get; }
+    unsafe IntPtr CopyTo (IntPtr memory);
+    void CopyTo <T>(ref T container) where T : IExistentialContainer;
+}
+```
+
+From there, we need as many concrete implementations of `IExistentialContainer` as we see fit. By far the most common existential container is the variety with a single protocol witness table in it.
+
+Given this, I created 9 structs representing existential containers with 0 to 8 inclusive witness table slots.
+Since most of the code is boiler plate, I made static internal utility functions to copy existential containers to and from raw memory and to each other.
+
+I also created methods to unbox payloads from existential containers and to box into a 0 witness table container i.e. `Any`.
+
+There is also a second flavor of existential container which is a special case reserved for types constrained to `AnyObject` which has the following layout:
+| Index | Contents | Size in Machine Words |
+|   0   | Payload  | 1 |
+|   1   | Witness Tables | variable: 0 or more |
+
+This is noted in [Apple's documentation](https://github.com/swiftlang/swift/blob/main/docs/ABI/TypeLayout.rst#class-existential-containers). I have never encountered this in Apple's code nor in the wild. This is mostly due to Apple encouraging Swift to be a value type based language.
+
+Although this would not be a priority for us, the type could be represented like this:
+```csharp
+public interface IClassExistentialContainer {
+    NativeHandle Object { get; set; }
+    NativeHandle this [int index] { get; set; } // this and count could just as easily by IEnumerable<NativeHandle>
+    int Count { get; }
+    int Sizeof { get; }
+    unsafe IntPtr CopyTo (IntPtr memory);
+    void CopyTo <T>(ref T container) where T : IExistentialContainer;
+}
+```

--- a/src/docs/runtime-existential-containers.md
+++ b/src/docs/runtime-existential-containers.md
@@ -26,7 +26,7 @@ public interface IExistentialContainer {
     NativeHandle this [int index] { get; set; } // this[] and Count could just as easily be IEnumerable<NativeHandle>
     int Count { get; }
     int Sizeof { get; }
-    unsafe IntPtr CopyTo (IntPtr memory);
+    IntPtr CopyTo (IntPtr memory);
     void CopyTo <T>(ref T container) where T : IExistentialContainer;
 }
 ```
@@ -54,7 +54,7 @@ public interface IClassExistentialContainer {
     NativeHandle this [int index] { get; set; } // this and count could just as easily by IEnumerable<NativeHandle>
     int Count { get; }
     int Sizeof { get; }
-    unsafe IntPtr CopyTo (IntPtr memory);
+    IntPtr CopyTo (IntPtr memory);
     void CopyTo <T>(ref T container) where T : IExistentialContainer;
 }
 ```


### PR DESCRIPTION
This PR changes the error reduction to include a severity.

Initially there are two levels of severity: Low and High.

The meaning of these is effectively that if we get an error reduction of low severity, we can safely ignore it, but if we get an error of high severity, we care about it because it represents something in the demangling that we need but hasn't been accounted for (yet).

For example, we don't _need_ default argument initializers yet, if ever, so if are asked to reduce one, we honestly don't care. It's technically an error, but we can let it go by because ignoring it doesn't affect the binding. However, if we get an error while reducing a metadata accessor, we care very much since we need those for every type that we handle, therefore if that reducer encounters an error, it will either return a new `ReductionError` with high severity or it will promote an existing `ReductionError` to high severity.
