### PR TITLE
[SwiftBindings] Better demangle errors

### DIFF
--- a/src/Swift.Bindings/src/Demangler/Enums.cs
+++ b/src/Swift.Bindings/src/Demangler/Enums.cs
@@ -384,7 +384,7 @@ public enum SymbolicReferenceKind {
 /// <summary>
 /// Represents the severity of a reduction error
 /// </summary>
-public enum ReductErrorSeverity {
+public enum ReductionErrorSeverity {
 	/// <summary>
 	/// A low severity error that can be ignored
 	/// </summary>

--- a/src/Swift.Bindings/src/Demangler/Enums.cs
+++ b/src/Swift.Bindings/src/Demangler/Enums.cs
@@ -380,3 +380,17 @@ internal enum MatchNodeContentType {
 public enum SymbolicReferenceKind {
 	Context,
 }
+
+/// <summary>
+/// Represents the severity of a reduction error
+/// </summary>
+public enum ReductErrorSeverity {
+	/// <summary>
+	/// A low severity error that can be ignored
+	/// </summary>
+	Low = 0,
+	/// <summary>
+	/// A high severity error that should not be ignored
+	/// </summary>
+	High,
+}

--- a/src/Swift.Bindings/src/Demangler/IReduction.cs
+++ b/src/Swift.Bindings/src/Demangler/IReduction.cs
@@ -25,6 +25,11 @@ public class ReductionError : IReduction {
     /// Returns an error message describing the error
     /// </summary>
     public required string Message { get; init; }
+
+    /// <summary>
+    /// Returns the severity of the error
+    /// </summary>
+    public ReductErrorSeverity Severity { get; set; } = ReductErrorSeverity.Low;
 }
 
 /// <summary>

--- a/src/Swift.Bindings/src/Demangler/IReduction.cs
+++ b/src/Swift.Bindings/src/Demangler/IReduction.cs
@@ -29,7 +29,7 @@ public class ReductionError : IReduction {
     /// <summary>
     /// Returns the severity of the error
     /// </summary>
-    public ReductErrorSeverity Severity { get; set; } = ReductErrorSeverity.Low;
+    public ReductionErrorSeverity Severity { get; set; } = ReductionErrorSeverity.Low;
 }
 
 /// <summary>

--- a/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
@@ -174,7 +174,7 @@ internal class Swift5Reducer {
         }
         var grandchild = Convert (child.Children [0], mangledName);
         if (grandchild is ReductionError error) {
-            error.Severity = ReductErrorSeverity.High;
+            error.Severity = ReductionErrorSeverity.High;
             return error;
         }
         var implementingType = grandchild as TypeSpecReduction;
@@ -184,7 +184,7 @@ internal class Swift5Reducer {
 
         grandchild = Convert (child.Children [1], mangledName);
         if (grandchild is ReductionError error1) {
-            error1.Severity = ReductErrorSeverity.High;
+            error1.Severity = ReductionErrorSeverity.High;
             return error1;
         }
         var protocolType = grandchild as TypeSpecReduction;
@@ -202,7 +202,7 @@ internal class Swift5Reducer {
                     return ReductionErrorHigh (ExpectedButGot ("A top-level module name", prov.Provenance.ToString(), mangledName), mangledName);
                 return new ProtocolConformanceDescriptorReduction() { Symbol = mangledName, ImplementingType = impNamed, ProtocolType = protoNamed, Module = prov.Provenance.Module};
             } else if (grandchild is ReductionError error2) {
-                error2.Severity = ReductErrorSeverity.High;
+                error2.Severity = ReductionErrorSeverity.High;
                 return error2;
             } else {
                 return ReductionErrorHigh (ExpectedButGot ("ProvenanceReduction", grandchild.GetType().Name, mangledName), mangledName);
@@ -398,7 +398,7 @@ internal class Swift5Reducer {
             reduction = TypeSpecToProvenance (ts);
 
         if (reduction is ReductionError error) {
-            error.Severity = ReductErrorSeverity.High;
+            error.Severity = ReductionErrorSeverity.High;
             return error;
         }
         else if (reduction is ProvenanceReduction provenance) {
@@ -406,7 +406,7 @@ internal class Swift5Reducer {
             var labels = labelList is not null ? labelList.Children.Select (n => n.Kind == NodeKind.Identifier ? n.Text : "").ToArray() : new string [0];
             reduction = Convert (typeNode, mangledName);
             if (reduction is ReductionError typeError) {
-                typeError.Severity = ReductErrorSeverity.High;
+                typeError.Severity = ReductionErrorSeverity.High;
                 return typeError;
             }
             else if (reduction is TypeSpecReduction typeSpecReduction) {
@@ -451,14 +451,14 @@ internal class Swift5Reducer {
             reduction = TypeSpecToProvenance (ts);
 
         if (reduction is ReductionError error) {
-            error.Severity = ReductErrorSeverity.High;
+            error.Severity = ReductionErrorSeverity.High;
             return error;
         }
         else if (reduction is ProvenanceReduction provenance) {
             var identifier = "__allocating_init";
             reduction = Convert (typeNode, mangledName);
             if (reduction is ReductionError typeError) {
-                typeError.Severity = ReductErrorSeverity.High;
+                typeError.Severity = ReductionErrorSeverity.High;
                 return typeError;
             }
             else if (reduction is TypeSpecReduction typeSpecReduction) {
@@ -488,7 +488,7 @@ internal class Swift5Reducer {
     {
         var childReduction = ConvertFirstChild (node, mangledName);
         if (childReduction is ReductionError error) {
-            error.Severity = ReductErrorSeverity.High;
+            error.Severity = ReductionErrorSeverity.High;
             return error;
         }
         if (childReduction is FunctionReduction funcReduction) {
@@ -512,7 +512,7 @@ internal class Swift5Reducer {
         //       nominal type
         var childReduction = ConvertFirstChild (node, mangledName);
         if (childReduction is ReductionError error) {
-            error.Severity = ReductErrorSeverity.High;
+            error.Severity = ReductionErrorSeverity.High;
             return error;
         }
         if (childReduction is TypeSpecReduction typeSpec)
@@ -580,7 +580,7 @@ internal class Swift5Reducer {
     /// <summary>
     /// Convenience factory for reduction errors
     /// </summary>
-    static ReductionError ReductionError (string message, string mangledName, ReductErrorSeverity severity)
+    static ReductionError ReductionError (string message, string mangledName, ReductionErrorSeverity severity)
     {
         return new ReductionError() { Symbol = mangledName, Message = message, Severity = severity };
     }
@@ -593,7 +593,7 @@ internal class Swift5Reducer {
     /// <returns>a Reduction error of low severity</returns>
     static ReductionError ReductionErrorLow (string message, string mangledName)
     {
-        return ReductionError (message, mangledName, ReductErrorSeverity.Low);
+        return ReductionError (message, mangledName, ReductionErrorSeverity.Low);
     }
 
     /// <summary>
@@ -604,7 +604,7 @@ internal class Swift5Reducer {
     /// <returns>a Reduction error of high severity</returns>
     static ReductionError ReductionErrorHigh (string message, string mangledName)
     {
-        return ReductionError (message, mangledName, ReductErrorSeverity.High);
+        return ReductionError (message, mangledName, ReductionErrorSeverity.High);
     }
 
     /// <summary>

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -222,4 +222,15 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
         Assert.NotNull (metadataAccessor);
         Assert.Equal ("GeneralHackingNonsense.Duplet", metadataAccessor.TypeSpec.Name);
     }
+
+    [Fact]
+    public void TestUnknownEntry()
+    {
+        var symbol = "_$ss5print_9separator10terminatoryypd_S2StFfA0_"; // default argument initializer
+        var demangler = new Swift5Demangler (symbol);
+        var result = demangler.Run();
+        var error = result as ReductionError;
+        Assert.NotNull (error);
+        Assert.Equal (ReductErrorSeverity.Low, error.Severity);
+    }    
 }

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -231,6 +231,6 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
         var result = demangler.Run();
         var error = result as ReductionError;
         Assert.NotNull (error);
-        Assert.Equal (ReductErrorSeverity.Low, error.Severity);
+        Assert.Equal (ReductionErrorSeverity.Low, error.Severity);
     }    
 }


### PR DESCRIPTION
This PR changes the error reduction to include a severity.

Initially there are two levels of severity: Low and High.

The meaning of these is effectively that if we get an error reduction of low severity, we can safely ignore it, but if we get an error of high severity, we care about it because it represents something in the demangling that we need but hasn't been accounted for (yet).

For example, we don't need default argument initializers yet, if ever, so if are asked to reduce one, we honestly don't care. It's technically an error, but we can let it go by because ignoring it doesn't affect the binding. However, if we get an error while reducing a metadata accessor, we care very much since we need those for every type that we handle, therefore if that reducer encounters an error, it will either return a new ReductionError with high severity or it will promote an existing ReductionError to high severity.