### PR TITLE
[NativeAOT-LLVM] Emit type debug info into a single module

### DIFF
--- a/eng/pipelines/runtimelab/install-wasmtime.ps1
+++ b/eng/pipelines/runtimelab/install-wasmtime.ps1
@@ -9,7 +9,9 @@ $ProgressPreference = "SilentlyContinue"
 
 Set-Location $InstallDir
 
-$WasmtimeVersion = "v26.0.1"
+# Currently we need to use the daily releases for the debugging test to work.
+$UsePreRelease = $true
+$WasmtimeVersion = $UsePreRelease ? "dev" : "v26.0.1"
 
 if ($IsWindows)
 {

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -841,26 +841,7 @@ void Llvm::GetJitTestInfo(CorInfoLlvmJitTestKind kind, CORINFO_LLVM_JIT_TEST_INF
     CallEEApi<EEAI_GetJitTestInfo, CORINFO_GENERIC_HANDLE>(m_pEECorInfo, kind, pInfo);
 }
 
-extern "C" DLLEXPORT int registerLlvmCallbacks(void** jitImports, void** jitExports)
-{
-    assert((jitImports != nullptr) && (jitImports[EEAI_Count] == (void*)0x1234));
-    assert(jitExports != nullptr);
-
-    memcpy(g_callbacks, jitImports, static_cast<int>(EEAI_Count) * sizeof(void*));
-
-    jitExports[CJAI_StartSingleThreadedCompilation] = (void*)&Llvm::StartSingleThreadedCompilation;
-    jitExports[CJAI_FinishSingleThreadedCompilation] = (void*)&Llvm::FinishSingleThreadedCompilation;
-    jitExports[CJAI_Count] = (void*)0x1234;
-
-    for (int i = 0; i < CJAI_Count; i++)
-    {
-        assert(jitExports[i] != nullptr);
-    }
-
-    return 1;
-}
-
-/* static */ SingleThreadedCompilationContext* Llvm::StartSingleThreadedCompilation(
+static SingleThreadedCompilationContext* StartSingleThreadedCompilation(
     const char* path, const char* triple, const char* dataLayout)
 {
     SingleThreadedCompilationContext* context = new SingleThreadedCompilationContext(path);
@@ -870,12 +851,14 @@ extern "C" DLLEXPORT int registerLlvmCallbacks(void** jitImports, void** jitExpo
     return context;
 }
 
-/* static */ void Llvm::FinishSingleThreadedCompilation(SingleThreadedCompilationContext* context)
+static void FinishSingleThreadedCompilation(SingleThreadedCompilationContext* context)
 {
     assert(context != nullptr);
 
+    context->FinishDebugInfo();
+
     Module& module = context->Module;
-    if (context->DebugCompileUnitsMap.GetCount() != 0)
+    if (!context->Module.debug_compile_units().empty())
     {
         module.addModuleFlag(llvm::Module::Warning, "Dwarf Version", 4);
         module.addModuleFlag(llvm::Module::Warning, "Debug Info Version", 3);
@@ -894,4 +877,25 @@ extern "C" DLLEXPORT int registerLlvmCallbacks(void** jitImports, void** jitExpo
     llvm::WriteBitcodeToFile(module, bitCodeFileStream);
 
     delete context;
+}
+
+extern "C" DLLEXPORT int registerLlvmCallbacks(void** jitImports, void** jitExports)
+{
+    assert((jitImports != nullptr) && (jitImports[EEAI_Count] == (void*)0x1234));
+    assert(jitExports != nullptr);
+
+    memcpy(g_callbacks, jitImports, static_cast<int>(EEAI_Count) * sizeof(void*));
+
+    jitExports[CJAI_StartSingleThreadedCompilation] = (void*)&StartSingleThreadedCompilation;
+    jitExports[CJAI_FinishSingleThreadedCompilation] = (void*)&FinishSingleThreadedCompilation;
+    jitExports[CJAI_EmitDebugTypeInfo] = (void*)&SingleThreadedCompilationContext::EmitDebugTypeInfo;
+    jitExports[CJAI_EmitDebugMethodDecl] = (void*)&SingleThreadedCompilationContext::EmitDebugMethodDecl;
+    jitExports[CJAI_Count] = (void*)0x1234;
+
+    for (int i = 0; i < CJAI_Count; i++)
+    {
+        assert(jitExports[i] != nullptr);
+    }
+
+    return 1;
 }

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -89,19 +89,17 @@ struct CORINFO_LLVM_JIT_TEST_INFO
 };
 
 typedef unsigned CORINFO_LLVM_DEBUG_TYPE_HANDLE;
+typedef unsigned CORINFO_LLVM_DEBUG_METHOD_DECL_HANDLE;
 
 const CORINFO_LLVM_DEBUG_TYPE_HANDLE NO_DEBUG_TYPE = 0;
 
-struct CORINFO_LLVM_FORWARD_REF_TYPE_DEBUG_INFO;
-struct CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO;
-struct CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO;
-struct CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO;
-struct CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO;
-struct CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO;
 struct CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO;
+struct CORINFO_LLVM_METHOD_DECL_DEBUG_INFO;
 struct CORINFO_LLVM_METHOD_DEBUG_INFO;
 struct CORINFO_LLVM_TYPE_DEBUG_INFO;
 
+template <typename T>
+struct JitStdMallocAllocator;
 struct MallocAllocator
 {
     template <typename T>
@@ -118,6 +116,29 @@ struct MallocAllocator
     void deallocate(void* p)
     {
         free(p);
+    }
+
+    template <typename U>
+    struct rebind
+    {
+        typedef struct JitStdMallocAllocator<U> allocator;
+    };
+};
+
+template <typename T>
+struct JitStdMallocAllocator
+{
+    MallocAllocator m_alloc;
+    JitStdMallocAllocator(MallocAllocator alloc) : m_alloc(alloc) { }
+
+    T* allocate(size_t count)
+    {
+        return m_alloc.allocate<T>(count);
+    }
+
+    void deallocate(void* p, size_t size)
+    {
+        m_alloc.deallocate(p);
     }
 };
 
@@ -255,24 +276,25 @@ struct EHRegionInfo
     Value* CatchArgValue;
 };
 
+class TypeDebugInfoModule;
 class SingleThreadedCompilationContext
 {
 public:
     LLVMContext Context;
     Module Module;
-    JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, Type*, MallocAllocator> LlvmStructTypesMap;
-    JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, StructDesc*, MallocAllocator> StructDescMap;
-    JitHashTable<CORINFO_LLVM_DEBUG_TYPE_HANDLE, JitSmallPrimitiveKeyFuncs<CORINFO_LLVM_DEBUG_TYPE_HANDLE>, llvm::DIType*, MallocAllocator> DebugTypesMap;
-    JitHashTable<llvm::DIFile*, JitPtrKeyFuncs<llvm::DIFile>, llvm::DICompileUnit*, MallocAllocator> DebugCompileUnitsMap;
+    JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, Type*, MallocAllocator> LlvmStructTypesMap = {{}};
+    JitHashTable<CORINFO_CLASS_HANDLE, JitPtrKeyFuncs<CORINFO_CLASS_STRUCT_>, StructDesc*, MallocAllocator> StructDescMap = {{}};
+    JitHashTable<CORINFO_LLVM_DEBUG_TYPE_HANDLE, JitSmallPrimitiveKeyFuncs<CORINFO_LLVM_DEBUG_TYPE_HANDLE>, llvm::DIType*, MallocAllocator> DebugTypesMap = {{}};
+    JitHashTable<llvm::DIFile*, JitPtrKeyFuncs<llvm::DIFile>, llvm::DICompileUnit*, MallocAllocator> DebugCompileUnitsMap = {{}};
+    TypeDebugInfoModule* DebugTypes = nullptr;
 
-    SingleThreadedCompilationContext(StringRef name)
-        : Module(name, Context)
-        , LlvmStructTypesMap({})
-        , StructDescMap({})
-        , DebugTypesMap({})
-        , DebugCompileUnitsMap({})
+    SingleThreadedCompilationContext(StringRef name) : Module(name, Context)
     {
     }
+
+    static CORINFO_LLVM_DEBUG_TYPE_HANDLE EmitDebugTypeInfo(SingleThreadedCompilationContext* context, CORINFO_LLVM_TYPE_DEBUG_INFO* pInfo);
+    static CORINFO_LLVM_DEBUG_METHOD_DECL_HANDLE EmitDebugMethodDecl(SingleThreadedCompilationContext* context, CORINFO_LLVM_METHOD_DECL_DEBUG_INFO* pInfo);
+    void FinishDebugInfo();
 };
 
 class Llvm
@@ -413,11 +435,6 @@ private:
         unsigned* pAbsoluteValue, unsigned shadowFrameSize, CORINFO_LLVM_EH_CLAUSE* pClauses, int clauseCount);
     bool IsVirtualUnwindFrameVisible();
     void GetJitTestInfo(CorInfoLlvmJitTestKind kind, CORINFO_LLVM_JIT_TEST_INFO* pInfo);
-
-public:
-    static SingleThreadedCompilationContext* StartSingleThreadedCompilation(
-        const char* path, const char* triple, const char* dataLayout);
-    static void FinishSingleThreadedCompilation(SingleThreadedCompilationContext* context);
 
     // ================================================================================================================
     // |                                                 Type system                                                  |
@@ -719,20 +736,8 @@ private:
     llvm::DILocation* getDebugLocation(unsigned lineNo);
     llvm::DILocation* getArtificialDebugLocation();
     llvm::DILocation* getCurrentOrArtificialDebugLocation();
-    llvm::DIFile* getUnknownDebugFile();
 
     llvm::DIType* getOrCreateDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle);
     llvm::DIType* createDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle);
-    llvm::DIType* createDebugTypeForPrimitive(CorInfoType type);
-    llvm::DIType* createDebugTypeForCompositeType(
-        CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle, CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO* pInfo);
-    llvm::DIType* createDebugTypeForEnumType(CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO* pInfo);
-    llvm::DIType* createDebugTypeForArrayType(CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO* pInfo);
-    llvm::DIType* createDebugTypeForPointerType(CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO* pInfo);
-    llvm::DIType* createFixedArrayDebugType(llvm::DIType* elementDebugType, unsigned size);
-    llvm::DISubroutineType* createDebugTypeForFunctionType(CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO* pInfo);
-    llvm::DIType* createClassDebugType(StringRef name, unsigned size, ArrayRef<llvm::Metadata*> elements);
-    llvm::DIDerivedType* createDebugMember(StringRef name, llvm::DIType* debugType, unsigned offset);
-    llvm::DIDerivedType* createPointerDebugType(llvm::DIType* pointeeDebugType);
 };
 #endif /* End of _LLVM_H_ */

--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -9,26 +9,24 @@
 
 using namespace llvm::dwarf;
 
+using llvm::DIBuilder;
 using llvm::Metadata;
 using llvm::DINode;
 using llvm::DINodeArray;
+using llvm::DICompileUnit;
 using llvm::DIFile;
 using llvm::DIType;
+using llvm::DICompositeType;
 using llvm::DIDerivedType;
 using llvm::DISubroutineType;
+using llvm::DISubprogram;
 using llvm::DILocation;
 using llvm::DIExpression;
 
-enum CorInfoLlvmDebugTypeKind
+struct CORINFO_LLVM_STRING
 {
-    CORINFO_LLVM_DEBUG_TYPE_UNDEF,
-    CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE,
-    CORINFO_LLVM_DEBUG_TYPE_COMPOSITE,
-    CORINFO_LLVM_DEBUG_TYPE_ENUM,
-    CORINFO_LLVM_DEBUG_TYPE_ARRAY,
-    CORINFO_LLVM_DEBUG_TYPE_POINTER,
-    CORINFO_LLVM_DEBUG_TYPE_FUNCTION,
-    CORINFO_LLVM_DEBUG_TYPE_COUNT
+    const char* Data;
+    size_t Length;
 };
 
 struct CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO
@@ -88,6 +86,12 @@ struct CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO
     int IsReference;
 };
 
+struct CORINFO_LLVM_FORWARD_TYPE_DEBUG_INFO
+{
+    const char* Name;
+    CorInfoLlvmDebugTypeForwardKind Kind;
+};
+
 struct CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO
 {
     CORINFO_LLVM_DEBUG_TYPE_HANDLE TypeOfThisPointer;
@@ -107,6 +111,7 @@ struct CORINFO_LLVM_TYPE_DEBUG_INFO
         CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO EnumInfo;
         CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO ArrayInfo;
         CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO PointerInfo;
+        CORINFO_LLVM_FORWARD_TYPE_DEBUG_INFO ForwardInfo;
         CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO FunctionInfo;
     };
 };
@@ -124,18 +129,46 @@ struct CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO
     unsigned LineNumber;
 };
 
-struct CORINFO_LLVM_METHOD_DEBUG_INFO
+struct CORINFO_LLVM_METHOD_DECL_DEBUG_INFO
 {
     const char* Name;
+    CORINFO_LLVM_STRING LinkageName;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE OwnerType;
+};
+
+struct CORINFO_LLVM_METHOD_DEBUG_INFO
+{
+    CORINFO_LLVM_METHOD_DECL_DEBUG_INFO Decl;
     const char* Directory;
     const char* FileName;
     unsigned LineNumberCount;
     CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO* SortedLineNumbers;
-    CORINFO_LLVM_DEBUG_TYPE_HANDLE OwnerType;
-    CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
     unsigned VariableCount;
     CORINFO_LLVM_VARIABLE_DEBUG_INFO* Variables;
 };
