### PR TITLE
[SwiftBindings] Added returning non-frozen structs from methods

### DIFF
--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/ModuleHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/ModuleHandler.cs
@@ -72,6 +72,7 @@ namespace BindingsGeneration
             writer.WriteLine($"using System.Runtime.InteropServices.Swift;");
             writer.WriteLine($"using Swift;");
             writer.WriteLine($"using Swift.Runtime;");
+            writer.WriteLine($"using Swift.Runtime.InteropServices;");
             writer.WriteLine();
             writer.WriteLine($"namespace {generatedNamespace}");
             writer.WriteLine("{");

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/TypeHandler.cs
@@ -206,7 +206,7 @@ namespace BindingsGeneration
 
             WritePrivateFields(writer, structDecl);
             WriteDisposeMethod(writer);
-            WriteFinalizer(writer, structDecl.Name);
+            WriteFinalizer(writer, structDecl);
             WritePayloadSize(writer);
             WritePayload(writer);
 
@@ -259,9 +259,9 @@ namespace BindingsGeneration
         /// <summary>
         /// Writes the finalizer for the class.
         /// </summary>
-        private static void WriteFinalizer(IndentedTextWriter writer, string className)
+        private static void WriteFinalizer(IndentedTextWriter writer, StructDecl structDecl)
         {
-            writer.WriteLine($"~{className}()");
+            writer.WriteLine($"~{structDecl.Name}()");
             writer.WriteLine("{");
             writer.Indent++;
             writer.WriteLine("NativeMemory.Free((void*)_payload);");
@@ -360,6 +360,9 @@ namespace BindingsGeneration
         }
     }
 
+    /// <summary>
+    /// Class responsible for emitting the necessary code for ISwiftObject methods.
+    /// </summary>
     class ISwiftObjectMethodWriter
     {
         private readonly IndentedTextWriter _writer;
@@ -375,6 +378,9 @@ namespace BindingsGeneration
             _structDecl = structDecl;
         }
 
+        /// <summary>
+        /// Writes the implementation for ISwiftObject methods for non-frozen structs.
+        /// </summary>
         public void WriteNonFrozenStructImplementation()
         {
             WriteGetTypeMetadata();
@@ -382,6 +388,9 @@ namespace BindingsGeneration
             WriteMarshalToSwift();
         }
 
+        /// <summary>
+        /// Writes the implementation for ISwiftObject methods for frozen structs.
+        /// </summary>
         public void WriteFrozenStructImplementation()
         {
             WriteGetTypeMetadata();
@@ -389,6 +398,9 @@ namespace BindingsGeneration
             WriteMarshalToSwift();
         }
 
+        /// <summary>
+        /// Writes the GetTypeMetadata method for the struct along with the PInvoke method.
+        /// </summary>
         private void WriteGetTypeMetadata()
         {
             _writer.WriteLine("static TypeMetadata ISwiftObject.GetTypeMetadata() => PInvoke_getMetadata();");
@@ -400,6 +412,9 @@ namespace BindingsGeneration
             _writer.WriteLine();
         }
 
+        /// <summary>
+        /// Writes the NewFromPayload method for the struct.
+        /// </summary>
         private void WriteNewFromPayloadFrozenStruct()
         {
             _writer.WriteLine("static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle handle)");
@@ -411,6 +426,9 @@ namespace BindingsGeneration
             _writer.WriteLine();
         }
 
+        /// <summary>
+        /// Writes the NewFromPayload method for the struct.
+        /// </summary>
         private void WriteNewFromPayloadNonFrozenStruct()
         {
             _writer.WriteLine("static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle handle)");
@@ -424,7 +442,9 @@ namespace BindingsGeneration
             EmitPrivateConstructor();
         }
 
-
+        /// <summary>
+        /// Writes the private constructor accepting a SwiftHandle.
+        /// </summary>
         private void EmitPrivateConstructor()
         {
             _writer.WriteLine($"unsafe {_structDecl.Name}(SwiftHandle handle)");
@@ -436,6 +456,9 @@ namespace BindingsGeneration
             _writer.WriteLine();
         }
 
