### PR TITLE
[NativeAOT-LLVM] Add WasmExternalDwarf property to create an external_debug_info section

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -107,8 +107,8 @@
     <Delete Files="$(PublishDir)\$(TargetName).wasm" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName).wasm" DestinationFolder="$(PublishDir)" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
 
-    <Delete Files="$(PublishDir)\$(TargetName).wasm.debug.wasm" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
-    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).wasm.debug.wasm" DestinationFolder="$(PublishDir)" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
+    <Delete Files="$(PublishDir)\$(TargetName).debug.wasm" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
+    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).debug.wasm" DestinationFolder="$(PublishDir)" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
 
     <ItemGroup>
       <_FilesToCopyToNative Include="$(NativeOutputPath)\dotnet.native.js" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -106,7 +106,10 @@
 
     <Delete Files="$(PublishDir)\$(TargetName).wasm" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName).wasm" DestinationFolder="$(PublishDir)" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
-    
+
+    <Delete Files="$(PublishDir)\$(TargetName).wasm.debug.wasm" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
+    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).wasm.debug.wasm" DestinationFolder="$(PublishDir)" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
+
     <ItemGroup>
       <_FilesToCopyToNative Include="$(NativeOutputPath)\dotnet.native.js" />
       <_FilesToCopyToNative Include="$(NativeOutputPath)\dotnet.native.wasm" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -107,8 +107,8 @@
     <Delete Files="$(PublishDir)\$(TargetName).wasm" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
     <Copy SourceFiles="$(NativeOutputPath)$(TargetName).wasm" DestinationFolder="$(PublishDir)" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
 
-    <Delete Files="$(PublishDir)\$(TargetName).debug.wasm" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
-    <Copy SourceFiles="$(NativeOutputPath)$(TargetName).debug.wasm" DestinationFolder="$(PublishDir)" Condition="'$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'"/>
+    <Delete Files="$(PublishDir)\$(TargetName).debug.wasm" Condition="'$(_targetOS)' == 'browser'"/>
+    <Copy SourceFiles="$(WasmSymbolFile)" DestinationFolder="$(PublishDir)" Condition="'$(_targetOS)' == 'browser' and Exists('$(WasmSymbolFile)')"/>
 
     <ItemGroup>
       <_FilesToCopyToNative Include="$(NativeOutputPath)\dotnet.native.js" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -579,7 +579,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- see https://github.com/emscripten-core/emscripten/issues/16836 for the issue that means we have to force the linker to include these symbols before LTO -->
       <!--<CustomLinkerArg Condition="'$(Optimize)' != 'true'" Include="$(WasmOptimizationSetting) -flto" /> -->
       <CustomLinkerArg Condition="'$(IlcLlvmTarget)' != ''" Include="-target $(IlcLlvmTarget)" />
-	    <CustomLinkerArg Condition="'$(StripSymbols)' == 'true'" Include="-gseparate-dwarf=&quot;$(WasmSymbolFile)&quot;" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(_targetOS)' == 'browser'" >
@@ -592,6 +591,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-s TOTAL_STACK=$(IlcWasmStackSize)" />
       <CustomLinkerArg Condition="'$(WasmEnableJSBigIntIntegration)' == 'true'" Include="-s WASM_BIGINT=1" />
       <CustomLinkerArg Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'" Include="-s DISABLE_EXCEPTION_CATCHING=0" />
+	    <CustomLinkerArg Condition="'$(StripSymbols)' == 'true'" Include="-gseparate-dwarf=&quot;$(WasmSymbolFile)&quot;" />
 
       <CustomLinkerArg Include="$(EmccFlags)" />
       <CustomLinkerArg Include="-s MAXIMUM_MEMORY=$(EmccMaximumHeapSize)" Condition="'$(EmccMaximumHeapSize)' != ''" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -390,11 +390,9 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup>
       <LlvmObjects Include="@(_IlcProducedFiles)" Condition="'%(Extension)' == '$(LlvmObjectExt)'">
         <NativeObject>%(RelativeDir)%(Filename)$(NativeObjectExt)</NativeObject>
-        <DwarfObject>&quot;%(RelativeDir)%(Filename).dwo&quot;</DwarfObject>
       </LlvmObjects>
       <NativeObjects Include="@(_IlcProducedFiles)" Condition="'%(Extension)' == '$(NativeObjectExt)'" />
       <NativeObjects Include="@(LlvmObjects->'%(NativeObject)')" />
