### PR TITLE
[Runtime Async] Addressing test failures.

### DIFF
--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -5942,9 +5942,11 @@ MethodTableBuilder::FindDeclMethodOnInterfaceEntry(bmtInterfaceEntry *pItfEntry,
             if ((slotDeclMethod->GetOwningType() == declRTMethod->GetOwningType()) &&
                 (slotDeclMethod->GetMethodDesc()->GetMethodTable() == declRTMethod->GetMethodDesc()->GetMethodTable()) &&
                 (slotDeclMethod->GetMethodDesc()->GetMemberDef() == declRTMethod->GetMethodDesc()->GetMemberDef()) &&
-                (slotDeclMethod->GetMethodDesc()->IsAsyncThunkMethod() == declRTMethod->GetMethodDesc()->IsAsyncThunkMethod()))
+                (slotDeclMethod->GetMethodDesc()->IsAsyncThunkMethod() != declRTMethod->GetMethodDesc()->IsAsyncThunkMethod()))
             {
                 declMethod = slotIt->Decl();
+                foundOtherVariant = true;
+                break;
             }
         }
 

--- a/src/tests/Loader/async/async2-eh-microbench.cs
+++ b/src/tests/Loader/async/async2-eh-microbench.cs
@@ -16,10 +16,12 @@ using Xunit;
 
 public class Async2EHMicrobench
 {
-    [Fact]
-    public static void TestEntryPoint()
+    public static int Main()
     {
         Task.Run(AsyncEntry).Wait();
+
+        Console.WriteLine("Test Passed");
+        return 100;
     }
 
     public static async Task AsyncEntry()

--- a/src/tests/Loader/async/async2-eh-microbench.csproj
+++ b/src/tests/Loader/async/async2-eh-microbench.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <Optimize>True</Optimize>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Loader/async/async2-mincallcost-microbench.cs
+++ b/src/tests/Loader/async/async2-mincallcost-microbench.cs
@@ -16,10 +16,12 @@ using Xunit;
 
 public class Async2MinCallCostMicrobench
 {
-    [Fact]
-    public static void TestEntryPoint()
+    public static int Main()
     {
         Task.Run(AsyncEntry).Wait();
+
+        Console.WriteLine("Test Passed");
+        return 100;
     }
 
     public static async Task AsyncEntry()

--- a/src/tests/Loader/async/async2-mincallcost-microbench.csproj
+++ b/src/tests/Loader/async/async2-mincallcost-microbench.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <Optimize>True</Optimize>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Loader/async/async2fibonacci-with-yields-topLevel.cs
+++ b/src/tests/Loader/async/async2fibonacci-with-yields-topLevel.cs
@@ -8,10 +8,11 @@ using Xunit;
 
 const uint Threshold = 1_000;
 bool done = false;
+const int iterations = 1;
 
 async Task AsyncEntry()
 {
-    for (int i = 0; i < 10 && !done; i++)
+    for (int i = 0; i < iterations && !done; i++)
     {
         var sw = new Stopwatch();
         sw.Start();

--- a/src/tests/Loader/async/async2fibonacci-with-yields.cs
+++ b/src/tests/Loader/async/async2fibonacci-with-yields.cs
@@ -10,6 +10,7 @@ public class Async2FibonacceWithYields
 {
     const uint Threshold = 1_000;
     static bool done;
+    const int iterations = 1;
 
     [Fact]
     public static void Test()
@@ -19,7 +20,7 @@ public class Async2FibonacceWithYields
 
     public static async Task AsyncEntry()
     {
-        for (int i = 0; i < 10 && !done; i++)
+        for (int i = 0; i < iterations && !done; i++)
         {
             var sw = new Stopwatch();
             sw.Start();

--- a/src/tests/Loader/async/async2fibonacci-without-yields.cs
+++ b/src/tests/Loader/async/async2fibonacci-without-yields.cs
@@ -10,6 +10,7 @@ public class Async2FibonacceWithoutYields
 {
     const uint Threshold = 1_000;
     static bool doYields = false;
+    const int iterations = 1;
 
     [Fact]
     public static void Test()
@@ -19,7 +20,7 @@ public class Async2FibonacceWithoutYields
 
     public static async Task AsyncEntry()
     {
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < iterations; i++)
         {
             var sw = new Stopwatch();
             sw.Start();

--- a/src/tests/Loader/async/async2gcRootsScan.cs
+++ b/src/tests/Loader/async/async2gcRootsScan.cs
@@ -17,17 +17,17 @@ public class Async2RootReporting
 
         // make some garbage
         object o1 = n;
-        //object o2 = n;
-        //object o3 = n;
-        //object o4 = n;
-        //object o5 = n;
-        //object o6 = n;
-        //object o7 = n;
-        //object o8 = n;
-        //object o9 = n;
-        //object o10 = n;
-        //object o11 = n;
-        //object o12 = n;
+        object o2 = n;
+        object o3 = n;
+        object o4 = n;
+        object o5 = n;
+        object o6 = n;
+        object o7 = n;
+        object o8 = n;
+        object o9 = n;
+        object o10 = n;
+        object o11 = n;
+        object o12 = n;
 
         if (n == 0)
             return await cTask;
@@ -35,17 +35,17 @@ public class Async2RootReporting
         var result = await Recursive1(n - 1);
 
         Assert.Equal(n, (int)o1);
-        //Assert.Equal(n, (int)o2);
-        //Assert.Equal(n, (int)o3);
-        //Assert.Equal(n, (int)o4);
-        //Assert.Equal(n, (int)o5);
-        //Assert.Equal(n, (int)o6);
-        //Assert.Equal(n, (int)o7);
-        //Assert.Equal(n, (int)o8);
-        //Assert.Equal(n, (int)o9);
-        //Assert.Equal(n, (int)o10);
-        //Assert.Equal(n, (int)o11);
-        //Assert.Equal(n, (int)o12);
+        Assert.Equal(n, (int)o2);
+        Assert.Equal(n, (int)o3);
+        Assert.Equal(n, (int)o4);
+        Assert.Equal(n, (int)o5);
+        Assert.Equal(n, (int)o6);
+        Assert.Equal(n, (int)o7);
+        Assert.Equal(n, (int)o8);
+        Assert.Equal(n, (int)o9);
+        Assert.Equal(n, (int)o10);
+        Assert.Equal(n, (int)o11);
+        Assert.Equal(n, (int)o12);
 
         return result;
     }
@@ -57,18 +57,17 @@ public class Async2RootReporting
         // make some garbage
         object o1 = n;
 
-// THIS CAUSES CRASHES IN UNWINDER FLAVOR
-        //object o2 = n;
-        //object o3 = n;
-        //object o4 = n;
-        //object o5 = n;
-        //object o6 = n;
-        //object o7 = n;
-        //object o8 = n;
-        //object o9 = n;
-        //object o10 = n;
-        //object o11 = n;
-        //object o12 = n;
+        object o2 = n;
+        object o3 = n;
+        object o4 = n;
+        object o5 = n;
+        object o6 = n;
+        object o7 = n;
+        object o8 = n;
+        object o9 = n;
+        object o10 = n;
+        object o11 = n;
+        object o12 = n;
 
         if (n == 0)
             return await cTask;
@@ -76,25 +75,24 @@ public class Async2RootReporting
         var result = await Recursive2(n - 1);
 
         Assert.Equal(n, (int)o1);
-        //Assert.Equal(n, (int)o2);
-        //Assert.Equal(n, (int)o3);
-        //Assert.Equal(n, (int)o4);
-        //Assert.Equal(n, (int)o5);
-        //Assert.Equal(n, (int)o6);
-        //Assert.Equal(n, (int)o7);
-        //Assert.Equal(n, (int)o8);
-        //Assert.Equal(n, (int)o9);
-        //Assert.Equal(n, (int)o10);
-        //Assert.Equal(n, (int)o11);
-        //Assert.Equal(n, (int)o12);
+        Assert.Equal(n, (int)o2);
+        Assert.Equal(n, (int)o3);
+        Assert.Equal(n, (int)o4);
+        Assert.Equal(n, (int)o5);
+        Assert.Equal(n, (int)o6);
+        Assert.Equal(n, (int)o7);
+        Assert.Equal(n, (int)o8);
+        Assert.Equal(n, (int)o9);
+        Assert.Equal(n, (int)o10);
+        Assert.Equal(n, (int)o11);
+        Assert.Equal(n, (int)o12);
 
         return result;
     }
 
     static System.Collections.Generic.List<object> d = new System.Collections.Generic.List<object>();
 
-    [Fact]
-    public static void Test()
+    public static int Main()
     {
         int numStacks = 10000;
         int stackDepth = 100;
@@ -207,5 +205,7 @@ public class Async2RootReporting
             cs.SetResult(100);
             Task.WaitAll(tasks);
         }
+
+        return 100;
     }
 }

--- a/src/tests/Loader/async/async2gcRootsScan.csproj
+++ b/src/tests/Loader/async/async2gcRootsScan.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <Optimize>True</Optimize>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
    <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Loader/async/syncfibonacci-with-yields.cs
+++ b/src/tests/Loader/async/syncfibonacci-with-yields.cs
@@ -12,8 +12,7 @@ public class SyncFibonacciWithYields
 {
     const uint Threshold = 1_000;
 
-    [Fact]
-    public static void Test()
+    public static int Main()
     {
         for (int i = 0; i < 10; i++)
         {
@@ -22,6 +21,8 @@ public class SyncFibonacciWithYields
             uint result = A(100_000_000);
             Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
         }
+
+        return 100;
     }
 
     static uint A(uint n)

--- a/src/tests/Loader/async/syncfibonacci-with-yields.csproj
+++ b/src/tests/Loader/async/syncfibonacci-with-yields.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Loader/async/syncfibonacci-without-yields.cs
+++ b/src/tests/Loader/async/syncfibonacci-without-yields.cs
@@ -12,8 +12,7 @@ public class SyncFibonacciWithoutYields
 {
     const uint Threshold = 1_000;
 
-    [Fact]
-    public static void Test()
+    public static int Main()
     {
         for (int i = 0; i < 10; i++)
         {
@@ -22,6 +21,8 @@ public class SyncFibonacciWithoutYields
             uint result = A(100_000_000);
             Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
         }
+
+        return 100;
     }
 
     static uint A(uint n)

--- a/src/tests/Loader/async/syncfibonacci-without-yields.csproj
+++ b/src/tests/Loader/async/syncfibonacci-without-yields.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Loader/async/taskbased-asyncfibonacci-with-yields.cs
+++ b/src/tests/Loader/async/taskbased-asyncfibonacci-with-yields.cs
@@ -11,8 +11,7 @@ public class TaskBasedAsyncFibonacciWithYields
 {
     const uint Threshold = 1_000;
 
-    [Fact]
-    public static int Test() { return AsyncMain().Result; }
+    public static int Main() { return AsyncMain().Result; }
     
     static async Task<int> AsyncMain()
     {

--- a/src/tests/Loader/async/taskbased-asyncfibonacci-with-yields.csproj
+++ b/src/tests/Loader/async/taskbased-asyncfibonacci-with-yields.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Loader/async/taskbased-asyncfibonacci-without-yields.cs
+++ b/src/tests/Loader/async/taskbased-asyncfibonacci-without-yields.cs
@@ -11,8 +11,7 @@ public class TaskBasedAsyncFibonacciWithoutYields
 {
     const uint Threshold = 1_000;
 
-    [Fact]
-    public static int Test() { return AsyncMain().Result; }
+    public static int Main() { return AsyncMain().Result; }
     
     static async Task<int> AsyncMain()
     {

--- a/src/tests/Loader/async/taskbased-asyncfibonacci-without-yields.csproj
+++ b/src/tests/Loader/async/taskbased-asyncfibonacci-without-yields.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Loader/async/valuetaskbased-asyncfibonacci-with-yields.cs
+++ b/src/tests/Loader/async/valuetaskbased-asyncfibonacci-with-yields.cs
@@ -11,8 +11,7 @@ public class ValueTaskBasedAsyncFibonacciWithYields
 {
     const uint Threshold = 1_000;
 
-    [Fact]
-    public static int Test() { return AsyncMain().Result; }
+    public static int Main() { return AsyncMain().Result; }
     
     static async Task<int> AsyncMain()
     {

--- a/src/tests/Loader/async/valuetaskbased-asyncfibonacci-with-yields.csproj
+++ b/src/tests/Loader/async/valuetaskbased-asyncfibonacci-with-yields.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Loader/async/valuetaskbased-asyncfibonacci-without-yields.cs
+++ b/src/tests/Loader/async/valuetaskbased-asyncfibonacci-without-yields.cs
@@ -11,8 +11,7 @@ public class ValueTaskBasedAsyncFibonacciWithoutYields
 {
     const uint Threshold = 1_000;
 
-    [Fact]
-    public static int Test() { return AsyncMain().Result; }
+    public static int Main() { return AsyncMain().Result; }
     
     static async ValueTask<int> AsyncMain()
     {

--- a/src/tests/Loader/async/valuetaskbased-asyncfibonacci-without-yields.csproj
+++ b/src/tests/Loader/async/valuetaskbased-asyncfibonacci-without-yields.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <Optimize>True</Optimize>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This is a manual test/benchmark -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
With these changes I see only one failure when running runtime tests (related to shared generics) and that is being fixed in 
https://github.com/dotnet/runtimelab/pull/2755

In this change:
* there is one small type system fix that makes R2R determinism tests to pass.
* Bunch of benchmark-like tests were either made build-only or have reduced number of iterations (so that we still had coverage, without timing out)


