### PR TITLE
[SwiftBindings] first cut for Dynamo

### DIFF
--- a/SwiftBindings.sln
+++ b/SwiftBindings.sln
@@ -13,6 +13,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Swift.Runtime.Tests", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Swift.Bindings.Integration.Tests", "src\Swift.Bindings\tests\IntegrationTests\Swift.Bindings.Integration.Tests.csproj", "{CF9035B8-57F0-49A2-B985-94B1F6389339}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E20064C3-DB10-4C70-A97A-6E49C1F90A54}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dynamo", "Dynamo", "{5C795F44-0891-467B-9A35-7152247547FB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dynamo", "src\Dynamo\src\Dynamo.csproj", "{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,5 +92,21 @@ Global
 		{CF9035B8-57F0-49A2-B985-94B1F6389339}.Release|x64.Build.0 = Release|Any CPU
 		{CF9035B8-57F0-49A2-B985-94B1F6389339}.Release|x86.ActiveCfg = Release|Any CPU
 		{CF9035B8-57F0-49A2-B985-94B1F6389339}.Release|x86.Build.0 = Release|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Debug|x64.Build.0 = Debug|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Debug|x86.Build.0 = Debug|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Release|x64.ActiveCfg = Release|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Release|x64.Build.0 = Release|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Release|x86.ActiveCfg = Release|Any CPU
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5C795F44-0891-467B-9A35-7152247547FB} = {E20064C3-DB10-4C70-A97A-6E49C1F90A54}
+		{31CDCAEA-2A55-4730-8DEB-935CB9CE0B3F} = {5C795F44-0891-467B-9A35-7152247547FB}
 	EndGlobalSection
 EndGlobal