-      <DwarfObjects Include="@(LlvmObjects->'%(DwarfObject)')" />
     </ItemGroup>
   </Target>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -100,7 +100,6 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <NativeObject>$(NativeIntermediateOutputPath)$(TargetName)$(NativeObjectExt)</NativeObject>
     <NativeBinary Condition="'$(NativeBinary)' == ''">$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)</NativeBinary>
-    <WasmBinary Condition="'$(_targetArchitecture)' == 'wasm'">$(NativeOutputPath)$(TargetName).wasm</WasmBinary>
     <IlcExportUnmanagedEntrypoints Condition="'$(IlcExportUnmanagedEntrypoints)' == '' and '$(NativeLib)' == 'Shared'">true</IlcExportUnmanagedEntrypoints>
     <ExportsFile Condition="$(ExportsFile) == '' and '$(BuildingFrameworkLibrary)' != 'true'">$(NativeIntermediateOutputPath)$(TargetName)$(ExportsFileExt)</ExportsFile>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -35,7 +35,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     <IlcTreatWarningsAsErrors Condition="'$(IlcTreatWarningsAsErrors)' == ''">$(TreatWarningsAsErrors)</IlcTreatWarningsAsErrors>
     <_IsiOSLikePlatform Condition="'$(_targetOS)' == 'maccatalyst' or $(_targetOS.StartsWith('ios')) or $(_targetOS.StartsWith('tvos'))">true</_IsiOSLikePlatform>
     <_IsApplePlatform Condition="'$(_targetOS)' == 'osx' or '$(_IsiOSLikePlatform)' == 'true'">true</_IsApplePlatform>
-    <WasmExternalDwarf Condition="'$(WasmExternalDwarf)' == ''and '$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'">true</WasmExternalDwarf>
   </PropertyGroup>
 
   <!-- Set up default feature switches -->
@@ -443,8 +442,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <WasmCompilerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)bin/clang++&quot;</WasmCompilerPath>
       <WasmLinkerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/emscripten/emcc$(EmccScriptExt)&quot;</WasmLinkerPath>
       <WasmLinkerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)emscripten/emcc$(EmccScriptExt)&quot;</WasmLinkerPath>
-      <WasmDwarfLinkerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/bin/llvm-dwp$(ExeExt)&quot;</WasmDwarfLinkerPath>
-      <WasmDwarfLinkerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)/bin/llvm-dwp$(ExeExt)&quot;</WasmDwarfLinkerPath>
     </PropertyGroup>
 
    <PropertyGroup Condition="'$(_targetOS)' == 'wasi'">
@@ -543,6 +540,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <PropertyGroup>
       <IlcIsLibLikeApp Condition="'$(IlcIsLibLikeApp)' == '' and ('$(NativeLib)' != '' or '$(CustomNativeMain)' != '')">true</IlcIsLibLikeApp>
+      <WasmSymbolFile>$([System.IO.Path]::ChangeExtension('$(NativeBinary)', '.debug.wasm'))</WasmSymbolFile>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(InvariantGlobalization)' != 'true'">
@@ -581,8 +579,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- see https://github.com/emscripten-core/emscripten/issues/16836 for the issue that means we have to force the linker to include these symbols before LTO -->
       <!--<CustomLinkerArg Condition="'$(Optimize)' != 'true'" Include="$(WasmOptimizationSetting) -flto" /> -->
       <CustomLinkerArg Condition="'$(IlcLlvmTarget)' != ''" Include="-target $(IlcLlvmTarget)" />
-
-	    <CustomLinkerArg Condition="'$(WasmExternalDwarf)' == 'true'" Include="-gseparate-dwarf" />
+	    <CustomLinkerArg Condition="'$(StripSymbols)' == 'true'" Include="-gseparate-dwarf=&quot;$(WasmSymbolFile)&quot;" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(_targetOS)' == 'browser'" >

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -35,6 +35,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <IlcTreatWarningsAsErrors Condition="'$(IlcTreatWarningsAsErrors)' == ''">$(TreatWarningsAsErrors)</IlcTreatWarningsAsErrors>
     <_IsiOSLikePlatform Condition="'$(_targetOS)' == 'maccatalyst' or $(_targetOS.StartsWith('ios')) or $(_targetOS.StartsWith('tvos'))">true</_IsiOSLikePlatform>
     <_IsApplePlatform Condition="'$(_targetOS)' == 'osx' or '$(_IsiOSLikePlatform)' == 'true'">true</_IsApplePlatform>