+        /// <summary>
+        /// Writes the MarshalToSwift method for the struct.
+        /// </summary>
         private void WriteMarshalToSwift()
         {
             _writer.WriteLine("IntPtr ISwiftObject.MarshalToSwift(IntPtr swiftDest) => throw new NotImplementedException();");

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/TypeHandler.cs
@@ -204,8 +204,8 @@ namespace BindingsGeneration
             writer.WriteLine("{");
             writer.Indent++;
 
-            WritePrivateFields(writer);
-            WriteDisposeMethod(writer, structDecl.Name);
+            WritePrivateFields(writer, structDecl);
+            WriteDisposeMethod(writer);
             WriteFinalizer(writer, structDecl.Name);
             WritePayloadSize(writer);
             WritePayload(writer);
@@ -219,23 +219,25 @@ namespace BindingsGeneration
 
             writer.Indent--;
             writer.WriteLine("}");
+            writer.WriteLine();
         }
 
         /// <summary>
         /// Writes the private fields for the class.
         /// </summary>
-        private static void WritePrivateFields(IndentedTextWriter writer)
+        private static void WritePrivateFields(IndentedTextWriter writer, StructDecl structDecl)
         {
             writer.WriteLine();
-            writer.WriteLine("private static nuint _payloadSize = GetTypeMetadata().Size;");
-            writer.WriteLine("private SwiftHandle _payload = SwiftHandle.Zero;");
-            writer.WriteLine("private bool _disposed = false;");
+            writer.WriteLine($"static nuint _payloadSize = SwiftObjectHelper<{structDecl.Name}>.GetTypeMetadata().Size;");
+            writer.WriteLine("SwiftHandle _payload = SwiftHandle.Zero;");
+            writer.WriteLine("bool _disposed = false;");
+            writer.WriteLine();
         }
 
         /// <summary>
         /// Writes the Dispose method for the class.
         /// </summary>
-        private static void WriteDisposeMethod(IndentedTextWriter writer, string className)
+        private static void WriteDisposeMethod(IndentedTextWriter writer)
         {
             writer.WriteLine("public void Dispose()");
             writer.WriteLine("{");
@@ -251,6 +253,7 @@ namespace BindingsGeneration
             writer.WriteLine("}");
             writer.Indent--;
             writer.WriteLine("}");
+            writer.WriteLine();
         }
 
         /// <summary>
@@ -265,6 +268,7 @@ namespace BindingsGeneration
             writer.WriteLine("_payload = SwiftHandle.Zero;");
             writer.Indent--;
             writer.WriteLine("}");
+            writer.WriteLine();
         }
 
         /// <summary>
@@ -282,6 +286,7 @@ namespace BindingsGeneration
         private static void WritePayload(IndentedTextWriter writer)
         {
             writer.WriteLine("public SwiftHandle Payload => _payload;");
+            writer.WriteLine();
         }
     }
 
@@ -351,6 +356,7 @@ namespace BindingsGeneration
 
             writer.Indent--;
             writer.WriteLine("}");
+            writer.WriteLine();
         }
     }
 