--- a/src/Dynamo/README.md
+++ b/src/Dynamo/README.md
@@ -1,0 +1,142 @@
+# Dyanmo
+
+Dynamo is code generator that uses C# combinators to write source code. The target language can be any language you wish. At present, it is built to support C# and Swift which are requirements for Binding Tools for Swift.
+
+Dynamo was meant to be a step up from using `Console.WriteLine` and as such doesn't care about the order in which the code is being generated. This is important in Binding Tools for Swift in that it allows locality of responsibility. Consider the process of writing a binding for an enum from Swift. If we start with the following Swift:
+
+```swift
+public enum OtherOptional<T> {
+    case none
+    case some(T)
+    case error(Error)
+    
+    public var hasError: Bool {
+        get {
+            switch (self) {
+            case .error(_): return true
+            default: return true
+            }
+        }
+    }
+}
+```
+
+We have to generate the following types in C#:
+1 - an enum for the cases
+2 - a class to represent the enum along with a payload
+3 - a class for pinvokes
+
+In C#, the binding will look something like this:
+```csharp
+public enum OtherOptionalCases {
+    None,
+    Some,
+    Error,
+}
+
+public class OtherOptional<T> : IDisposable, ISwiftObject {
+    byte [] _payload;
+    OtherOptional<T>(byte[] payload) {
+        _payload = payload;
+    }
+    public OtherOptionalCases Case {
+        get {
+            unsafe {
+                fixed (byte * payloadPtr = &_payload) {
+                    var typeMetadata = TypeMetadata.GetTypeMetadataOrThrow(typeof(T));
+                    return OtherOptionalPinvokes.Case(payloadPtr, typeMetadata);
+                }
+            }
+        }
+    }
+    
+    public static OtherOptional<T> CreateNone () {
+        var typeMetadata = TypeMetadata.GetTypeMetadataOrThrow(typeof(T));
+        byte[] payload = new byte[TypeMetadata.SizeOf(this);
+        OtherOptionalPinvokes.CreateNone(payload, typeMetadata);
+        return new OtherOptional(payload);
+    }
+    
+    public static OtherOptional<T> CreateSome(T value)
+    {
+        var typeMetadata = TypeMetadata.GetTypeMetadataOrThrow(typeof(T));
+        byte[] payload = new byte[TypeMetadata.SizeOf(this);
+        OtherOptionalPinvokes.CreateSome(payload, value, typeMetadata); // this is wrong, value needs to be runtime marshaled
+        return new OtherOptional(payload);
+    }
+    
+    public static OtherOptional<T> CreateError(SwiftError value)
+    {
+        var typeMetadata = TypeMetadata.GetTypeMetadataOrThrow(typeof(T));
+        byte[] payload = new byte[TypeMetadata.SizeOf(this);
+        OtherOptionalPinvokes.CreateNone(payload, value, typeMetadata);
+        return new OtherOptional(payload);
+    }
+    
+    public T SomeValue {
+        get {
+            if (Case != OtherOptionalCases.Some) throw new Exception ();
+            unsafe {
+                fixed (byte * payloadPtr = &_payload) {
+                    var typeMetadata = TypeMetadata.GetTypeMetadataOrThrow(typeof(this));
+                    return OtherOptionalPinvokes.SomeValue(payloadPtr, typeMetadata); // this is also wrong the return value needs to be marshaled
+                }
+            }
+        }
+    }
+    
+    public SwiftError {
+        get {
+            if (Case != OtherOptionalCases.Error) throw new Exception ();
+            unsafe {
+                fixed (byte *payloadPtr = &_payload) {
+                    var typeMetadata = TypeMetadata.GetTypeMetadataOrThrow(typeof(this));
+                    return OtherOptionalPinvokes.SomeValue(payloadPtr, typeMetadata);
+                }
+            }
+        }
+    }
+}
+
+internal static class OtherOptionalPinvokes {
+      public static unsafe extern void OtherOptionalCases Case(byte *payload, TypeMetadata meta);
+      public static unsafe extern void CreateNone(byte *payload, TypeMetadata meta);
+      public static unsafe extern void CreateSome(byte *payload, void *someValue, TypeMetadata meta);
+      public static unsafe extern void CreateError(byte *payload, SwiftError error, TypeMetadata meta);
+      public static unsafe extern void *SomeValue(byte *payload, TypeMetadata meta);
+      public static unsafe extern SwiftError ErrorValue(byte *payload, TypeMetadata meta);
+}
+```
+
+In order to do this with `Console.WriteLine` you must make 3 separate passes through the type from Swift: one for each of the types listed above, each of which will have to have similar repeated logic (does this case have a payload? is the payload generic? etc)
+
+With Dynamo, it's easy to manage this in one pass:
+
+```
+foreach case in cases
+    create the case in the enum
+    create the factory method in the main type
+    create the pinvoke method for the factory if needed
+    create the accessor method in the main type if needed
+    create the pinvoke method for the accessor if needed
+end
+```
+
+This gets even more complicated when you need to implement a Swift protocol as that will require writing Swift that calls back into C# (reverse pinvoke). Keeping everything in one place is a huge advantage. In the case of a protocol implementation, we have to write:
+1 - a C# interface
+2 - a C# proxy type that implements that interface
+3 - an extension in Swift that understand how to map to the proxy in C#
+4 - a C# class to hold reverse pinvokes
+5 - a C# class to hold pinvokes
+
+In writing methods, the interface declaration, the C# proxy method, the Swift extension method, the reverse pinvoke, and the pinvoke will all have very similar layouts and if marshaling is complicated by generics, the code will be interdependent.  Rather than scatter and duplicate this logic across 5 different places, it can instead be put in one place with locality of responsibility.
+
+## Operation 
+
+The general notion is that Dynamo lets you build up a syntax tree using language elements which can be connected with familiar collection methods or with C# operators.
+
+The Swift flavor, for example, has the abstract type `SLBaseExpr` which is a base type for expressions. From that there are unary, binary and ternary subclasses. `SLBaseExpr` overloads all the C# overloadable operators, so if you write `someExpr + someOtherExpr` this will combine them into a `SLBinaryExpr` with `+` operator. This makes it easy to generate syntactically correct expressions that read like the code you want it to be.
+
+Generally speaking all the types within Dynamo are meant to be immutable with the exception of collection types. For example a method declaration type would allow you to add to its body or to its parameters, but not modify its visibility, return type, etc.
+
+In addition to making writing code easier, Dynamo has an event system that is used when an element is written that makes it easy to create "attachments" to code elements. This is natural for attributes in C# which can appear before type declarations or parameter declarations. It also makes it straightforward to write conditional compilation directives, pragmas, regions, code comments and documentation, etc.

--- a/src/Dynamo/src/Dynamo.csproj
+++ b/src/Dynamo/src/Dynamo.csproj
@@ -4,8 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
-
 </Project>

