### PR TITLE
[RuntimeAsync] Fix support for pinvokes

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3368,7 +3368,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
         if (compIsAsync2())
         {
-            printf("OPTIONS: compilation is an async2\n");
+            printf("OPTIONS: compilation is an async2 state machine\n");
         }
     }
 #endif

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4888,7 +4888,6 @@ void Lowering::LowerRet(GenTreeOp* ret)
         }
     }
 
-    // Method doing PInvokes has exactly one return block unless it has tail calls.
     if (comp->compMethodRequiresPInvokeFrame())
     {
         InsertPInvokeMethodEpilog(comp->compCurBB DEBUGARG(ret));
@@ -5331,6 +5330,11 @@ void Lowering::LowerReturnSuspend(GenTree* node)
     while (BlockRange().LastNode() != node)
     {
         BlockRange().Remove(BlockRange().LastNode(), true);
+    }
+
+    if (comp->compMethodRequiresPInvokeFrame())
+    {
+        InsertPInvokeMethodEpilog(comp->compCurBB DEBUGARG(node));
     }
 }
 

--- a/src/tests/async/pinvoke.cs
+++ b/src/tests/async/pinvoke.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2PInvoke
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        AsyncEntryPoint().Wait();
+    }
+
+    private static async2 Task AsyncEntryPoint()
+    {
+        unsafe
+        {
+            Assert.Equal(5, GetFPtr()());
+        }
+
+        await Task.Yield();
+
+        unsafe
+        {
+            Assert.Equal(5, GetFPtr()());
+        }
+
+        await Task.Yield();
+
+        unsafe
+        {
+            Assert.Equal(5, GetFPtr()());
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static unsafe delegate* unmanaged<int> GetFPtr() => &GetValue;
+
+    [UnmanagedCallersOnly]
+    private static int GetValue() => 5;
+}

--- a/src/tests/async/pinvoke.csproj
+++ b/src/tests/async/pinvoke.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Make sure async transformation leaves a scratch BB around for the pinvoke prolog to be inserted into
- Make sure we properly insert pinvoke epilogs for `GT_RETURN_SUSPEND` nodes (needed on x86)
- Ensure the pinvoke frame related locals are not captured by the async transformation