### PR TITLE
[RuntimeAsync] Add x86 support

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -434,13 +434,6 @@ void Async2Transformation::Transform(
         returnInGCData = varTypeIsGC(call->gtReturnType);
     }
 
-    if (returnSize > 0)
-    {
-        JITDUMP("  Will store return of type %s, size %u in %sGC data\n",
-                call->gtReturnType == TYP_STRUCT ? returnStructLayout->GetClassName() : varTypeName(call->gtReturnType),
-                returnSize, returnInGCData ? "" : "non-");
-    }
-
     assert((returnSize > 0) == (call->gtReturnType != TYP_VOID));
 
     // The return value is always stored:
@@ -457,9 +450,25 @@ void Async2Transformation::Transform(
     {
         returnValDataOffset = dataSize;
         dataSize += returnSize;
-
-        JITDUMP("  at offset %u\n", returnValDataOffset);
     }
+
+#ifdef DEBUG
+    if (returnSize > 0)
+    {
+        JITDUMP("  Will store return of type %s, size %u in",
+            call->gtReturnType == TYP_STRUCT ? returnStructLayout->GetClassName() : varTypeName(call->gtReturnType),
+            returnSize);
+
+        if (returnInGCData)
+        {
+            JITDUMP(" GC data\n");
+        }
+        else
+        {
+            JITDUMP(" non-GC data at offset %u\n", returnValDataOffset);
+        }
+    }
+#endif
 
     unsigned exceptionGCDataIndex = UINT_MAX;
     if (block->hasTryIndex())

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -192,6 +192,22 @@ PhaseStatus Async2Transformation::Run()
     m_objectClsHnd = m_comp->info.compCompHnd->getBuiltinClass(CLASSID_SYSTEM_OBJECT);
     m_byteClsHnd   = m_comp->info.compCompHnd->getBuiltinClass(CLASSID_SYSTEM_BYTE);
 
+#ifdef JIT32_GCENCODER
+    // Due to a hard cap on epilogs we need a shared return here.
+    m_sharedReturnBB = m_comp->fgNewBBafter(BBJ_RETURN, m_comp->fgLastBBInMainFunction(), false);
+    m_sharedReturnBB->bbSetRunRarely();
+    m_sharedReturnBB->clearTryIndex();
+    m_sharedReturnBB->clearHndIndex();
+
+    GenTree* continuation = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
+    GenTree* ret = m_comp->gtNewOperNode(GT_RETURN_SUSPEND, TYP_VOID, continuation);
+    LIR::AsRange(m_sharedReturnBB).InsertAtEnd(continuation, ret);
+
+    JITDUMP("Created shared return BB " FMT_BB "\n", m_sharedReturnBB->bbNum);
+
+    DISPRANGE(LIR::AsRange(m_sharedReturnBB));
+#endif
+
     if (m_comp->opts.OptimizationEnabled())
     {
         if (m_comp->m_dfsTree == nullptr)
@@ -543,15 +559,20 @@ void Async2Transformation::Transform(
         m_lastSuspensionBB = m_comp->fgLastBBInMainFunction();
     }
 
-    BasicBlock* retBB = m_comp->fgNewBBafter(BBJ_RETURN, m_lastSuspensionBB, false);
-    retBB->bbSetRunRarely();
-    retBB->clearTryIndex();
-    retBB->clearHndIndex();
-    m_lastSuspensionBB = retBB;
+    BasicBlock* suspendBB = m_comp->fgNewBBafter(BBJ_RETURN, m_lastSuspensionBB, false);
+    suspendBB->bbSetRunRarely();
+    suspendBB->clearTryIndex();
+    suspendBB->clearHndIndex();
+    m_lastSuspensionBB = suspendBB;
 
-    JITDUMP("  Created suspension " FMT_BB " for state %u\n", retBB->bbNum, stateNum);
+    if (m_sharedReturnBB != nullptr)
+    {
+        suspendBB->SetKindAndTargetEdge(BBJ_ALWAYS, m_comp->fgAddRefPred(m_sharedReturnBB, suspendBB));
+    }
 
-    FlowEdge* retBBEdge = m_comp->fgAddRefPred(retBB, block);
+    JITDUMP("  Created suspension " FMT_BB " for state %u\n", suspendBB->bbNum, stateNum);
+
+    FlowEdge* retBBEdge = m_comp->fgAddRefPred(suspendBB, block);
     block->SetCond(retBBEdge, block->GetTargetEdge());
 
     block->GetTrueEdge()->setLikelihood(RESUME_SUSPEND_LIKELIHOOD);
@@ -564,27 +585,27 @@ void Async2Transformation::Transform(
     GenTreeCall* allocContinuation = m_comp->gtNewHelperCallNode(CORINFO_HELP_ALLOC_CONTINUATION, TYP_REF,
                                                                  returnedContinuation, gcRefsCountNode, dataSizeNode);
 
-    m_comp->compCurBB = retBB;
+    m_comp->compCurBB = suspendBB;
     m_comp->fgMorphTree(allocContinuation);
 
-    LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, allocContinuation));
+    LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, allocContinuation));
 
     GenTree* storeNewContinuation = m_comp->gtNewStoreLclVarNode(m_newContinuationVar, allocContinuation);