--- a/src/Dynamo/src/Dynamo.csproj
+++ b/src/Dynamo/src/Dynamo.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/Dynamo/src/Extensions.cs
+++ b/src/Dynamo/src/Extensions.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+
+namespace Dynamo;
+
+/// <summary>
+/// Extensions to make writing code easier.
+/// </summary>
+public static class Extensions
+{
+    /// <summary>
+    /// Write all code elements and recurse if needed.
+    /// </summary>
+    /// <param name="elem">a code element to write</param>
+    /// <param name="writer">a code write</param>
+    public static void WriteAll(this ICodeElement elem, ICodeWriter writer)
+    {
+        var memento = elem.BeginWrite(writer);
+        elem.Write(writer, memento);
+        if (elem is ICodeElementSet set)
+        {
+            foreach (var sub in set.Elements)
+            {
+                sub.WriteAll(writer);
+            }
+        }
+        elem.EndWrite(writer, memento);
+    }
+
+    /// <summary>
+    /// Fire an event in reverse order.
+    /// </summary>
+    /// <typeparam name="T">The event handler type constrained to event args</typeparam>
+    /// <param name="handler">an event handler</param>
+    /// <param name="sender">The event source</param>
+    /// <param name="args">the event arguments</param>
+    public static void FireInReverse<T>(this EventHandler<T> handler, object sender, EventArgs args) where T : EventArgs
+    {
+        var dels = handler.GetInvocationList();
+        for (int i = dels.Length - 1; i >= 0; i--)
+        {
+            dels[i].DynamicInvoke(new object[] { sender, args });
+        }
+    }
+
+    /// <summary>
+    /// Interleave a separator between elements in a collection. This is useful for writing lists of elements
+    /// such as array initializers, function arguments, etc.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements</typeparam>
+    /// <param name="contents">The contents to interleave</param>
+    /// <param name="separator">The separator code element</param>
+    /// <param name="includeSeparatorFirst">if true, inject the separator before the elements</param>
+    /// <returns></returns>
+    public static IEnumerable<T> Interleave<T>(this IEnumerable<T> contents, T separator, bool includeSeparatorFirst = false)
+    {
+        bool first = true;
+        foreach (T t in contents)
+        {
+            if (!first || includeSeparatorFirst)
+                yield return separator;
+            first = false;
+            yield return t;
+        }
+    }
+
+    /// <summary>
+    /// Interleave a separator between elements in a collection injecting a start and end element. This is useful
+    /// for writing array initializers, dictionary initializers, etc.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements</typeparam>
+    /// <param name="contents">The contents to interleave</param>
+    /// <param name="start">The start element</param>
+    /// <param name="end">The end element</param>
+    /// <param name="separator">The separator</param>
+    /// <param name="includeSeparatorFirst">if true, inject the separator before the elements</param>
+    /// <returns></returns>
+    public static IEnumerable<T> BracketInterleave<T>(this IEnumerable<T> contents, T start, T end, T separator, bool includeSeparatorFirst = false)
+    {
+        yield return start;
+        foreach (T t in contents.Interleave(separator, includeSeparatorFirst))
+            yield return t;
+        yield return end;
+    }
+
+    /// <summary>
+    /// Attach a code element before another code element. This is useful for adding attributes or adding
+    /// #if/#else/#endif constructs
+    /// </summary>
+    /// <typeparam name="T">The type to attach, constrained to ICodeElement</typeparam>
+    /// <param name="attacher">The element to attach</param>
+    /// <param name="attachTo">The element that will be attached to</param>
+    /// <returns>the attacher</returns>
+    public static T AttachBefore<T>(this T attacher, ICodeElement attachTo) where T : ICodeElement
+    {
+        attachTo.Begin += (s, eventArgs) =>
+        {
+            attacher.WriteAll(eventArgs.Writer);
+        };
+        return attacher;
+    }
+
+    /// <summary>
+    /// Attach a code element after another code element. This is useful for adding #else/#endif constructs
+    /// </summary>
+    /// <typeparam name="T">The type of the element to attach constrained to ICodeElement</typeparam>
+    /// <param name="attacher">The element to attach</param>
+    /// <param name="attachTo">The element that will be attached to</param>
+    /// <returns>The attacher</returns>
+    public static T AttachAfter<T>(this T attacher, ICodeElement attachTo) where T : ICodeElement
+    {
+        attachTo.End += (s, eventArgs) =>
+        {
+            attacher.WriteAll(eventArgs.Writer);
+        };
+        return attacher;
+    }
+}
+
+