+
+static StringRef AsRef(CORINFO_LLVM_STRING string)
+{
+    return StringRef(string.Data, string.Length);
+}
+
+static DICompileUnit* CreateCompileUnit(DIBuilder* diBuilder, DIFile* debugFile)
+{
+    return diBuilder->createCompileUnit(DW_LANG_C_plus_plus, debugFile, "ILC", false, "", 1, "",
+        DICompileUnit::FullDebug, 0, false);
+}
+
+template <typename TGetTypeFunc>
+static DISubprogram* CreateMethodDecl(DIBuilder* diBuilder, CORINFO_LLVM_METHOD_DECL_DEBUG_INFO* pInfo, TGetTypeFunc getType)
+{
+    DIType* debugOwnerType = getType(pInfo->OwnerType);
+    DISubroutineType* debugFuncType = llvm::cast<DISubroutineType>(getType(pInfo->Type));
+
+    DISubprogram* debugDecl = diBuilder->createMethod(debugOwnerType, pInfo->Name, AsRef(pInfo->LinkageName), nullptr, 0,
+        debugFuncType, 0, 0, nullptr, DINode::FlagPrototyped);
+    return debugDecl;
+}
 
 void Llvm::initializeDebugInfo()
 {
@@ -155,16 +188,17 @@ void Llvm::initializeDebugInfo()
     assert(info.SortedLineNumbers != nullptr);
     m_lineNumberCount = info.LineNumberCount;
     m_lineNumbers = info.SortedLineNumbers;
-
     DIFile* debugFile = initializeDebugInfoBuilder(&info);
-    DIType* ownerDebugType = getOrCreateDebugType(info.OwnerType);
-    unsigned lineNum = m_lineNumbers[0].LineNumber;
-    DISubroutineType* debugFuncType = llvm::cast<DISubroutineType>(getOrCreateDebugType(info.Type));
-    StringRef linkageName = getRootLlvmFunction()->getName();
-    llvm::DISubprogram::DISPFlags flags = llvm::DISubprogram::SPFlagDefinition | llvm::DISubprogram::SPFlagLocalToUnit;
 
-    m_diFunction = m_diBuilder->createMethod(ownerDebugType, info.Name, linkageName, debugFile, lineNum, debugFuncType,
-                                             0, 0, nullptr, DINode::FlagZero, flags);
+    // For debug type unification across compile units to work, we need to first declare our methods. This is not
+    // really specified anywhere, but it is how C++ DI is emitted and how LLDB expects these things to be shaped.
+    DISubprogram* debugDecl = CreateMethodDecl(
+        m_diBuilder, &info.Decl, [this](CORINFO_LLVM_DEBUG_TYPE_HANDLE hnd) { return getOrCreateDebugType(hnd); });
+    unsigned lineNo = m_lineNumbers[0].LineNumber;
+    DISubprogram::DISPFlags funcFlags = DISubprogram::SPFlagDefinition;
+
+    m_diFunction = m_diBuilder->createFunction(nullptr, debugDecl->getName(), debugDecl->getLinkageName(),
+        debugFile, lineNo, debugDecl->getType(), 0, DINode::FlagPrototyped, funcFlags, nullptr, debugDecl);
 
     initializeDebugVariables(&info);
 
@@ -178,7 +212,7 @@ DIFile* Llvm::initializeDebugInfoBuilder(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)
 
     DIFile* debugFile = DIFile::get(m_context->Context, pInfo->FileName, pInfo->Directory);
 
-    llvm::DICompileUnit* debugCompileUnit = nullptr;
+    DICompileUnit* debugCompileUnit = nullptr;
     m_context->DebugCompileUnitsMap.Lookup(debugFile, &debugCompileUnit);
 
     m_diBuilder =
@@ -186,8 +220,7 @@ DIFile* Llvm::initializeDebugInfoBuilder(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)
 
     if (debugCompileUnit == nullptr)
     {
-        debugCompileUnit = m_diBuilder->createCompileUnit(DW_LANG_C_plus_plus, debugFile, "ILC", false, "", 1, "",
-                                                          llvm::DICompileUnit::FullDebug, 0, false);
+        debugCompileUnit = CreateCompileUnit(m_diBuilder, debugFile);
         m_context->DebugCompileUnitsMap.Set(debugFile, debugCompileUnit);
     }
 
@@ -366,49 +399,7 @@ DILocation* Llvm::getCurrentOrArtificialDebugLocation()
     return debugLocation;
 }
 
-DIFile* Llvm::getUnknownDebugFile()
-{
-    return m_diBuilder->createFile("<unknown>", "");
-}
-
-DIType* Llvm::getOrCreateDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle)
-{
-    DIType* debugType;
-    auto& debugTypesMap = m_context->DebugTypesMap;
-    if (!debugTypesMap.Lookup(debugTypeHandle, &debugType))
-    {
-        debugType = createDebugType(debugTypeHandle);
-        debugTypesMap.Set(debugTypeHandle, debugType, decltype(m_context->DebugTypesMap)::Overwrite);
-    }
-
-    return debugType;
-}
-
-DIType* Llvm::createDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle)
-{
-    CORINFO_LLVM_TYPE_DEBUG_INFO info;
-    GetDebugInfoForDebugType(debugTypeHandle, &info);
-
-    switch (info.Kind)
-    {
-        case CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE:
-            return createDebugTypeForPrimitive(info.PrimitiveType);
-        case CORINFO_LLVM_DEBUG_TYPE_COMPOSITE:
-            return createDebugTypeForCompositeType(debugTypeHandle, &info.CompositeInfo);
-        case CORINFO_LLVM_DEBUG_TYPE_ENUM:
-            return createDebugTypeForEnumType(&info.EnumInfo);
-        case CORINFO_LLVM_DEBUG_TYPE_ARRAY:
-            return createDebugTypeForArrayType(&info.ArrayInfo);
-        case CORINFO_LLVM_DEBUG_TYPE_POINTER:
-            return createDebugTypeForPointerType(&info.PointerInfo);
-        case CORINFO_LLVM_DEBUG_TYPE_FUNCTION:
-            return createDebugTypeForFunctionType(&info.FunctionInfo);
-        default:
-            unreached();
-    }
-}
-
-DIType* Llvm::createDebugTypeForPrimitive(CorInfoType type)
+static DIType* CreatePrimitiveType(DIBuilder* m_diBuilder, CorInfoType type)
 {
     switch (type)
     {
@@ -419,25 +410,25 @@ DIType* Llvm::createDebugTypeForPrimitive(CorInfoType type)
         case CORINFO_TYPE_CHAR:
             return m_diBuilder->createBasicType("char16_t", 16, DW_ATE_UTF);
         case CORINFO_TYPE_BYTE:
-            return m_diBuilder->createBasicType("sbyte", 8, DW_ATE_signed);
+            return m_diBuilder->createBasicType("signed char", 8, DW_ATE_signed);
         case CORINFO_TYPE_UBYTE:
-            return m_diBuilder->createBasicType("byte", 8, DW_ATE_unsigned);
+            return m_diBuilder->createBasicType("unsigned char", 8, DW_ATE_unsigned);
         case CORINFO_TYPE_SHORT:
             return m_diBuilder->createBasicType("short", 16, DW_ATE_signed);
         case CORINFO_TYPE_USHORT:
-            return m_diBuilder->createBasicType("ushort", 16, DW_ATE_unsigned);
+            return m_diBuilder->createBasicType("unsigned short", 16, DW_ATE_unsigned);
         case CORINFO_TYPE_INT:
             return m_diBuilder->createBasicType("int", 32, DW_ATE_signed);
         case CORINFO_TYPE_UINT:
-            return m_diBuilder->createBasicType("uint", 32, DW_ATE_unsigned);
+            return m_diBuilder->createBasicType("unsigned int", 32, DW_ATE_unsigned);
         case CORINFO_TYPE_LONG:
-            return m_diBuilder->createBasicType("long", 64, DW_ATE_signed);
+            return m_diBuilder->createBasicType("long long", 64, DW_ATE_signed);
         case CORINFO_TYPE_ULONG:
-            return m_diBuilder->createBasicType("ulong", 64, DW_ATE_unsigned);
+            return m_diBuilder->createBasicType("unsigned long long", 64, DW_ATE_unsigned);
         case CORINFO_TYPE_NATIVEINT:
-            return m_diBuilder->createBasicType("nint", TARGET_POINTER_BITS, DW_ATE_signed);
+            return m_diBuilder->createBasicType("long", TARGET_POINTER_BITS, DW_ATE_signed);
         case CORINFO_TYPE_NATIVEUINT:
-            return m_diBuilder->createBasicType("nuint", TARGET_POINTER_BITS, DW_ATE_unsigned);
+            return m_diBuilder->createBasicType("unsigned long", TARGET_POINTER_BITS, DW_ATE_unsigned);
         case CORINFO_TYPE_FLOAT:
             return m_diBuilder->createBasicType("float", 32, DW_ATE_float);
         case CORINFO_TYPE_DOUBLE:
@@ -447,96 +438,10 @@ DIType* Llvm::createDebugTypeForPrimitive(CorInfoType type)
     }
 }
 
-DIType* Llvm::createDebugTypeForCompositeType(
-    CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle, CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO* pInfo)
+template <typename TGetTypeFunc>
+static DIType* CreatePointerType(DIBuilder* diBuilder, CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO* pInfo, TGetTypeFunc getType)
 {
-    // Forward-declare our structure to handle recursion.
-    StringRef name = pInfo->Name;
-    DIFile* debugFile = getUnknownDebugFile();
-    llvm::TempDIType declType = llvm::TempDIType(
-        m_diBuilder->createReplaceableCompositeType(DW_TAG_structure_type, name, nullptr, debugFile, 0));
-    m_context->DebugTypesMap.Set(debugTypeHandle, declType.get());
-
-    unsigned debugElementsCount = (pInfo->BaseClass != NO_DEBUG_TYPE) + pInfo->InstanceFieldCount;
-    ArrayStack<Metadata*> debugElements(_compiler->getAllocator(CMK_DebugInfo), debugElementsCount);
-    if (pInfo->BaseClass != NO_DEBUG_TYPE)
-    {
-        DIType* baseDebugType = getOrCreateDebugType(pInfo->BaseClass);
-        debugElements.Push(m_diBuilder->createInheritance(declType.get(), baseDebugType, 0, 0, DINode::FlagZero));
-    }
-
-    for (size_t i = 0; i < pInfo->InstanceFieldCount; i++)
-    {
-        CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* pFieldInfo = &pInfo->InstanceFields[i];
-        DIType* fieldDebugType = getOrCreateDebugType(pFieldInfo->Type);
-        DIDerivedType* debugField = createDebugMember(pFieldInfo->Name, fieldDebugType, pFieldInfo->Offset);
-        debugElements.Push(debugField);
-    }
-
-    DIType* debugType = createClassDebugType(name, pInfo->Size, AsRef(debugElements));
-    m_diBuilder->replaceTemporary(std::move(declType), debugType);
-
-    // TODO-LLVM-DI: static fields.
-    return debugType;
-}
-
-DIType* Llvm::createDebugTypeForEnumType(CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO* pInfo)
-{
-    ArrayStack<Metadata*> elements(_compiler->getAllocator(CMK_DebugInfo), static_cast<unsigned>(pInfo->ElementCount));
-    for (size_t i = 0; i < pInfo->ElementCount; i++)
-    {
-        CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* pElementInfo = &pInfo->Elements[i];
-        llvm::DIEnumerator* element = m_diBuilder->createEnumerator(pElementInfo->Name, pElementInfo->Value);
-        elements.Push(element);
-    }
-
-    DINodeArray elementsArray = m_diBuilder->getOrCreateArray(AsRef(elements));
-    DIType* underlyingDebugType = getOrCreateDebugType(pInfo->ElementType);
-    DIType* enumDebugType =
-        m_diBuilder->createEnumerationType(nullptr, pInfo->Name, getUnknownDebugFile(), 0,
-                                           underlyingDebugType->getSizeInBits(), underlyingDebugType->getAlignInBits(),
-                                           elementsArray, underlyingDebugType);
-
-    return enumDebugType;
-}
-
-DIType* Llvm::createDebugTypeForArrayType(CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO* pInfo)
-{
-    // Array layout: [void* m_pEEType, int32 Length, [int32 padding on 64 bit], <bounds>, Data].
-    // Where <bounds> (for an MD array) is an array of [LowerBound..., Length...].
-    unsigned rank = pInfo->Rank;
-    bool isMDArray = pInfo->IsMultiDimensional != 0;
-    ArrayStack<Metadata*> members(_compiler->getAllocator(CMK_DebugInfo));
-
-    DIType* lengthDebugType = createDebugTypeForPrimitive(CORINFO_TYPE_INT);
-    DIDerivedType* lengthDebugField = createDebugMember("Length", lengthDebugType, OFFSETOF__CORINFO_Array__length);
-    members.Push(lengthDebugField);
-
-    if (isMDArray)
-    {
-        unsigned lowerBoundsOffset = _compiler->eeGetMDArrayLowerBoundOffset(rank, 0);
-        DIType* boundsDebugType = createFixedArrayDebugType(lengthDebugType, rank);
-        DIDerivedType* lowerBoundsDebugField = createDebugMember("LowerBounds", boundsDebugType, lowerBoundsOffset);
-        members.Push(lowerBoundsDebugField);
-
-        unsigned lengthsOffset = _compiler->eeGetMDArrayLengthOffset(rank, 0);
-        DIDerivedType* lengthsDebugField = createDebugMember("Lengths", boundsDebugType, lengthsOffset);
-        members.Push(lengthsDebugField);
-    }
-
-    unsigned dataOffset = isMDArray ? _compiler->eeGetMDArrayDataOffset(rank) : _compiler->eeGetArrayDataOffset();
-    DIType* elementDebugType = getOrCreateDebugType(pInfo->ElementType);
-    DIType* dataDebugType = createFixedArrayDebugType(elementDebugType, 0);
-    DIDerivedType* dataDebugField = createDebugMember("Data", dataDebugType, dataOffset);
-    members.Push(dataDebugField);
-
-    DIType* debugType = createClassDebugType(pInfo->Name, dataOffset, AsRef(members));
-    return debugType;
-}
-
-DIType* Llvm::createDebugTypeForPointerType(CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO* pInfo)
-{
-    DIType* debugPointeeType = getOrCreateDebugType(pInfo->ElementType);
+    DIType* debugPointeeType = getType(pInfo->ElementType);
     DIType* debugPointerType;
     if (pInfo->IsReference != 0)
     {
@@ -544,66 +449,359 @@ DIType* Llvm::createDebugTypeForPointerType(CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO
         // a pointer instead.
         if (debugPointeeType->getTag() == DW_TAG_reference_type)
         {
-            debugPointeeType = createPointerDebugType(llvm::cast<DIDerivedType>(debugPointeeType)->getBaseType());
+            debugPointeeType = llvm::cast<DIDerivedType>(debugPointeeType)->getBaseType();
+            debugPointeeType = diBuilder->createPointerType(debugPointeeType, TARGET_POINTER_BITS);
         }
 
         debugPointerType =
-            m_diBuilder->createReferenceType(DW_TAG_reference_type, debugPointeeType, TARGET_POINTER_BITS);
+            diBuilder->createReferenceType(DW_TAG_reference_type, debugPointeeType, TARGET_POINTER_BITS);
     }
     else
     {
-        debugPointerType = createPointerDebugType(debugPointeeType);
+        debugPointerType = diBuilder->createPointerType(debugPointeeType, TARGET_POINTER_BITS);
     }
 
     return debugPointerType;
 }
 
-DISubroutineType* Llvm::createDebugTypeForFunctionType(CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO* pInfo)
+static DIType* CreateForwardType(DIBuilder* diBuilder, CORINFO_LLVM_FORWARD_TYPE_DEBUG_INFO* pInfo)
 {
-    ArrayStack<Metadata*> debugParameters(_compiler->getAllocator(CMK_DebugInfo));
-    debugParameters.Push(getOrCreateDebugType(pInfo->ReturnType));
+    unsigned tag;
+    switch (pInfo->Kind)
+    {
+        case CORINFO_LLVM_DEBUG_TYPE_FORWARD_STRUCT:
+            tag = DW_TAG_structure_type;
+            break;
+        case CORINFO_LLVM_DEBUG_TYPE_FORWARD_ENUM:
+            tag = DW_TAG_enumeration_type;
+            break;
+        default:
+            unreached();
+    }
+    return diBuilder->createForwardDecl(tag, pInfo->Name, nullptr, nullptr, 0);
+}
 
+template <typename TGetTypeFunc, typename TAlloc>
+static DIType* CreateFunctionType(
+    DIBuilder* diBuilder, CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO* pInfo, TAlloc alloc, TGetTypeFunc getType)
+{
+    unsigned debugParameterCount = 1 + (pInfo->TypeOfThisPointer != NO_DEBUG_TYPE) + pInfo->NumberOfArguments;
+    Metadata** debugParameters = alloc.template allocate<Metadata*>(debugParameterCount);
+
+    size_t index = 0;
+    debugParameters[index++] = getType(pInfo->ReturnType);
     if (pInfo->TypeOfThisPointer != NO_DEBUG_TYPE)
     {
-        debugParameters.Push(getOrCreateDebugType(pInfo->TypeOfThisPointer));
+        debugParameters[index++] = getType(pInfo->TypeOfThisPointer);
     }
-
     for (size_t i = 0; i < pInfo->NumberOfArguments; i++)
     {
-        debugParameters.Push(getOrCreateDebugType(pInfo->ArgumentTypes[i]));
+        debugParameters[index++] = getType(pInfo->ArgumentTypes[i]);
     }
+    llvm::DITypeRefArray debugParametersArray =
+        diBuilder->getOrCreateTypeArray(ArrayRef(debugParameters, debugParameterCount));
+    DIType* debugFuncType = diBuilder->createSubroutineType(debugParametersArray);
 
-    llvm::DITypeRefArray debugParametersArray = m_diBuilder->getOrCreateTypeArray(AsRef(debugParameters));
-    return m_diBuilder->createSubroutineType(debugParametersArray);
+    alloc.deallocate(debugParameters);
+    return debugFuncType;
 }
 
-DIType* Llvm::createFixedArrayDebugType(DIType* elementDebugType, unsigned size)
+static DIType* CreateClassType(
+    LLVMContext& context, DIBuilder* diBuilder, StringRef name, unsigned size, ArrayRef<Metadata*> elements)
+{
+    // We create a distinct array here because we may later need to append declared methods to it.
+    DINodeArray members = llvm::MDTuple::getDistinct(context, elements);
+    DIType* debugType = diBuilder->createClassType(nullptr, name, nullptr, 0, size * BITS_PER_BYTE, 0, 0,
+        DINode::FlagZero, nullptr, members);
+    return debugType;
+}
+
+static DIType* CreateFixedArrayType(DIBuilder* diBuilder, DIType* elementDebugType, unsigned size)
 {
     uint64_t sizeInBits = elementDebugType->getSizeInBits() * size;
-    llvm::DISubrange* boundsRange = m_diBuilder->getOrCreateSubrange(0, size);
-    DINodeArray boundsArray = m_diBuilder->getOrCreateArray(boundsRange);
+    llvm::DISubrange* boundsRange = diBuilder->getOrCreateSubrange(0, size);
+    DINodeArray boundsArray = diBuilder->getOrCreateArray(boundsRange);
     DIType* debugType =
-        m_diBuilder->createArrayType(sizeInBits, elementDebugType->getAlignInBits(), elementDebugType, boundsArray);
+        diBuilder->createArrayType(sizeInBits, elementDebugType->getAlignInBits(), elementDebugType, boundsArray);
 
     return debugType;
 }
 
-DIType* Llvm::createClassDebugType(StringRef name, unsigned size, ArrayRef<Metadata*> elements)
+static DIDerivedType* CreateMember(
+    DIBuilder* diBuilder, StringRef name, llvm::DIType* debugType, unsigned offset)
 {
-    DINodeArray fieldsArray = m_diBuilder->getOrCreateArray(elements);
-    DIType* debugType = m_diBuilder->createClassType(nullptr, name, getUnknownDebugFile(), 0, size * BITS_PER_BYTE,
-                                                     0, 0, DINode::FlagZero, nullptr, fieldsArray);
-    return debugType;
+    return diBuilder->createMemberType(nullptr, name, nullptr, 0, debugType->getSizeInBits(),
+        debugType->getAlignInBits(), offset * BITS_PER_BYTE, DINode::FlagZero, debugType);
 }
 
-DIDerivedType* Llvm::createDebugMember(StringRef name, llvm::DIType* debugType, unsigned offset)
+DIType* Llvm::getOrCreateDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle)
 {
-    return m_diBuilder->createMemberType(nullptr, name, getUnknownDebugFile(), 0, debugType->getSizeInBits(),
-                                         debugType->getAlignInBits(), offset * BITS_PER_BYTE, DINode::FlagZero,
-                                         debugType);
+    DIType** pDebugType = m_context->DebugTypesMap.LookupPointerOrAdd(debugTypeHandle, nullptr);
+    if (*pDebugType == nullptr)
+    {
+        *pDebugType = createDebugType(debugTypeHandle);
+    }
+    return *pDebugType;
 }
 
