### PR TITLE
awaits of Task-returning methods from async2 are done as thunk calls.

### DIFF
--- a/buildroslynnugets.cmd
+++ b/buildroslynnugets.cmd
@@ -1,7 +1,7 @@
 setlocal ENABLEEXTENSIONS
 pushd %~dp0
-set ASYNC_ROSLYN_COMMIT=8bb20e76b6d7e041a2cd0a3152d95fdff6578050
-set ASYNC_SUFFIX=async-9
+set ASYNC_ROSLYN_COMMIT=fa251ef06afcc9d1c79761a112b89c6341c0ccfa
+set ASYNC_SUFFIX=async-10
 set ASYNC_ROSLYN_BRANCH=demos/async2-experiment1
 
 cd ..

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,9 +43,9 @@
       Any tools that contribute to the design-time experience should use the MicrosoftCodeAnalysisVersion_LatestVS property above to ensure
       they do not break the local dev experience.
     -->
-    <MicrosoftCodeAnalysisCSharpVersion>4.13.0-async-9</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisVersion>4.13.0-async-9</MicrosoftCodeAnalysisVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.13.0-async-9</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.13.0-async-10</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisVersion>4.13.0-async-10</MicrosoftCodeAnalysisVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.13.0-async-10</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <!--
     For source generator support we need to target multiple versions of Roslyn in order to be able to run on older versions of Roslyn.

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -346,10 +346,15 @@ DEFINE_METHOD(TASK, FROM_EXCEPTION, FromException, SM_Exception_RetTask)
 DEFINE_METHOD(TASK, FROM_EXCEPTION_1, FromException, GM_Exception_RetTaskOfT)
 DEFINE_METHOD(TASK, FROM_RESULT_T, FromResult, GM_T_RetTaskOfT)
 DEFINE_METHOD(TASK, GET_COMPLETED_TASK, get_CompletedTask, SM_RetTask)