--- a/src/Dynamo/src/ICodeElement.cs
+++ b/src/Dynamo/src/ICodeElement.cs
@@ -12,7 +12,7 @@ public interface ICodeElement
 {
     /// <summary>
     /// When implemented, this method should write the code element to the code writer.
-    /// BeginWrite should also fire the Begin event beforeq writing anything.
+    /// BeginWrite should also fire the Begin event before writing anything.
     /// </summary>
     /// <param name="writer">The writer for the code</param>
     /// <returns>A memento that will be passed back to Write and EndWrite</returns>

--- a/src/Dynamo/src/ICodeElement.cs
+++ b/src/Dynamo/src/ICodeElement.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Dynamo;
+
+/// <summary>
+/// Represents a code element that can be written to a code writer.
+/// </summary>
+public interface ICodeElement
+{
+    /// <summary>
+    /// When implemented, this method should write the code element to the code writer.
+    /// BeginWrite should also fire the Begin event beforeq writing anything.
+    /// </summary>
+    /// <param name="writer">The writer for the code</param>
+    /// <returns>A memento that will be passed back to Write and EndWrite</returns>
+    object BeginWrite(ICodeWriter writer);
+
+    /// <summary>
+    /// When implemented, this method should write the code element to the code writer.
+    /// </summary>
+    /// <param name="writer">The writer for the code</param>
+    /// <param name="memento">The memento returned from BeginWrite</param>
+    void Write(ICodeWriter writer, object memento);
+
+    /// <summary>
+    /// When implemented, this method should perform any cleanup or final writing of the code element to the code writer.
+    /// EndWrite should also fire the End event after writing everything in *reverse* order.
+    /// This can be done by calling GetInvocationList on the event and iterating in reverse order.
+    /// </summary>
+    /// <param name="writer">The writer for the code</param>
+    /// <param name="memento">The memento returned from BeginWrite</param>
+    void EndWrite(ICodeWriter writer, object memento);
+
+    // These events seem redundant, but they are intended for use for non-structural code elements
+    // such as block comments or #region or #if/#else/#endif
+
+    /// <summary>
+    /// Event that is fired before writing the code element.
+    /// </summary>
+    event EventHandler<WriteEventArgs> Begin;
+    /// <summary>
+    /// Event that is fired after writing the code element.
+    /// </summary>
+    event EventHandler<WriteEventArgs> End;
+}
+

--- a/src/Dynamo/src/ICodeElementSet.cs
+++ b/src/Dynamo/src/ICodeElementSet.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Dynamo;
+
+/// <summary>
+/// Represents a set of code elements
+/// </summary>
+public interface ICodeElementSet : ICodeElement
+{
+    /// <summary>
+    /// Returns the code elements in the set.
+    /// </summary>
+    IEnumerable<ICodeElement> Elements { get; }
+}
+

--- a/src/Dynamo/src/ICodeWriter.cs
+++ b/src/Dynamo/src/ICodeWriter.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Dynamo;
+
+/// <summary>
+/// Interface for writing code to a file or other output. Code writers track
+/// position in line and indentation level.
+/// </summary>
+public interface ICodeWriter {
+    /// <summary>
+    /// Start a new line, optionally prepending indents.
+    /// </summary>
+    /// <param name="prependIndents"></param>
+    void BeginNewLine (bool prependIndents);
+
+    /// <summary>
+    /// Ends the current line.
+    /// </summary>
+    void EndLine ();
+
+    /// <summary>
+    /// Write a single character to the output.
+    /// </summary>
+    /// <param name="c">The character to write</param>
+    /// <param name="allowSplit">If true, allows the writer to insert a line break, splitting the current line</param>
+    void Write (char c, bool allowSplit);
+
+    /// <summary>
+    /// Write a string to the output.
+    /// </summary>
+    /// <param name="text">The text to write</param>
+    /// <param name="allowSplit">If truw, allows the writer to insert a line break, splitting the current line.</param>
+    void Write (string text, bool allowSplit);
+
+    /// <summary>
+    /// Increase the current indentation level.
+    /// </summary>
+    void Indent ();
+
+    /// <summary>
+    /// Decrease the current indentation level.
+    /// </summary>
+    void Exdent ();
+
+    /// <summary>
+    /// Returns the current indentation level.
+    /// </summary>
+    int IndentLevel { get; }
+
+    /// <summary>
+    /// Returns true if the writer is at the start of a line.
+    /// </summary>
+    bool IsAtLineStart { get; }
+}
+

--- a/src/Dynamo/src/ICodeWriter.cs
+++ b/src/Dynamo/src/ICodeWriter.cs
@@ -32,7 +32,7 @@ public interface ICodeWriter {
     /// Write a string to the output.
     /// </summary>
     /// <param name="text">The text to write</param>
-    /// <param name="allowSplit">If truw, allows the writer to insert a line break, splitting the current line.</param>
+    /// <param name="allowSplit">If true, allows the writer to insert a line break, splitting the current line.</param>
     void Write (string text, bool allowSplit);
 
     /// <summary>

--- a/src/Dynamo/src/SimpleElement.cs
+++ b/src/Dynamo/src/SimpleElement.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace Dynamo;
+
+[DebuggerDisplay("{Label}")]
+public class SimpleElement : ICodeElement
+{
+    bool allowSplit;
+    public SimpleElement(string label, bool allowSplit = false)
+    {
+        Label = label;
+        this.allowSplit = allowSplit;
+    }
+
+    public string Label { get; private set; }
+
+    public event EventHandler<WriteEventArgs> Begin = (s, e) => { };
+
+    public event EventHandler<WriteEventArgs> End = (s, e) => { };
+
+    public object BeginWrite(ICodeWriter writer)
+    {
+        OnBegin(new WriteEventArgs(writer));
+        return new object();
+    }
+
+    protected virtual void OnBegin(WriteEventArgs args)
+    {
+        Begin(this, args);
+    }
+
+    public void Write(ICodeWriter writer, object o)
+    {
+        writer.Write(Label, allowSplit);
+    }
+
+    public void EndWrite(ICodeWriter writer, object o)
+    {
+        OnEnd(new WriteEventArgs(writer));
+    }
+
+    protected virtual void OnEnd(WriteEventArgs args)
+    {
+        End.FireInReverse(this, args);
+    }
+
+    public override string ToString()
+    {
+        return Label;
+    }
+
+    static SimpleElement spacer = new SimpleElement(" ", true);
+    public static SimpleElement Spacer { get { return spacer; } }
+}
+

--- a/src/Dynamo/src/SimpleElement.cs
+++ b/src/Dynamo/src/SimpleElement.cs
@@ -5,6 +5,9 @@ using System.Diagnostics;
 
 namespace Dynamo;
 
+/// <summary>
+/// SimpleElement is a basic code element that contains a single string label.
+/// </summary>
 [DebuggerDisplay("{Label}")]
 public class SimpleElement : ICodeElement
 {
@@ -15,44 +18,65 @@ public class SimpleElement : ICodeElement
         this.allowSplit = allowSplit;
     }
 
+    /// <summary>
+    /// The label for the element.
+    /// </summary>
     public string Label { get; private set; }
 
+    /// <inheritdoc/>
     public event EventHandler<WriteEventArgs> Begin = (s, e) => { };
 
+    /// <inheritdoc/>
     public event EventHandler<WriteEventArgs> End = (s, e) => { };
 
+    /// <inheritdoc/>
     public object BeginWrite(ICodeWriter writer)
     {
         OnBegin(new WriteEventArgs(writer));
         return new object();
     }
 
+    /// <summary>
+    /// Fire the Begin event.
+    /// </summary>
+    /// <param name="args">the event arguments for the Begin event</param>    
     protected virtual void OnBegin(WriteEventArgs args)
     {
         Begin(this, args);
     }
 
+    /// <inheritdoc/>
     public void Write(ICodeWriter writer, object o)
     {
         writer.Write(Label, allowSplit);
     }
 
+    /// <inheritdoc/>
     public void EndWrite(ICodeWriter writer, object o)
     {
         OnEnd(new WriteEventArgs(writer));
     }
 
+    /// <summary>
+    /// Fire the End event.
+    /// </summary>
+    /// <param name="args">the event arguments for the End event</param>
     protected virtual void OnEnd(WriteEventArgs args)
     {
         End.FireInReverse(this, args);
     }
 
+    /// <inheritdoc/>
     public override string ToString()
     {
         return Label;
     }
 
     static SimpleElement spacer = new SimpleElement(" ", true);
+
+    /// <summary>
+    /// A simple element that represents a space.
+    /// </summary>
     public static SimpleElement Spacer { get { return spacer; } }
 }
 

--- a/src/Dynamo/src/SimpleLineElement.cs
+++ b/src/Dynamo/src/SimpleLineElement.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+
+namespace Dynamo;
+
+/// <summary>
+/// Represents a code element that is exists on a single line.
+/// </summary>
+[DebuggerDisplay("{Contents}")]
+public class SimpleLineElement : ICodeElement
+{
+    bool indent, prependIndents, allowSplit;
+
+    /// <summary>
+    /// Creates a new SimpleLineElement with the specified contents.
+    /// </summary>
+    /// <param name="contents">The contents of the line</param>
+    /// <param name="indent">if true, indent the line before writing</param>
+    /// <param name="prependIdents">if true, prepend the indents before the new line</param>
+    /// <param name="allowSplit">if true, allow a line break in the contents</param>
+    public SimpleLineElement(string contents, bool indent, bool prependIdents, bool allowSplit)
+    {
+        Contents = contents;
+        this.indent = indent;
+        this.prependIndents = prependIdents;
+        this.allowSplit = allowSplit;
+    }
+
+    /// <summary>
+    /// The contents of the line.
+    /// </summary>
+    public string Contents { get; private set; }
+
+    /// <inheritdoc/>
+    public event EventHandler<WriteEventArgs> Begin = (s, e) => { };
+
+    /// <inheritdoc/>
+    public event EventHandler<WriteEventArgs> End = (s, e) => { };
+
+    /// <inheritdoc/>
+    public object BeginWrite(ICodeWriter writer)
+    {
+        OnBegin(new WriteEventArgs(writer));
+        return new object();
+    }
+
+    /// <inheritdoc/>
+    protected virtual void OnBegin(WriteEventArgs args)
+    {
+        Begin(this, args);
+    }
+
+    /// <inheritdoc/>
+    public void Write(ICodeWriter writer, object memento)
+    {
+        if (indent)
+            writer.Indent();
+        writer.BeginNewLine(prependIndents);
+        writer.Write(Contents, allowSplit);
+        writer.EndLine();
+    }
+
+    /// <inheritdoc/>
+    public void EndWrite(ICodeWriter writer, object memento)
+    {
+        OnEnd(new WriteEventArgs(writer));
+    }
+
+    /// <inheritdoc/>
+    protected virtual void OnEnd(WriteEventArgs args)
+    {
+        End.FireInReverse(this, args);
+    }
+
+    public override string ToString()
+    {
+        return Contents;
+    }
+}
+
+

--- a/src/Dynamo/src/SimpleLineElement.cs
+++ b/src/Dynamo/src/SimpleLineElement.cs
@@ -46,7 +46,10 @@ public class SimpleLineElement : ICodeElement
         return new object();
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Fire the Begin event.
+    /// </summary>
+    /// <param name="args">the event arguments for the Begin event</param>    
     protected virtual void OnBegin(WriteEventArgs args)
     {
         Begin(this, args);
@@ -68,12 +71,16 @@ public class SimpleLineElement : ICodeElement
         OnEnd(new WriteEventArgs(writer));
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Fire the End event.
+    /// </summary>
+    /// <param name="args">the event arguments for the End event</param>
     protected virtual void OnEnd(WriteEventArgs args)
     {
         End.FireInReverse(this, args);
     }
 
+    /// <inheritdoc/>
     public override string ToString()
     {
         return Contents;

--- a/src/Dynamo/src/WriteEventArgs.cs
+++ b/src/Dynamo/src/WriteEventArgs.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Dynamo;
+
+/// <summary>
+/// Represents event args for a code writer.
+/// </summary>
+public class WriteEventArgs : EventArgs
+{
+    public WriteEventArgs(ICodeWriter writer)
+    {
+        Writer = writer;
+    }
+
+    /// <summary>
+    /// Gets the code writer.
+    /// </summary>
+    public ICodeWriter Writer { get; private set; }
+}
+
+


### PR DESCRIPTION
This is the first step to integrating Dynamo into the Swift bindings generation.

This PR includes the main interfaces that define code elements, sets of code elements and the operations to write them.
There are two concrete implementations of this `SimpleCodeElement` and `SimpleLineElement`.
Included are a set of extensions which make working with these easier, including code to fire events in reverse order.

It should be noted that there has been a great deal of discussion as to whether or not Dynamo should be a part of this project. Ultimately the decision came down to 3 important reasons:

1. Dynamo allows non-linear generation of code (see the README.md)
2. Dynamo is extremely well-tested in BTfS
3. Dynamo generates Swift and C#

It is also important to note that ultimately this code base will not live or be maintained by the runtime team. It is going to ultimately be owned and maintained by the macios team and the macios team is OK with this.