-DIDerivedType* Llvm::createPointerDebugType(DIType* pointeeDebugType)
+DIType* Llvm::createDebugType(CORINFO_LLVM_DEBUG_TYPE_HANDLE debugTypeHandle)
 {
-    return m_diBuilder->createPointerType(pointeeDebugType, TARGET_POINTER_BITS);
+    CORINFO_LLVM_TYPE_DEBUG_INFO info;
+    GetDebugInfoForDebugType(debugTypeHandle, &info);
+
+    switch (info.Kind)
+    {
+        case CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE:
+            return CreatePrimitiveType(m_diBuilder, info.PrimitiveType);
+        case CORINFO_LLVM_DEBUG_TYPE_POINTER:
+            return CreatePointerType(m_diBuilder, &info.PointerInfo,
+                [this](CORINFO_LLVM_DEBUG_TYPE_HANDLE hnd) { return getOrCreateDebugType(hnd); });
+        case CORINFO_LLVM_DEBUG_TYPE_FORWARD:
+            return CreateForwardType(m_diBuilder, &info.ForwardInfo);
+        case CORINFO_LLVM_DEBUG_TYPE_FUNCTION:
+            return CreateFunctionType(m_diBuilder, &info.FunctionInfo, _compiler->getAllocator(CMK_DebugInfo),
+                [this](CORINFO_LLVM_DEBUG_TYPE_HANDLE hnd) { return getOrCreateDebugType(hnd); });
+        default:
+            unreached();
+    }
+}
+
+class TypeDebugInfoModule
+{
+    SingleThreadedCompilationContext* m_context;
+    DIBuilder m_diBuilder;
+    jitstd::vector<DIType*, MallocAllocator> m_diTypes;
+    unsigned m_declIndex = 0;
+
+public:
+    TypeDebugInfoModule(SingleThreadedCompilationContext* context)
+        : m_context(context)
+        , m_diBuilder(context->Module, /* AllowUnresolved */ true)
+        , m_diTypes({})
+    {
+        m_diTypes.push_back(nullptr);
+        DIFile* debugFile = m_diBuilder.createFile(".NET Types", "");
+        CreateCompileUnit(&m_diBuilder, debugFile);
+    }
+
+    void Finish()
+    {
+        EmitDebugInfoRootFunction();
+        m_diBuilder.finalize();
+    }
+
+    CORINFO_LLVM_DEBUG_TYPE_HANDLE EmitType(CORINFO_LLVM_TYPE_DEBUG_INFO* pInfo)
+    {
+        DIType* debugType;
+        switch (pInfo->Kind)
+        {
+            case CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE:
+                debugType = CreatePrimitiveType(&m_diBuilder, pInfo->PrimitiveType);
+                break;
+            case CORINFO_LLVM_DEBUG_TYPE_COMPOSITE:
+                debugType = EmitCompositeType(&pInfo->CompositeInfo);
+                break;
+            case CORINFO_LLVM_DEBUG_TYPE_ENUM:
+                debugType = EmitEnumType(&pInfo->EnumInfo);
+                break;
+            case CORINFO_LLVM_DEBUG_TYPE_ARRAY:
+                debugType = EmitArrayType(&pInfo->ArrayInfo);
+                break;
+            case CORINFO_LLVM_DEBUG_TYPE_POINTER:
+                debugType = CreatePointerType(&m_diBuilder, &pInfo->PointerInfo,
+                    [this](CORINFO_LLVM_DEBUG_TYPE_HANDLE hnd) { return GetEmittedType(hnd); });
+                break;
+            case CORINFO_LLVM_DEBUG_TYPE_FORWARD:
+                debugType = CreateForwardType(&m_diBuilder, &pInfo->ForwardInfo);
+                break;
+            case CORINFO_LLVM_DEBUG_TYPE_FUNCTION:
+                debugType = CreateFunctionType(&m_diBuilder, &pInfo->FunctionInfo, MallocAllocator{},
+                    [this](CORINFO_LLVM_DEBUG_TYPE_HANDLE hnd) { return GetEmittedType(hnd); });
+                break;
+            default:
+                unreached();
+        }
+
+        unsigned index = static_cast<unsigned>(m_diTypes.size());
+        m_diTypes.push_back(debugType);
+        return index;
+    }
+
+    CORINFO_LLVM_DEBUG_METHOD_DECL_HANDLE EmitMethodDecl(CORINFO_LLVM_METHOD_DECL_DEBUG_INFO* pInfo)
+    {
+        DISubprogram* debugDecl = CreateMethodDecl(
+            &m_diBuilder, pInfo, [this](CORINFO_LLVM_DEBUG_TYPE_HANDLE hnd) { return GetEmittedType(hnd); });
+
+        // We've previously made the elements distinct, hence we can add to them.
+        DICompositeType* debugOwnerType = llvm::cast<DICompositeType>(GetEmittedType(pInfo->OwnerType));
+        debugOwnerType->getElements()->push_back(debugDecl);
+        return ++m_declIndex;
+    }
+
+private:
+    DIType* GetEmittedType(CORINFO_LLVM_DEBUG_TYPE_HANDLE handle)
+    {
+        unsigned index = handle;
+        assert(index < m_diTypes.size());
+        return m_diTypes[index];
+    }
+
+    DIType* EmitCompositeType(CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO* pInfo)
+    {
+        // Forward-declare our structure to handle inheritance.
+        llvm::TempDIType declType = llvm::TempDIType(
+            m_diBuilder.createReplaceableCompositeType(DW_TAG_structure_type, "", nullptr, nullptr, 0));
+        unsigned debugElementsCount = (pInfo->BaseClass != NO_DEBUG_TYPE) + pInfo->InstanceFieldCount;
+        llvm::SmallVector<Metadata*> debugElements(debugElementsCount);
+        if (pInfo->BaseClass != NO_DEBUG_TYPE)
+        {
+            DIType* baseDebugType = GetEmittedType(pInfo->BaseClass);
+            DIDerivedType* inheritance =
+                m_diBuilder.createInheritance(declType.get(), baseDebugType, 0, 0, DINode::FlagZero);
+            debugElements.push_back(inheritance);
+        }
+
+        for (size_t i = 0; i < pInfo->InstanceFieldCount; i++)
+        {
+            CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* pFieldInfo = &pInfo->InstanceFields[i];
+            DIType* fieldDebugType = GetEmittedType(pFieldInfo->Type);
+            DIDerivedType* debugField =
+                CreateMember(&m_diBuilder, pFieldInfo->Name, fieldDebugType, pFieldInfo->Offset);
+            debugElements.push_back(debugField);
+        }
+
+        DIType* debugType =
+            CreateClassType(m_context->Context, &m_diBuilder, pInfo->Name, pInfo->Size, debugElements);
+        m_diBuilder.replaceTemporary(std::move(declType), debugType);
+
+        // TODO-LLVM-DI: static fields.
+        return debugType;
+    }
+
+    DIType* EmitEnumType(CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO* pInfo)
+    {
+        llvm::SmallVector<Metadata*, 24> elements(static_cast<size_t>(pInfo->ElementCount));
+        for (size_t i = 0; i < pInfo->ElementCount; i++)
+        {
+            CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* pElementInfo = &pInfo->Elements[i];
+            llvm::DIEnumerator* element = m_diBuilder.createEnumerator(pElementInfo->Name, pElementInfo->Value);
+            elements.push_back(element);
+        }
+
+        DINodeArray elementsArray = m_diBuilder.getOrCreateArray(elements);
+        DIType* underlyingDebugType = GetEmittedType(pInfo->ElementType);
+        DIType* enumDebugType =
+            m_diBuilder.createEnumerationType(nullptr, pInfo->Name, nullptr, 0,
+                underlyingDebugType->getSizeInBits(), underlyingDebugType->getAlignInBits(),
+                elementsArray, underlyingDebugType);
+
+        return enumDebugType;
+    }
+
+    DIType* EmitArrayType(CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO* pInfo)
+    {
+        // Array layout: [void* m_pEEType, int32 Length, [int32 padding on 64 bit], <bounds>, Data].
+        // Where <bounds> (for an MD array) is an array of [LowerBound..., Length...].
+        unsigned rank = pInfo->Rank;
+        bool isMDArray = pInfo->IsMultiDimensional != 0;
+        llvm::SmallVector<Metadata*> members;
+
+        DIType* lengthDebugType = CreatePrimitiveType(&m_diBuilder, CORINFO_TYPE_INT);
+        DIDerivedType* lengthDebugField =
+            CreateMember(&m_diBuilder, "Length", lengthDebugType, OFFSETOF__CORINFO_Array__length);
+        members.push_back(lengthDebugField);
+
+        if (isMDArray)
+        {
+            unsigned lowerBoundsOffset = Compiler::eeGetMDArrayLowerBoundOffset(rank, 0);
+            DIType* boundsDebugType = CreateFixedArrayType(&m_diBuilder, lengthDebugType, rank);
+            DIDerivedType* lowerBoundsDebugField =
+                CreateMember(&m_diBuilder, "LowerBounds", boundsDebugType, lowerBoundsOffset);
+            members.push_back(lowerBoundsDebugField);
+
+            unsigned lengthsOffset = Compiler::eeGetMDArrayLengthOffset(rank, 0);
+            DIDerivedType* lengthsDebugField = CreateMember(&m_diBuilder, "Lengths", boundsDebugType, lengthsOffset);
+            members.push_back(lengthsDebugField);
+        }
+
+        unsigned dataOffset = isMDArray ? Compiler::eeGetMDArrayDataOffset(rank) : Compiler::eeGetArrayDataOffset();
+        DIType* elementDebugType = GetEmittedType(pInfo->ElementType);
+        DIType* dataDebugType = CreateFixedArrayType(&m_diBuilder, elementDebugType, 0);
+        DIDerivedType* dataDebugField = CreateMember(&m_diBuilder, "Data", dataDebugType, dataOffset);
+        members.push_back(dataDebugField);
+
+        DIType* debugType = CreateClassType(m_context->Context, &m_diBuilder, pInfo->Name, dataOffset, members);
+        return debugType;
+    }
+
+    void EmitDebugInfoRootFunction()
+    {
+        // Create our no-op defined function.
+        Type* llvmPtrType = llvm::PointerType::getUnqual(m_context->Context);
+        FunctionType* llvmFuncType = FunctionType::get(llvmPtrType, /* isVarArg */ true);
+        Function* llvmFunc = Function::Create(
+            llvmFuncType, llvm::GlobalValue::ExternalLinkage, "dotnet_debug_types_root", m_context->Module);
+        llvm::BasicBlock* llvmBlock = llvm::BasicBlock::Create(m_context->Context, "", llvmFunc);
+        llvm::ReturnInst::Create(m_context->Context, llvm::Constant::getNullValue(llvmPtrType), llvmBlock);
+
+        // Make sure it's preserved by the linker.
+        llvm::ArrayType* usedType = llvm::ArrayType::get(llvmFunc->getType(), 1);
+        llvm::Constant* usedValue = llvm::ConstantArray::get(usedType, {llvmFunc});
+        new llvm::GlobalVariable(m_context->Module, usedType, true, llvm::GlobalValue::AppendingLinkage, usedValue, "llvm.used");
+
+        // Now for the last step - pretend it's got a huge function pointer containing all of the types we've emitted.
+        // This way, our consumers (wasmtime's DI GC) will preserve the types. This is a workaround which wouldn't be
+        // needed had LLVM had a way to emit DWARF's DW_FORM_ref_addr relocations directly. Alas, we have to rely on
+        // forward declarations, which won't be resolved by the simple-minded GC algorithm in wasmtime.
+        // TODO-LLVM-DI: make this into a linked list of some kind to avoid algorithmic problems in consumers.
+        llvm::DITypeRefArray diRootedTypes = llvm::DINode::getDistinct(m_context->Context, {nullptr});
+        for (int i = 0; i < m_diTypes.size(); i++)
+        {
+            DIType* diType = m_diTypes[i];
+            if ((diType != nullptr) &&
+                (diType->getTag() == DW_TAG_structure_type || diType->getTag() == DW_TAG_enumeration_type) &&
+                !diType->isForwardDecl())
+            {
+                // We could optimize this by only including roots of strongly connected components.
+                diRootedTypes->push_back(diType);
+            }
+        }
+        DIType* diRootTypes = m_diBuilder.createSubroutineType(diRootedTypes);
+        diRootTypes = m_diBuilder.createPointerType(diRootTypes, TARGET_POINTER_BITS);
+
+        DISubroutineType* debugFuncType = m_diBuilder.createSubroutineType(m_diBuilder.getOrCreateTypeArray({diRootTypes}));
+        DISubprogram* debugFunc = m_diBuilder.createFunction(
+            nullptr, llvmFunc->getName(), "", nullptr, 0, debugFuncType, 0, DINode::FlagZero, DISubprogram::SPFlagDefinition);
+        llvmFunc->setSubprogram(debugFunc);
+    }
+};
+
+CORINFO_LLVM_DEBUG_TYPE_HANDLE SingleThreadedCompilationContext::EmitDebugTypeInfo(
+    SingleThreadedCompilationContext* context, CORINFO_LLVM_TYPE_DEBUG_INFO* pInfo)
+{
+    if (context->DebugTypes == nullptr)
+    {
+        context->DebugTypes = new TypeDebugInfoModule(context);
+    }
+    return context->DebugTypes->EmitType(pInfo);
+}
+
+CORINFO_LLVM_DEBUG_METHOD_DECL_HANDLE SingleThreadedCompilationContext::EmitDebugMethodDecl(
+    SingleThreadedCompilationContext* context, CORINFO_LLVM_METHOD_DECL_DEBUG_INFO* pInfo)
+{
+    if (context->DebugTypes == nullptr)
+    {
+        context->DebugTypes = new TypeDebugInfoModule(context);
+    }
+    return context->DebugTypes->EmitMethodDecl(pInfo);
+}
+
+void SingleThreadedCompilationContext::FinishDebugInfo()
+{
+    if (DebugTypes != nullptr)
+    {
+        DebugTypes->Finish();
+        delete DebugTypes;
+        DebugTypes = nullptr;
+    }
 }