+    <WasmExternalDwarf Condition="'$(WasmExternalDwarf)' == ''and '$(_targetOS)' == 'browser' and '$(DotNetJsApi)' != 'true'">true</WasmExternalDwarf>
   </PropertyGroup>
 
   <!-- Set up default feature switches -->
@@ -100,6 +101,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <NativeObject>$(NativeIntermediateOutputPath)$(TargetName)$(NativeObjectExt)</NativeObject>
     <NativeBinary Condition="'$(NativeBinary)' == ''">$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)</NativeBinary>
+    <WasmBinary Condition="'$(_targetArchitecture)' == 'wasm'">$(NativeOutputPath)$(TargetName).wasm</WasmBinary>
     <IlcExportUnmanagedEntrypoints Condition="'$(IlcExportUnmanagedEntrypoints)' == '' and '$(NativeLib)' == 'Shared'">true</IlcExportUnmanagedEntrypoints>
     <ExportsFile Condition="$(ExportsFile) == '' and '$(BuildingFrameworkLibrary)' != 'true'">$(NativeIntermediateOutputPath)$(TargetName)$(ExportsFileExt)</ExportsFile>
 
@@ -390,9 +392,11 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup>
       <LlvmObjects Include="@(_IlcProducedFiles)" Condition="'%(Extension)' == '$(LlvmObjectExt)'">
         <NativeObject>%(RelativeDir)%(Filename)$(NativeObjectExt)</NativeObject>
+        <DwarfObject>&quot;%(RelativeDir)%(Filename).dwo&quot;</DwarfObject>
       </LlvmObjects>
       <NativeObjects Include="@(_IlcProducedFiles)" Condition="'%(Extension)' == '$(NativeObjectExt)'" />
       <NativeObjects Include="@(LlvmObjects->'%(NativeObject)')" />
+      <DwarfObjects Include="@(LlvmObjects->'%(DwarfObject)')" />
     </ItemGroup>
   </Target>
 
@@ -439,12 +443,14 @@ The .NET Foundation licenses this file to you under the MIT license.
       <WasmCompilerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)bin/clang++&quot;</WasmCompilerPath>
       <WasmLinkerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/emscripten/emcc$(EmccScriptExt)&quot;</WasmLinkerPath>
       <WasmLinkerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)emscripten/emcc$(EmccScriptExt)&quot;</WasmLinkerPath>
+      <WasmDwarfLinkerPath Condition="'$(EMSDK)' != ''">&quot;$(EMSDK)/upstream/bin/llvm-dwp$(ExeExt)&quot;</WasmDwarfLinkerPath>
+      <WasmDwarfLinkerPath Condition="'$(EMSDK)' == ''">&quot;$(EmscriptenSdkToolsPath)/bin/llvm-dwp$(ExeExt)&quot;</WasmDwarfLinkerPath>
     </PropertyGroup>
 
    <PropertyGroup Condition="'$(_targetOS)' == 'wasi'">
       <WasmCompilerPath>&quot;$(WASI_SDK_PATH)/bin/clang++&quot;</WasmCompilerPath>
       <WasmLinkerPath>&quot;$(WASI_SDK_PATH)/bin/clang&quot;</WasmLinkerPath>
-    </PropertyGroup>
+  </PropertyGroup>
 
     <!-- Invoke the compilers in parallel. -->
     <ItemGroup>
@@ -575,6 +581,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <!-- see https://github.com/emscripten-core/emscripten/issues/16836 for the issue that means we have to force the linker to include these symbols before LTO -->
       <!--<CustomLinkerArg Condition="'$(Optimize)' != 'true'" Include="$(WasmOptimizationSetting) -flto" /> -->
       <CustomLinkerArg Condition="'$(IlcLlvmTarget)' != ''" Include="-target $(IlcLlvmTarget)" />
+
+	    <CustomLinkerArg Condition="'$(WasmExternalDwarf)' == 'true'" Include="-gseparate-dwarf" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(_targetOS)' == 'browser'" >


### PR DESCRIPTION
This PR adds a `WasmExternalDwarf ` build property, `true` by default for `browser` that will add a `external_debug_info` section and place the DWARF info a separate `.debug.wasm` file.  `wasmtime` does not support this, at present, so only applies for the browser build.