@@ -385,7 +391,7 @@ namespace BindingsGeneration
 
         private void WriteGetTypeMetadata()
         {
-            _writer.WriteLine("public static TypeMetadata GetTypeMetadata() => PInvoke_getMetadata();");
+            _writer.WriteLine("static TypeMetadata ISwiftObject.GetTypeMetadata() => PInvoke_getMetadata();");
 
             _writer.WriteLine("[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]");
             string libPath = _typeDatabase.GetLibraryPath(_moduleDecl.Name);
@@ -396,7 +402,7 @@ namespace BindingsGeneration
 
         private void WriteNewFromPayloadFrozenStruct()
         {
-            _writer.WriteLine("public static ISwiftObject NewFromPayload(SwiftHandle handle)");
+            _writer.WriteLine("static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle handle)");
             _writer.WriteLine("{");
             _writer.Indent++;
             _writer.WriteLine($"return *({_structDecl.Name}*)handle;");
@@ -407,7 +413,7 @@ namespace BindingsGeneration
 
         private void WriteNewFromPayloadNonFrozenStruct()
         {
-            _writer.WriteLine("public static ISwiftObject NewFromPayload(SwiftHandle handle)");
+            _writer.WriteLine("static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle handle)");
             _writer.WriteLine("{");
             _writer.Indent++;
             _writer.WriteLine($"return new {_structDecl.Name}(handle);");
@@ -421,7 +427,7 @@ namespace BindingsGeneration
 
         private void EmitPrivateConstructor()
         {
-            _writer.WriteLine($"private unsafe {_structDecl.Name}(SwiftHandle handle)");
+            _writer.WriteLine($"unsafe {_structDecl.Name}(SwiftHandle handle)");
             _writer.WriteLine("{");
             _writer.Indent++;
             _writer.WriteLine("_payload = handle;");
@@ -432,7 +438,7 @@ namespace BindingsGeneration
 
         private void WriteMarshalToSwift()
         {
-            _writer.WriteLine("public IntPtr MarshalToSwift(IntPtr swiftDest) => throw new NotImplementedException();");
+            _writer.WriteLine("IntPtr ISwiftObject.MarshalToSwift(IntPtr swiftDest) => throw new NotImplementedException();");
             _writer.WriteLine();
         }
     }

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/TypeHandler.cs
@@ -67,6 +67,9 @@ namespace BindingsGeneration
             var moduleDecl = structDecl.ModuleDecl ?? throw new ArgumentNullException(nameof(structDecl.ParentDecl));
             // Retrieve type info from the type database
             var typeRecord = env.TypeDatabase.GetTypeRecordOrThrow(moduleDecl.Name, structDecl.FullyQualifiedNameWithoutModule);
+
+            var ISwiftObjectMethodWriter = new ISwiftObjectMethodWriter(writer, env.TypeDatabase, moduleDecl, structDecl);
+
             SwiftTypeInfo? swiftTypeInfo = typeRecord?.SwiftTypeInfo;
 
             if (swiftTypeInfo.HasValue)
@@ -78,7 +81,7 @@ namespace BindingsGeneration
                     writer.WriteLine($"[StructLayout(LayoutKind.Sequential, Size = {swiftTypeInfo.Value.ValueWitnessTable->Size})]");
                 }
             }
-            writer.WriteLine($"public unsafe struct {structDecl.Name} {{");
+            writer.WriteLine($"public unsafe struct {structDecl.Name} : {typeof(ISwiftObject).Name} {{");
             writer.Indent++;
 
             // Emit each field in the struct
@@ -96,6 +99,8 @@ namespace BindingsGeneration
                 // }
             }
             writer.WriteLine();
+
+            ISwiftObjectMethodWriter.WriteFrozenStructImplementation();
 
             base.HandleBaseDecl(writer, structDecl.Types, conductor, env.TypeDatabase);
             base.HandleBaseDecl(writer, structDecl.Methods, conductor, env.TypeDatabase);
@@ -193,15 +198,19 @@ namespace BindingsGeneration
             var structDecl = (StructDecl)structEnv.TypeDecl;
             var moduleDecl = structDecl.ModuleDecl ?? throw new ArgumentNullException(nameof(structDecl.ModuleDecl));
 
-            writer.WriteLine($"public unsafe class {structDecl.Name} : IDisposable");
+            var ISwiftObjectMethodWriter = new ISwiftObjectMethodWriter(writer, env.TypeDatabase, moduleDecl, structDecl);
+
+            writer.WriteLine($"public unsafe class {structDecl.Name} : IDisposable, {typeof(ISwiftObject).Name}");
             writer.WriteLine("{");
             writer.Indent++;
 
             WritePrivateFields(writer);
             WriteDisposeMethod(writer, structDecl.Name);
             WriteFinalizer(writer, structDecl.Name);
+            WritePayloadSize(writer);
             WritePayload(writer);
-            WriteMetadata(writer, moduleDecl.Name, structDecl.MangledName, env.TypeDatabase);
+
+            ISwiftObjectMethodWriter.WriteNonFrozenStructImplementation();
 
             writer.WriteLine();
 