--- a/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
@@ -21,6 +21,7 @@ namespace Internal.Text
             _value = Encoding.UTF8.GetBytes(s);
         }
 
+        public byte[] Value => _value;
         public int Length => _value.Length;
 
         // For now, define implicit conversions between string and Utf8String to aid the transition

--- a/src/coreclr/tools/Common/JitInterface/JitEEApi.Shared.cspp
+++ b/src/coreclr/tools/Common/JitInterface/JitEEApi.Shared.cspp
@@ -10,6 +10,8 @@ enum CorJitApiId
 {
     CJAI_StartSingleThreadedCompilation,
     CJAI_FinishSingleThreadedCompilation,
+    CJAI_EmitDebugTypeInfo,
+    CJAI_EmitDebugMethodDecl,
     CJAI_Count
 };
 
@@ -42,4 +44,23 @@ enum CorInfoLlvmVirtualUnwindModel
 {
     CILVUM_Sparse,
     CILVUM_Precise
+};
+
+enum CorInfoLlvmDebugTypeKind
+{
+    CORINFO_LLVM_DEBUG_TYPE_UNDEF,
+    CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE,
+    CORINFO_LLVM_DEBUG_TYPE_COMPOSITE,
+    CORINFO_LLVM_DEBUG_TYPE_ENUM,
+    CORINFO_LLVM_DEBUG_TYPE_ARRAY,
+    CORINFO_LLVM_DEBUG_TYPE_POINTER,
+    CORINFO_LLVM_DEBUG_TYPE_FORWARD,
+    CORINFO_LLVM_DEBUG_TYPE_FUNCTION,
+    CORINFO_LLVM_DEBUG_TYPE_COUNT
+};
+
+enum CorInfoLlvmDebugTypeForwardKind
+{
+    CORINFO_LLVM_DEBUG_TYPE_FORWARD_STRUCT,
+    CORINFO_LLVM_DEBUG_TYPE_FORWARD_ENUM
 };

--- a/src/coreclr/tools/Common/TypeSystem/TypesDebugInfoWriter/TypesDebugInfoWriter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/TypesDebugInfoWriter/TypesDebugInfoWriter.cs
@@ -106,6 +106,7 @@ namespace Internal.TypeSystem.TypesDebugInfo
     [StructLayout(LayoutKind.Sequential)]
     public struct MemberFunctionIdTypeDescriptor
     {
+        public MethodDesc Method;
         public uint MemberFunction;
         public uint ParentClass;
         public string Name;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -1003,7 +1003,7 @@ namespace ILCompiler
             return _cctorContextsGenerated;
         }
 
