### PR TITLE
[SwiftBindings] added full demangling results with easy accessors and cleaned up the code to require fewer allocations

### DIFF
--- a/src/Swift.Bindings/src/Demangler/DemanglingResults.cs
+++ b/src/Swift.Bindings/src/Demangler/DemanglingResults.cs
@@ -1,0 +1,107 @@
+using BindingsGeneration.Demangling;
+using Xamarin;
+
+/// <summary>
+/// A class to contain results from demangling the set of symbols in a MachO file.
+/// </summary>
+public class DemanglingResults
+{
+    /// <summary>
+    /// Constructs a DemanglingResults object with the desired reductions separated out
+    /// </summary>
+    /// <param name="reductions">An array of reductions</param>
+    DemanglingResults (IReduction [] reductions)
+    {
+        Errors = ArrayOf<ReductionError> (reductions);
+        MetadataAccessors = ArrayOf<MetadataAccessorReduction> (reductions);
+        DispatchThunks = ArrayOf<DispatchThunkFunctionReduction> (reductions);
+        ProtocolWitnessTables = ArrayOf<ProtocolWitnessTableReduction> (reductions);
+        ProtocolConformanceDescriptors = ArrayOf<ProtocolConformanceDescriptorReduction> (reductions);
+    }
+
+    /// <summary>
+    /// A utility routine to filter out a specific type of reduction from a set of general reductions
+    /// </summary>
+    /// <typeparam name="T">The type of the desired aggregation of reductions</typeparam>
+    /// <param name="reductions">an array of general reductions to filter</param>
+    /// <returns>An array of the requested filtered reductions</returns>
+    static T[] ArrayOf<T> (IReduction [] reductions) where T : IReduction
+    {
+        return reductions.OfType<T> ().ToArray ();
+    }
+
+    /// <summary>
+    /// All errors encountered while demangling symbols
+    /// </summary>
+    public ReductionError [] Errors { get; private set; }
+
+    /// <summary>
+    /// All type metadata accessor functions encountered while demangling symbols
+    /// </summary>
+    public MetadataAccessorReduction [] MetadataAccessors { get; private set; }
+
+    /// <summary>
+    /// All dispatch thunk functions encountered while demangling symbols
+    /// </summary>
+    public DispatchThunkFunctionReduction [] DispatchThunks { get; private set; }
+
+    /// <summary>
+    /// All protocol witness tables found while demangling symbols
+    /// </summary>
+    public ProtocolWitnessTableReduction [] ProtocolWitnessTables { get; private set; }
+
+    /// <summary>
+    /// All protocol conformance descriptors founc while demangling symbols
+    /// </summary>
+    public ProtocolConformanceDescriptorReduction [] ProtocolConformanceDescriptors { get; private set; }
+
+    /// <summary>
+    /// Factory method to generate a suite of demangling results from the set of MachO files with the given target
+    /// </summary>
+    /// <param name="machOFiles">The MachO files to demangle</param>
+    /// <param name="target">The target Abi to demangle from</param>
+    /// <returns>A set of demangling results</returns>
+    public static DemanglingResults FromMachOFiles (IEnumerable<MachOFile> machOFiles, Abi target)
+    {
+        var nlistEntries = machOFiles.PublicSymbols (target);
+        var demangler = new Swift5Demangler ();
+        var allReductions = nlistEntries.Select (nle => demangler.Run (nle.str)).ToArray ();
+        return new DemanglingResults (allReductions);
+    }
+
+    /// <summary>
+    /// Async factory method to generate a suite of demangling results from the set of MachO files with the given target
+    /// </summary>
+    /// <param name="machOFiles"></param>
+    /// <param name="target"></param>
+    /// <param name="machOFiles">The MachO files to demangle</param>
+    /// <param name="target">The target Abi to demangle from</param>
+    /// <returns>A set of demangling results</returns>
+    public static async Task<DemanglingResults> FromMachOFilesAsync (IEnumerable<MachOFile> machOFiles, Abi target)
+    {
+        return await Task.Run (() => FromMachOFiles (machOFiles, target));
+    }
+
+    /// <summary>
+    /// Factory method to generate a suite of demangling results from the given file with the given target.
+    /// </summary>
+    /// <param name="path">Path to the file while contains symbols</param>
+    /// <param name="target">The target Abi to demangle from</param>
+    /// <returns>A set of demangling results</returns>
+    public static DemanglingResults FromFile (string path, Abi target)
+    {
+        var files = MachO.Read (path);
+        return FromMachOFiles (files, target);
+    }
+
+    /// <summary>
+    /// Async factory method to generate a suite of demangling results from the given file with the given target.
+    /// </summary>
+    /// <param name="path">Path to the file while contains symbols</param>
+    /// <param name="target">The target Abi to demangle from</param>
+    /// <returns>A set of demangling results</returns>
+    public static async Task<DemanglingResults> FromFileAsync (string path, Abi target)
+    {
+        return await Task.Run (() => FromFile (path, target));
+    }
+}

