### PR TITLE
[NativeAOT-LLVM] only require EMSDK when building for browser

### DIFF
--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -349,9 +349,11 @@ for /f "delims=" %%a in ("-%__RequestedBuildComponents%-") do (
         set __CMakeTarget=!__CMakeTarget! nativeaot
 
         if "%__TargetArch%"=="wasm" (
-            if not defined EMSDK (
-                echo %__ErrMsgPrefix%%__MsgPrefix%Error: The EMSDK environment variable pointing to emsdk root must be set.
-                goto ExitWithError
+            if "%__TargetOS%"=="browser" (
+                if not defined EMSDK (
+                    echo %__ErrMsgPrefix%%__MsgPrefix%Error: The EMSDK environment variable pointing to emsdk root must be set.
+                    goto ExitWithError
+                )
             )
         )
     )

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -347,15 +347,6 @@ for /f "delims=" %%a in ("-%__RequestedBuildComponents%-") do (
     )
     if not "!string:-nativeaot-=!"=="!string!" (
         set __CMakeTarget=!__CMakeTarget! nativeaot
-
-        if "%__TargetArch%"=="wasm" (
-            if "%__TargetOS%"=="browser" (
-                if not defined EMSDK (
-                    echo %__ErrMsgPrefix%%__MsgPrefix%Error: The EMSDK environment variable pointing to emsdk root must be set.
-                    goto ExitWithError
-                )
-            )
-        )
     )
     if not "!string:-spmi-=!"=="!string!" (
         set __CMakeTarget=!__CMakeTarget! spmi


### PR DESCRIPTION
The WASI build no longer requires EMSDK.