@@ -218,7 +227,7 @@ namespace BindingsGeneration
         private static void WritePrivateFields(IndentedTextWriter writer)
         {
             writer.WriteLine();
-            writer.WriteLine("private static nuint _payloadSize = Metadata.Size;");
+            writer.WriteLine("private static nuint _payloadSize = GetTypeMetadata().Size;");
             writer.WriteLine("private SwiftHandle _payload = SwiftHandle.Zero;");
             writer.WriteLine("private bool _disposed = false;");
         }
@@ -259,16 +268,12 @@ namespace BindingsGeneration
         }
 
         /// <summary>
-        /// Writes the metadata for the class.
+        /// Writes the payload size accessor for the class.
         /// </summary>
-        private static void WriteMetadata(IndentedTextWriter writer, string moduleName, string mangledName, ITypeDatabase typeDatabase)
+        private static void WritePayloadSize(IndentedTextWriter writer)
         {
-            writer.WriteLine("public static TypeMetadata Metadata => PInvoke_getMetadata();");
-
-            writer.WriteLine("[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]");
-            string libPath = typeDatabase.GetLibraryPath(moduleName);
-            writer.WriteLine($"[DllImport(\"{libPath}\", EntryPoint = \"{mangledName}Ma\")]");
-            writer.WriteLine("internal static extern TypeMetadata PInvoke_getMetadata();");
+            writer.WriteLine("public static nuint PayloadSize => _payloadSize;");
+            writer.WriteLine();
         }
 
         /// <summary>
@@ -346,6 +351,89 @@ namespace BindingsGeneration
 
             writer.Indent--;
             writer.WriteLine("}");
+        }
+    }
+
+    class ISwiftObjectMethodWriter
+    {
+        private readonly IndentedTextWriter _writer;
+        private readonly ITypeDatabase _typeDatabase;
+        private readonly ModuleDecl _moduleDecl;
+        private readonly StructDecl _structDecl;
+
+        public ISwiftObjectMethodWriter(IndentedTextWriter writer, ITypeDatabase typeDatabase, ModuleDecl moduleDecl, StructDecl structDecl)
+        {
+            _writer = writer;
+            _typeDatabase = typeDatabase;
+            _moduleDecl = moduleDecl;
+            _structDecl = structDecl;
+        }
+
+        public void WriteNonFrozenStructImplementation()
+        {
+            WriteGetTypeMetadata();
+            WriteNewFromPayloadNonFrozenStruct();
+            WriteMarshalToSwift();
+        }
+
+        public void WriteFrozenStructImplementation()
+        {
+            WriteGetTypeMetadata();
+            WriteNewFromPayloadFrozenStruct();
+            WriteMarshalToSwift();
+        }
+
+        private void WriteGetTypeMetadata()
+        {
+            _writer.WriteLine("public static TypeMetadata GetTypeMetadata() => PInvoke_getMetadata();");
+
+            _writer.WriteLine("[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]");
+            string libPath = _typeDatabase.GetLibraryPath(_moduleDecl.Name);
+            _writer.WriteLine($"[DllImport(\"{libPath}\", EntryPoint = \"{_structDecl.MangledName}Ma\")]");
+            _writer.WriteLine("internal static extern TypeMetadata PInvoke_getMetadata();");
+            _writer.WriteLine();
+        }
+
+        private void WriteNewFromPayloadFrozenStruct()
+        {
+            _writer.WriteLine("public static ISwiftObject NewFromPayload(SwiftHandle handle)");
+            _writer.WriteLine("{");
+            _writer.Indent++;
+            _writer.WriteLine($"return *({_structDecl.Name}*)handle;");
+            _writer.Indent--;
+            _writer.WriteLine("}");
+            _writer.WriteLine();
+        }
+
+        private void WriteNewFromPayloadNonFrozenStruct()
+        {
+            _writer.WriteLine("public static ISwiftObject NewFromPayload(SwiftHandle handle)");
+            _writer.WriteLine("{");
+            _writer.Indent++;
+            _writer.WriteLine($"return new {_structDecl.Name}(handle);");
+            _writer.Indent--;
+            _writer.WriteLine("}");
+            _writer.WriteLine();
+
+            EmitPrivateConstructor();
+        }
+
+
+        private void EmitPrivateConstructor()
+        {
+            _writer.WriteLine($"private unsafe {_structDecl.Name}(SwiftHandle handle)");
+            _writer.WriteLine("{");
+            _writer.Indent++;
+            _writer.WriteLine("_payload = handle;");
+            _writer.Indent--;
+            _writer.WriteLine("}");
+            _writer.WriteLine();
+        }
+
+        private void WriteMarshalToSwift()
+        {
+            _writer.WriteLine("public IntPtr MarshalToSwift(IntPtr swiftDest) => throw new NotImplementedException();");
+            _writer.WriteLine();
         }
     }
 }

