### PR TITLE
added TypeMetadataCache

### DIFF
--- a/src/Swift.Runtime/src/Metadata/ITypeMetadataCache.cs
+++ b/src/Swift.Runtime/src/Metadata/ITypeMetadataCache.cs
@@ -12,27 +12,20 @@ namespace Swift.Runtime;
 public interface ITypeMetadataCache
 {
     /// <summary>
-    /// Returns true if and only if the cache contains an entry for t
-    /// </summary>
-    /// <param name="type">The type to look up in the cache</param>
-    /// <returns>true if and only if the cache contains t, false otherwise</returns>
-    bool Contains(Type type);
-
-    /// <summary>
-    /// Returns true if the cache contains an entry for t and sets metadata to the resulting value,
+    /// Returns true if the cache contains an entry for type and sets metadata to the resulting value,
     /// otherwise it returns false and metadata will be null.
     /// </summary>
-    /// <param name="type"></param>
-    /// <param name="metadata"></param>
+    /// <param name="type">The type to look up in the cache</param>
+    /// <param name="metadata">The resulting metadata if found</param>
     /// <returns>true if the lookup was successful, false otherwise</returns>
     bool TryGet(Type type, [NotNullWhen(true)]out TypeMetadata? metadata);
 
     /// <summary>
-    /// Gets the TypeMetadata for the given Type t or if it is not present,
+    /// Gets the TypeMetadata for the given Type type or if it is not present,
     /// adds it to the cache using the given factory to generate the value.
     /// </summary>
-    /// <param name="type"></param>
-    /// <param name="metadataFactory"></param>
-    /// <returns>The TypeMetadata associated with the give Type t</returns>
+    /// <param name="type">The type to look up in the cache</param>
+    /// <param name="metadataFactory">a factory to generate the TypeMetadata if not present</param>
+    /// <returns>The TypeMetadata associated with the give Type type</returns>
     TypeMetadata GetOrAdd(Type type, Func<Type, TypeMetadata> metadataFactory);
 }

--- a/src/Swift.Runtime/src/Metadata/ITypeMetadataCache.cs
+++ b/src/Swift.Runtime/src/Metadata/ITypeMetadataCache.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Swift.Runtime;
+
+/// <summary>
+/// Represents an interface that defines how a cache for TypeMetadata should operate.
+/// The implementation of this interface needs to be thread safe.
+/// </summary>
+public interface ITypeMetadataCache
+{
+    /// <summary>
+    /// Returns true if and only if the cache contains an entry for t
+    /// </summary>
+    /// <param name="t">The type to look up in the cache</param>
+    /// <returns>true if and only if the cache contains t, false otherwise</returns>
+    bool Contains(Type t);
+
+    /// <summary>
+    /// Returns true if the cache contains an entry for t and sets metadata to the resulting value,
+    /// otherwise it returns false and metadata will be null.
+    /// </summary>
+    /// <param name="t"></param>
+    /// <param name="metadata"></param>
+    /// <returns>true if the lookup was successful, false otherwise</returns>
+    bool TryGet(Type t, [NotNullWhen(true)]out TypeMetadata? metadata);
+
+    /// <summary>
+    /// Gets the TypeMetadata for the given Type t or if it is not present,
+    /// adds it to the cache using the given factory to generate the value.
+    /// </summary>
+    /// <param name="t"></param>
+    /// <param name="metadataFactory"></param>
+    /// <returns>The TypeMetadata associated with the give Type t</returns>
+    TypeMetadata GetOrAdd(Type t, Func<Type, TypeMetadata> metadataFactory);
+}

--- a/src/Swift.Runtime/src/Metadata/ITypeMetadataCache.cs
+++ b/src/Swift.Runtime/src/Metadata/ITypeMetadataCache.cs
@@ -14,25 +14,25 @@ public interface ITypeMetadataCache
     /// <summary>
     /// Returns true if and only if the cache contains an entry for t
     /// </summary>