-    LIR::AsRange(retBB).InsertAtEnd(storeNewContinuation);
+    LIR::AsRange(suspendBB).InsertAtEnd(storeNewContinuation);
 
     // Fill in 'Resume'
     GenTree* newContinuation = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
     unsigned resumeOffset    = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationResumeFldHnd);
     GenTree* resumeStubAddr  = CreateResumptionStubAddrTree();
     GenTree* storeResume     = StoreAtOffset(newContinuation, resumeOffset, resumeStubAddr);
-    LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, storeResume));
+    LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeResume));
 
     // Fill in 'state'
     newContinuation       = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
     unsigned stateOffset  = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationStateFldHnd);
     GenTree* stateNumNode = m_comp->gtNewIconNode((ssize_t)stateNum, TYP_INT);
     GenTree* storeState   = StoreAtOffset(newContinuation, stateOffset, stateNumNode);
-    LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, storeState));
+    LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeState));
 
     // Fill in 'flags'
     unsigned continuationFlags = 0;
@@ -599,7 +620,7 @@ void Async2Transformation::Transform(
     unsigned flagsOffset = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationFlagsFldHnd);
     GenTree* flagsNode   = m_comp->gtNewIconNode((ssize_t)continuationFlags, TYP_INT);
     GenTree* storeFlags  = StoreAtOffset(newContinuation, flagsOffset, flagsNode);
-    LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, storeFlags));
+    LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeFlags));
 
     // Fill in GC pointers
     if (gcRefsCount > 0)
@@ -610,7 +631,7 @@ void Async2Transformation::Transform(
         unsigned gcDataOffset = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationGCDataFldHnd);
         GenTree* gcDataInd    = LoadFromOffset(newContinuation, gcDataOffset, TYP_REF);
         GenTree* storeAllocedObjectArr = m_comp->gtNewStoreLclVarNode(objectArrLclNum, gcDataInd);
-        LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, storeAllocedObjectArr));
+        LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeAllocedObjectArr));
 
         for (LiveLocalInfo& inf : m_liveLocals)
         {
@@ -627,7 +648,7 @@ void Async2Transformation::Transform(
                 GenTree* store =
                     StoreAtOffset(objectArr, OFFSETOF__CORINFO_Array__data + (inf.GCDataIndex * TARGET_POINTER_SIZE),
                                   value);
-                LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
+                LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
             }
             else
             {
@@ -659,7 +680,7 @@ void Async2Transformation::Transform(
                     unsigned offset =
                         OFFSETOF__CORINFO_Array__data + ((inf.GCDataIndex + gcRefIndex) * TARGET_POINTER_SIZE);
                     GenTree* store = StoreAtOffset(objectArr, offset, value);
-                    LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
+                    LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
 
                     gcRefIndex++;
 
@@ -678,7 +699,7 @@ void Async2Transformation::Transform(
                             store = m_comp->gtNewStoreLclFldNode(inf.LclNum, TYP_REF, i * TARGET_POINTER_SIZE, null);
                         }
 
-                        LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
+                        LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
                     }
                 }
 
@@ -696,7 +717,7 @@ void Async2Transformation::Transform(
         unsigned dataOffset          = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationDataFldHnd);
         GenTree* dataInd             = LoadFromOffset(newContinuation, dataOffset, TYP_REF);
         GenTree* storeAllocedByteArr = m_comp->gtNewStoreLclVarNode(byteArrLclNum, dataInd);
-        LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, storeAllocedByteArr));
+        LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeAllocedByteArr));
 
         if (m_comp->doesMethodHavePatchpoints() || m_comp->opts.IsOSR())
         {
@@ -709,7 +730,7 @@ void Async2Transformation::Transform(
             GenTree* byteArr               = m_comp->gtNewLclvNode(byteArrLclNum, TYP_REF);
             unsigned offset                = OFFSETOF__CORINFO_Array__data;
             GenTree* storePatchpointOffset = StoreAtOffset(byteArr, offset, ilOffsetToStore);
-            LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, storePatchpointOffset));
+            LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storePatchpointOffset));
         }
 
         // Fill in data
