### PR TITLE
Exclude src/docs from CI

### DIFF
--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -15,6 +15,7 @@ trigger:
     - eng/Version.Details.xml
     - .github/*
     - docs/*
+    - src/docs/*
     - CODE-OF-CONDUCT.md
     - LICENSE.TXT
     - PATENTS.TXT

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -15,6 +15,7 @@ trigger:
     - eng/Version.Details.xml
     - .github/*
     - docs/*
+    - src/docs/*
     - CODE-OF-CONDUCT.md
     - LICENSE.TXT
     - PATENTS.TXT


### PR DESCRIPTION
I noticed that we run CI for docs in src/docs which seems wasteful. This should disable the runs.