### PR TITLE
[NativeAOT-LLVM] Add the `WasmComponentTypeWit` item group

### DIFF
--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -71,6 +71,8 @@ Another large contributor to the size is globalization support (ICU data and cod
 
 Additionally, NativeAOT-LLVM supports the following properties:
 - `WasmHtmlTemplate`: specifies path to the HTML template within which the WASM application will be embedded. An example of a minimal template can be found in the Emscripten repo: https://github.com/emscripten-core/emscripten/blob/main/src/shell_minimal.html
+And item groups:
+- `WasmComponentTypeWit`: WIT files that will be passed to the linker to define the imports and exports ('world') of the application as a component.
 
 ## WebAssembly native libraries
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -548,7 +548,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
-      <_WasiComponentImports Include="$(IlcFrameworkNativePath)*.wit" />
+      <WasmComponentTypeWit Include="$(IlcFrameworkNativePath)*.wit" />
 
       <NativeLibrary Include="$(IlcFrameworkNativePath)libSystem.Native.a" />
       <NativeLibrary Include="$(IlcFrameworkNativePath)libSystem.Native.TimeZoneData.a" Condition="'$(InvariantTimezone)' != 'true'" />
@@ -566,7 +566,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="@(NativeObjects->'&quot;%(Identity)&quot;'->Replace(&quot;\&quot;, &quot;/&quot;))" />
       <!-- The canary function should be last in the linked output. But adding it to Native[Library|Object] runs into https://github.com/dotnet/msbuild/issues/5937. -->
       <CustomLinkerArg Include="&quot;$(IlcSdkPath.Replace('\', '/'))libStackTraceIpCanary.o&quot;" Condition="'$(_targetOS)' == 'browser'" />
-      <CustomLinkerArg Include="@(_WasiComponentImports->Replace('\', '/')->'-Wl,--component-type,&quot;%(Identity)&quot;')" />
+      <CustomLinkerArg Include="@(WasmComponentTypeWit->'%(FullPath)'->Replace('\', '/')->'-Wl,--component-type,&quot;%(Identity)&quot;')" />
       <CustomLinkerArg Include="-o &quot;$(NativeBinary.Replace(&quot;\&quot;, &quot;/&quot;))&quot;" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' == 'true'" Include="-g3" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' != 'true'" Include="-Wl,--strip-all" />

--- a/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.cs
+++ b/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.cs
@@ -147,29 +147,16 @@ namespace SharedLibrary
         }
 
         [UnmanagedCallersOnly(EntryPoint = "test-http")]
-        public static unsafe void wasmExportTestHttp(int p0)
+        public static unsafe void TestHttp(int port)
         {
-            TestHttp((((ushort)p0)));
-        }
+            [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "PollWasiEventLoopUntilResolvedVoid")]
+            static extern void PollWasiEventLoopUntilResolvedVoid(Thread t, Task task);
 
-        public static void TestHttp(ushort port)
-        {
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
-
-            var task = TestHttpAsync(port);
-            while (!task.IsCompleted)
-            {
-                WasiEventLoop.DispatchWasiEventLoop();
-            }
-            var exception = task.Exception;
-            if (exception is not null)
-            {
-                throw exception;
-            }
-
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            PollWasiEventLoopUntilResolvedVoid(null, TestHttpAsync((ushort)port));
             stopwatch.Stop();
-            // Verify that `WasiEventLoop.DispatchWasiEventLoop` returned
+
+            // Verify that `PollWasiEventLoopUntilResolvedVoid` returned
             // promptly once the main task finished, even if there were other
             // tasks (e.g. the default 100 second HttpClient timeout) still in
             // progress.
@@ -237,17 +224,6 @@ namespace SharedLibrary
             stopwatch.Stop();
             Trace.Assert(stopwatch.ElapsedMilliseconds >= 100);
             Trace.Assert(stopwatch.ElapsedMilliseconds < 1000);
-        }
-    }
-
-    internal static class WasiEventLoop
-    {
-        internal static void DispatchWasiEventLoop()
-        {
-            CallDispatchWasiEventLoop((Thread)null!);
-
-            [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "DispatchWasiEventLoop")]
-            static extern void CallDispatchWasiEventLoop(Thread t);
         }
     }
 }

--- a/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/SharedLibrary/SharedLibrary.csproj
@@ -13,9 +13,6 @@
     <!-- Unable to compile a project with the Library output type for apple mobile devices -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
 
-    <!-- https://github.com/dotnet/runtimelab/issues/2648 -->
-    <CLRTestTargetUnsupported Condition="'$(TargetOS)' == 'wasi'">true</CLRTestTargetUnsupported>
-
     <!-- Regression test for https://github.com/dotnet/runtime/issues/105330: make sure the UnmanagedCallersOnly are completely unreferenced,
          not even from stack trace mapping data -->
     <StackTraceSupport>false</StackTraceSupport>
@@ -66,6 +63,6 @@ cp SharedLibraryDriver$(NativeExtension) native/SharedLibrary$(NativeExtension)
 
   <ItemGroup Condition="'$(WasiReactorTestUsingNodeJS)' == 'true'">
     <Content Include="SharedLibraryDriver.mjs" CopyToOutputDirectory="PreserveNewest" />
-    <CustomLinkerArg Include="-Wl,--component-type,&quot;$(MSBuildProjectDirectory.Replace(&quot;\&quot;, &quot;/&quot;))/wit/world.wit&quot;" />
+    <WasmComponentTypeWit Include="wit/world.wit" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Since pretty much all P2 projects will need to specify WITs, we can make it a bit more convenient with this item group.

Also, turns out we had `SharedLibrary` still disabled, so fix it a little and enable back.