-    /// <param name="t">The type to look up in the cache</param>
+    /// <param name="type">The type to look up in the cache</param>
     /// <returns>true if and only if the cache contains t, false otherwise</returns>
-    bool Contains(Type t);
+    bool Contains(Type type);
 
     /// <summary>
     /// Returns true if the cache contains an entry for t and sets metadata to the resulting value,
     /// otherwise it returns false and metadata will be null.
     /// </summary>
-    /// <param name="t"></param>
+    /// <param name="type"></param>
     /// <param name="metadata"></param>
     /// <returns>true if the lookup was successful, false otherwise</returns>
-    bool TryGet(Type t, [NotNullWhen(true)]out TypeMetadata? metadata);
+    bool TryGet(Type type, [NotNullWhen(true)]out TypeMetadata? metadata);
 
     /// <summary>
     /// Gets the TypeMetadata for the given Type t or if it is not present,
     /// adds it to the cache using the given factory to generate the value.
     /// </summary>
-    /// <param name="t"></param>
+    /// <param name="type"></param>
     /// <param name="metadataFactory"></param>
     /// <returns>The TypeMetadata associated with the give Type t</returns>
-    TypeMetadata GetOrAdd(Type t, Func<Type, TypeMetadata> metadataFactory);
+    TypeMetadata GetOrAdd(Type type, Func<Type, TypeMetadata> metadataFactory);
 }

--- a/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
@@ -244,7 +244,7 @@ public readonly struct TypeMetadata : IEquatable<TypeMetadata> {
         return handle.GetHashCode ();
     }
 
-    static TypeMetadataCache cache;
+    static readonly TypeMetadataCache cache;
     /// <summary>
     /// Gets the type metadata cache for the runtime.
     /// </summary>