@@ -751,13 +772,16 @@ void Async2Transformation::Transform(
                 store = StoreAtOffset(byteArr, offset, value);
             }
 
-            LIR::AsRange(retBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
+            LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
         }
     }
 
-    newContinuation = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
-    GenTree* ret    = m_comp->gtNewOperNode(GT_RETURN_SUSPEND, TYP_VOID, newContinuation);
-    LIR::AsRange(retBB).InsertAtEnd(newContinuation, ret);
+    if (suspendBB->KindIs(BBJ_RETURN))
+    {
+        newContinuation = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
+        GenTree* ret = m_comp->gtNewOperNode(GT_RETURN_SUSPEND, TYP_VOID, newContinuation);
+        LIR::AsRange(suspendBB).InsertAtEnd(newContinuation, ret);
+    }
 
     if (m_lastResumptionBB == nullptr)
     {

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -32,6 +32,7 @@ class Async2Transformation
     unsigned                      m_exceptionVar            = BAD_VAR_NUM;
     BasicBlock*                   m_lastSuspensionBB        = nullptr;
     BasicBlock*                   m_lastResumptionBB        = nullptr;
+    BasicBlock* m_sharedReturnBB                            = nullptr;
 
     void LiftLIREdges(BasicBlock*                    block,
                       GenTree*                       beyond,

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -494,6 +494,7 @@ void BasicBlock::dspFlags() const
         {BBF_HAS_ALIGN, "has-align"},
         {BBF_HAS_MDARRAYREF, "mdarr"},
         {BBF_NEEDS_GCPOLL, "gcpoll"},
+        {BBF_ASYNC_RESUMPTION, "resume"},
     };
 
     bool first = true;
@@ -508,10 +509,6 @@ void BasicBlock::dspFlags() const
             printf("%s", bbFlagDisplay[i].displayString);
             first = false;
         }
-    }
-    if (bbFlags & BBF_ASYNC_RESUMPTION)
-    {
-        printf("resume ");
     }
 }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2420,7 +2420,18 @@ PhaseStatus Compiler::fgAddInternal()
         }
         else
         {
-            merger.SetMaxReturns(MergedReturns::ReturnCountHardLimit);
+            unsigned limit = MergedReturns::ReturnCountHardLimit;
+#ifdef JIT32_GCENCODER
+            // For the jit32 GC encoder the limit is an actual hard limit. In
+            // async2 functions we will be introducing another return during
+            // the async2 transformation, so make sure there's a free epilog
+            // for it.
+            if (compIsAsync2())
+            {
+                limit--;
+            }
+#endif
+            merger.SetMaxReturns(limit);
         }
     }
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1499,7 +1499,10 @@ void Compiler::lvaInitAsyncContinuation(InitVarDscInfo* varDscInfo)
     lvaAsyncContinuationArg = varDscInfo->varNum;
     LclVarDsc* varDsc       = varDscInfo->varDsc;
     varDsc->lvType          = TYP_REF;
-    varDsc->lvIsParam       = 1;
+    varDsc->lvIsParam       = true;
+
+     // The final home for this incoming register might be our local stack frame
+    varDsc->lvOnFrame = true;
 
 #ifdef DEBUG
     varDsc->lvReason = "Async continuation arg";
@@ -1514,7 +1517,6 @@ void Compiler::lvaInitAsyncContinuation(InitVarDscInfo* varDscInfo)
 #if FEATURE_MULTIREG_ARGS
         varDsc->SetOtherArgReg(REG_NA);
 #endif
