### PR TITLE
[NativeAOT-LLVM] Disable `SharedLibrary.csproj`

### DIFF
--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -31,27 +31,27 @@ steps:
     - ${{ if eq(parameters.platform, 'browser_wasm_win') }}:
       - script: |
           call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) ci tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
         displayName: Build WebAssembly tests
     - ${{ elseif eq(parameters.platform, 'wasi_wasm_win') }}:
       - script: |
-          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) ci wasi tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci wasi tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
         displayName: Build WebAssembly tests
     - ${{ elseif eq(parameters.platform, 'Browser_wasm_linux_x64_naot_llvm') }}:
       - script: |
           source $(Build.SourcesDirectory)/wasm-tools/emsdk/emsdk_env.sh
-          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) $(crossArg) ci -browser tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) $(crossArg) $(_officialBuildParameter) ci -browser tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
         displayName: Build WebAssembly tests
     - ${{ elseif eq(parameters.platform, 'wasi_wasm_linux_x64_naot_llvm') }}:
       - script: |
-          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) $(crossArg) ci -wasi tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) $(crossArg) $(_officialBuildParameter) ci -wasi tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
         displayName: Build WebAssembly tests
 
     - ${{ elseif eq(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) ci ${{ parameters.testFilter }} /p:NativeAotMultimodule=true /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+      - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci ${{ parameters.testFilter }} /p:NativeAotMultimodule=true /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
         displayName: Build tests
     - ${{ else }}:
-      - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) ci 'tree nativeaot' /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+      - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci 'tree nativeaot' /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
         displayName: Build tests
 
     - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -23,6 +23,8 @@
       <DisabledProjects Include="$(TestRoot)nativeaot\CustomMainWithStubExe\CustomMainWithStubExe.csproj" /> <!-- dlopen-based test -->
       <!-- Determinism uses File.Open read which Wasm can't support without Wasi or Emscripten file system support which we don't enable by default. -->
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\Determinism\Determinism.csproj" />
+      <!-- Fails sporadically in CI: https://github.com/dotnet/runtimelab/issues/2903. -->
+      <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\SharedLibrary\SharedLibrary.csproj" />
 
       <!-- Only automated on WASI with LLDB, which we don't have on Windows CI machines. -->
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\HelloWasm\WasmDebugging.csproj" Condition="'$(TargetOS)' == 'browser' or '$(OS)' == 'Windows_NT'" />


### PR DESCRIPTION
https://github.com/dotnet/runtimelab/pull/2859#issuecomment-2555604725

Let's see if these failures show up in regular CI. Edit: they do.