### PR TITLE
[Swift bindings] Enable test signing for experimental NuGet binding package

### DIFF
--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -43,10 +43,11 @@ jobs:
     
     steps:
     - script: >-
-        build.cmd -restore -sign -publish -ci -configuration Release
-        /p:RestoreToolsetOnly=true
+        build.cmd -ci
+        -publish
+        -pack
+        -configuration Release
         /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
-        /p:DownloadDirectory=$(Build.SourcesDirectory)\artifacts\PackageDownload\
         /p:OfficialBuildId=$(Build.BuildNumber)
         /p:SignType=$(_SignType)
         /p:DotNetSignType=$(_SignType)

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
 
     variables:
       - name: '_SignType'
-        value: $[ coalesce(variables.OfficialSignType, 'test') ]
+        value: $[ coalesce(variables.OfficialSignType, 'real') ]
       
     templateContext:
       inputs:

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -23,7 +23,7 @@ jobs:
 
     variables:
       - name: '_SignType'
-        value: $[ coalesce(variables.OfficialSignType, 'real') ]
+        value: $[ coalesce(variables.OfficialSignType, 'test') ]
       
     templateContext:
       inputs:

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -43,11 +43,10 @@ jobs:
     
     steps:
     - script: >-
-        build.cmd -ci
-        -publish
-        -pack
-        -configuration Release
+        build.cmd -restore -sign -publish -ci -configuration Release
+        /p:RestoreToolsetOnly=true
         /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
+        /p:DownloadDirectory=$(Build.SourcesDirectory)\artifacts\PackageDownload\
         /p:OfficialBuildId=$(Build.BuildNumber)
         /p:SignType=$(_SignType)
         /p:DotNetSignType=$(_SignType)

--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -31,6 +31,8 @@ variables:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
   - name: TeamName
     value: dotnet-core
+  - name: OfficialSignType
+    value: test
 extends:
   template: /eng/pipelines/common/templates/template1es.yml@self
   parameters:


### PR DESCRIPTION
## Description

Currently, there is a signing issue with NuGet packages in the official build pipeline. This PR enables test signing to fix the pipeline until the issue is fixed, as the experimental NuGet package isn't officially supported.

## Validation

The internal build pipeline completed successfully.

This change will be reverted: https://github.com/dotnet/runtimelab/issues/2897