--- a/src/Swift.Bindings/src/Demangler/DemanglingResults.cs
+++ b/src/Swift.Bindings/src/Demangler/DemanglingResults.cs
@@ -65,7 +65,7 @@ public class DemanglingResults
     {
         var nlistEntries = machOFiles.PublicSymbols (target);
         var demangler = new Swift5Demangler ();
-        var allReductions = nlistEntries.Select (nle => demangler.Run (nle.str)).ToArray ();
+        var allReductions = nlistEntries.Select (nle => nle.str).Where (Swift5Demangler.IsSwiftSymbol).Select (demangler.Run).ToArray ();
         return new DemanglingResults (allReductions);
     }
 

--- a/src/Swift.Bindings/src/Demangler/Swift5Demangler.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Demangler.cs
@@ -11,39 +11,43 @@ using System.Text;
 namespace BindingsGeneration.Demangling {
 	public class Swift5Demangler {
 		const int kMaxRepeatCount = 2048;
-		ulong offset;
-		string originalIdentifier;
+		string originalIdentifier = "";
 		Stack<Node> nodeStack = new Stack<Node> ();
 		List<Node> substitutions = new List<Node> ();
-		string text;
+		string text = "";
 		List<string> words = new List<string> ();
-		StringSlice slice;
+		StringSlice slice = new StringSlice ("");
 		bool isOldFunctionTypeMangling = false;
 
 		public Func<SymbolicReferenceKind, Directness, int, byte [], Node> SymbolicReferenceResolver { get; set; }
 
+		object runLock = new object ();
 		static string [] prefixes = {
 		    /*Swift 4*/   "_T0",
 		    /*Swift 4.x*/ "$S", "_$S",
 		    /*Swift 5+*/  "$s", "_$s"
     		};
 
-		Swift5Demangler ()
+		public Swift5Demangler ()
 		{
 		}
 
-
-		public Swift5Demangler (string mangledName, ulong offset = 0)
+		public IReduction Run (string mangledName)
 		{
-			originalIdentifier = mangledName;
-			this.offset = offset;
-			slice = new StringSlice (originalIdentifier);
-			slice.Advance (GetManglingPrefixLength (originalIdentifier));
+			lock (runLock) {
+				nodeStack.Clear ();
+				substitutions.Clear ();
+				words.Clear ();
+				originalIdentifier = mangledName;
+				slice = new StringSlice (originalIdentifier);
+				slice.Advance (GetManglingPrefixLength (originalIdentifier));
+				return Run ();
+			}
 		}
 
-		public IReduction Run ()
+		IReduction Run ()
 		{
-			Node topLevelNode = DemangleType (null);
+			var topLevelNode = DemangleType (null);
 			if (topLevelNode is not null && topLevelNode.IsAttribute() && nodeStack.Count >= 1) {
 				var attribute = ExtractAttribute (topLevelNode);
 				var nextReduction = Run ();
@@ -54,7 +58,7 @@ namespace BindingsGeneration.Demangling {
 			} else if (topLevelNode is not null) {
 				return Swift5Reducer.Convert (topLevelNode, originalIdentifier);
 			} else {
-				return new ReductionError () {Symbol = originalIdentifier,  Message = $"Unable to demangle {originalIdentifier}" };
+				return new ReductionError () {Symbol = originalIdentifier,  Message = $"Unable to demangle {originalIdentifier}", Severity = ReductionErrorSeverity.High };
 			}
 		}
 

--- a/src/Swift.Bindings/src/Demangler/Swift5Demangler.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Demangler.cs
@@ -245,7 +245,7 @@ namespace BindingsGeneration.Demangling {
 			}
 		}
 
-		int GetManglingPrefixLength (string mangledName)
+		static int GetManglingPrefixLength (string mangledName)
 		{
 			if (string.IsNullOrEmpty (mangledName))
 				return 0;
@@ -256,7 +256,7 @@ namespace BindingsGeneration.Demangling {
 			return 0;
 		}
 
-		bool IsSwiftSymbol (string mangledName)
+		public static bool IsSwiftSymbol (string mangledName)
 		{
 			if (IsOldFunctionTypeMangling (mangledName))
 				return true;
@@ -269,7 +269,7 @@ namespace BindingsGeneration.Demangling {
 			return nameWithoutPrefix.StartsWith ("So", StringComparison.Ordinal) || nameWithoutPrefix.StartsWith ("Sc", StringComparison.Ordinal);
 		}
 
-		bool IsOldFunctionTypeMangling (string mangledName)
+		static bool IsOldFunctionTypeMangling (string mangledName)
 		{
 			return mangledName.StartsWith ("_T", StringComparison.Ordinal);
 		}

--- a/src/Swift.Bindings/src/Demangler/Swift5Demangler.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Demangler.cs
@@ -480,7 +480,7 @@ namespace BindingsGeneration.Demangling {
 		{
 			foreach (var nd in children)
 				if (nd == null)
-					throw new ArgumentOutOfRangeException (nameof (children));
+					throw new ArgumentOutOfRangeException (nameof (children), $"Error while demangling {this.originalIdentifier}");
 			var node = new Node (kind);
 			node.Children.AddRange (children);
 			return node;

--- a/src/Swift.Bindings/src/Model/SwiftFunction.cs
+++ b/src/Swift.Bindings/src/Model/SwiftFunction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics;
+using System.Text;
 
 namespace BindingsGeneration;
 
@@ -26,6 +27,11 @@ public class SwiftFunction {
     public required TupleTypeSpec ParameterList { get; init; }
 
     /// <summary>
+    /// Gets the generic parameters for this functions
+    /// </summary>
+    public List<TypeSpec> GenericParameters { get; private set; } = new List<TypeSpec> ();
+
+    /// <summary>
     /// Gets the return type of the function
     /// </summary>
     public required TypeSpec Return { get; init; }
@@ -39,10 +45,26 @@ public class SwiftFunction {
     {
         if (o is SwiftFunction other) {
             return Name == other.Name && Provenance.Equals (other.Provenance) &&
-                ParameterList.Equals (other.ParameterList) && Return.Equals (other.Return);
+                ParameterList.Equals (other.ParameterList) && Return.Equals (other.Return) && GenericsMatch (other.GenericParameters);
         } else {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Returns true if and only if the GenericParameters match the given list
+    /// </summary>
+    /// <param name="otherGenerics"></param>
+    /// <returns>true if the generic parameters match</returns>
+    bool GenericsMatch (List<TypeSpec> otherGenerics)
+    {
+        if (GenericParameters.Count != otherGenerics.Count)
+            return false;
+        for (var i = 0; i < GenericParameters.Count; i++) {
+            if (!GenericParameters [i].Equals (otherGenerics [i]))
+                return false;
+        }
+        return true;
     }
 
     /// <summary>
@@ -55,5 +77,12 @@ public class SwiftFunction {
     /// Returns a string representation of the function
     /// </summary>
     /// <returns>a string representation of the function</returns>
-    public override string ToString () => $"{Provenance}.{Name}{ParameterList} -> {Return}";
+    public override string ToString () => $"{Provenance}.{Name}{GenericParameterString ()}{ParameterList} -> {Return}";
+    string GenericParameterString ()
+    {
+        if (GenericParameters.Count == 0) return "";
+        var sb = new StringBuilder ();
+        sb.Append("<").AppendJoin (", ", GenericParameters).Append (">");
+        return sb.ToString ();
+    }
 }

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -28,8 +28,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestProtocolWitnessTable()
     {
         var symbol = "_$s20GenericTestFramework6ThingyCAA7StanleyAAWP";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var protoWitnessReduction = result as ProtocolWitnessTableReduction;
         Assert.NotNull(protoWitnessReduction);
         Assert.Equal("GenericTestFramework.Thingy", protoWitnessReduction.ImplementingType.Name);
@@ -40,8 +40,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestOtherProtocolWitnessTable()
     {
         var symbol = "_$s20GenericTestFramework6ThingyCAA8IsItRealAAWP";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var protoWitnessReduction = result as ProtocolWitnessTableReduction;
         Assert.NotNull(protoWitnessReduction);
         Assert.Equal("GenericTestFramework.Thingy", protoWitnessReduction.ImplementingType.Name);
@@ -52,8 +52,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestFailDemangleNonsense()
     {
         var symbol = "_$ThisIsJustGarbage";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var err = result as ReductionError;
         Assert.NotNull(err);
         Assert.Equal("No rule for node FirstElementMarker", err.Message);
@@ -63,8 +63,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestNestedProtocolWitnessTable()
     {
         var symbol = "_$s20GenericTestFramework3FooC6ThingyCAA8IsItRealAAWP";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var protoWitnessReduction = result as ProtocolWitnessTableReduction;
         Assert.NotNull(protoWitnessReduction);
         Assert.Equal("GenericTestFramework.Foo.Thingy", protoWitnessReduction.ImplementingType.Name);
@@ -75,8 +75,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestOtherProtocolConformanceDescriptor()
     {
         var symbol = "_$s10someclient14CSAgeableProxyCAA7AgeableAAMc";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var conf = result as ProtocolConformanceDescriptorReduction;
         Assert.NotNull(conf);
         Assert.Equal("someclient.CSAgeableProxy", conf.ImplementingType.Name);
@@ -88,8 +88,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestFuncWithTuple()
     {
         var symbol = "_$s17unitHelpFrawework10ReturnsInt3arg1cS2u1a_Si1bt_SitF";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var func = result as FunctionReduction;
         Assert.NotNull (func);
         Assert.Equal ("ReturnsInt", func.Function.Name);
@@ -113,8 +113,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestDispatchThunkFunc()
     {
         var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassC12identityFunc1aS2i_tFTj";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var thunk = result as DispatchThunkFunctionReduction;
         Assert.NotNull (thunk);
         var provenance = thunk.Function.Provenance;
@@ -131,8 +131,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestDispatchThunkFuncAllocator()
     {
         var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassCACycfCTj";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var thunk = result as DispatchThunkFunctionReduction;
         Assert.NotNull (thunk);
         var provenance = thunk.Function.Provenance;
@@ -149,8 +149,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestFuncNoArgs()
     {
         var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassC11returnSevenSiyF";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var func = result as FunctionReduction;
         Assert.NotNull (func);
         var provenance = func.Function.Provenance;
@@ -166,8 +166,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestFuncNoLabels()
     {
         var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassC22noPublicParameterNamesyS2i_SitF";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var func = result as FunctionReduction;
         Assert.NotNull (func);
         var provenance = func.Function.Provenance;
@@ -185,8 +185,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestFuncFewLabels()
     {
         var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassC23fewPublicParameterNames_1b_S2i_S2itF";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var func = result as FunctionReduction;
         Assert.NotNull (func);
         var provenance = func.Function.Provenance;
@@ -204,8 +204,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestMetadataAccessor()
     {
         var symbol = "_$s22GeneralHackingNonsense12ThisIsAClassCMa";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var metadataAccessor = result as MetadataAccessorReduction;
         Assert.NotNull (metadataAccessor);
         Assert.Equal ("GeneralHackingNonsense.ThisIsAClass", metadataAccessor.TypeSpec.Name);
@@ -216,8 +216,8 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestGenericMetadataAccessor()
     {
         var symbol = "_$s22GeneralHackingNonsense6DupletVMa";
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run ();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run (symbol);
         var metadataAccessor = result as MetadataAccessorReduction;
         Assert.NotNull (metadataAccessor);
         Assert.Equal ("GeneralHackingNonsense.Duplet", metadataAccessor.TypeSpec.Name);
@@ -227,10 +227,31 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
     public void TestUnknownEntry()
     {
         var symbol = "_$ss5print_9separator10terminatoryypd_S2StFfA0_"; // default argument initializer
-        var demangler = new Swift5Demangler (symbol);
-        var result = demangler.Run();
+        var demangler = new Swift5Demangler ();
+        var result = demangler.Run(symbol);
         var error = result as ReductionError;
         Assert.NotNull (error);
         Assert.Equal (ReductionErrorSeverity.Low, error.Severity);
-    }    
+    }
+
+    [Fact]
+    public void TestConformanceWithGeneric()
+    {
+        var symbol = "_$sSayxGSlsMc";
+        var result = new Swift5Demangler ().Run (symbol);
+        var proto = result as ProtocolConformanceDescriptorReduction;
+        Assert.NotNull (proto);
+        Assert.Equal ("Swift.Array<T_0_0>", proto.ImplementingType.ToString ());
+        Assert.Equal ("Swift.Collection", proto.ProtocolType.ToString ());
+    }
+
+    [Fact]
+    public void TestGenericWithAssociatedType ()
+    {
+        var symbol = "_$ss16IndexingIteratorV4next7ElementQzSgyF";
+        var result = new Swift5Demangler ().Run (symbol);
+        var func = result as FunctionReduction;
+        Assert.NotNull (func);
+        Assert.Equal ("Swift.IndexingIterator.next() -> Swift.Optional<T_0_0.Element>", func.Function.ToString ());
+    }
 }

--- a/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
+++ b/src/Swift.Bindings/tests/DemanglerTests/BasicDemanglingTests.cs
@@ -254,4 +254,14 @@ public class BasicDemanglingTests : IClassFixture<BasicDemanglingTests.TestFixtu
         Assert.NotNull (func);
         Assert.Equal ("Swift.IndexingIterator.next() -> Swift.Optional<T_0_0.Element>", func.Function.ToString ());
     }
+
+    [Fact]
+    public void TestThrowFunc ()
+    {
+        var symbol = "_$ss15withUnsafeBytes2of_q_x_q_SWKXEtKr0_lF";
+        var result = new Swift5Demangler ().Run (symbol);
+        var func = result as FunctionReduction;
+        Assert.NotNull (func);
+        Assert.Equal ("Swift.withUnsafeBytes<T_0_0, T_0_1>(of: T_0_0, (Swift.UnsafeRawBufferPointer) throws -> T_0_1) -> T_0_1", func.Function.ToString ());
+    }
 }

--- a/src/Swift.Bindings/tests/MachOTests/MachOTests.cs
+++ b/src/Swift.Bindings/tests/MachOTests/MachOTests.cs
@@ -76,6 +76,16 @@ namespace BindingsGeneration.Tests
                 var any = symbols.Any(sy => sy.IsPrivate);
                 Assert.False(any);
             }
+
+            [Fact]
+            public static void NoHighErrors()
+            {
+                var abis = MachO.GetArchitectures (_dylibPath);
+                var demanglingResults = DemanglingResults.FromFile (_dylibPath, abis[0]);
+                var highErrors = demanglingResults.Errors.Where (e => e.Severity == Demangling.ReductionErrorSeverity.High).ToArray ();
+                var any = demanglingResults.Errors.Any (err => err.Severity == Demangling.ReductionErrorSeverity.High);
+                Assert.False(any);
+            }
         }
     }
 }

--- a/src/Swift.Bindings/tests/MachOTests/MachOTests.cs
+++ b/src/Swift.Bindings/tests/MachOTests/MachOTests.cs
@@ -83,8 +83,8 @@ namespace BindingsGeneration.Tests
                 var abis = MachO.GetArchitectures (_dylibPath);
                 var demanglingResults = DemanglingResults.FromFile (_dylibPath, abis[0]);
                 var highErrors = demanglingResults.Errors.Where (e => e.Severity == Demangling.ReductionErrorSeverity.High).ToArray ();
-                var any = demanglingResults.Errors.Any (err => err.Severity == Demangling.ReductionErrorSeverity.High);
-                Assert.False(any);
+                var highError = demanglingResults.Errors.FirstOrDefault (err => err.Severity == Demangling.ReductionErrorSeverity.High);
+                Assert.True (highError is null, highError?.Message ?? "no error");
             }
         }
     }

--- a/src/Swift.Bindings/tests/MachOTests/MachOTests.cs
+++ b/src/Swift.Bindings/tests/MachOTests/MachOTests.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography.X509Certificates;
+using BindingsGeneration.Demangling;
 using Xamarin;
 using Xunit;
 
@@ -84,7 +85,14 @@ namespace BindingsGeneration.Tests
                 var demanglingResults = DemanglingResults.FromFile (_dylibPath, abis[0]);
                 var highErrors = demanglingResults.Errors.Where (e => e.Severity == Demangling.ReductionErrorSeverity.High).ToArray ();
                 var highError = demanglingResults.Errors.FirstOrDefault (err => err.Severity == Demangling.ReductionErrorSeverity.High);
-                Assert.True (highError is null, highError?.Message ?? "no error");
+                Assert.True (highError is null, HighErrorToMessage (highError));
+            }
+
+            static string HighErrorToMessage (ReductionError err)
+            {
+                if (err is null)
+                    return "no error";
+                return $"Symbol {err.Symbol} -> {err.Message}";
             }
         }
     }


### PR DESCRIPTION
There are 3 pieces to this PR to keep in mind.

The first is that I refactored the demangler itself so that `Run ()` now takes the symbol to demangle. This is good in that we don't need to throw away the demangler after every call to Run, which is once per symbol in the file. The is less good in that we need to keep in mind that the demangler is not thread safe so instances of the demangler should not be shared across threads.

The second is that I added a general class for holding demangling results along with factory methods for generating them. Since this process is potentially slow (let's say a few milliseconds per symbol and several hundred symbols to several thousand symbols per file), I added async flavors so this could be run in parallel to another early task (for example, parsing the abi.json file).

The third is that the first test that I wrote was to parse the entire test file turned up a few Nodes that we needed but had no reductions for.  The test file is by no means exhaustive in terms of nodes we will encounter in the wild, but it's more than the piecemeal tests that we had before.
As we move forward, we are going to encounter nodes that we need to handle. That's fine - fully expected. The thing to do under these circumstances is:
Write code to check for High severity errors in the DemanglingResults, take the symbols out of the errors and open issues with the symbols in the issue. That makes it easy to write unit tests around them and fix the issues faster.

One of the new Node types I encountered is a pointer to a generic parameter. In Swift these are presented as a depth and an index. The depth is how far away the parameter is from its call site. For example, a generic parameter declared in a function will always have depth 0 since it is at its declaration site. If you have something like this:
```swift
public struct Foo<T> {
    public func doSomething<U, V> (a: T, b: U, c: V) { }
}
```
Then in `doSomething`, U and V have a depth of 0 and T has a depth of 1.
Index is the position of the generic in the generic declaration. U has an index of 0 and V has an index of 1.

For the time being, I'm making the generic name be in the form `T_depth_index`, but I could see the value of making generic parameters be unpronounceable to make it easier to distinguish them in code. For example, they could be named in the form `#depth#index` or use some other character which is generally hostile to the language as along as its easy to identify and easy to parse. The goal would be to make it easy to write the following predicate:
```csharp
bool IsUnboundGeneric (NamedTypeSpec ns) { }
```