--- a/src/Swift.Bindings/src/Marshaler/MarshallingHelpers.cs
+++ b/src/Swift.Bindings/src/Marshaler/MarshallingHelpers.cs
@@ -12,7 +12,7 @@ namespace BindingsGeneration
             if (methodDecl.IsConstructor && !(parentDecl is StructDecl structDecl && StructIsMarshalledAsCSStruct(structDecl))) return true;
             var returnType = methodDecl.CSSignature.First();
 
-            if (returnType.Name == "") return false; // TODO: Void should be handled differently
+            if (returnType.SwiftTypeSpec.IsEmptyTuple) return false;
 
             if (!ArgumentIsMarshalledAsCSStruct(returnType, typeDatabase)) return true;
             return false;

--- a/src/Swift.Bindings/src/Model/TypeDecl/BaseDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/BaseDecl.cs
@@ -31,6 +31,6 @@ namespace BindingsGeneration
         /// <summary>
         /// The module declaration.
         /// </summary>
-        public required BaseDecl? ModuleDecl { get; set; }
+        public required ModuleDecl? ModuleDecl { get; set; }
     }
 }

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -176,7 +176,7 @@ namespace BindingsGeneration
         /// <param name="parentDecl">The parent declaration.</param>
         /// <param name="moduleDecl">The module declaration.</param>
         /// <returns>The list of collected declarations.</returns>
