### PR TITLE
[SwiftBindings] Added support for size, stride, alignment, and the value witness table

### DIFF
--- a/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
@@ -179,17 +179,17 @@ public readonly struct TypeMetadata : IEquatable<TypeMetadata> {
     /// <summary>
     /// Returns the size of the Swift type in bytes
     /// </summary>
-    public unsafe nuint Size => (*this.ValueWitnessTable).Size;
+    public unsafe nuint Size => this.ValueWitnessTable->Size;
 
     /// <summary>
     /// Returns the stride of the Swift type in bytes
     /// </summary>
-    public unsafe nuint Stride => (*this.ValueWitnessTable).Stride;
-    
+    public unsafe nuint Stride => this.ValueWitnessTable->Stride;
+
     /// <summary>
     /// Returns the alignment of the Swift type
     /// </summary>
-    public unsafe int Alignment => (*this.ValueWitnessTable).Alignment;
+    public unsafe int Alignment => this.ValueWitnessTable->Alignment;
 
     /// <summary>
     /// Reads a pointer sized integer from the location supplied

--- a/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
@@ -172,6 +172,26 @@ public readonly struct TypeMetadata : IEquatable<TypeMetadata> {
     }
 
     /// <summary>
+    /// Returns a pointer to the value witness table for the given type
+    /// </summary>
+    public unsafe ValueWitnessTable *ValueWitnessTable => (ValueWitnessTable*)(*((IntPtr*)handle - 1));
+
+    /// <summary>
+    /// Returns the size of the Swift type in bytes
+    /// </summary>
+    public unsafe nuint Size => (*this.ValueWitnessTable).Size;
+
+    /// <summary>
+    /// Returns the stride of the Swift type in bytes
+    /// </summary>
+    public unsafe nuint Stride => (*this.ValueWitnessTable).Stride;
+    
+    /// <summary>
+    /// Returns the alignment of the Swift type
+    /// </summary>
+    public unsafe int Alignment => (*this.ValueWitnessTable).Alignment;
+
+    /// <summary>
     /// Reads a pointer sized integer from the location supplied
     /// </summary>
     /// <param name="p">a pointer to memory</param>

--- a/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
@@ -174,7 +174,7 @@ public readonly struct TypeMetadata : IEquatable<TypeMetadata> {
     /// <summary>
     /// Returns a pointer to the value witness table for the given type
     /// </summary>
-    public unsafe ValueWitnessTable *ValueWitnessTable => (ValueWitnessTable*)(*((IntPtr*)handle - 1));
+    public unsafe ValueWitnessTable *ValueWitnessTable => IsValid ? (ValueWitnessTable*)(*((IntPtr*)handle - 1)) : throw new NullReferenceException ("TypeMetadata is null");
 
     /// <summary>
     /// Returns the size of the Swift type in bytes

--- a/src/Swift.Runtime/src/Metadata/ValueWitnessTable.cs
+++ b/src/Swift.Runtime/src/Metadata/ValueWitnessTable.cs
@@ -36,12 +36,10 @@ namespace Swift.Runtime
 		public IntPtr AssignWithTake;
 		public IntPtr GetEnumTagSinglePayload;
 		public IntPtr StoreEnumTagSinglePayload;
-		private IntPtr _Size;
-		private IntPtr _Stride;
+		public nuint Size;
+		public nuint Stride;
 		public ValueWitnessFlags Flags;
 		public uint ExtraInhabitantCount;
-        public int Size => _Size.ToInt32();
-        public int Stride => _Stride.ToInt32();
 		public int Alignment => (int)((Flags & ValueWitnessFlags.AlignmentMask) + 1);
 		public bool IsNonPOD => Flags.HasFlag (ValueWitnessFlags.IsNonPOD);
 		public bool IsNonBitwiseTakable => Flags.HasFlag (ValueWitnessFlags.IsNonBitwiseTakable);

--- a/src/Swift.Runtime/src/Metadata/ValueWitnessTable.cs
+++ b/src/Swift.Runtime/src/Metadata/ValueWitnessTable.cs
@@ -122,7 +122,7 @@ namespace Swift.Runtime
 		/// <summary>
 		/// Returns true if the value can NOT be copied bitwise.
 		/// </summary>
-		public bool IsNonBitwiseTakable => (Flags &ValueWitnessFlags.IsNonBitwiseTakable) != 0;
+		public bool IsNonBitwiseTakable => (Flags & ValueWitnessFlags.IsNonBitwiseTakable) != 0;
 
 		/// <summary>
 		/// Returns true if and only if the type has extra inhabitants.

--- a/src/Swift.Runtime/src/Metadata/ValueWitnessTable.cs
+++ b/src/Swift.Runtime/src/Metadata/ValueWitnessTable.cs
@@ -26,23 +26,107 @@ namespace Swift.Runtime
 	/// See https://github.com/apple/swift/blob/main/include/swift/ABI/ValueWitness.def
 	/// </summary>
 	[StructLayout (LayoutKind.Sequential)]
-	public ref struct ValueWitnessTable
+	public unsafe ref struct ValueWitnessTable
 	{
-		public IntPtr InitializeBufferWithCopyOfBuffer;
-		public IntPtr Destroy;
-		public IntPtr InitWithCopy;
-		public IntPtr AssignWithCopy;
-		public IntPtr InitWithTake;
-		public IntPtr AssignWithTake;
-		public IntPtr GetEnumTagSinglePayload;
-		public IntPtr StoreEnumTagSinglePayload;
+		/// <summary>
+		/// void *InitializeBufferWithCopyOfBuffer (dest, src, metadata)
+		/// Initialize an invalid buffer dest with a copy of src. Returns dest.
+		/// </summary>
+		public delegate* unmanaged<void *, void *, TypeMetadata, void *> InitializeBufferWithCopyOfBuffer;
+
+		/// <summary>
+		/// void Destroy (object, witnessTable)
+		/// Destroy the type pointed to by object leaving it invalid.
+		/// </summary>
+		public delegate* unmanaged<void *, ValueWitnessTable *, void> Destroy;
+
+		/// <summary>
+		/// void *InitializeWithCopy (dest, src, metadata)
+		/// Initialize object dest with a copy of source. Returns dest.
+		/// </summary>
+		public delegate* unmanaged<void *, void *, TypeMetadata, void *> InitializeWithCopy;
+
+		/// <summary>
+		/// void *AssignWithCopy (dest, src, metadata)
+		/// Overwrite an existing object, dest, with a copy of source, destroying the exisiting
+		/// value in dest. Returns dest.
+		/// </summary>
+		public delegate* unmanaged<void *, void *, TypeMetadata, void *> AssignWithCopy;
+
+		/// <summary>
+		/// void *InitializeWithTake (dest, src, metadata)
+		/// Initialize an invalid object dest with a copy of source, destroying src.
+		/// Returns dest.
+		/// </summary>
+		public delegate* unmanaged<void *, void *, TypeMetadata, void *> InitializeWithTake;
+
+		/// <summary>
+		/// void *AssignWithTake (dest, src, metadata)
+		/// Overwrite an existing object, dest, with a copy of source, destroying the existing
+		/// value in dest and then destroying src after the copy. Returns dest.
+		/// </summary>
+		public delegate* unmanaged<void *, void *, TypeMetadata, void *> AssignWithTake;
+
+		/// <summary>
+		/// nuint GetEnumTagSinglePayload (enum, emptyCases, metadata)
+		/// Given an instance of a valid single payload enum whose type is represented by
+		/// metadata, get the tag of the enum.
+		/// </summary>
+		public delegate* unmanaged<void *, nuint, TypeMetadata, nuint> GetEnumTagSinglePayload;
+
+		/// <summary>
+		/// void StoreEnumTagSinglePayload (enum, whichCase, emptyCases, metadata)
+		/// Given uninitialized memory for an instance of a single payload enum with a payload
+		/// whose is represented by metadata, store the tag.
+		/// </summary>
+		public delegate* unmanaged<void *, nuint, nuint, TypeMetadata, void> StoreEnumTagSinglePayload;
+
+		/// <summary>
+		/// The size of the type in bytes.
+		/// </summary>
 		public nuint Size;
+
+		/// <summary>
+		/// The stride of the type in bytes.
+		/// </summary>
 		public nuint Stride;
+
+		/// <summary>
+		/// Flags describing the type represented by the witness table.
+		/// </summary>
 		public ValueWitnessFlags Flags;
+
+		/// <summary>
+		/// The number of extra inhabitants in the type.
+		/// </summary>
 		public uint ExtraInhabitantCount;
+
+		/// <summary>
+		/// Returns the alignment of the type in bytes.
+		/// </summary>
 		public int Alignment => (int)((Flags & ValueWitnessFlags.AlignmentMask) + 1);
+
+		/// <summary>
+		/// Returns true if and only if the type is a POD type. A POD type is:
+		/// * integer types
+		/// * floating point numbers
+		/// * C enums
+		/// * fixed sized-arrays (presented as homogeneous tuples of POD types)
+		/// * C structs whose contents are POD types
+		/// * pointers to C types
+		/// * C function pointers
+		/// See https://github.com/swiftlang/swift/blob/6221b29c6835442706fbb44b67b755d370a87d96/docs/proposals/AttrC.rst#type-bridging
+		/// </summary>
 		public bool IsNonPOD => (Flags & ValueWitnessFlags.IsNonPOD) != 0;
+
+		/// <summary>
+		/// Returns true if the value can NOT be copied bitwise.
+		/// </summary>
 		public bool IsNonBitwiseTakable => (Flags &ValueWitnessFlags.IsNonBitwiseTakable) != 0;
+
+		/// <summary>
+		/// Returns true if and only if the type has extra inhabitants.
+		/// </summary>
 		public bool HasExtraInhabitants => ExtraInhabitantCount != 0;
 	}
 }

--- a/src/Swift.Runtime/src/Metadata/ValueWitnessTable.cs
+++ b/src/Swift.Runtime/src/Metadata/ValueWitnessTable.cs
@@ -41,8 +41,8 @@ namespace Swift.Runtime
 		public ValueWitnessFlags Flags;
 		public uint ExtraInhabitantCount;
 		public int Alignment => (int)((Flags & ValueWitnessFlags.AlignmentMask) + 1);
-		public bool IsNonPOD => Flags.HasFlag (ValueWitnessFlags.IsNonPOD);
-		public bool IsNonBitwiseTakable => Flags.HasFlag (ValueWitnessFlags.IsNonBitwiseTakable);
+		public bool IsNonPOD => (Flags & ValueWitnessFlags.IsNonPOD) != 0;
+		public bool IsNonBitwiseTakable => (Flags &ValueWitnessFlags.IsNonBitwiseTakable) != 0;
 		public bool HasExtraInhabitants => ExtraInhabitantCount != 0;
 	}
 }


### PR DESCRIPTION
Added an accessor for ValueWitnessTable and added Size, Stride and Alignment properties.
The definition of Size and Stride are unsigned machine word-sized ints, so I changed them to be `nuint`

This addresses issue [2800](https://github.com/dotnet/runtimelab/issues/2800).