-        internal IEnumerable<MetadataType> GetTypesWithStaticBases()
+        public IEnumerable<MetadataType> GetTypesWithStaticBases()
         {
             var allTypes = new SortedSet<MetadataType>(CompilerComparer.Instance);
             allTypes.UnionWith(_typesWithNonGCStaticsGenerated);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -231,6 +231,7 @@ namespace ILCompiler
 
                 MemberFunctionIdTypeDescriptor descriptor = default(MemberFunctionIdTypeDescriptor);
 
+                descriptor.Method = method;
                 descriptor.MemberFunction = GetMethodTypeIndex(method);
                 descriptor.ParentClass = GetTypeIndex(method.OwningType, true);
                 descriptor.Name = method.Name;

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMMethodCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMMethodCodeNode.cs
@@ -9,6 +9,7 @@ using ILCompiler.DependencyAnalysis.Wasm;
 using ILCompiler.DependencyAnalysisFramework;
 
 using Internal.IL;
+using Internal.JitInterface;
 using Internal.Text;
 using Internal.TypeSystem;
 
@@ -16,9 +17,11 @@ using CombinedDependencyList = System.Collections.Generic.List<ILCompiler.Depend
 
 namespace ILCompiler.DependencyAnalysis
 {
-    internal sealed class LLVMMethodCodeNode : DependencyNodeCore<NodeFactory>, IMethodBodyNode, IMethodCodeNode, IWasmMethodCodeNode, ISpecialUnboxThunkNode
+    internal sealed class LLVMMethodCodeNode : DependencyNodeCore<NodeFactory>, IMethodBodyNode, IMethodCodeNode, IWasmMethodCodeNode, INodeWithDebugInfo, ISpecialUnboxThunkNode
     {
         private readonly MethodDesc _method;
+        private MethodDebugInformation _debugInfo;
+        private TypeDesc[] _localTypes;
         private DependencyList _dependencies;
 
         public LLVMMethodCodeNode(MethodDesc method)
@@ -29,6 +32,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public MethodDesc Method => _method;
         public WasmMethodPreciseVirtualUnwindInfoNode PreciseVirtualUnwindInfo { get; private set; }
+        public bool HasDebugInfo => _debugInfo != null;
+        public bool IsStateMachineMoveNextMethod => _debugInfo.IsStateMachineMoveNextMethod;
         public bool CompilationCompleted { get; set; }
 
         public int Offset => 0;
@@ -71,9 +76,23 @@ namespace ILCompiler.DependencyAnalysis
 
         public void InitializeDebugVarInfos(DebugVarInfo[] debugVarInfos) { }
 
-        public void InitializeDebugInfo(MethodDebugInformation debugInfo) { }
+        public void InitializeDebugInfo(MethodDebugInformation debugInfo)
+        {
+            Debug.Assert(_debugInfo == null);
+            _debugInfo = debugInfo;
+        }
 
-        public void InitializeLocalTypes(TypeDesc[] localTypes) { }
+        public void InitializeLocalTypes(TypeDesc[] localTypes)
+        {
+            // This should really be combined with "InitializeDebugInfo".
+            Debug.Assert(_localTypes == null);
+            _localTypes = localTypes;
+        }
+
+        public IEnumerable<NativeSequencePoint> GetNativeSequencePoints() => null;
+
+        public IEnumerable<DebugVarInfoMetadata> GetDebugVars() =>
+            CorInfoImpl.GetDebugVarsForMethod(_method, _localTypes, static t => t, _debugInfo, out _);
 
         public void InitializeNonRelocationDependencies(DependencyList additionalDependencies)
         {

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -23,6 +23,7 @@ namespace ILCompiler
     {
         private Dictionary<int, CorInfoImpl> _compilationContexts;
         private readonly LLVMCompilationResults _compilationResults = new();
+        private readonly ParallelOptions _parallelOptions;
         private string _outputFile;
 
         internal LLVMCodegenConfigProvider Options { get; }
@@ -44,6 +45,7 @@ namespace ILCompiler
             : base(dependencyGraph, nodeFactory, roots, ilProvider, debugInformationProvider, logger, inliningPolicy, instructionSetSupport,
                 null /* ProfileDataManager */, errorProvider, readOnlyFieldPolicy, baseOptions, parallelism)
         {
+            _parallelOptions = new() { MaxDegreeOfParallelism = parallelism };
             NodeFactory = nodeFactory;
             Options = options;
         }
@@ -51,22 +53,16 @@ namespace ILCompiler
         protected override void CompileInternal(string outputFile, ObjectDumper dumper)
         {
             Stopwatch stopwatch = Stopwatch.StartNew();
-
             StartCompilation(outputFile);
 
             _dependencyGraph.ComputeMarkedNodes();
-            NodeFactory.SetMarkingComplete();
             Console.WriteLine($"LLVM compilation to IR finished in {stopwatch.Elapsed.TotalSeconds:0.##} seconds");
 
             stopwatch.Restart();
             FinishCompilation();
             Console.WriteLine($"LLVM generation of bitcode finished in {stopwatch.Elapsed.TotalSeconds:0.##} seconds");
 
-            double allocatedBytes = GC.GetAllocatedBytesForCurrentThread();
-            stopwatch.Restart();
-            WasmObjectWriter.EmitObject(outputFile, _dependencyGraph.MarkedNodeList, this, dumper);
-            allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBytes;
-            Console.WriteLine($"Object writing finished in {stopwatch.Elapsed.TotalSeconds:0.##} seconds, allocated {allocatedBytes / 1024 / 1024:0.##} MB");
+            Parallel.ForEach([EmitTypeDebugInfo, () => EmitObject(dumper)], _parallelOptions, action => action());
         }
 
         private void StartCompilation(string outputFile)
@@ -76,12 +72,63 @@ namespace ILCompiler
 
         private void FinishCompilation()
         {
-            Parallel.ForEach(_compilationContexts, new() { MaxDegreeOfParallelism = _parallelism }, context =>
+            NodeFactory.SetMarkingComplete();
+            Parallel.ForEach(_compilationContexts, _parallelOptions, context =>
             {
                 context.Value.JitFinishSingleThreadedCompilation();
             });
 
             _compilationContexts = null;
+        }
+
+        private void EmitTypeDebugInfo()
+        {
+            if (_debugInformationProvider is NullDebugInformationProvider)
+            {
+                return;
+            }
+
+            long start = Stopwatch.GetTimestamp();
+            CorInfoImpl diModule = CreateModuleCompilationContext("debug");
+            LlvmTypesDebugInfoEmit diEmit = new LlvmTypesDebugInfoEmit(this, diModule);
+
+            // Keep the logic below in sync with "ObjectWriter::EmitObject".
+            foreach (DependencyNode node in _dependencyGraph.MarkedNodeList)
+            {
+                // Ensure any allocated MethodTables have debug info.
+                if (node is ConstructedEETypeNode methodTable)
+                {
+                    diEmit.EmitTypeInfo(methodTable.Type);
+                }
+                else if (node is LLVMMethodCodeNode { HasDebugInfo: true } methodNode)
+                {
+                    diEmit.EmitMethodInfo(methodNode.Method, methodNode);
+                }
+            }
+
+            // Ensure all fields associated with generated static bases have debug info.
+            foreach (MetadataType typeWithStaticBase in _nodeFactory.MetadataManager.GetTypesWithStaticBases())
+            {
+                diEmit.EmitTypeInfo(typeWithStaticBase);
+            }
+
+            // Finish up and emit the module.
+            diModule.JitFinishSingleThreadedCompilation();
+
+            TimeSpan elapsed = Stopwatch.GetElapsedTime(start);
+            Console.WriteLine($"LLVM generation of debug info finished in {elapsed.TotalSeconds:0.##} seconds");
+        }
+
+        private void EmitObject(ObjectDumper dumper)
+        {
+            double allocatedBytes = GC.GetAllocatedBytesForCurrentThread();
+            long start = Stopwatch.GetTimestamp();
+
+            WasmObjectWriter.EmitObject(_outputFile, _dependencyGraph.MarkedNodeList, this, dumper);
+
+            TimeSpan elapsed = Stopwatch.GetElapsedTime(start);
+            allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBytes;
+            Console.WriteLine($"Object writing finished in {elapsed.TotalSeconds:0.##} seconds, allocated {allocatedBytes / 1024 / 1024:0.##} MB");
         }
 
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)
@@ -125,19 +172,15 @@ namespace ILCompiler
             int moduleCount = Options.MaxLlvmModuleCount;
             if (_compilationContexts == null)
             {
-                _compilationContexts = new();
+                _compilationContexts = new(moduleCount);
                 for (int index = 0; index < moduleCount; index++)
                 {
                     CorInfoImpl corInfo = new CorInfoImpl(this);
-                    string outputFilePath = Path.ChangeExtension(_outputFile, null) + $".{index}.bc";
-
-                    corInfo.JitStartSingleThreadedCompilation(outputFilePath, Options.Target, Options.DataLayout);
-                    _compilationResults.Add(outputFilePath);
-                    _compilationContexts[index] = corInfo;
+                    _compilationContexts[index] = CreateModuleCompilationContext(index.ToString());
                 }
             }
 
-            Parallel.For(0, moduleCount, new() { MaxDegreeOfParallelism = _parallelism }, index =>
+            Parallel.For(0, moduleCount, _parallelOptions, index =>
             {
                 CorInfoImpl corInfo = _compilationContexts[index];
                 int allMethodsCount = methodsToCompile.Count;
@@ -191,6 +234,16 @@ namespace ILCompiler
                 else
                     Logger.LogError($"Method will always throw because: {exception.Message}", 1005, method, MessageSubCategory.AotAnalysis);
             }
+        }
+
+        private CorInfoImpl CreateModuleCompilationContext(string kind)
+        {
+            CorInfoImpl corInfo = new CorInfoImpl(this);
+            string outputFilePath = Path.ChangeExtension(_outputFile, $".{kind}.bc");
+
+            corInfo.JitStartSingleThreadedCompilation(outputFilePath, Options.Target, Options.DataLayout);
+            _compilationResults.Add(outputFilePath);
+            return corInfo;
         }
 
         public override ISymbolNode GetExternalMethodAccessor(MethodDesc method, ReadOnlySpan<TargetAbiType> sig)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -27,7 +27,7 @@ namespace ILCompiler
         private readonly ProfileDataManager _profileDataManager;
         protected readonly MethodImportationErrorProvider _methodImportationErrorProvider;
         private readonly ReadOnlyFieldPolicy _readOnlyFieldPolicy;
-        protected readonly int _parallelism;
+        private readonly int _parallelism;
 
         public InstructionSetSupport InstructionSetSupport { get; }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.DebugInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.DebugInfo.cs
@@ -8,13 +8,35 @@ using System.IO;
 using System.Runtime.InteropServices;
 
 using ILCompiler;
+using ILCompiler.DependencyAnalysis;
 
 using Internal.IL;
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.TypesDebugInfo;
 
 namespace Internal.JitInterface
 {
+    // Our debug info support is structured as follows:
+    // 1. When emitting code, we only emit definitions for basic types and pointers, everything else - enums, arrays, structs,
+    //    becomes a declaration.
+    // 2. At the end of the compilation, one "debug" module is emitted, consisting wholly of DWARF definitions for all of the
+    //    various complex types.
+    //
+    // This design was driven by the following constraints:
+    // 1) "UserDefinedTypeDescriptor" (aka UDTD), our DI 'backend', relies on the marking having been complete to determine
+    //    things like what static and instance fields should be included.
+    // 2) The way C++ DWARF is structured, a class definition must include all methods belonging to the class, as declarations.
+    //    Since we do not want the compilation partitioning to be constrained by DI rules, the only way to achieve this while
+    //    having methods spread across compile units is by emitting the definition after marking.
+    // 3) We do not want to duplicate DI information; this slows everything down. Because we can run DI emit in parallel with
+    //    object writing, which is single-threaded anyway, 'phase 2' is essentially free TP-wise.
+    //
+    // Notably, the current implementation has a lot of room for TP improvement: we don't need all the information UDTD provides
+    // in the compilation phase, and we should probably switch to the "push" model there too. Changing the former would imply
+    // changing upstream code, however.
+    // TODO-LLVM-Upstream: augment UDTD to allow only requesting what we need.
+    //
     internal sealed unsafe partial class CorInfoImpl : ITypesDebugInfoWriter
     {
         // We want to reuse the code inside UserDefinedTypeDescriptor for our debug info writing. That code assumes a  "push"
@@ -33,93 +55,74 @@ namespace Internal.JitInterface
         private UserDefinedTypeDescriptor _debugTypesDescriptor;
         private ArrayBuilder<DebugTypeShape> _debugTypesShapes;
         private ArrayBuilder<MemberFunctionIdTypeDescriptor> _debugFunctions;
-        private Dictionary<string, uint> _incompleteTypesMap;
 
-        private UserDefinedTypeDescriptor DebugTypesDescriptor => _debugTypesDescriptor ??= InitializeLlvmDebugInfo();
+        private UserDefinedTypeDescriptor DebugTypes => _debugTypesDescriptor ??= InitializeLlvmDebugInfo();
 
         private UserDefinedTypeDescriptor InitializeLlvmDebugInfo()
         {
             // Make zero an illegal shape index.
             _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_COUNT, null));
-            _incompleteTypesMap = new();
-
             return new(this, _compilation.NodeFactory);
         }
 
-        public uint GetEnumTypeIndex(EnumTypeDescriptor enumTypeDescriptor, EnumRecordTypeDescriptor[] typeRecords)
+        uint ITypesDebugInfoWriter.GetEnumTypeIndex(EnumTypeDescriptor enumType, EnumRecordTypeDescriptor[] typeRecords)
         {
             uint index = (uint)_debugTypesShapes.Count;
-            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ENUM, (enumTypeDescriptor, typeRecords)));
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD, (enumType.Name, CorInfoLlvmDebugTypeForwardKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD_ENUM)));
             return index;
         }
 
-        public uint GetClassTypeIndex(ClassTypeDescriptor classTypeDescriptor)
-        {
-            // Multiple type forwards may be requested for the same underlying type. Return the same index for all of of them to support later
-            // updating the entry with a complete type.
-            ref uint index = ref CollectionsMarshal.GetValueRefOrAddDefault(_incompleteTypesMap, classTypeDescriptor.Name, out bool exists);
-            if (exists)
-            {
-                return index;
-            }
-
-            index = (uint)_debugTypesShapes.Count;
-            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_UNDEF, null));
-            return index;
-        }
-
-        public uint GetCompleteClassTypeIndex(ClassTypeDescriptor classTypeDescriptor, ClassFieldsTypeDescriptor classFieldsTypeDescriptor, DataFieldDescriptor[] fields, StaticDataFieldDescriptor[] statics)
+        uint ITypesDebugInfoWriter.GetClassTypeIndex(ClassTypeDescriptor classType)
         {
             uint index = (uint)_debugTypesShapes.Count;
-            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_COMPOSITE, (classTypeDescriptor, classFieldsTypeDescriptor, fields, statics)));
-
-            if (_incompleteTypesMap.TryGetValue(classTypeDescriptor.Name, out uint incompleteTypeIndex))
-            {
-                _debugTypesShapes[(int)incompleteTypeIndex] = new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_UNDEF, index);
-            }
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD, (classType.Name, CorInfoLlvmDebugTypeForwardKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD_STRUCT)));
             return index;
         }
 
-        public uint GetArrayTypeIndex(ClassTypeDescriptor classDescriptor, ArrayTypeDescriptor arrayTypeDescriprtor)
+        uint ITypesDebugInfoWriter.GetCompleteClassTypeIndex(ClassTypeDescriptor classType, ClassFieldsTypeDescriptor classFields, DataFieldDescriptor[] fields, StaticDataFieldDescriptor[] statics)
         {
             uint index = (uint)_debugTypesShapes.Count;
-            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ARRAY, (classDescriptor, arrayTypeDescriprtor)));
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD, (classType.Name, CorInfoLlvmDebugTypeForwardKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD_STRUCT)));
             return index;
         }
 
-        public uint GetPointerTypeIndex(PointerTypeDescriptor pointerDescriptor)
+        uint ITypesDebugInfoWriter.GetArrayTypeIndex(ClassTypeDescriptor classType, ArrayTypeDescriptor arrayType)
         {
             uint index = (uint)_debugTypesShapes.Count;
-            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_POINTER, pointerDescriptor));
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD, (classType.Name, CorInfoLlvmDebugTypeForwardKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD_STRUCT)));
             return index;
         }
 
-        public uint GetMemberFunctionTypeIndex(MemberFunctionTypeDescriptor memberDescriptor, uint[] argumentTypes)
+        uint ITypesDebugInfoWriter.GetPointerTypeIndex(PointerTypeDescriptor pointerType)
         {
             uint index = (uint)_debugTypesShapes.Count;
-            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FUNCTION, (memberDescriptor, argumentTypes)));
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_POINTER, pointerType));
             return index;
         }
 
-        public uint GetMemberFunctionId(MemberFunctionIdTypeDescriptor memberIdDescriptor)
+        uint ITypesDebugInfoWriter.GetMemberFunctionTypeIndex(MemberFunctionTypeDescriptor funcType, uint[] argumentTypes)
+        {
+            uint index = (uint)_debugTypesShapes.Count;
+            _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FUNCTION, (funcType, argumentTypes)));
+            return index;
+        }
+
+        uint ITypesDebugInfoWriter.GetMemberFunctionId(MemberFunctionIdTypeDescriptor method)
         {
             // Note that function descriptors reside in a namespace distinct from "types".
             uint index = (uint)_debugFunctions.Count;
-            _debugFunctions.Add(memberIdDescriptor);
+            _debugFunctions.Add(method);
             return index;
         }
 
-        public uint GetPrimitiveTypeIndex(TypeDesc type)
+        uint ITypesDebugInfoWriter.GetPrimitiveTypeIndex(TypeDesc type)
         {
             uint index = (uint)_debugTypesShapes.Count;
             _debugTypesShapes.Add(new(CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE, type));
             return index;
         }
 
-        public string GetMangledName(TypeDesc type)
-        {
-            return _compilation.NodeFactory.NameMangler.GetMangledTypeName(type);
-        }
+        string ITypesDebugInfoWriter.GetMangledName(TypeDesc type) => GetDebugTypeName(type);
 
         private struct DebugTypeShape
         {
@@ -129,114 +132,10 @@ namespace Internal.JitInterface
             public DebugTypeShape(CorInfoLlvmDebugTypeKind kind, object data) => (Kind, Data) = (kind, data);
         }
 
-        private enum CORINFO_LLVM_DEBUG_TYPE_HANDLE { }
-
-        private enum CorInfoLlvmDebugTypeKind
-        {
-            CORINFO_LLVM_DEBUG_TYPE_UNDEF,
-            CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE,
-            CORINFO_LLVM_DEBUG_TYPE_COMPOSITE,
-            CORINFO_LLVM_DEBUG_TYPE_ENUM,
-            CORINFO_LLVM_DEBUG_TYPE_ARRAY,
-            CORINFO_LLVM_DEBUG_TYPE_POINTER,
-            CORINFO_LLVM_DEBUG_TYPE_FUNCTION,
-            CORINFO_LLVM_DEBUG_TYPE_COUNT
-        }
-
-        private struct CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO
-        {
-            public byte* Name;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
-            public uint Offset;
-        }
-
-        private struct CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO
-        {
-            public byte* Name;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
-            public byte* BaseSymbolName;
-            public uint StaticOffset;
-            public int IsStaticDataInObject;
-        }
-
-        private struct CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO
-        {
-            public byte* Name;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE BaseClass;
-            public uint Size;
-
-            public uint InstanceFieldCount;
-            public CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* InstanceFields;
-
-            public uint StaticFieldCount;
-            public CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO* StaticFields;
-        }
-
-        private struct CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO
-        {
-            public byte* Name;
-            public ulong Value;
-        }
-
-        private struct CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO
-        {
-            public byte* Name;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
-            public ulong ElementCount;
-            public CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* Elements;
-        }
-
-        private struct CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO
-        {
-            public byte* Name;
-            public uint Rank;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
-            public int IsMultiDimensional;
-        }
-
-        private struct CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO
-        {
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
-            public int IsReference;
-        }
-
-        private struct CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO
-        {
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE TypeOfThisPointer;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE ReturnType;
-            public uint NumberOfArguments;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE* ArgumentTypes;
-        }
-
-        private struct CORINFO_LLVM_TYPE_DEBUG_INFO
-        {
-            public CorInfoLlvmDebugTypeKind Kind;
-#pragma warning disable CS0649
-            public CORINFO_LLVM_TYPE_DEBUG_INFO_UNION Union;
-#pragma warning restore CS0649
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        private struct CORINFO_LLVM_TYPE_DEBUG_INFO_UNION
-        {
-            [FieldOffset(0)]
-            public CorInfoType PrimitiveType;
-            [FieldOffset(0)]
-            public CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO CompositeInfo;
-            [FieldOffset(0)]
-            public CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO EnumInfo;
-            [FieldOffset(0)]
-            public CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO ArrayInfo;
-            [FieldOffset(0)]
-            public CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO PointerInfo;
-            [FieldOffset(0)]
-            public CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO FunctionInfo;
-        }
-
         private CORINFO_LLVM_DEBUG_TYPE_HANDLE GetDebugTypeForType(CORINFO_CLASS_STRUCT_* typeHandle)
         {
             TypeDesc type = HandleToObject(typeHandle);
-            uint index = DebugTypesDescriptor.GetVariableTypeIndex(type);
+            uint index = DebugTypes.GetVariableTypeIndex(type);
 
             return IndexToDebugTypeHandle(index);
         }
@@ -252,17 +151,11 @@ namespace Internal.JitInterface
                 case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE:
                     GetDebugInfoForPrimitiveType(shape.Data, &pInfo->Union.PrimitiveType);
                     break;
-                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_COMPOSITE:
-                    GetDebugInfoForCompositeType(shape.Data, &pInfo->Union.CompositeInfo);
-                    break;
-                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ENUM:
-                    GetDebugInfoForEnumType(shape.Data, &pInfo->Union.EnumInfo);
-                    break;
-                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ARRAY:
-                    GetDebugInfoForArrayType(shape.Data, &pInfo->Union.ArrayInfo);
-                    break;
                 case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_POINTER:
                     GetDebugInfoForPointerType(shape.Data, &pInfo->Union.PointerInfo);
+                    break;
+                case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD:
+                    GetDebugInfoForForwardType(shape.Data, &pInfo->Union.ForwardInfo);
                     break;
                 case CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FUNCTION:
                     GetDebugInfoForFunctionType(shape.Data, &pInfo->Union.FunctionInfo);
@@ -280,79 +173,6 @@ namespace Internal.JitInterface
             *pType = asCorInfoType(type);
         }
 