-        varDsc->lvOnFrame = true; // The final home for this incoming register might be our local stack frame
 
         varDscInfo->intRegArgNum++;
 

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -436,7 +436,11 @@ struct HijackArgs
     DWORD Esi;
     DWORD Ebx;
     DWORD Edx;
-    DWORD Ecx;
+    union
+    {
+        DWORD Ecx;
+        size_t AsyncRet;
+    };
     union
     {
         DWORD Eax;

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -2644,7 +2644,7 @@ HCIMPL1(void, IL_ThrowExact, Object* obj)
     OBJECTREF oref = ObjectToOBJECTREF(obj);
 
 #if defined(_DEBUG) && defined(TARGET_X86)
-    __helperframe.InsureInit(false, NULL);
+    __helperframe.InsureInit(NULL);
     g_ExceptionEIP = (LPVOID)__helperframe.GetReturnAddress();
 #endif // defined(_DEBUG) && defined(TARGET_X86)
 
@@ -3927,6 +3927,15 @@ HCIMPL1(VOID, JIT_PartialCompilationPatchpoint, int ilOffset)
     UNREACHABLE();
 }
 HCIMPLEND
+
+void JIT_ResumeOSR(unsigned ilOffset)
+{
+    // Stub version if OSR feature is disabled
+    //
+    // Should not be called.
+
+    UNREACHABLE();
+}
 
 #endif // FEATURE_ON_STACK_REPLACEMENT
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14514,12 +14514,16 @@ CORINFO_METHOD_HANDLE CEEJitInfo::getAsyncResumptionStub()
     NativeCodeVersion ncv = config->GetCodeVersion();
     if (ncv.GetOptimizationTier() == NativeCodeVersion::OptimizationTier1OSR)
     {
+#ifdef FEATURE_ON_STACK_REPLACEMENT
         // The OSR version needs to resume in the tier0 version. The tier0
         // version will handle setting up the frame that the OSR version
         // expects and then delegating back into the OSR version (knowing to do
         // so through information stored in the continuation).
         _ASSERTE(m_pPatchpointInfoFromRuntime != NULL);
         pCode->EmitLDC((DWORD_PTR)m_pPatchpointInfoFromRuntime->GetTier0EntryPoint());
+#else
+        _ASSERTE(!"Unexpected optimization tier with OSR disabled");
+#endif
     }
     else
     {

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2639,8 +2639,7 @@ void MethodDesc::CreateDerivedTargetSigWithExtraParams(MetaSig& msig, SigBuilder
     stubSigBuilder->AppendByte(callingConvention);
 
     unsigned numArgs = msig.NumFixedArgs();
-    bool hasInstParam = msig.HasGenericContextArg() != FALSE;
-    if (hasInstParam)
+    if (msig.HasGenericContextArg())
         numArgs++;
     if (msig.HasAsyncContinuation())
         numArgs++;
@@ -2652,7 +2651,7 @@ void MethodDesc::CreateDerivedTargetSigWithExtraParams(MetaSig& msig, SigBuilder
     pReturn.ConvertToInternalExactlyOne(msig.GetModule(), msig.GetSigTypeContext(), stubSigBuilder);
 
 #ifndef TARGET_X86
-    if (hasInstParam)
+    if (msig.HasGenericContextArg())
     {
         // The hidden context parameter
         stubSigBuilder->AppendElementType(ELEMENT_TYPE_I);
@@ -2673,13 +2672,13 @@ void MethodDesc::CreateDerivedTargetSigWithExtraParams(MetaSig& msig, SigBuilder
     }
 
 #ifdef TARGET_X86
-    if (hasInstParam)
+    if (msig.HasGenericContextArg())
     {
         // The hidden context parameter
         stubSigBuilder->AppendElementType(ELEMENT_TYPE_I);
     }
 
-    if (hasAsyncCont)
+    if (msig.HasAsyncContinuation())
     {
         stubSigBuilder->AppendElementType(ELEMENT_TYPE_OBJECT);
     }


### PR DESCRIPTION
This PR makes all our async2 tests pass on win-x86. The main thing needed is that the JIT32 GC encoder has a hard limit on 4 epilogs, so the JIT needs to share suspension epilogs, and also needs to ensure we have at most 3 other normal epilogs when we get to the async2 transformation.

Contributes to #2764