--- a/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadata.cs
@@ -124,6 +124,12 @@ public enum TypeMetadataKind {
 public readonly struct TypeMetadata : IEquatable<TypeMetadata> {
     readonly IntPtr handle;
 
+    static TypeMetadata ()
+    {
+        // TODO - add metadata for common built-in types like scalars and strings
+        cache = new TypeMetadataCache();
+    }
+
     /// <summary>
     /// An empty/invalid TypeMetadata object
     /// </summary>
@@ -237,4 +243,10 @@ public readonly struct TypeMetadata : IEquatable<TypeMetadata> {
     {
         return handle.GetHashCode ();
     }
+
+    static TypeMetadataCache cache;
+    /// <summary>
+    /// Gets the type metadata cache for the runtime.
+    /// </summary>
+    public static ITypeMetadataCache Cache => cache;
 }

--- a/src/Swift.Runtime/src/Metadata/TypeMetadataCache.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadataCache.cs
@@ -29,7 +29,7 @@ internal class TypeMetadataCache : ITypeMetadataCache
     public TypeMetadataCache(IEnumerable<(Type, TypeMetadata)> initialValues)
     {
         var dictCache = (IDictionary<Type, TypeMetadata>)cache;
-        foreach (var (key, value) in initalValues)
+        foreach (var (key, value) in initialValues)
         {
             dictCache.Add(key, value);
         }

--- a/src/Swift.Runtime/src/Metadata/TypeMetadataCache.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadataCache.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Swift.Runtime;
+
+/// <summary>
+/// Internal implementation of ITypeMetadataCache
+/// </summary>
+internal class TypeMetadataCache : ITypeMetadataCache
+{
+    ConcurrentDictionary<Type, TypeMetadata> cache = new();
+
+    /// <summary>
+    /// Constructs an empty cache.
+    /// </summary>
+    public TypeMetadataCache()
+    {
+
+    }
+
+    /// <summary>
+    /// Constructs a cache with the supplied initial values.
+    /// </summary>
+    /// <param name="initalValues">An enumeration of tuples of Type and TypeMetadata to initialize the cache</param>
+    public TypeMetadataCache(IEnumerable<(Type, TypeMetadata)> initalValues)
+    {
+        var dictCache = (IDictionary<Type, TypeMetadata>)cache;
+        foreach (var (key, value) in initalValues)
+        {
+            dictCache.Add(key, value);
+        }
+    }
+
+
+    /// <summary>
+    /// Returns true if and only if the cache contains an entry for t.
+    /// </summary>
+    /// <param name="t">The type to look up in the cache</param>
+    /// <returns>true if and only if the cache contains t, false otherwise</returns>
+    public bool Contains(Type t)
+    {
+        return cache.ContainsKey(t);
+    }
+
+    /// <summary>
+    /// Returns true if the cache contains an entry for t and sets metadata to the resulting value,
+    /// otherwise it returns false and metadata will be null.
+    /// </summary>
+    /// <param name="t"></param>
+    /// <param name="metadata"></param>
+    /// <returns>true if the lookup was successful, false otherwise</returns>
+    public bool TryGet(Type t, [NotNullWhen(true)] out TypeMetadata? metadata)
+    {
+        if (cache.TryGetValue(t, out var md))
+        {
+            metadata = md;
+            return true;
+        }
+        else
+        {
+            metadata = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Gets the TypeMetadata for the given Type t or if it is not present,
+    /// adds it to the cache using the given factory to generate the value.
+    /// </summary>
+    /// <param name="t"></param>
+    /// <param name="metadataFactory"></param>
+    /// <returns>The TypeMetadata associated with the give Type t</returns>
+    public TypeMetadata GetOrAdd(Type t, Func<Type, TypeMetadata> metadataFactory)
+    {
+        return cache.GetOrAdd(t, metadataFactory);
+    }
+}

--- a/src/Swift.Runtime/src/Metadata/TypeMetadataCache.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadataCache.cs
@@ -12,7 +12,7 @@ namespace Swift.Runtime;
 /// </summary>
 internal class TypeMetadataCache : ITypeMetadataCache
 {
-    ConcurrentDictionary<Type, TypeMetadata> cache = new();
+    readonly ConcurrentDictionary<Type, TypeMetadata> cache = new();
 
     /// <summary>
     /// Constructs an empty cache.
@@ -25,8 +25,8 @@ internal class TypeMetadataCache : ITypeMetadataCache
     /// <summary>
     /// Constructs a cache with the supplied initial values.
     /// </summary>
-    /// <param name="initalValues">An enumeration of tuples of Type and TypeMetadata to initialize the cache</param>
-    public TypeMetadataCache(IEnumerable<(Type, TypeMetadata)> initalValues)
+    /// <param name="initialValues">An enumeration of tuples of Type and TypeMetadata to initialize the cache</param>
+    public TypeMetadataCache(IEnumerable<(Type, TypeMetadata)> initialValues)
     {
         var dictCache = (IDictionary<Type, TypeMetadata>)cache;
         foreach (var (key, value) in initalValues)
@@ -39,23 +39,23 @@ internal class TypeMetadataCache : ITypeMetadataCache
     /// <summary>
     /// Returns true if and only if the cache contains an entry for t.
     /// </summary>
-    /// <param name="t">The type to look up in the cache</param>
+    /// <param name="type">The type to look up in the cache</param>
     /// <returns>true if and only if the cache contains t, false otherwise</returns>
-    public bool Contains(Type t)
+    public bool Contains(Type type)
     {
-        return cache.ContainsKey(t);
+        return cache.ContainsKey(type);
     }
 
     /// <summary>
     /// Returns true if the cache contains an entry for t and sets metadata to the resulting value,
     /// otherwise it returns false and metadata will be null.
     /// </summary>
-    /// <param name="t"></param>
+    /// <param name="type"></param>
     /// <param name="metadata"></param>
     /// <returns>true if the lookup was successful, false otherwise</returns>
-    public bool TryGet(Type t, [NotNullWhen(true)] out TypeMetadata? metadata)
+    public bool TryGet(Type type, [NotNullWhen(true)] out TypeMetadata? metadata)
     {
-        if (cache.TryGetValue(t, out var md))
+        if (cache.TryGetValue(type, out var md))
         {
             metadata = md;
             return true;
@@ -71,11 +71,11 @@ internal class TypeMetadataCache : ITypeMetadataCache
     /// Gets the TypeMetadata for the given Type t or if it is not present,
     /// adds it to the cache using the given factory to generate the value.
     /// </summary>
-    /// <param name="t"></param>
+    /// <param name="type"></param>
     /// <param name="metadataFactory"></param>
     /// <returns>The TypeMetadata associated with the give Type t</returns>
-    public TypeMetadata GetOrAdd(Type t, Func<Type, TypeMetadata> metadataFactory)
+    public TypeMetadata GetOrAdd(Type type, Func<Type, TypeMetadata> metadataFactory)
     {
-        return cache.GetOrAdd(t, metadataFactory);
+        return cache.GetOrAdd(type, metadataFactory);
     }
 }

--- a/src/Swift.Runtime/src/Metadata/TypeMetadataCache.cs
+++ b/src/Swift.Runtime/src/Metadata/TypeMetadataCache.cs
@@ -35,23 +35,12 @@ internal class TypeMetadataCache : ITypeMetadataCache
         }
     }
 
-
     /// <summary>
-    /// Returns true if and only if the cache contains an entry for t.
-    /// </summary>
-    /// <param name="type">The type to look up in the cache</param>
-    /// <returns>true if and only if the cache contains t, false otherwise</returns>
-    public bool Contains(Type type)
-    {
-        return cache.ContainsKey(type);
-    }
-
-    /// <summary>
-    /// Returns true if the cache contains an entry for t and sets metadata to the resulting value,
+    /// Returns true if the cache contains an entry for type and sets metadata to the resulting value,
     /// otherwise it returns false and metadata will be null.
     /// </summary>
-    /// <param name="type"></param>
-    /// <param name="metadata"></param>
+    /// <param name="type">The type to look up in the cache</param>
+    /// <param name="metadata">The resulting metadata if found</param>
     /// <returns>true if the lookup was successful, false otherwise</returns>
     public bool TryGet(Type type, [NotNullWhen(true)] out TypeMetadata? metadata)
     {
@@ -68,12 +57,12 @@ internal class TypeMetadataCache : ITypeMetadataCache
     }
 
     /// <summary>
-    /// Gets the TypeMetadata for the given Type t or if it is not present,
+    /// Gets the TypeMetadata for the given Type type or if it is not present,
     /// adds it to the cache using the given factory to generate the value.
     /// </summary>
-    /// <param name="type"></param>
-    /// <param name="metadataFactory"></param>
-    /// <returns>The TypeMetadata associated with the give Type t</returns>
+    /// <param name="type">The type to look up in the cache</param>
+    /// <param name="metadataFactory">a factory to generate the TypeMetadata if not present</param>
+    /// <returns>The TypeMetadata associated with the give Type type</returns>
     public TypeMetadata GetOrAdd(Type type, Func<Type, TypeMetadata> metadataFactory)
     {
         return cache.GetOrAdd(type, metadataFactory);

--- a/src/Swift.Runtime/src/Swift.Runtime.csproj
+++ b/src/Swift.Runtime/src/Swift.Runtime.csproj
@@ -18,6 +18,9 @@
     <Content Include="Library/*.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Metadata/*.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/Swift.Runtime/tests/TypeMetadataTests/TypeMetadataTests.cs
+++ b/src/Swift.Runtime/tests/TypeMetadataTests/TypeMetadataTests.cs
@@ -38,12 +38,6 @@ public class TypeMetadataTests : IClassFixture<TypeMetadataTests.TestFixture>
     }
 
     [Fact]
-    public static void CacheDoesntContain()
-    {
-        Assert.False(TypeMetadata.Cache.Contains(typeof(System.EventArgs)));
-    }
-
-    [Fact]
     public static void CacheWorks()
     {
         var fakeMeta = MakePhonyMetadata(42);
@@ -51,7 +45,7 @@ public class TypeMetadataTests : IClassFixture<TypeMetadataTests.TestFixture>
         {
             return fakeMeta;
         });
-        Assert.True(TypeMetadata.Cache.Contains(typeof(System.Convert)));
+        Assert.True(TypeMetadata.Cache.TryGet(typeof(System.Convert), out var result));
     }
 
     [Fact]

--- a/src/Swift.Runtime/tests/TypeMetadataTests/TypeMetadataTests.cs
+++ b/src/Swift.Runtime/tests/TypeMetadataTests/TypeMetadataTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+using Swift.Runtime;
+using System.Reflection;
+
+namespace BindingsGeneration.Tests;
+
+public class TypeMetadataTests : IClassFixture<TypeMetadataTests.TestFixture>
+{
+    private readonly TestFixture _fixture;
+
+    public TypeMetadataTests(TestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public class TestFixture
+    {
+        static TestFixture()
+        {
+        }
+
+        private static void InitializeResources()
+        {
+        }
+    }
+
+    static TypeMetadata MakePhonyMetadata(int value)
+    {
+        IntPtr p = new IntPtr(value);
+
+        var t = typeof(TypeMetadata);
+        var ci = t.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, new Type[] { typeof(IntPtr) })!;
+
+        return (TypeMetadata)(ci.Invoke(new object[] { p }));
+    }
+
+    [Fact]
+    public static void CacheDoesntContain()
+    {
+        Assert.False(TypeMetadata.Cache.Contains(typeof(System.EventArgs)));
+    }
+
+    [Fact]
+    public static void CacheWorks()
+    {
+        var fakeMeta = MakePhonyMetadata(42);
+        TypeMetadata.Cache.GetOrAdd(typeof(System.Convert), (t) =>
+        {
+            return fakeMeta;
+        });
+        Assert.True(TypeMetadata.Cache.Contains(typeof(System.Convert)));
+    }
+
+    [Fact]
+    public static void TryGetFail()
+    {
+        var contains = TypeMetadata.Cache.TryGet(typeof(System.EventArgs), out var result);
+        Assert.False(contains);
+    }
+
+    [Fact]
+    public static void TryGetSucceed()
+    {
+        var fakeMeta = MakePhonyMetadata(43);
+        TypeMetadata.Cache.GetOrAdd(typeof(System.Random), (t) =>
+        {
+            return fakeMeta;
+        });
+        var contains = TypeMetadata.Cache.TryGet(typeof(System.Random), out var result);
+        Assert.True(contains);
+    }
+}


### PR DESCRIPTION
Added caching for type metadata.
The cache will be used by most bindings in their static GetTypeMetadata() accessor.

Typical usage will be:
```csharp
public struct SomeGeneratedBinding : ISwiftObject // this will come later, but it defines the GetTypeMetadata() method
    public static TypeMetadata GetTypeMetadata() {
        return TypeMetadata.Cache.GetOrAdd(typeof(SomeGeneratedBinding), (t) => PInvokesForSGB._MetadataAccessor());
    }
}
```
It will also be used later on in the set of static methods that will be used to get the type metadata for a given type.  For example, if the bound type is generic, it will look like this:

```
public struct SomeGeneric<T> : ISwiftObject {
    public static TypeMetadataGetTypeMetadata() {
        return TypeMetadata.Cache.GetOrAdd(typeof(SomeGeneric<T>), (t) => PInvokesForSG._MetadataAccessor (TypeMetadata.GetMetadataOrThrow(typeof(T))));
    }
}
```
The notion being that you call `GetOrAdd` only when you have something to put in (hence the factory), but you call GetMetadataOrThrow() when it's possible to fail. This is the case since we don't know what T will contain at compile time.

The implementation of GetMetadataOrThrow() will look in the cache via TryGet before trying other approaches.