-        private void GetDebugInfoForCompositeType(object data, CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO* pInfo)
-        {
-            var (descriptor, _, fields, statics) = ((ClassTypeDescriptor, ClassFieldsTypeDescriptor, DataFieldDescriptor[], StaticDataFieldDescriptor[]))data;
-
-            pInfo->Name = ToPinnedUtf8String(descriptor.Name);
-            pInfo->BaseClass = IndexToDebugTypeHandle(descriptor.BaseClassId);
-            pInfo->Size = checked((uint)descriptor.InstanceSize);
-
-            int instanceFieldCount = fields.Length - statics.Length;
-            var instanceFieldsInfo = instanceFieldCount != 0 ? new CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO[instanceFieldCount] : null;
-            int staticFieldCount = statics.Length;
-            var staticFieldsInfo = staticFieldCount != 0 ? new CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO[staticFieldCount] : null;
-
-            for (int i = 0, s = 0, j = 0; j < fields.Length; j++)
-            {
-                DataFieldDescriptor field = fields[j];
-                byte* pName = ToPinnedUtf8String(field.Name);
-
-                if (field.Offset == 0xFFFFFFFF) // Static field.
-                {
-                    StaticDataFieldDescriptor staticField = statics[s];
-                    ref CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO fieldInfo = ref staticFieldsInfo[s++];
-                    fieldInfo.Name = pName;
-                    fieldInfo.Type = IndexToDebugTypeHandle(field.FieldTypeIndex);
-                    fieldInfo.BaseSymbolName = ToPinnedUtf8String(staticField.StaticDataName);
-                    fieldInfo.StaticOffset = checked((uint)staticField.StaticOffset);
-                    fieldInfo.IsStaticDataInObject = staticField.IsStaticDataInObject;
-                }
-                else
-                {
-                    ref CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO fieldInfo = ref instanceFieldsInfo[i++];
-                    fieldInfo.Name = pName;
-                    fieldInfo.Type = IndexToDebugTypeHandle(field.FieldTypeIndex);
-                    fieldInfo.Offset = checked((uint)field.Offset);
-                }
-            }
-
-            pInfo->InstanceFieldCount = (uint)instanceFieldCount;
-            pInfo->InstanceFields = instanceFieldsInfo != null ? (CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO*)GetPin(instanceFieldsInfo) : null;
-            pInfo->StaticFieldCount = (uint)staticFieldCount;
-            pInfo->StaticFields = staticFieldsInfo != null ? (CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO*)GetPin(staticFieldsInfo) : null;
-        }
-
-        private void GetDebugInfoForEnumType(object data, CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO* pInfo)
-        {
-            var (descriptor, elements) = ((EnumTypeDescriptor, EnumRecordTypeDescriptor[]))data;
-
-            pInfo->ElementType = IndexToDebugTypeHandle(descriptor.ElementType);
-            pInfo->Name = ToPinnedUtf8String(descriptor.Name);
-            pInfo->ElementCount = descriptor.ElementCount;
-
-            CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO[] elementsInfo = new CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO[elements.Length];
-            for (int i = 0; i < elementsInfo.Length; i++)
-            {
-                EnumRecordTypeDescriptor element = elements[i];
-                ref CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO elementInfo = ref elementsInfo[i];
-                elementInfo.Name = ToPinnedUtf8String(element.Name);
-                elementInfo.Value = element.Value;
-            }
-
-            pInfo->Elements = (CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO*)GetPin(elementsInfo);
-        }
-
-        private void GetDebugInfoForArrayType(object data, CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO* pInfo)
-        {
-            var (classDescriptor, arrayDescriptor) = ((ClassTypeDescriptor, ArrayTypeDescriptor))data;
-
-            pInfo->Name = ToPinnedUtf8String(classDescriptor.Name);
-            pInfo->Rank = arrayDescriptor.Rank;
-            pInfo->ElementType = IndexToDebugTypeHandle(arrayDescriptor.ElementType);
-            pInfo->IsMultiDimensional = arrayDescriptor.IsMultiDimensional;
-        }
-
         private void GetDebugInfoForPointerType(object data, CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO* pInfo)
         {
             var descriptor = (PointerTypeDescriptor)data;
@@ -361,12 +181,23 @@ namespace Internal.JitInterface
             pInfo->IsReference = descriptor.IsReference;
         }
 
+        private void GetDebugInfoForForwardType(object data, CORINFO_LLVM_FORWARD_TYPE_DEBUG_INFO* pInfo)
+        {
+            var (name, kind) = ((string, CorInfoLlvmDebugTypeForwardKind))data;
+
+            pInfo->Kind = kind;
+            pInfo->Name = ToPinnedUtf8String(name);
+        }
+
         private void GetDebugInfoForFunctionType(object data, CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO* pInfo)
         {
             var (descriptor, argumentTypes) = ((MemberFunctionTypeDescriptor, uint[]))data;
 
-            uint voidTypeIndex = DebugTypesDescriptor.GetTypeIndex(_compilation.TypeSystemContext.GetWellKnownType(WellKnownType.Void), needsCompleteType: true);
-            if (descriptor.TypeIndexOfThisPointer == voidTypeIndex)
+            if (_debugTypesShapes[(int)descriptor.TypeIndexOfThisPointer] is
+                {
+                    Kind: CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE,
+                    Data: TypeDesc { Category: TypeFlags.Void }
+                })
             {
                 pInfo->TypeOfThisPointer = 0;
             }
@@ -380,42 +211,10 @@ namespace Internal.JitInterface
             pInfo->ArgumentTypes = (CORINFO_LLVM_DEBUG_TYPE_HANDLE*)GetPin(argumentTypes);
         }
 
