### PR TITLE
[NativeAOT-LLVM] ignore `-Wdeprecated-declarations` in llvmlssa.cpp

### DIFF
--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -1639,6 +1639,7 @@ private:
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-security"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif // __clang__
             if (pBuffer == nullptr)
             {


### PR DESCRIPTION
This fixes the build on MacOS.