-        private List<BaseDecl> CollectDeclarations(IEnumerable<Node> nodes, BaseDecl parentDecl, BaseDecl moduleDecl)
+        private List<BaseDecl> CollectDeclarations(IEnumerable<Node> nodes, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
             var declarations = new List<BaseDecl>();
             foreach (var node in nodes)
@@ -195,7 +195,7 @@ namespace BindingsGeneration
         /// <param name="parentDecl">The parent declaration.</param>
         /// <param name="moduleDecl">The module declaration.</param>
         /// <returns>The declaration.</returns>
-        private BaseDecl? HandleNode(Node node, BaseDecl parentDecl, BaseDecl moduleDecl)
+        private BaseDecl? HandleNode(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
             BaseDecl? result = null;
             try
@@ -242,7 +242,7 @@ namespace BindingsGeneration
         /// <param name="parentDecl">The parent declaration.</param>
         /// <param name="moduleDecl">The module declaration.</param>
         /// <returns>The type declaration.</returns>
-        private TypeDecl? HandleTypeDecl(Node node, BaseDecl parentDecl, BaseDecl moduleDecl)
+        private TypeDecl? HandleTypeDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
             if (_typeDatabase.IsTypeProcessed(node.ModuleName, ExtractFullyQualifiedName(parentDecl.FullyQualifiedName, node.Name)))
             {
@@ -308,7 +308,7 @@ namespace BindingsGeneration
         /// <param name="parentDecl">The parent declaration.</param>
         /// <param name="moduleDecl">The module declaration.</param>
         /// <returns>The struct declaration.</returns>
-        private StructDecl CreateStructDecl(Node node, BaseDecl parentDecl, BaseDecl moduleDecl, bool hasFrozenAttribute)
+        private StructDecl CreateStructDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl, bool hasFrozenAttribute)
         {
             return new StructDecl
             {
@@ -332,7 +332,7 @@ namespace BindingsGeneration
         /// <param name="parentDecl">The parent declaration.</param>
         /// <param name="moduleDecl">The module declaration.</param>
         /// <returns>The class declaration.</returns>
-        private ClassDecl CreateClassDecl(Node node, BaseDecl parentDecl, BaseDecl moduleDecl)
+        private ClassDecl CreateClassDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
             return new ClassDecl
             {
@@ -354,7 +354,7 @@ namespace BindingsGeneration
         /// <param name="parentDecl">The parent declaration.</param>
         /// <param name="moduleDecl">The module declaration.</param>
         /// <returns>The method declaration.</returns>
-        private MethodDecl CreateMethodDecl(Node node, BaseDecl parentDecl, BaseDecl moduleDecl)
+        private MethodDecl CreateMethodDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
             // Extract parameter names from the signature
             var paramNames = ExtractParameterNames(node.PrintedName);
@@ -405,7 +405,7 @@ namespace BindingsGeneration
         /// <param name="parentDecl">The parent declaration.</param>
         /// <param name="moduleDecl">The module declaration.</param>
         /// <returns>The field declaration.</returns>
-        private FieldDecl CreateFieldDecl(Node node, BaseDecl parentDecl, BaseDecl moduleDecl)
+        private FieldDecl CreateFieldDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
             var typeSpec = CreateTypeSpec(node.Children.ElementAt(0));
             var fieldDecl = new FieldDecl

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
@@ -56,7 +56,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(y, gotY);
         }
 
-        [Fact(Skip = "Indirect result on non-constructor not implemented")]
+        [Fact]
         public void TestNonFrozenStructWithNonFrozenMemberCreation()
         {
             IntPtr frozenX = 1;
@@ -77,7 +77,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(nonFrozenY, gotNF.getY());
         }
 
-        [Fact(Skip = "Indirect result on non-constructor not implemented")]
+        [Fact]
         public void TestFrozenStructWithNonFrozenMemberCreation()
         {
             IntPtr frozenX = 1;
@@ -199,7 +199,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(y, result.getY());
         }
 
-        [Fact(Skip = "Indirect result on non-constructor not implemented")]
+        [Fact]
         public void TestModuleFuncReturningNonFrozenStruct()
         {
             IntPtr x = 1;
@@ -224,7 +224,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(y, result.getY());
         }
 
-        [Fact(Skip = "Indirect result on non-constructor not implemented")]
+        [Fact]
         public void TestInstanceMethodReturningNonFrozenStruct()
         {
             IntPtr x = 1;
@@ -249,7 +249,7 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(y, result.getY());
         }
 
-        [Fact(Skip = "Indirect result on non-constructor not implemented")]
+        [Fact]
         public void TestStaticMethodReturningNonFrozenStruct()
         {
             IntPtr x = 1;

--- a/src/Swift.Runtime/src/Swift/AnyType.cs
+++ b/src/Swift.Runtime/src/Swift/AnyType.cs
@@ -25,9 +25,9 @@ public struct AnyType : ISwiftObject {
     /// <summary>
     /// Creates a new SwiftOptional from a Swift payload
     /// </summary>
-    static ISwiftObject ISwiftObject.NewFromPayload(IntPtr payload)
+    static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle payload)
     {
-        return new AnyType(new SwiftHandle(payload));
+        return new AnyType(payload);
     }
 
     /// <summary>

--- a/src/Swift.Runtime/src/Swift/Runtime/ISwiftObject.cs
+++ b/src/Swift.Runtime/src/Swift/Runtime/ISwiftObject.cs
@@ -17,12 +17,12 @@ public interface ISwiftObject
     /// <summary>  
     /// Creates a new Swift object from a given payload
     /// </summary>
-    public static abstract ISwiftObject NewFromPayload(IntPtr payload);
+    public static abstract ISwiftObject NewFromPayload(SwiftHandle payload);
 
     /// <summary>
     /// Marshals this object to a Swift destination
     /// </summary>
-    unsafe IntPtr MarshalToSwift(IntPtr swiftDest);    
+    unsafe IntPtr MarshalToSwift(IntPtr swiftDest);
 }
 
 /// <summary>  
@@ -44,7 +44,7 @@ public struct SwiftObjectHelper<T> where T : ISwiftObject
     /// </summary>
     /// <param name="payload"></param>
     /// <returns>a new ISwiftObject</returns>
-    public static ISwiftObject NewFromPayload(IntPtr payload)
+    public static ISwiftObject NewFromPayload(SwiftHandle payload)
     {
         return T.NewFromPayload(payload);
     }

--- a/src/Swift.Runtime/src/Swift/Runtime/InteropServices/SwiftMarshal.cs
+++ b/src/Swift.Runtime/src/Swift/Runtime/InteropServices/SwiftMarshal.cs
@@ -98,10 +98,10 @@ public static class SwiftMarshal {
     /// <param name="swiftSource">Memory to read from</param>
     /// <returns>The C# type created by marshaling</returns>
     /// <exception cref="NotSupportedException"></exception>
-    public static T MarshalFromSwift<T>(IntPtr swiftSource) {
+    public static T MarshalFromSwift<T>(SwiftHandle swiftSource) {
         if (typeof(ISwiftObject).IsAssignableFrom(typeof(T))) {
             var helper = typeof(SwiftObjectHelper<>).MakeGenericType(typeof(T));
-            return (T)helper.GetMethod("NewFromPayload")!.Invoke(null, new object[] { new IntPtr(swiftSource) })!;
+            return (T)helper.GetMethod("NewFromPayload")!.Invoke(null, new object[] { new SwiftHandle(swiftSource) })!;
         }
         var type = typeof(T);
         if (type.IsPrimitive) {

--- a/src/Swift.Runtime/src/Swift/Runtime/SwiftHandle.cs
+++ b/src/Swift.Runtime/src/Swift/Runtime/SwiftHandle.cs
@@ -87,9 +87,9 @@ public readonly struct SwiftHandle : IEquatable<SwiftHandle> {
     }
 
     /// <summary>
-    /// Implicit conversion from IntPtr to SwiftHandle
+    /// Explicit conversion from IntPtr to SwiftHandle
     /// </summary>
-    public static implicit operator SwiftHandle (IntPtr value)
+    public static explicit operator SwiftHandle (IntPtr value)
     {
         return new SwiftHandle (value);
     }

--- a/src/Swift.Runtime/src/Swift/SwiftOptional.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftOptional.cs
@@ -43,7 +43,7 @@ public class SwiftOptional<T> : ISwiftObject
     /// <summary>
     /// Creates a new SwiftOptional from a Swift payload
     /// </summary>
-    static ISwiftObject ISwiftObject.NewFromPayload(IntPtr payload)
+    static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle payload)
     {
         var metadata = SwiftObjectHelper<SwiftOptional<T>>.GetTypeMetadata();
         var instance = new SwiftOptional<T>();
@@ -130,7 +130,7 @@ public class SwiftOptional<T> : ISwiftObject
                 _payload.CopyTo(payload);
                 fixed (byte* payloadPtr = payload) {
                     metadata.ValueWitnessTable->DestructiveProjectEnumData(payloadPtr, metadata);                  
-                    return SwiftMarshal.MarshalFromSwift<T>(new IntPtr (payloadPtr));
+                    return SwiftMarshal.MarshalFromSwift<T>((SwiftHandle) new IntPtr (payloadPtr));
                 }
             }
         }

--- a/src/Swift.Runtime/tests/TypeMetadataTests/TypeMetadataTests.cs
+++ b/src/Swift.Runtime/tests/TypeMetadataTests/TypeMetadataTests.cs
@@ -81,7 +81,7 @@ public class TypeMetadataTests : IClassFixture<TypeMetadataTests.TestFixture>
             return swiftDest;
         }
 
-        static ISwiftObject ISwiftObject.NewFromPayload(IntPtr payload)
+        static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle payload)
         {
             return new ThisOnlyGetsUsedHere();
         }


### PR DESCRIPTION
Fixes #2885. 

This PR introduces the following changes:
- Makes projected structs implement `ISwiftObject` interface. 
- Adds correct handling of `IndirectResult` on non-init methods
- Makes `IntPtr` to `SwiftHandle` conversion explicit to prevent name clashes (constructor accepting IntPtr vs constructor accepting SwiftHandle)
- Makes `MarshalFromSwift` use `SwiftHandle` instead of `IntPtr`