-        private struct CORINFO_LLVM_VARIABLE_DEBUG_INFO
+        private void GetDebugInfoForCurrentMethod(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)
         {
-            public byte* Name;
-            public uint VarNumber;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
-        }
-
-        private struct CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO
-        {
-            public uint ILOffset;
-            public uint LineNumber;
-        }
-
-        private struct CORINFO_LLVM_METHOD_DEBUG_INFO
-        {
-            public byte* Name;
-            public byte* Directory;
-            public byte* FileName;
-            public uint LineNumberCount;
-            public CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO* SortedLineNumbers;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE OwnerType;
-            public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
-            public uint VariableCount;
-            public CORINFO_LLVM_VARIABLE_DEBUG_INFO* Variables;
-        }
-
-        private void GetDebugInfoForMethod(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)
-        {
-            MethodDesc method = _methodCodeNode.Method;
-            int methodIndex = (int)DebugTypesDescriptor.GetMethodFunctionIdTypeIndex(method);
-            MemberFunctionIdTypeDescriptor descriptor = _debugFunctions[methodIndex];
-
             *pInfo = default;
-            pInfo->Name = ToPinnedUtf8String(descriptor.Name);
-            pInfo->OwnerType = IndexToDebugTypeHandle(descriptor.ParentClass);
-            pInfo->Type = IndexToDebugTypeHandle(descriptor.MemberFunction);
+            MethodDesc method = _methodCodeNode.Method;
 
             string documentPath = null;
             ArrayBuilder<CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO> lineNumbersBuilder = default;
@@ -427,8 +226,18 @@ namespace Internal.JitInterface
 
             if (documentPath == null)
             {
-                return; // No debug info for this method.
+                _debugInfo = null; // Remember there is no debug info for this method.
+                return;
             }
+
+            uint declIndex = DebugTypes.GetMethodFunctionIdTypeIndex(method);
+            MemberFunctionIdTypeDescriptor decl = _debugFunctions[(int)declIndex];
+            Utf8String linkageName = _compilation.NameMangler.GetMangledMethodName(decl.Method);
+            pInfo->Decl.Name = ToPinnedUtf8String(decl.Name);
+            pInfo->Decl.LinkageName.Data = (byte*)GetPin(linkageName.Value);
+            pInfo->Decl.LinkageName.Length = (nuint)linkageName.Length;
+            pInfo->Decl.Type = IndexToDebugTypeHandle(decl.MemberFunction);
+            pInfo->Decl.OwnerType = IndexToDebugTypeHandle(decl.ParentClass);
 
             pInfo->Directory = ToPinnedUtf8String(Path.GetDirectoryName(documentPath));
             pInfo->FileName = ToPinnedUtf8String(Path.GetFileName(documentPath));
@@ -439,15 +248,55 @@ namespace Internal.JitInterface
             pInfo->LineNumberCount = (uint)lineNumbers.Length;
             pInfo->SortedLineNumbers = (CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO*)GetPin(lineNumbers);
 
-            bool isStateMachineMoveNextMethod = _debugInfo.IsStateMachineMoveNextMethod;
-            MethodSignature sig = method.Signature;
-            int offset = sig.IsStatic ? 0 : 1;
-            int parameterCount = sig.Length + offset;
-            uint variableCount = 0;
+            MethodIL methodIL = (MethodIL)HandleToObject(_methodScope);
+            IEnumerable<DebugVarInfoMetadata> debugVars =
+                GetDebugVarsForMethod(method, methodIL.GetLocals(), static l => l.Type, _debugInfo, out uint variableCount);
 
             int i = 0;
+            CORINFO_LLVM_VARIABLE_DEBUG_INFO[] variables = new CORINFO_LLVM_VARIABLE_DEBUG_INFO[variableCount];
+            foreach (DebugVarInfoMetadata debugVar in debugVars)
+            {
+                ref CORINFO_LLVM_VARIABLE_DEBUG_INFO info = ref variables[i++];
+                info.Name = ToPinnedUtf8String(debugVar.Name);
+                info.VarNumber = debugVar.DebugVarInfo.VarNumber;
+
+                uint variableTypeIndex;
+                if (info.VarNumber == 0 && !method.Signature.IsStatic)
+                {
+                    // We emit special types for async state machines (see also "ObjectWriter.EmitDebugVar").
+                    variableTypeIndex = _debugInfo.IsStateMachineMoveNextMethod
+                        ? DebugTypes.GetStateMachineThisVariableTypeIndex(method.OwningType)
+                        : DebugTypes.GetThisTypeIndex(method.OwningType);
+                }
+                else
+                {
+                    variableTypeIndex = DebugTypes.GetVariableTypeIndex(debugVar.Type);
+                }
+                info.Type = IndexToDebugTypeHandle(variableTypeIndex);
+            }
+            Debug.Assert(i == variableCount);
+
+            pInfo->VariableCount = (uint)variableCount;
+            pInfo->Variables = (CORINFO_LLVM_VARIABLE_DEBUG_INFO*)GetPin(variables);
+        }
+
+        private static CORINFO_LLVM_DEBUG_TYPE_HANDLE IndexToDebugTypeHandle(uint index) => (CORINFO_LLVM_DEBUG_TYPE_HANDLE)index;
+        private static uint DebugTypeHandleToIndex(CORINFO_LLVM_DEBUG_TYPE_HANDLE handle) => (uint)handle;
+
+        private byte* ToPinnedUtf8String(string name) => (byte*)GetPin(StringToUTF8(name));
+
+        public static IEnumerable<DebugVarInfoMetadata> GetDebugVarsForMethod<TLocal>(
+            MethodDesc method, TLocal[] locals, Func<TLocal, TypeDesc> getLocalType, MethodDebugInformation debugInfo, out uint count)
+        {
+            bool isStateMachineMoveNextMethod = debugInfo.IsStateMachineMoveNextMethod;
+            MethodSignature sig = method.Signature;
+            int offset = sig.IsStatic ? 0 : 1;
+            int parameterCount = offset + sig.Length;
+            uint variableCount = 0;
+
+            uint i = 0;
             string[] parameterNames = new string[parameterCount];
-            foreach (var paramName in _debugInfo.GetParameterNames())
+            foreach (string paramName in debugInfo.GetParameterNames())
             {
                 string assignedName;
                 if (!sig.IsStatic && i == 0)
@@ -467,11 +316,8 @@ namespace Internal.JitInterface
                 i++;
             }
 
-            MethodIL methodIL = (MethodIL)HandleToObject(_methodScope);
-            LocalVariableDefinition[] locals = methodIL.GetLocals();
-
             string[] localNames = new string[locals.Length];
-            foreach (var local in _debugInfo.GetLocalVariables())
+            foreach (ILLocalVariable local in debugInfo.GetLocalVariables())
             {
                 if (!local.CompilerGenerated && local.Slot < localNames.Length && localNames[local.Slot] != local.Name)
                 {
@@ -479,67 +325,467 @@ namespace Internal.JitInterface
                     variableCount++;
                 }
             }
+            count = variableCount;
 
-            i = 0;
-            CORINFO_LLVM_VARIABLE_DEBUG_INFO[] variables = new CORINFO_LLVM_VARIABLE_DEBUG_INFO[variableCount];
-            for (int num = 0; num < parameterNames.Length + locals.Length; num++)
+            IEnumerable<DebugVarInfoMetadata> GetResults()
             {
-                string name;
-                uint typeIndex;
-                if (num < parameterCount)
+                for (int num = 0; num < parameterNames.Length + locals.Length; num++)
                 {
-                    // This is a parameter
-                    if (!sig.IsStatic && num == 0)
+                    string name;
+                    TypeDesc type;
+                    bool isParameter = num < parameterCount;
+                    if (isParameter)
                     {
-                        // We emit special types for async state machines (see also "ObjectWriter.EmitDebugVar").
-                        typeIndex = isStateMachineMoveNextMethod
-                            ? DebugTypesDescriptor.GetStateMachineThisVariableTypeIndex(method.OwningType)
-                            : DebugTypesDescriptor.GetThisTypeIndex(method.OwningType);
+                        if (!sig.IsStatic && num == 0)
+                        {
+                            type = method.OwningType.IsValueType
+                                ? method.OwningType.MakeByRefType()
+                                : method.OwningType;
+                        }
+                        else
+                        {
+                            type = method.Signature[num - offset];
+                        }
+
+                        name = parameterNames[num];
                     }
                     else
                     {
-                        typeIndex = DebugTypesDescriptor.GetVariableTypeIndex(method.Signature[num - offset]);
+                        // This is a local
+                        int localNumber = num - parameterCount;
+                        type = getLocalType(locals[localNumber]);
+                        name = localNames[localNumber];
                     }
 
-                    name = parameterNames[num];
+                    if (name != null)
+                    {
+                        yield return new DebugVarInfoMetadata(name, type, isParameter, new DebugVarInfo((uint)num, null));
+                    }
+                }
+            }
+
+            return GetResults();
+        }
+
+        public string GetDebugTypeName(TypeDesc type)
+        {
+            // The default mangler produces simple names for these classes which collide with the C++ runtime.
+            if (type.IsObject)
+            {
+                return "System_Object";
+            }
+            if (type.IsString)
+            {
+                return "System_String";
+            }
+            return _compilation.NodeFactory.NameMangler.GetMangledTypeName(type);
+        }
+    }
+
+    internal unsafe class LlvmTypesDebugInfoEmit : ITypesDebugInfoWriter
+    {
+        private readonly Utf8StringBuilder _utf8 = new();
+        private readonly RyuJitCompilation _compilation;
+        private readonly CorInfoImpl _module;
+        private readonly UserDefinedTypeDescriptor _debugTypes;
+        private uint _voidTypeIndex;
+
+        public LlvmTypesDebugInfoEmit(RyuJitCompilation compilation, CorInfoImpl module)
+        {
+            _compilation = compilation;
+            _module = module;
+            _debugTypes = new UserDefinedTypeDescriptor(this, compilation.NodeFactory);
+        }
+
+        public void EmitTypeInfo(TypeDesc type)
+        {
+            // Should not be used for pointers/byrefs.
+            Debug.Assert(type.IsDefType || type.IsArray);
+            _debugTypes.GetTypeIndex(type, needsCompleteType: true);
+        }
+
+        public void EmitMethodInfo(MethodDesc method, INodeWithDebugInfo node)
+        {
+            foreach (DebugVarInfoMetadata debugVar in node.GetDebugVars())
+            {
+                try
+                {
+                    if (debugVar.DebugVarInfo.VarNumber == 0 && node.IsStateMachineMoveNextMethod)
+                    {
+                        // TODO-LLVM-DI: we're emitting a pointer here, which is wasteful...
+                        // These types are per-method, we probably should emit them into each CU instead.
+                        _debugTypes.GetStateMachineThisVariableTypeIndex(debugVar.Type);
+                    }
+                    else
+                    {
+                        EmitVariableTypeInfo(debugVar.Type);
+                    }
+                }
+                catch (TypeSystemException) { }
+            }
+
+            // Emit the declaration itself.
+            _debugTypes.GetMethodFunctionIdTypeIndex(method);
+        }
+
+        private void EmitVariableTypeInfo(TypeDesc type)
+        {
+            while (type.IsPointer || type.IsByRef)
+            {
+                type = ((ParameterizedType)type).ParameterType;
+            }
+            if (type.IsFunctionPointer)
+            {
+                // Currenly function pointers are not faithfully represented (they're emitted as void*).
+                // Once/if that changes, we'll need to enumerate and emit all of the component types here.
+                return;
+            }
+
+            EmitTypeInfo(type);
+        }
+
+        private byte* GetOffsetAndAppendName(string name)
+        {
+            int offset = _utf8.Length;
+            AppendName(name);
+            return (byte*)offset;
+        }
+
+        private ReadOnlySpan<byte> AppendName(string name) => _utf8.Append(name).Append('\0').AsSpan();
+
+        private static CORINFO_LLVM_DEBUG_TYPE_HANDLE IndexToDebugTypeHandle(uint index) => (CORINFO_LLVM_DEBUG_TYPE_HANDLE)index;
+        private static uint DebugTypeHandleToIndex(CORINFO_LLVM_DEBUG_TYPE_HANDLE handle) => (uint)handle;
+
+        uint ITypesDebugInfoWriter.GetClassTypeIndex(ClassTypeDescriptor classType)
+        {
+            _utf8.Clear();
+            CORINFO_LLVM_TYPE_DEBUG_INFO info;
+            info.Kind = CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD;
+            fixed (byte* pName = AppendName(classType.Name))
+            {
+                info.Union.ForwardInfo.Name = pName;
+                info.Union.ForwardInfo.Kind = CorInfoLlvmDebugTypeForwardKind.CORINFO_LLVM_DEBUG_TYPE_FORWARD_STRUCT;
+                return DebugTypeHandleToIndex(_module.JitEmitDebugTypeInfo(&info));
+            }
+        }
+
+        uint ITypesDebugInfoWriter.GetCompleteClassTypeIndex(ClassTypeDescriptor classType, ClassFieldsTypeDescriptor classFieldTypes, DataFieldDescriptor[] fields, StaticDataFieldDescriptor[] statics)
+        {
+            _utf8.Clear();
+            CORINFO_LLVM_TYPE_DEBUG_INFO info;
+            info.Kind = CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_COMPOSITE;
+
+            info.Union.CompositeInfo.Name = GetOffsetAndAppendName(classType.Name);
+            info.Union.CompositeInfo.BaseClass = IndexToDebugTypeHandle(classType.BaseClassId);
+            info.Union.CompositeInfo.Size = checked((uint)classType.InstanceSize);
+
+            int instanceFieldCount = fields.Length - statics.Length;
+            var instanceFieldsInfo = instanceFieldCount != 0 ? new CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO[instanceFieldCount] : null;
+            int staticFieldCount = statics.Length;
+            var staticFieldsInfo = staticFieldCount != 0 ? new CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO[staticFieldCount] : null;
+
+            string lastBaseSymbolName = null;
+            byte* lastBaseSymbolNameOffset = null;
+            for (int i = 0, s = 0, j = 0; j < fields.Length; j++)
+            {
+                DataFieldDescriptor field = fields[j];
+                if (field.Offset == 0xFFFFFFFF) // Static field.
+                {
+                    StaticDataFieldDescriptor staticField = statics[s];
+                    ref CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO fieldInfo = ref staticFieldsInfo[s++];
+                    fieldInfo.Name = GetOffsetAndAppendName(field.Name);
+                    fieldInfo.Type = IndexToDebugTypeHandle(field.FieldTypeIndex);
+                    if (lastBaseSymbolName == staticField.StaticDataName)
+                    {
+                        fieldInfo.BaseSymbolName = lastBaseSymbolNameOffset;
+                    }
+                    else
+                    {
+                        fieldInfo.BaseSymbolName = GetOffsetAndAppendName(staticField.StaticDataName);
+                        lastBaseSymbolName = staticField.StaticDataName;
+                        lastBaseSymbolNameOffset = fieldInfo.BaseSymbolName;
+                    }
+                    fieldInfo.StaticOffset = checked((uint)staticField.StaticOffset);
+                    fieldInfo.IsStaticDataInObject = staticField.IsStaticDataInObject;
                 }
                 else
                 {
-                    // This is a local
-                    int localNumber = num - parameterCount;
-                    typeIndex = DebugTypesDescriptor.GetVariableTypeIndex(locals[localNumber].Type);
-                    name = localNames[localNumber];
-                }
-
-                if (name != null)
-                {
-                    ref CORINFO_LLVM_VARIABLE_DEBUG_INFO info = ref variables[i++];
-                    info.Name = ToPinnedUtf8String(name);
-                    info.VarNumber = (uint)num;
-                    info.Type = IndexToDebugTypeHandle(typeIndex);
+                    ref CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO fieldInfo = ref instanceFieldsInfo[i++];
+                    fieldInfo.Name = GetOffsetAndAppendName(field.Name);
+                    fieldInfo.Type = IndexToDebugTypeHandle(field.FieldTypeIndex);
+                    fieldInfo.Offset = checked((uint)field.Offset);
                 }
             }
-            Debug.Assert(i == variableCount);
 
-            pInfo->VariableCount = variableCount;
-            pInfo->Variables = (CORINFO_LLVM_VARIABLE_DEBUG_INFO*)GetPin(variables);
-        }
-
-        private CORINFO_LLVM_DEBUG_TYPE_HANDLE IndexToDebugTypeHandle(uint index)
-        {
-            // Replace incomplete type references with complete ones so that the Jit never sees them.
-            DebugTypeShape shape = _debugTypesShapes[(int)index];
-            if (shape.Kind == CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_UNDEF)
+            fixed (byte* pNameBase = _utf8.UnderlyingArray)
+            fixed (CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* pInstanceFieldsInfo = instanceFieldsInfo)
+            fixed (CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO* pStaticFieldsInfo = staticFieldsInfo)
             {
-                Debug.Assert(shape.Data is not null);
-                index = (uint)shape.Data;
-            }
+                info.Union.CompositeInfo.Name += (nint)pNameBase;
+                foreach (ref CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO fieldInfo in instanceFieldsInfo.AsSpan())
+                {
+                    fieldInfo.Name += (nint)pNameBase;
+                }
+                foreach (ref CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO fieldInfo in staticFieldsInfo.AsSpan())
+                {
+                    fieldInfo.Name += (nint)pNameBase;
+                    fieldInfo.BaseSymbolName += (nint)pNameBase;
+                }
 
-            return (CORINFO_LLVM_DEBUG_TYPE_HANDLE)index;
+                info.Union.CompositeInfo.InstanceFieldCount = (uint)instanceFieldCount;
+                info.Union.CompositeInfo.InstanceFields = pInstanceFieldsInfo;
+                info.Union.CompositeInfo.StaticFieldCount = (uint)staticFieldCount;
+                info.Union.CompositeInfo.StaticFields = pStaticFieldsInfo;
+                return DebugTypeHandleToIndex(_module.JitEmitDebugTypeInfo(&info));
+            }
         }
 
-        private static uint DebugTypeHandleToIndex(CORINFO_LLVM_DEBUG_TYPE_HANDLE handle) => (uint)handle;
+        uint ITypesDebugInfoWriter.GetArrayTypeIndex(ClassTypeDescriptor classType, ArrayTypeDescriptor arrayType)
+        {
+            _utf8.Clear();
+            CORINFO_LLVM_TYPE_DEBUG_INFO info;
+            info.Kind = CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ARRAY;
+            fixed (byte* pName = AppendName(classType.Name))
+            {
+                info.Union.ArrayInfo.Name = pName;
+                info.Union.ArrayInfo.Rank = arrayType.Rank;
+                info.Union.ArrayInfo.ElementType = IndexToDebugTypeHandle(arrayType.ElementType);
+                info.Union.ArrayInfo.IsMultiDimensional = arrayType.IsMultiDimensional;
+                return DebugTypeHandleToIndex(_module.JitEmitDebugTypeInfo(&info));
+            }
+        }
 