+DEFINE_METHOD(TASK, GET_AWAITER, GetAwaiter, NoSig)
 
 DEFINE_CLASS(TASK_AWAITER_1, CompilerServices, TaskAwaiter`1)
 DEFINE_METHOD(TASK_AWAITER_1, GET_ISCOMPLETED, get_IsCompleted, NoSig)
 DEFINE_METHOD(TASK_AWAITER_1, GET_RESULT, GetResult, NoSig)
+
+DEFINE_CLASS(TASK_AWAITER, CompilerServices, TaskAwaiter)
+DEFINE_METHOD(TASK_AWAITER, GET_ISCOMPLETED, get_IsCompleted, NoSig)
+DEFINE_METHOD(TASK_AWAITER, GET_RESULT, GetResult, NoSig)
 
 DEFINE_CLASS(TYPE_HANDLE,           System,                 RuntimeTypeHandle)
 DEFINE_CLASS(RT_TYPE_HANDLE,        System,                 RuntimeTypeHandle)

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1996,6 +1996,8 @@ private:
     void EmitAsync2MethodThunk(MethodDesc* pAsyncOtherVariant, MetaSig& msig, ILStubLinker* pSL);
     SigPointer GetAsync2ThunkResultTypeSig();
     int GetTokenForGenericMethodCallWithAsyncReturnType(ILCodeStream* pCode, MethodDesc* md);
+    int GetTokenForGenericTypeMethodCallWithAsyncReturnType(ILCodeStream* pCode, MethodDesc* md);
+    int GetTokenForAwaitAwaiterInstantiatedOverTaskAwaiterType(ILCodeStream* pCode, TypeHandle taskAwaiterType);
 public:
     static void CreateDerivedTargetSigWithExtraParams(MetaSig& msig, SigBuilder* stubSigBuilder);
     bool TryGenerateTransientILImplementation(DynamicResolver** resolver, COR_ILMETHOD_DECODER** methodILDecoder);

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1828,7 +1828,7 @@ public:
             return false;
         auto asyncType = GetAddrOfAsyncMethodData()->type;
 
-        return asyncType == AsyncMethodType::Async;
+        return asyncType == AsyncMethodType::Async || asyncType == AsyncMethodType::AsyncToTask;
     }
 
     inline bool RequiresAsyncContinuationArg()

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2027,7 +2027,7 @@ void MethodDesc::EmitJitStateMachineBasedRuntimeAsyncThunk(MethodDesc* pAsyncOth
 // (MVAR 0). For Task<int>, it returns the signature representing (int).
 SigPointer MethodDesc::GetAsync2ThunkResultTypeSig()
 {
-    _ASSERTE(GetAsyncMethodData().type == AsyncMethodType::TaskToAsync);
+    _ASSERTE(GetAsyncMethodData().type == AsyncMethodType::TaskToAsync || GetAsyncMethodData().type == AsyncMethodType::AsyncToTask);
     PCCOR_SIGNATURE pSigRaw;
     DWORD cSig;
     if (FAILED(GetMDImport()->GetSigOfMethodDef(GetMemberDef(), &cSig, &pSigRaw)))
@@ -2098,16 +2098,54 @@ int MethodDesc::GetTokenForGenericMethodCallWithAsyncReturnType(ILCodeStream* pC
     return pCode->GetToken(md, mdTokenNil, methodSigToken);
 }
 
+// Given a method Bar<T>.Foo, return a MethodSpec token for Bar<T>.Foo
+// instantiated with the result type from the current async method's return
+// type. For example, if "this" represents async2 Task<List<T>> Foo<T>(), and
+// "md" is TaskAwaiter<T>.GetResult(), this returns a MethodSpec representing
+// TaskAwaiter<List<T>>.GetResult().
+int MethodDesc::GetTokenForGenericTypeMethodCallWithAsyncReturnType(ILCodeStream* pCode, MethodDesc* md)
+{
+    if (!md->HasClassOrMethodInstantiation())
+    {
+        return pCode->GetToken(md);
+    }
+
+    // We never get here with a method instantiation currently.
+    _ASSERTE(!md->HasMethodInstantiation());
+
+    SigBuilder typeSigBuilder;
+    typeSigBuilder.AppendData(ELEMENT_TYPE_GENERICINST);
+    typeSigBuilder.AppendData(ELEMENT_TYPE_INTERNAL);
+    // TODO: Encoding potentially shared method tables in
+    // signatures of tokens seems odd, but this hits assert
+    // with the typical method table.
+    typeSigBuilder.AppendPointer(md->GetMethodTable());
+    typeSigBuilder.AppendData(1);
+
+    SigPointer retTypeSig = GetAsync2ThunkResultTypeSig();
+    PCCOR_SIGNATURE retTypeSigRaw;
+    uint32_t retTypeSigLen;
+    retTypeSig.GetSignature(&retTypeSigRaw, &retTypeSigLen);
+
+    typeSigBuilder.AppendBlob((const PVOID)retTypeSigRaw, retTypeSigLen);
+
+    DWORD typeSigLen;
+    PCCOR_SIGNATURE typeSig = (PCCOR_SIGNATURE)typeSigBuilder.GetSignature(&typeSigLen);
+    int typeSigToken = pCode->GetSigToken(typeSig, typeSigLen);
+
+    return pCode->GetToken(md, typeSigToken);
+}
+
 void MethodDesc::EmitAsync2MethodThunk(MethodDesc* pAsyncOtherVariant, MetaSig& msig, ILStubLinker* pSL)
 {
     // Implement IL that is effectively the following
     /*
     {
-        var awaiter = Thunk(arg).GetAwaiter();
+        TaskAwaiter<RetType> awaiter = Thunk(arg).GetAwaiter();
         if (!awaiter.IsCompleted)
         {
             // Magic function which will suspend the current run of async methods
-            RuntimeHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<AwaiterType>(awaiter);
+            RuntimeHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<TaskAwaiter<RetType>>(awaiter);
         }
         return awaiter.GetResult();
     }
@@ -2140,7 +2178,7 @@ void MethodDesc::EmitAsync2MethodThunk(MethodDesc* pAsyncOtherVariant, MetaSig& 
         mdIsCompleted = CoreLibBinder::GetMethod(METHOD__TASK_AWAITER_1__GET_ISCOMPLETED);
         mdIsCompleted = thTaskAwaiter.GetMethodTable()->GetParallelMethodDesc(mdIsCompleted);
         mdGetResult = CoreLibBinder::GetMethod(METHOD__TASK_AWAITER_1__GET_RESULT);
-        mdIsCompleted = thTaskAwaiter.GetMethodTable()->GetParallelMethodDesc(mdGetResult);
+        mdGetResult = thTaskAwaiter.GetMethodTable()->GetParallelMethodDesc(mdGetResult);
     }
 
     DWORD localArg = 0;
@@ -2214,24 +2252,72 @@ void MethodDesc::EmitAsync2MethodThunk(MethodDesc* pAsyncOtherVariant, MetaSig& 
     }
 
     pCode->EmitCALL(token, localArg, 1);
-    pCode->EmitCALLVIRT(pCode->GetToken(mdGetAwaiter), 1, 1);
+
+    int getAwaiterToken;
+    int getIsCompletedToken;
+    int getResultToken;
+    if (!msig.IsReturnTypeVoid())
+    {
+        getAwaiterToken = GetTokenForGenericTypeMethodCallWithAsyncReturnType(pCode, mdGetAwaiter);
+        getIsCompletedToken = GetTokenForGenericTypeMethodCallWithAsyncReturnType(pCode, mdIsCompleted);
+        getResultToken = GetTokenForGenericTypeMethodCallWithAsyncReturnType(pCode, mdGetResult);
+    }
+    else 
+    {
+        getAwaiterToken = pCode->GetToken(mdGetAwaiter);
+        getIsCompletedToken = pCode->GetToken(mdIsCompleted);
+        getResultToken = pCode->GetToken(mdGetResult);
+    }
+
+    pCode->EmitCALLVIRT(getAwaiterToken, 1, 1);
     pCode->EmitSTLOC(awaiterLocal);
     pCode->EmitLDLOCA(awaiterLocal);
-    pCode->EmitCALL(pCode->GetToken(mdIsCompleted), 1, 1);
+    pCode->EmitCALL(getIsCompletedToken, 1, 1);
     pCode->EmitBRTRUE(pGetResultLabel);
     pCode->EmitLDLOC(awaiterLocal);
-    MethodDesc* pMagicAwaitFunc = CoreLibBinder::GetMethod(METHOD__RUNTIME_HELPERS__UNSAFE_AWAIT_AWAITER_FROM_RUNTIME_ASYNC_1);
-    TypeHandle thInstantiations[]{ thTaskAwaiter };
 
-    pMagicAwaitFunc = FindOrCreateAssociatedMethodDesc(pMagicAwaitFunc, pMagicAwaitFunc->GetMethodTable(), FALSE, Instantiation(thInstantiations, 1), FALSE);
-
-    pCode->EmitCALL(pCode->GetToken(pMagicAwaitFunc), 1, 0);
+    int awaitAwaiterToken = GetTokenForAwaitAwaiterInstantiatedOverTaskAwaiterType(pCode, thTaskAwaiter);
+    pCode->EmitCALL(awaitAwaiterToken, 1, 0);
     pCode->EmitLabel(pGetResultLabel);
 
     pCode->EmitLDLOCA(awaiterLocal);
-    pCode->EmitCALL(pCode->GetToken(mdGetResult), 1, mdGetResult->IsVoid() ? 0: 1);
+    pCode->EmitCALL(getResultToken, 1, mdGetResult->IsVoid() ? 0 : 1);
 
     pCode->EmitRET();
+}
+
+// Get a token for RuntimeHelpers.UnsafeAwaitAwaiterFromRuntimeAsync<TaskAwaiter<T>>()
+// with T substituted by the return type of the async method.
+int MethodDesc::GetTokenForAwaitAwaiterInstantiatedOverTaskAwaiterType(ILCodeStream* pCode, TypeHandle taskAwaiterType)
+{
+    MethodDesc* awaitAwaiter = CoreLibBinder::GetMethod(METHOD__RUNTIME_HELPERS__UNSAFE_AWAIT_AWAITER_FROM_RUNTIME_ASYNC_1);
+    TypeHandle thInstantiations[]{ taskAwaiterType };
+    awaitAwaiter = FindOrCreateAssociatedMethodDesc(awaitAwaiter, awaitAwaiter->GetMethodTable(), FALSE, Instantiation(thInstantiations, 1), FALSE);
+
+    if (!taskAwaiterType.IsSharedByGenericInstantiations())
+    {
+        return pCode->GetToken(awaitAwaiter);
+    }
+
+    SigBuilder methodSigBuilder;
+    methodSigBuilder.AppendByte(IMAGE_CEE_CS_CALLCONV_GENERICINST);
+    methodSigBuilder.AppendData(1);
+    SigPointer retTypeSig = GetAsync2ThunkResultTypeSig();
+    PCCOR_SIGNATURE retTypeSigRaw;
+    uint32_t retTypeSigLen;
+    retTypeSig.GetSignature(&retTypeSigRaw, &retTypeSigLen);
+
+    methodSigBuilder.AppendElementType(ELEMENT_TYPE_GENERICINST);
+    methodSigBuilder.AppendElementType(ELEMENT_TYPE_INTERNAL);
+    methodSigBuilder.AppendPointer(taskAwaiterType.GetMethodTable());
+    methodSigBuilder.AppendData(1);
+    methodSigBuilder.AppendBlob((const PVOID)retTypeSigRaw, retTypeSigLen);
+
+    DWORD methodSigLen;
+    PCCOR_SIGNATURE methodSig = (PCCOR_SIGNATURE)methodSigBuilder.GetSignature(&methodSigLen);
+    int methodSigToken = pCode->GetSigToken(methodSig, methodSigLen);
+
+    return pCode->GetToken(awaitAwaiter, mdTokenNil, methodSigToken);
 }
 
 bool MethodDesc::TryGenerateUnsafeAccessor(DynamicResolver** resolver, COR_ILMETHOD_DECODER** methodILDecoder)


### PR DESCRIPTION
Two changes here:

* bump the Roslyn reference to a version that emits awaits to Task-returning methods as async2 thunk calls when the caller is an async2 method
I.E - regardless if the calee is an actual async2 method or just something that returns Task/ValueTask, compiler emits a call to an async2 method (actual or a thunk).  
This way the calee can swap back and forth between async1 and async2 without binary-breaking the call.

awaits of custom task-like things, which are not Task/ValueTask are still emitted as GetAwaiter+etc pattern.

* tried to fix the a2->a1 thunks at least enough to pass tests.  (incomplete)