-        private byte* ToPinnedUtf8String(string name) => (byte*)GetPin(StringToUTF8(name));
+        uint ITypesDebugInfoWriter.GetEnumTypeIndex(EnumTypeDescriptor enumType, EnumRecordTypeDescriptor[] elements)
+        {
+            _utf8.Clear();
+            int pNameOffset = (int)GetOffsetAndAppendName(enumType.Name);
+            CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO[] elementsInfo = new CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO[elements.Length];
+            for (int i = 0; i < elementsInfo.Length; i++)
+            {
+                EnumRecordTypeDescriptor element = elements[i];
+                ref CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO elementInfo = ref elementsInfo[i];
+                elementInfo.Name = GetOffsetAndAppendName(element.Name);
+                elementInfo.Value = element.Value;
+            }
+
+            fixed (byte* pNameBase = _utf8.UnderlyingArray)
+            fixed (CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* pElements = elementsInfo)
+            {
+                foreach (ref CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO elementInfo in elementsInfo.AsSpan())
+                {
+                    elementInfo.Name += (nint)pNameBase;
+                }
+
+                CORINFO_LLVM_TYPE_DEBUG_INFO info;
+                info.Kind = CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_ENUM;
+                info.Union.EnumInfo.Name = pNameBase + pNameOffset;
+                info.Union.EnumInfo.ElementType = IndexToDebugTypeHandle(enumType.ElementType);
+                info.Union.EnumInfo.ElementCount = enumType.ElementCount;
+                info.Union.EnumInfo.Elements = pElements;
+                return DebugTypeHandleToIndex(_module.JitEmitDebugTypeInfo(&info));
+            }
+        }
+
+        uint ITypesDebugInfoWriter.GetMemberFunctionTypeIndex(MemberFunctionTypeDescriptor methodType, uint[] argumentTypes)
+        {
+            CORINFO_LLVM_TYPE_DEBUG_INFO info;
+            info.Kind = CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_FUNCTION;
+            if (methodType.TypeIndexOfThisPointer == _voidTypeIndex)
+            {
+                info.Union.FunctionInfo.TypeOfThisPointer = 0;
+            }
+            else
+            {
+                info.Union.FunctionInfo.TypeOfThisPointer = IndexToDebugTypeHandle(methodType.TypeIndexOfThisPointer);
+            }
+
+            fixed (uint* pArgumentTypes = argumentTypes)
+            {
+                info.Union.FunctionInfo.ReturnType = IndexToDebugTypeHandle(methodType.ReturnType);
+                info.Union.FunctionInfo.NumberOfArguments = methodType.NumberOfArguments;
+                info.Union.FunctionInfo.ArgumentTypes = (CORINFO_LLVM_DEBUG_TYPE_HANDLE*)pArgumentTypes;
+                return DebugTypeHandleToIndex(_module.JitEmitDebugTypeInfo(&info));
+            }
+        }
+
+        uint ITypesDebugInfoWriter.GetPointerTypeIndex(PointerTypeDescriptor pointerType)
+        {
+            CORINFO_LLVM_TYPE_DEBUG_INFO info;
+            info.Kind = CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_POINTER;
+            info.Union.PointerInfo.ElementType = IndexToDebugTypeHandle(pointerType.ElementType);
+            info.Union.PointerInfo.IsReference = pointerType.IsReference;
+            return DebugTypeHandleToIndex(_module.JitEmitDebugTypeInfo(&info));
+        }
+
+        uint ITypesDebugInfoWriter.GetPrimitiveTypeIndex(TypeDesc type)
+        {
+            CORINFO_LLVM_TYPE_DEBUG_INFO info;
+            info.Kind = CorInfoLlvmDebugTypeKind.CORINFO_LLVM_DEBUG_TYPE_PRIMITIVE;
+            info.Union.PrimitiveType = (CorInfoType)type.Category;
+            uint index = DebugTypeHandleToIndex(_module.JitEmitDebugTypeInfo(&info));
+            if (type.IsVoid)
+            {
+                _voidTypeIndex = index;
+            }
+            return index;
+        }
+
+        uint ITypesDebugInfoWriter.GetMemberFunctionId(MemberFunctionIdTypeDescriptor method)
+        {
+            _utf8.Clear();
+            CORINFO_LLVM_METHOD_DECL_DEBUG_INFO info;
+            ReadOnlySpan<byte> linkageName = _compilation.NameMangler.GetMangledMethodName(method.Method).AsSpan();
+            fixed (byte* pName = AppendName(method.Name))
+            fixed (byte* pLinkageName = linkageName)
+            {
+                info.Name = pName;
+                info.LinkageName.Data = pLinkageName;
+                info.LinkageName.Length = (nuint)linkageName.Length;
+                info.Type = IndexToDebugTypeHandle(method.MemberFunction);
+                info.OwnerType = IndexToDebugTypeHandle(method.ParentClass);
+                return (uint)_module.JitEmitDebugMethodDecl(&info);
+            }
+        }
+
+        string ITypesDebugInfoWriter.GetMangledName(TypeDesc type) => _module.GetDebugTypeName(type);
+    }
+
+    internal enum CORINFO_LLVM_DEBUG_TYPE_HANDLE { }
+    internal enum CORINFO_LLVM_DEBUG_METHOD_DECL_HANDLE { }
+
+    internal unsafe struct CORINFO_LLVM_STRING
+    {
+        public byte* Data;
+        public nuint Length;
+    }
+
+    internal unsafe struct CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO
+    {
+        public byte* Name;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+        public uint Offset;
+    }
+
+    internal unsafe struct CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO
+    {
+        public byte* Name;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+        public byte* BaseSymbolName;
+        public uint StaticOffset;
+        public int IsStaticDataInObject;
+    }
+
+    internal unsafe struct CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO
+    {
+        public byte* Name;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE BaseClass;
+        public uint Size;
+
+        public uint InstanceFieldCount;
+        public CORINFO_LLVM_INSTANCE_FIELD_DEBUG_INFO* InstanceFields;
+
+        public uint StaticFieldCount;
+        public CORINFO_LLVM_STATIC_FIELD_DEBUG_INFO* StaticFields;
+    }
+
+    internal unsafe struct CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO
+    {
+        public byte* Name;
+        public ulong Value;
+    }
+
+    internal unsafe struct CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO
+    {
+        public byte* Name;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+        public ulong ElementCount;
+        public CORINFO_LLVM_ENUM_ELEMENT_DEBUG_INFO* Elements;
+    }
+
+    internal unsafe struct CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO
+    {
+        public byte* Name;
+        public uint Rank;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+        public int IsMultiDimensional;
+    }
+
+    internal struct CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO
+    {
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE ElementType;
+        public int IsReference;
+    }
+
+    internal unsafe struct CORINFO_LLVM_FORWARD_TYPE_DEBUG_INFO
+    {
+        public byte* Name;
+        public CorInfoLlvmDebugTypeForwardKind Kind;
+    }
+
+    internal unsafe struct CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO
+    {
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE TypeOfThisPointer;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE ReturnType;
+        public uint NumberOfArguments;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE* ArgumentTypes;
+    }
+
+    internal struct CORINFO_LLVM_TYPE_DEBUG_INFO
+    {
+        public CorInfoLlvmDebugTypeKind Kind;
+#pragma warning disable CS0649
+        public CORINFO_LLVM_TYPE_DEBUG_INFO_UNION Union;
+#pragma warning restore CS0649
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct CORINFO_LLVM_TYPE_DEBUG_INFO_UNION
+    {
+        [FieldOffset(0)]
+        public CorInfoType PrimitiveType;
+        [FieldOffset(0)]
+        public CORINFO_LLVM_COMPOSITE_TYPE_DEBUG_INFO CompositeInfo;
+        [FieldOffset(0)]
+        public CORINFO_LLVM_ENUM_TYPE_DEBUG_INFO EnumInfo;
+        [FieldOffset(0)]
+        public CORINFO_LLVM_ARRAY_TYPE_DEBUG_INFO ArrayInfo;
+        [FieldOffset(0)]
+        public CORINFO_LLVM_POINTER_TYPE_DEBUG_INFO PointerInfo;
+        [FieldOffset(0)]
+        public CORINFO_LLVM_FORWARD_TYPE_DEBUG_INFO ForwardInfo;
+        [FieldOffset(0)]
+        public CORINFO_LLVM_FUNCTION_TYPE_DEBUG_INFO FunctionInfo;
+    }
+
+    internal unsafe struct CORINFO_LLVM_VARIABLE_DEBUG_INFO
+    {
+        public byte* Name;
+        public uint VarNumber;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+    }
+
+    internal struct CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO
+    {
+        public uint ILOffset;
+        public uint LineNumber;
+    }
+
+    internal unsafe struct CORINFO_LLVM_METHOD_DECL_DEBUG_INFO
+    {
+        public byte* Name;
+        public CORINFO_LLVM_STRING LinkageName;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE Type;
+        public CORINFO_LLVM_DEBUG_TYPE_HANDLE OwnerType;
+    }
+
+    internal unsafe struct CORINFO_LLVM_METHOD_DEBUG_INFO
+    {
+        public CORINFO_LLVM_METHOD_DECL_DEBUG_INFO Decl;
+        public byte* Directory;
+        public byte* FileName;
+        public uint LineNumberCount;
+        public CORINFO_LLVM_LINE_NUMBER_DEBUG_INFO* SortedLineNumbers;
+        public uint VariableCount;
+        public CORINFO_LLVM_VARIABLE_DEBUG_INFO* Variables;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -431,7 +431,7 @@ namespace Internal.JitInterface
         [UnmanagedCallersOnly]
         private static void getDebugInfoForCurrentMethod(IntPtr thisHandle, CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)
         {
-            GetThis(thisHandle).GetDebugInfoForMethod(pInfo);
+            GetThis(thisHandle).GetDebugInfoForCurrentMethod(pInfo);
         }
 
         [DllImport(JitLibrary)]
@@ -479,7 +479,7 @@ namespace Internal.JitInterface
             }
         }
 
-        public void JitStartSingleThreadedCompilation(string outputFileName, string triple, string dataLayout)
+        internal void JitStartSingleThreadedCompilation(string outputFileName, string triple, string dataLayout)
         {
             fixed (byte* pOutputFileName = StringToUTF8(outputFileName), pTriple = StringToUTF8(triple), pDataLayout = StringToUTF8(dataLayout))
             {
@@ -488,9 +488,21 @@ namespace Internal.JitInterface
             }
         }
 
-        public void JitFinishSingleThreadedCompilation()
+        internal void JitFinishSingleThreadedCompilation()
         {
             ((delegate* unmanaged<void*, void>)GetJitExport(CorJitApiId.CJAI_FinishSingleThreadedCompilation))(_pNativeContext);
+        }
+
+        internal CORINFO_LLVM_DEBUG_TYPE_HANDLE JitEmitDebugTypeInfo(CORINFO_LLVM_TYPE_DEBUG_INFO* pInfo)
+        {
+            void* pExport = GetJitExport(CorJitApiId.CJAI_EmitDebugTypeInfo);
+            return ((delegate* unmanaged<void*, CORINFO_LLVM_TYPE_DEBUG_INFO*, CORINFO_LLVM_DEBUG_TYPE_HANDLE>)pExport)(_pNativeContext, pInfo);
+        }
+
+        internal CORINFO_LLVM_DEBUG_METHOD_DECL_HANDLE JitEmitDebugMethodDecl(CORINFO_LLVM_METHOD_DECL_DEBUG_INFO* pInfo)
+        {
+            void* pExport = GetJitExport(CorJitApiId.CJAI_EmitDebugMethodDecl);
+            return ((delegate* unmanaged<void*, CORINFO_LLVM_METHOD_DECL_DEBUG_INFO*, CORINFO_LLVM_DEBUG_METHOD_DECL_HANDLE>)pExport)(_pNativeContext, pInfo);
         }
 
         private static void* GetJitExport(CorJitApiId id) => s_jitExports[(int)id];

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.cs
@@ -56,9 +56,9 @@ unsafe class Program
         Debugger.Break(); // Both "p1" and "p2" parameters should be inspectable and equal to "{ 1, 2.0 }".
     }
 
-    private static void TestPointerDisplay(SimpleStruct* s)
+    private static void TestPointerDisplay(SimpleStruct* p)
     {
-        Debugger.Break(); // The "*s" value should be inspectable and equal to "{ 1, 2.0 }".
+        Debugger.Break(); // The "*p" value should be inspectable and equal to "{ 1, 2.0 }".
     }
 
     private static void TestStringDisplay(string s)

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.py
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.py
@@ -26,8 +26,20 @@ def run_wasm_debugging_tests(debugger):
 
     test_basic_types_display(target, process, thread)
     test_enum_display(target, process, thread)
-    # TODO-LLVM-DI: https://github.com/dotnet/runtimelab/issues/2728.
-    # test_by_ref_display(target, process, thread)
+    test_by_ref_display(target, process, thread)
+    test_pointer_display(target, process, thread)
+    test_string_display(target, process, thread)
+    test_basic_array_display(target, process, thread)
+    test_complex_array_display(target, process, thread)
+    test_basic_multi_dimensional_array_display(target, process, thread)
+    # TODO-LLVM-DI: issue number needed.
+    process.Continue() # test_simple_struct_display(target, process, thread)
+    test_simple_class_display(target, process, thread)
+    test_derived_class_display(target, process, thread)
+    test_recursive_class_display(target, process, thread)
+    # TODO-LLVM-DI: need to fix wasmtime issues with "this".
+    process.Continue() # test_struct_instance_method(target, process, thread)
+    process.Continue() # test_class_instance_method(target, process, thread)
 
     if all_tests_passed:
         print('==== All WASM debugging tests passed ====')
@@ -85,7 +97,51 @@ def test_by_ref_display(target, process, thread):
         [('(*p1).IntField', '1'), ('(*p1).FloatField', '2'),
          ('(*p2)->IntField', '1'), ('(*p2)->FloatField', '2')])
 
-def test_values_display_impl(target, process, thread, pyname, expected_values, use_get_variable_path=False):
+def test_pointer_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_pointer_display',
+        [('p->IntField', '1'), ('p->FloatField', '2')])
+
+def test_string_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_string_display',
+        [('&s->_firstChar', 'u"Basic string"')], # TODO-LLVM-DI: improve string display.
+        use_get_summary=True)
+
+def test_basic_array_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_basic_array_display',
+        [('p1->Data[0]', '1'), ('p1->Data[1]', '2'), ('p1->Data[2]', '3'), ('p1->Length', '3'), # TODO-LLVM-DI: improve array indexing.
+         ('p2->Data[0]', '1'), ('p2->Data[1]', '2'), ('p2->Data[2]', '3'), ('p2->Length', '3')]) # TODO-LLVM-DI: improve array display.
+
+def test_complex_array_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_complex_array_display',
+        [('p1->Data[0]->IntField', '1'), ('p1->Data[0]->FloatField', '2'),
+         ('p2->Data[0].IntField', '1'), ('p2->Data[0].FloatField', '2')])
+
+def test_basic_multi_dimensional_array_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_basic_multi_dimensional_array_display',
+        [('s->Length', '6'),
+         ('sizeof(s->LowerBounds) / sizeof(*s->LowerBounds)', '2'), ('s->LowerBounds[0]', '0'), ('s->LowerBounds[1]', '0'),
+         ('sizeof(s->Lengths) / sizeof(*s->Lengths)', '2'), ('s->Lengths[0]', '2'), ('s->Lengths[1]', '3'),
+         ('s->Data[0]', '1'), ('s->Data[1]', '2'), ('s->Data[2]', '3'),
+         ('s->Data[3]', '4'), ('s->Data[4]', '5'), ('s->Data[5]', '6')])
+
+def test_simple_struct_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_simple_struct_display',
+        [('s.IntField', '1'), ('s.FloatField', '2')],
+        use_get_variable_path=True)
+
+def test_simple_class_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_simple_class_display',
+        [('s->IntField', '1'), ('s->FloatField', '2')])
+
+def test_derived_class_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_derived_class_display',
+        [('s->IntField', '1'), ('s->FloatField', '2'), ('s->LongField', '3')])
+
+def test_recursive_class_display(target, process, thread):
+    test_values_display_impl(target, process, thread, 'test_recursive_class_display',
+        [('s->Value', '1'), ('s->Next->Value', '2')])
+
+def test_values_display_impl(target, process, thread, pyname, expected_values, use_get_variable_path=False, use_get_summary=False):
     start_test(pyname)
     process.Continue()
     frame = thread.GetSelectedFrame()
@@ -95,8 +151,12 @@ def test_values_display_impl(target, process, thread, pyname, expected_values, u
             actual_sb_value = frame.GetValueForVariablePath(name)
         else:
             actual_sb_value = frame.EvaluateExpression(name)
-        if actual_sb_value.GetValue() != value:
-            fail_test(f'unexpected "{name}": "{actual_sb_value}" (expected "{value}")')
+        if use_get_summary:
+            actual_value_as_string = actual_sb_value.GetSummary()
+        else:
+            actual_value_as_string = actual_sb_value.GetValue()
+        if actual_value_as_string != value:
+            fail_test(f'unexpected "{name}": "{actual_value_as_string}" (expected "{value}")')
             return
     pass_test()
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.py
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.py
@@ -32,7 +32,7 @@ def run_wasm_debugging_tests(debugger):
     test_basic_array_display(target, process, thread)
     test_complex_array_display(target, process, thread)
     test_basic_multi_dimensional_array_display(target, process, thread)
-    # TODO-LLVM-DI: issue number needed.
+    # TODO-LLVM-DI: https://github.com/dotnet/runtimelab/issues/2884.
     process.Continue() # test_simple_struct_display(target, process, thread)
     test_simple_class_display(target, process, thread)
     test_derived_class_display(target, process, thread)


### PR DESCRIPTION
So far, we have been emitting type definitions into each compile unit
where they were 'used'. This proved problematic (wrong) as the debugger
does not "unify" types across compile units - they are expected to be
the same, due to ODR.

To solve this fundamental issue, this change introduces a more elaborate emission scheme, where during compilation only type forwards are emitted, which will later get satisfied by types defined in one big DI module.

While the idea is sound, the implementation is constrained by the lack of direct support for DW_FORM_ref_addr references in LLVM. Ideally, we would use those to refer to types in the debug module directly, however, in the absence of this, forward declarations have to do.

One problem with forward declarations that had to be worked around was wasmtime's DI GC, which only resolves DWARF's 'reference's. Thus, our types need manual 'rooting', which is accomplished in this change by emitting a dummy retained subroutine that references all of them.

With these changes, as well as some fixes in wasmtime (especially https://github.com/bytecodealliance/wasmtime/issues/9828), the expanded LLDB (finally) test passes.

Fixes #2728.