### PR TITLE
[SwiftBindings] Added support for generic methods without constraints

### DIFF
--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
@@ -5,75 +5,6 @@ using System.CodeDom.Compiler;
 
 namespace BindingsGeneration
 {
-    /// <summary>
-    /// Factory class for creating instances of ConstructorHandler.
-    /// </summary>
-    public class ConstructorHandlerFactory : IFactory<BaseDecl, IMethodHandler>
-    {
-        /// <summary>
-        /// Determines if the factory handles the specified declaration.
-        /// </summary>
-        /// <param name="decl">The base declaration.</param>
-        public bool Handles(BaseDecl decl)
-        {
-            return decl is MethodDecl methodDecl && methodDecl.IsConstructor;
-        }
-
-        /// <summary>
-        /// Constructs a new instance of ConstructorHandler.
-        /// </summary>
-        public IMethodHandler Construct()
-        {
-            return new ConstructorHandler();
-        }
-    }
-
-    /// <summary>
-    /// Handler class for constructor declarations.
-    /// </summary>
-    public class ConstructorHandler : BaseHandler, IMethodHandler
-    {
-        public ConstructorHandler()
-        {
-        }
-
-        /// <summary>
-        /// Marshals the specified constructor.
-        /// </summary>
-        /// <param name="methodDecl">The method declaration.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
-        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
-        {
-            if (decl is not MethodDecl methodDecl)
-            {
-                throw new ArgumentException("The provided decl must be a MethodDecl.", nameof(decl));
-            }
-            return new MethodEnvironment(methodDecl, typeDatabase);
-        }
-
-        /// <summary>
-        /// Emits the code for the specified environment.
-        /// </summary>
-        /// <param name="writer">The IndentedTextWriter instance.</param>
-        /// <param name="env">The environment.</param>
-        /// <param name="conductor">The conductor instance.</param>
-        public void Emit(IndentedTextWriter writer, IEnvironment env, Conductor conductor)
-        {
-            var methodEnv = (MethodEnvironment)env;
-            var signatureHandler = new SignatureHandler(methodEnv);
-
-            if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
-            {
-                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported signature: ({signatureHandler.GetWrapperSignature().ParametersString()}) -> {signatureHandler.GetWrapperSignature().ReturnType}");
-                return;
-            }
-
-            var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler);
-            wrapperEmitter.EmitConstructor(writer);
-            PInvokeEmitter.EmitPInvoke(writer, methodEnv, signatureHandler);
-            writer.WriteLine();
-        }
-    }
 
     /// <summary>
     /// Represents a method handler factory.
@@ -87,7 +18,7 @@ namespace BindingsGeneration
         /// <returns></returns>
         public bool Handles(BaseDecl decl)
         {
-            return decl is MethodDecl methodDecl && !methodDecl.IsConstructor;
+            return decl is MethodDecl;
         }
 
         /// <summary>
@@ -139,7 +70,14 @@ namespace BindingsGeneration
             }
 
             var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler);
-            wrapperEmitter.EmitMethod(writer);
+            if (methodEnv.MethodDecl.IsConstructor)
+            {
+                wrapperEmitter.EmitConstructor(writer);
+            }
+            else
+            {
+                wrapperEmitter.EmitMethod(writer);
+            }
             PInvokeEmitter.EmitPInvoke(writer, methodEnv, signatureHandler);
             writer.WriteLine();
         }

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
@@ -136,8 +136,8 @@ namespace BindingsGeneration
             var argument = _env.MethodDecl.CSSignature.First();
             if (argument.IsGeneric)
             {
-                var CSName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
-                SetReturnType(CSName.TypeName);
+                var placeholderName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].PlaceholderName;
+                SetReturnType(placeholderName);
             }
             else
             {
@@ -155,8 +155,8 @@ namespace BindingsGeneration
             {
                 if (argument.IsGeneric)
                 {
-                    var CSName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
-                    AddParameter(CSName.TypeName, argument.Name);
+                    var placeholderName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].PlaceholderName;
+                    AddParameter(placeholderName, argument.Name);
                 }
                 else
                 {
@@ -242,8 +242,8 @@ namespace BindingsGeneration
             {
                 if (argument.IsGeneric)
                 {
-                    var CSName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
-                    AddParameter("IntPtr", CSName.PayloadName);
+                    var payloadName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].PayloadName;
+                    AddParameter("IntPtr", payloadName);
                 }
                 else if (MarshallingHelpers.ArgumentIsMarshalledAsCSStruct(argument, _env.TypeDatabase))
                 {
@@ -264,8 +264,8 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var CSName = _env.GenericTypeMapping[genericParameter.TypeName];
-                AddParameter("TypeMetadata", CSName.MetadataName);
+                var metadataName = _env.GenericTypeMapping[genericParameter.TypeName].MetadataName;
+                AddParameter("TypeMetadata", metadataName);
             }
         }
 
@@ -671,7 +671,7 @@ namespace BindingsGeneration
         {
             var genericParams = _env.MethodDecl.IsGeneric switch
             {
-                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].TypeName))}>",
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].PlaceholderName))}>",
                 false => ""
             };
             writer.WriteLine($"public {_env.ParentDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
@@ -685,7 +685,7 @@ namespace BindingsGeneration
         {
             var genericParams = _env.MethodDecl.IsGeneric switch
             {
-                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].TypeName))}>",
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].PlaceholderName))}>",
                 false => ""
             };
 

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
@@ -502,6 +502,7 @@ namespace BindingsGeneration
             EmitBodyStart(writer);
             EmitSwiftSelf(writer);
             EmitIndirectResultConstructor(writer);
+            EmitGenericArguments(writer);
             EmitPInvokeCall(writer);
             EmitSwiftError(writer);
             EmitReturnConstructor(writer);
@@ -518,6 +519,7 @@ namespace BindingsGeneration
             EmitBodyStart(writer);
             EmitSwiftSelf(writer);
             EmitIndirectResultMethod(writer);
+            EmitGenericArguments(writer);
             EmitPInvokeCall(writer);
             EmitSwiftError(writer);
             EmitReturnMethod(writer);
@@ -582,25 +584,26 @@ namespace BindingsGeneration
         }
 
         /// <summary>
+        /// Emits the generic arguments setup.
+        /// </summary>
+        private void EmitGenericArguments(IndentedTextWriter writer)
+        {
+            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
+            {
+                var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                writer.WriteLine($"var {metadataName} = TypeMetadata.GetTypeMetadataOrThrow<{typeName}>();");
+                writer.WriteLine($"IntPtr {payloadName} = (IntPtr)NativeMemory.Alloc({metadataName}.Size);");
+                writer.WriteLine($"SwiftMarshal.MarshalToSwift({argument.Name}, {payloadName});");
+            }
+            writer.WriteLine();
+        }
+
+        /// <summary>
         /// Emits the PInvoke call.
         /// </summary>
         /// <param name="writer">The IndentedTextWriter instance.</param>
         private void EmitPInvokeCall(IndentedTextWriter writer)
         {
-            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1))
-            {
-                if (!argument.IsGeneric)
-                {
-                    continue;
-                }
-
-                var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
-                writer.WriteLine($"var {metadataName} = TypeMetadata.GetTypeMetadataOrThrow<{typeName}>();");
-                writer.WriteLine($"IntPtr {payloadName} = (IntPtr)NativeMemory.Alloc({metadataName}.Size);"); // Try - finally
-                writer.WriteLine($"SwiftMarshal.MarshalToSwift({argument.Name}, {payloadName});");
-            }
-            writer.WriteLine();
-
             var voidReturn = _env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple;
             var returnPrefix = (_requiresIndirectResult || voidReturn) ? "" : "var result = ";
             writer.WriteLine($"{returnPrefix}{NameProvider.GetPInvokeName(_env.MethodDecl)}({_pInvokeSignature.CallArgumentsString()});");

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
@@ -63,6 +63,13 @@ namespace BindingsGeneration
         {
             var methodEnv = (MethodEnvironment)env;
             var signatureHandler = new SignatureHandler(methodEnv);
+
+            if (methodEnv.MethodDecl.GenericParameters.Any(x => x.Constraints.Count > 0))
+            {
+                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported generic constraints");
+                return;
+            }
+
             if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
             {
                 Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported signature: ({signatureHandler.GetWrapperSignature().ParametersString()}) -> {signatureHandler.GetWrapperSignature().ReturnType}");
@@ -104,7 +111,6 @@ namespace BindingsGeneration
             return parameter switch
             {
                 { Type: "SwiftHandle" } => $"{parameter.Name}.Payload",
-                { Type: "IntPtr" } => parameter.Name,
                 { modifier: "out" } => $"out var {parameter.Name}",
                 _ => parameter.Name
             };
@@ -258,7 +264,7 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var CSName = _env.GenericTypeMapping[genericParameter];
+                var CSName = _env.GenericTypeMapping[genericParameter.TypeName];
                 AddParameter("TypeMetadata", CSName.MetadataName);
             }
         }
@@ -665,7 +671,7 @@ namespace BindingsGeneration
         {
             var genericParams = _env.MethodDecl.IsGeneric switch
             {
-                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p].TypeName))}>",
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].TypeName))}>",
                 false => ""
             };
             writer.WriteLine($"public {_env.ParentDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
@@ -679,7 +685,7 @@ namespace BindingsGeneration
         {
             var genericParams = _env.MethodDecl.IsGeneric switch
             {
-                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p].TypeName))}>",
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].TypeName))}>",
                 false => ""
             };
 

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.CodeDom.Compiler;
-using Swift.Runtime;
 
 namespace BindingsGeneration
 {
@@ -61,15 +60,17 @@ namespace BindingsGeneration
         public void Emit(IndentedTextWriter writer, IEnvironment env, Conductor conductor)
         {
             var methodEnv = (MethodEnvironment)env;
-            if (methodEnv.SignatureHandler.GetWrapperSignature().ContainsPlaceholder)
+            var signatureHandler = new SignatureHandler(methodEnv);
+
+            if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
             {
-                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported signature: ({methodEnv.SignatureHandler.GetWrapperSignature().ParametersString()}) -> {methodEnv.SignatureHandler.GetWrapperSignature().ReturnType}");
+                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported signature: ({signatureHandler.GetWrapperSignature().ParametersString()}) -> {signatureHandler.GetWrapperSignature().ReturnType}");
                 return;
             }
 
-            var wrapperEmitter = new WrapperEmitter(methodEnv);
+            var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler);
             wrapperEmitter.EmitConstructor(writer);
-            PInvokeEmitter.EmitPInvoke(writer, methodEnv);
+            PInvokeEmitter.EmitPInvoke(writer, methodEnv, signatureHandler);
             writer.WriteLine();
         }
     }
@@ -130,15 +131,16 @@ namespace BindingsGeneration
         public void Emit(IndentedTextWriter writer, IEnvironment env, Conductor conductor)
         {
             var methodEnv = (MethodEnvironment)env;
-            if (methodEnv.SignatureHandler.GetWrapperSignature().ContainsPlaceholder)
+            var signatureHandler = new SignatureHandler(methodEnv);
+            if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
             {
-                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported signature: ({methodEnv.SignatureHandler.GetWrapperSignature().ParametersString()}) -> {methodEnv.SignatureHandler.GetWrapperSignature().ReturnType}");
+                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported signature: ({signatureHandler.GetWrapperSignature().ParametersString()}) -> {signatureHandler.GetWrapperSignature().ReturnType}");
                 return;
             }
 
-            var wrapperEmitter = new WrapperEmitter(methodEnv);
+            var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler);
             wrapperEmitter.EmitMethod(writer);
-            PInvokeEmitter.EmitPInvoke(writer, methodEnv);
+            PInvokeEmitter.EmitPInvoke(writer, methodEnv, signatureHandler);
             writer.WriteLine();
         }
     }
@@ -171,6 +173,7 @@ namespace BindingsGeneration
             return parameter switch
             {
                 { Type: "SwiftHandle" } => $"{parameter.Name}.Payload",
+                { Type: "IntPtr" } => parameter.Name,
                 { modifier: "out" } => $"out var {parameter.Name}",
                 _ => parameter.Name
             };
@@ -181,15 +184,11 @@ namespace BindingsGeneration
     {
         private string _returnType = "invalid";
         private readonly List<Parameter> _parameters = new();
-        MethodDecl MethodDecl { get; }
-        BaseDecl ParentDecl { get; }
-        ITypeDatabase TypeDatabase { get; }
+        private readonly MethodEnvironment _env;
 
-        public WrapperSignatureBuilder(MethodDecl methodDecl, ITypeDatabase typeDatabase)
+        public WrapperSignatureBuilder(MethodEnvironment env)
         {
-            MethodDecl = methodDecl;
-            ParentDecl = methodDecl.ParentDecl!;
-            TypeDatabase = typeDatabase;
+            _env = env;
         }
 
         /// <summary>
@@ -197,9 +196,17 @@ namespace BindingsGeneration
         /// </summary>
         public void HandleReturnType()
         {
-            var argument = MethodDecl.CSSignature.First();
-            var typeRecord = TypeDatabase.GetTypeRecordOrAnyType(argument.SwiftTypeSpec);
-            SetReturnType(typeRecord.CSTypeIdentifier);
+            var argument = _env.MethodDecl.CSSignature.First();
+            if (argument.IsGeneric)
+            {
+                var CSName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                SetReturnType(CSName.TypeName);
+            }
+            else
+            {
+                var typeRecord = _env.TypeDatabase.GetTypeRecordOrAnyType(argument.SwiftTypeSpec);
+                SetReturnType(typeRecord.CSTypeIdentifier);
+            }
         }
 
         /// <summary>
@@ -207,10 +214,18 @@ namespace BindingsGeneration
         /// </summary>
         public void HandleArguments()
         {
-            foreach (var argument in MethodDecl.CSSignature.Skip(1))
+            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1))
             {
-                var typeRecord = TypeDatabase.GetTypeRecordOrAnyType(argument.SwiftTypeSpec);
-                AddParameter(typeRecord.CSTypeIdentifier, argument.Name);
+                if (argument.IsGeneric)
+                {
+                    var CSName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                    AddParameter(CSName.TypeName, argument.Name);
+                }
+                else
+                {
+                    var typeRecord = _env.TypeDatabase.GetTypeRecordOrAnyType(argument.SwiftTypeSpec);
+                    AddParameter(typeRecord.CSTypeIdentifier, argument.Name);
+                }
             }
         }
 
@@ -251,11 +266,7 @@ namespace BindingsGeneration
     {
         private string _returnType = "invalid";
         private readonly List<Parameter> _parameters = new();
-
-        MethodDecl MethodDecl { get; }
-        BaseDecl ParentDecl { get; }
-        ITypeDatabase TypeDatabase { get; }
-
+        private readonly MethodEnvironment _env;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PInvokeSignatureBuilder"/> class.
@@ -263,11 +274,9 @@ namespace BindingsGeneration
         /// <param name="methodDecl">The method declaration.</param>
         /// <param name="parentDecl">The parent declaration.</param>
         /// <param name="typeDatabase">The type database.</param>
-        public PInvokeSignatureBuilder(MethodDecl methodDecl, ITypeDatabase typeDatabase)
+        public PInvokeSignatureBuilder(MethodEnvironment env)
         {
-            MethodDecl = methodDecl;
-            ParentDecl = methodDecl.ParentDecl!;
-            TypeDatabase = typeDatabase;
+            _env = env;
         }
 
         /// <summary>
@@ -275,9 +284,9 @@ namespace BindingsGeneration
         /// </summary>
         public void HandleReturnType()
         {
-            if (!MarshallingHelpers.MethodRequiresIndirectResult(MethodDecl, ParentDecl, TypeDatabase))
+            if (!MarshallingHelpers.MethodRequiresIndirectResult(_env))
             {
-                var returnTypeRecord = TypeDatabase.GetTypeRecordOrThrow(MethodDecl.CSSignature.First().SwiftTypeSpec);
+                var returnTypeRecord = _env.TypeDatabase.GetTypeRecordOrThrow(_env.MethodDecl.CSSignature.First().SwiftTypeSpec);
                 SetReturnType(returnTypeRecord.CSTypeIdentifier);
             }
             else
@@ -292,17 +301,34 @@ namespace BindingsGeneration
         /// </summary>
         public void HandleArguments()
         {
-            foreach (var argument in MethodDecl.CSSignature.Skip(1))
+            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1))
             {
-                var argumentTypeRecord = TypeDatabase.GetTypeRecordOrThrow(argument.SwiftTypeSpec);
-                if (MarshallingHelpers.ArgumentIsMarshalledAsCSStruct(argument, TypeDatabase))
+                if (argument.IsGeneric)
                 {
+                    var CSName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                    AddParameter("IntPtr", CSName.PayloadName);
+                }
+                else if (MarshallingHelpers.ArgumentIsMarshalledAsCSStruct(argument, _env.TypeDatabase))
+                {
+                    var argumentTypeRecord = _env.TypeDatabase.GetTypeRecordOrThrow(argument.SwiftTypeSpec);
                     AddParameter(argumentTypeRecord.CSTypeIdentifier, argument.Name);
                 }
                 else
                 {
-                    AddParameter($"SwiftHandle", argument.Name);
+                    AddParameter("SwiftHandle", argument.Name);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Handles the metadata of generic arguments.
+        /// </summary>
+        public void HandleGenericMetadata()
+        {
+            foreach (var genericParameter in _env.MethodDecl.GenericParameters)
+            {
+                var CSName = _env.GenericTypeMapping[genericParameter];
+                AddParameter("TypeMetadata", CSName.MetadataName);
             }
         }
 
@@ -311,11 +337,11 @@ namespace BindingsGeneration
         /// </summary>
         public void HandleSwiftSelf()
         {
-            if (MarshallingHelpers.MethodRequiresSwiftSelf(MethodDecl, ParentDecl))
+            if (MarshallingHelpers.MethodRequiresSwiftSelf(_env))
             {
-                if (ParentDecl is StructDecl structDecl && MarshallingHelpers.StructIsMarshalledAsCSStruct(structDecl))
+                if (_env.ParentDecl is StructDecl structDecl && MarshallingHelpers.StructIsMarshalledAsCSStruct(structDecl))
                 {
-                    AddParameter($"SwiftSelf<{ParentDecl.Name}>", "self");
+                    AddParameter($"SwiftSelf<{_env.ParentDecl.Name}>", "self");
                 }
                 else
                 {
@@ -329,7 +355,7 @@ namespace BindingsGeneration
         /// </summary>
         public void HandleSwiftError()
         {
-            if (MethodDecl.Throws)
+            if (_env.MethodDecl.Throws)
             {
                 AddParameter("SwiftError", "error", "out");
             }
@@ -371,14 +397,11 @@ namespace BindingsGeneration
     {
         private Signature? _pInvokeSignature;
         private Signature? _wrapperSignature;
+        private readonly MethodEnvironment _env;
 
-        MethodDecl MethodDecl { get; }
-        ITypeDatabase TypeDatabase { get; }
-
-        public SignatureHandler(MethodDecl methodDecl, ITypeDatabase typeDatabase)
+        public SignatureHandler(MethodEnvironment env)
         {
-            MethodDecl = methodDecl;
-            TypeDatabase = typeDatabase;
+            _env = env;
         }
 
         /// <summary>
@@ -389,9 +412,10 @@ namespace BindingsGeneration
         {
             if (_pInvokeSignature == null)
             {
-                var pInvokeSignature = new PInvokeSignatureBuilder(MethodDecl, TypeDatabase);
+                var pInvokeSignature = new PInvokeSignatureBuilder(_env);
                 pInvokeSignature.HandleReturnType();
                 pInvokeSignature.HandleArguments();
+                pInvokeSignature.HandleGenericMetadata();
                 pInvokeSignature.HandleSwiftSelf();
                 pInvokeSignature.HandleSwiftError();
                 _pInvokeSignature = pInvokeSignature.Build();
@@ -407,7 +431,7 @@ namespace BindingsGeneration
         {
             if (_wrapperSignature == null)
             {
-                var wrapperSignature = new WrapperSignatureBuilder(MethodDecl, TypeDatabase);
+                var wrapperSignature = new WrapperSignatureBuilder(_env);
                 wrapperSignature.HandleReturnType();
                 wrapperSignature.HandleArguments();
                 _wrapperSignature = wrapperSignature.Build();
@@ -426,7 +450,7 @@ namespace BindingsGeneration
         /// </summary>
         /// <param name="writer">The IndentedTextWriter instance.</param>
         /// <param name="methodEnv">The method environment.</param>
-        public static void EmitPInvoke(IndentedTextWriter writer, MethodEnvironment methodEnv)
+        public static void EmitPInvoke(IndentedTextWriter writer, MethodEnvironment methodEnv, SignatureHandler signatureHandler)
         {
             var methodDecl = (MethodDecl)methodEnv.MethodDecl;
             var moduleDecl = methodDecl.ModuleDecl ?? throw new ArgumentNullException(nameof(methodDecl.ModuleDecl));
@@ -437,20 +461,9 @@ namespace BindingsGeneration
             writer.WriteLine("[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]");
             writer.WriteLine($"[DllImport(\"{libPath}\", EntryPoint = \"{methodDecl.MangledName}\")]");
 
-            var pInvokeSignature = methodEnv.SignatureHandler.GetPInvokeSignature();
+            var pInvokeSignature = signatureHandler.GetPInvokeSignature();
 
             writer.WriteLine($"private static extern {pInvokeSignature.ReturnType} {pInvokeName}({pInvokeSignature.ParametersString()});");
-        }
-    }
-
-    /// <summary>
-    /// Provides methods for generating names.
-    /// <summary>
-    public static class NameProvider
-    {
-        public static string GetPInvokeName(MethodDecl methodDecl)
-        {
-            return $"PInvoke_{methodDecl.Name}";
         }
     }
 
@@ -460,26 +473,23 @@ namespace BindingsGeneration
 
     internal class WrapperEmitter
     {
-        private readonly MethodDecl _methodDecl;
-        private readonly BaseDecl _parentDecl;
-        private readonly ITypeDatabase _typeDatabase;
+        private readonly MethodEnvironment _env;
         private readonly Signature _wrapperSignature;
         private readonly Signature _pInvokeSignature;
         private readonly bool _requiresIndirectResult;
         private readonly bool _requiresSwiftSelf;
         private readonly bool _requiresSwiftError;
 
-        internal WrapperEmitter(MethodEnvironment methodEnv)
+        internal WrapperEmitter(MethodEnvironment methodEnv, SignatureHandler signatureHandler)
         {
-            _methodDecl = methodEnv.MethodDecl;
-            _parentDecl = _methodDecl.ParentDecl ?? throw new ArgumentNullException(nameof(methodEnv.MethodDecl.ParentDecl));
-            _typeDatabase = methodEnv.TypeDatabase;
+            _env = methodEnv;
 
-            _wrapperSignature = methodEnv.SignatureHandler.GetWrapperSignature();
-            _pInvokeSignature = methodEnv.SignatureHandler.GetPInvokeSignature();
-            _requiresIndirectResult = MarshallingHelpers.MethodRequiresIndirectResult(_methodDecl, _parentDecl, _typeDatabase);
-            _requiresSwiftSelf = MarshallingHelpers.MethodRequiresSwiftSelf(_methodDecl, _parentDecl);
-            _requiresSwiftError = _methodDecl.Throws;
+            _wrapperSignature = signatureHandler.GetWrapperSignature();
+            _pInvokeSignature = signatureHandler.GetPInvokeSignature();
+
+            _requiresIndirectResult = MarshallingHelpers.MethodRequiresIndirectResult(methodEnv);
+            _requiresSwiftSelf = MarshallingHelpers.MethodRequiresSwiftSelf(methodEnv);
+            _requiresSwiftError = _env.MethodDecl.Throws;
         }
 
         /// <summary>
@@ -525,9 +535,9 @@ namespace BindingsGeneration
                 return;
             }
 
-            if (_methodDecl.ParentDecl is StructDecl structDecl && MarshallingHelpers.StructIsMarshalledAsCSStruct(structDecl))
+            if (_env.ParentDecl is StructDecl structDecl && MarshallingHelpers.StructIsMarshalledAsCSStruct(structDecl))
             {
-                writer.WriteLine($"var self = new SwiftSelf<{_methodDecl.ParentDecl.Name}>(this);");
+                writer.WriteLine($"var self = new SwiftSelf<{_env.ParentDecl.Name}>(this);");
             }
             else
             {
@@ -565,7 +575,8 @@ namespace BindingsGeneration
                 return;
             }
 
-            writer.WriteLine($"var payload = (SwiftHandle)NativeMemory.Alloc({_wrapperSignature.ReturnType}.PayloadSize);");
+            writer.WriteLine($"var returnMetadata = TypeMetadata.GetTypeMetadataOrThrow<{_wrapperSignature.ReturnType}>();");
+            writer.WriteLine($"var payload = (SwiftHandle)NativeMemory.Alloc(returnMetadata.Size);");
             writer.WriteLine("var swiftIndirectResult = new SwiftIndirectResult((void*)payload);");
             writer.WriteLine();
         }
@@ -576,9 +587,23 @@ namespace BindingsGeneration
         /// <param name="writer">The IndentedTextWriter instance.</param>
         private void EmitPInvokeCall(IndentedTextWriter writer)
         {
-            var voidReturn = _methodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple;
+            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1))
+            {
+                if (!argument.IsGeneric)
+                {
+                    continue;
+                }
+
+                var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                writer.WriteLine($"var {metadataName} = TypeMetadata.GetTypeMetadataOrThrow<{typeName}>();");
+                writer.WriteLine($"IntPtr {payloadName} = (IntPtr)NativeMemory.Alloc({metadataName}.Size);"); // Try - finally
+                writer.WriteLine($"SwiftMarshal.MarshalToSwift({argument.Name}, {payloadName});");
+            }
+            writer.WriteLine();
+
+            var voidReturn = _env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple;
             var returnPrefix = (_requiresIndirectResult || voidReturn) ? "" : "var result = ";
-            writer.WriteLine($"{returnPrefix}{NameProvider.GetPInvokeName(_methodDecl)}({_pInvokeSignature.CallArgumentsString()});");
+            writer.WriteLine($"{returnPrefix}{NameProvider.GetPInvokeName(_env.MethodDecl)}({_pInvokeSignature.CallArgumentsString()});");
             writer.WriteLine();
         }
 
@@ -596,7 +621,7 @@ namespace BindingsGeneration
             var text = $$"""
             if (error.Value != null)
             {
-                throw new SwiftRuntimeException("Call to Swift method {{_methodDecl.FullyQualifiedName}} failed.");
+                throw new SwiftRuntimeException("Call to Swift method {{_env.MethodDecl.FullyQualifiedName}} failed.");
             }
             """;
 
@@ -628,7 +653,7 @@ namespace BindingsGeneration
             }
             else
             {
-                if (_methodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple)
+                if (_env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple)
                 {
                     writer.WriteLine("return;");
                 }
@@ -645,7 +670,12 @@ namespace BindingsGeneration
         /// <param name="writer">The IndentedTextWriter instance.</param>
         private void EmitSignatureConstructor(IndentedTextWriter writer)
         {
-            writer.WriteLine($"public {_methodDecl.ParentDecl!.Name}({_wrapperSignature.ParametersString()})");
+            var genericParams = _env.MethodDecl.IsGeneric switch
+            {
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p].TypeName))}>",
+                false => ""
+            };
+            writer.WriteLine($"public {_env.ParentDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
         }
 
         /// <summary>
@@ -654,10 +684,16 @@ namespace BindingsGeneration
         /// <param name="writer">The IndentedTextWriter instance.</param>
         private void EmitSignatureMethod(IndentedTextWriter writer)
         {
-            var staticKeyword = _methodDecl.MethodType == MethodType.Static || _methodDecl.ParentDecl is ModuleDecl ? "static " : "";
-            var unsafeKeyword = _requiresIndirectResult ? "unsafe " : "";
+            var genericParams = _env.MethodDecl.IsGeneric switch
+            {
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p].TypeName))}>",
+                false => ""
+            };
 
-            writer.WriteLine($"public {staticKeyword}{unsafeKeyword} {_wrapperSignature.ReturnType} {_methodDecl.Name}({_wrapperSignature.ParametersString()})");
+            var staticKeyword = _env.MethodDecl.MethodType == MethodType.Static || _env.ParentDecl is ModuleDecl ? "static " : "";
+            var unsafeKeyword = _requiresIndirectResult || _env.MethodDecl.IsGeneric ? "unsafe " : "";
+
+            writer.WriteLine($"public {staticKeyword}{unsafeKeyword}{_wrapperSignature.ReturnType} {_env.MethodDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
         }
 
         /// <summary>

--- a/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringCSharpEmitter/Handler/MethodHandler.cs
@@ -70,14 +70,7 @@ namespace BindingsGeneration
             }
 
             var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler);
-            if (methodEnv.MethodDecl.IsConstructor)
-            {
-                wrapperEmitter.EmitConstructor(writer);
-            }
-            else
-            {
-                wrapperEmitter.EmitMethod(writer);
-            }
+            wrapperEmitter.Emit(writer);
             PInvokeEmitter.EmitPInvoke(writer, methodEnv, signatureHandler);
             writer.WriteLine();
         }
@@ -431,36 +424,84 @@ namespace BindingsGeneration
         }
 
         /// <summary>
+        /// Emits the wrapper.
+        /// </summary>
+        /// <param name="writer"></param>
+        internal void Emit(IndentedTextWriter writer)
+        {
+            if (_env.MethodDecl.IsConstructor)
+            {
+                EmitConstructor(writer);
+            }
+            else
+            {
+                EmitMethod(writer);
+            }
+        }
+
+        /// <summary>
         /// Emits the constructor wrapper.
         /// </summary>
         /// <param name="writer">The IndentedTextWriter instance.</param>
-        internal void EmitConstructor(IndentedTextWriter writer)
+        private void EmitConstructor(IndentedTextWriter writer)
         {
             EmitSignatureConstructor(writer);
             EmitBodyStart(writer);
+
+            EmitDeclarationsForAllocations(writer);
+
+            EmitTryBlockStart(writer);
+
             EmitSwiftSelf(writer);
             EmitIndirectResultConstructor(writer);
             EmitGenericArguments(writer);
             EmitPInvokeCall(writer);
             EmitSwiftError(writer);
             EmitReturnConstructor(writer);
+
+            EmitTryBlockEnd(writer);
+
+            EmitFinally(writer);
+
             EmitBodyEnd(writer);
+        }
+
+        /// <summary>
+        /// Emits the declarations for allocations.
+        /// </summary>
+        private void EmitDeclarationsForAllocations(IndentedTextWriter writer)
+        {
+            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
+            {
+                var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                writer.WriteLine($"IntPtr {payloadName} = IntPtr.Zero;");
+            }
         }
 
         /// <summary>
         /// Emits the method wrapper.
         /// </summary>
         /// <param name="writer">The IndentedTextWriter instance.</param>
-        internal void EmitMethod(IndentedTextWriter writer)
+        private void EmitMethod(IndentedTextWriter writer)
         {
             EmitSignatureMethod(writer);
             EmitBodyStart(writer);
+
+            EmitDeclarationsForAllocations(writer);
+
+            EmitTryBlockStart(writer);
+
             EmitSwiftSelf(writer);
             EmitIndirectResultMethod(writer);
             EmitGenericArguments(writer);
             EmitPInvokeCall(writer);
             EmitSwiftError(writer);
             EmitReturnMethod(writer);
+
+            EmitTryBlockEnd(writer);
+
+            EmitFinally(writer);
+
             EmitBodyEnd(writer);
         }
 
@@ -498,8 +539,12 @@ namespace BindingsGeneration
                 return;
             }
 
-            writer.WriteLine($"_payload = (SwiftHandle)NativeMemory.Alloc(_payloadSize);");
-            writer.WriteLine("var swiftIndirectResult = new SwiftIndirectResult((void*)_payload);");
+            var text = $$"""
+            _payload = (SwiftHandle)NativeMemory.Alloc(_payloadSize);
+            var swiftIndirectResult = new SwiftIndirectResult((void*)_payload);
+            """;
+
+            writer.WriteLines(text);
             writer.WriteLine();
         }
 
@@ -515,9 +560,13 @@ namespace BindingsGeneration
                 return;
             }
 
-            writer.WriteLine($"var returnMetadata = TypeMetadata.GetTypeMetadataOrThrow<{_wrapperSignature.ReturnType}>();");
-            writer.WriteLine($"var payload = (SwiftHandle)NativeMemory.Alloc(returnMetadata.Size);");
-            writer.WriteLine("var swiftIndirectResult = new SwiftIndirectResult((void*)payload);");
+            var text = $$"""
+            var returnMetadata = TypeMetadata.GetTypeMetadataOrThrow<{{_wrapperSignature.ReturnType}}>();
+            var payload = (SwiftHandle)NativeMemory.Alloc(returnMetadata.Size);
+            var swiftIndirectResult = new SwiftIndirectResult((void*)payload);
+            """;
+
+            writer.WriteLines(text);
             writer.WriteLine();
         }
 
@@ -529,9 +578,12 @@ namespace BindingsGeneration
             foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
             {
                 var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
-                writer.WriteLine($"var {metadataName} = TypeMetadata.GetTypeMetadataOrThrow<{typeName}>();");
-                writer.WriteLine($"IntPtr {payloadName} = (IntPtr)NativeMemory.Alloc({metadataName}.Size);");
-                writer.WriteLine($"SwiftMarshal.MarshalToSwift({argument.Name}, {payloadName});");
+                var text = $$"""
+                var {{metadataName}} = TypeMetadata.GetTypeMetadataOrThrow<{{typeName}}>();
+                {{payloadName}} = (IntPtr)NativeMemory.Alloc({{metadataName}}.Size);
+                SwiftMarshal.MarshalToSwift({{argument.Name}}, {{payloadName}});
+                """;
+                writer.WriteLines(text);
             }
             writer.WriteLine();
         }
@@ -635,6 +687,40 @@ namespace BindingsGeneration
             var unsafeKeyword = _requiresIndirectResult || _env.MethodDecl.IsGeneric ? "unsafe " : "";
 
             writer.WriteLine($"public {staticKeyword}{unsafeKeyword}{_wrapperSignature.ReturnType} {_env.MethodDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
+        }
+
+        /// <summary>
+        /// Emits the finally block.
+        /// </summary>
+        private void EmitFinally(IndentedTextWriter writer)
+        {
+            writer.WriteLine("finally");
+            EmitBodyStart(writer);
+
+            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
+            {
+                var (_, _, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                writer.WriteLine($"NativeMemory.Free((void*){payloadName});");
+            }
+
+            EmitBodyEnd(writer);
+        }
+
+        /// <summary>
+        /// Emits the try block start.
+        /// </summary>
+        private void EmitTryBlockStart(IndentedTextWriter writer)
+        {
+            writer.WriteLine("try");
+            EmitBodyStart(writer);
+        }
+
+        /// <summary>
+        /// Emits the try block end.
+        /// </summary>
+        private void EmitTryBlockEnd(IndentedTextWriter writer)
+        {
+            EmitBodyEnd(writer);
         }
 
         /// <summary>

--- a/src/Swift.Bindings/src/Marshaler/Conductor.cs
+++ b/src/Swift.Bindings/src/Marshaler/Conductor.cs
@@ -29,7 +29,6 @@ namespace BindingsGeneration
         private readonly List<IFieldHandlerFactory> _fieldHandlerFactories = [];
         private readonly List<IMethodHandlerFactory> _methodHandlerFactories = [
             new MethodHandlerFactory(),
-            new ConstructorHandlerFactory(),
         ];
         private readonly List<IArgumentHandlerFactory> _argumentHandlerFactories = [];
 

--- a/src/Swift.Bindings/src/Marshaler/IEnvironment.cs
+++ b/src/Swift.Bindings/src/Marshaler/IEnvironment.cs
@@ -73,6 +73,10 @@ namespace BindingsGeneration
         /// </summary>
         public MethodDecl MethodDecl { get; private set; } = methodDecl;
 
+        /// <summary>
+        /// Gets the parent declaration.
+        /// </summary>
+        public BaseDecl ParentDecl { get; } = methodDecl.ParentDecl ?? throw new ArgumentNullException($"Parent declaration on method {methodDecl.Name} is null.");
 
         /// <summary>
         /// Gets the TypeDatabase
@@ -80,8 +84,8 @@ namespace BindingsGeneration
         public ITypeDatabase TypeDatabase { get; } = typeDatabase;
 
         /// <summary>
-        /// Gets the SignatureHandler
+        /// Mapping of Swift generic type names to C# generic type names.
         /// </summary>
-        public SignatureHandler SignatureHandler { get; } = new SignatureHandler(methodDecl, typeDatabase);
+        public Dictionary<string, GenericParameterCSName> GenericTypeMapping { get; } = NameProvider.GetGenericTypeMapping(methodDecl);
     }
 }

--- a/src/Swift.Bindings/src/Marshaler/MarshallingHelpers.cs
+++ b/src/Swift.Bindings/src/Marshaler/MarshallingHelpers.cs
@@ -1,28 +1,27 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Swift.Runtime;
-
 namespace BindingsGeneration
 {
     public static class MarshallingHelpers // TODO: Find better place for those
     {
-        public static bool MethodRequiresIndirectResult(MethodDecl methodDecl, BaseDecl parentDecl, ITypeDatabase typeDatabase)
+        public static bool MethodRequiresIndirectResult(MethodEnvironment env)
         {
-            if (methodDecl.IsConstructor && !(parentDecl is StructDecl structDecl && StructIsMarshalledAsCSStruct(structDecl))) return true;
-            var returnType = methodDecl.CSSignature.First();
+            if (env.MethodDecl.IsConstructor && !(env.ParentDecl is StructDecl structDecl && StructIsMarshalledAsCSStruct(structDecl))) return true;
+            var returnType = env.MethodDecl.CSSignature.First();
 
+            if (returnType.IsGeneric) return true;
             if (returnType.SwiftTypeSpec.IsEmptyTuple) return false;
 
-            if (!ArgumentIsMarshalledAsCSStruct(returnType, typeDatabase)) return true;
+            if (!ArgumentIsMarshalledAsCSStruct(returnType, env.TypeDatabase)) return true;
             return false;
         }
 
-        public static bool MethodRequiresSwiftSelf(MethodDecl methodDecl, BaseDecl parentDecl)
+        public static bool MethodRequiresSwiftSelf(MethodEnvironment env)
         {
-            if (parentDecl is ModuleDecl) return false; // global funcs
-            if (methodDecl.MethodType == MethodType.Static) return false;
-            if (methodDecl.IsConstructor) return false;
+            if (env.ParentDecl is ModuleDecl) return false; // global funcs
+            if (env.MethodDecl.MethodType == MethodType.Static) return false;
+            if (env.MethodDecl.IsConstructor) return false;
 
             return true;
         }

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration;
+
+
+/// <summary>
+/// Represents a generic parameter name mapping.
+/// </summary>
+/// <param name="TypeName">The name of the generic type parameter e.g. T0.</param>
+/// <param name="MetadataName">The name of the metadata type parameter.</param>
+/// <param name="PayloadName">The name of the payload type parameter. </param>
+public record struct GenericParameterCSName(string TypeName, string MetadataName, string PayloadName);
+
+/// <summary>
+/// Provides methods for generating names.
+/// <summary>
+/// 
+public static class NameProvider
+{
+    /// <summary>
+    /// Provides the name of the PInvoke method.
+    /// </summary>
+    /// <param name="methodDecl">The method declaration.</param>
+    /// <returns>The name of the PInvoke method.</returns>
+    public static string GetPInvokeName(MethodDecl methodDecl)
+    {
+        return $"PInvoke_{methodDecl.Name}";
+    }
+
+    /// <summary>
+    /// Provides the mapping of generic type parameters.
+    /// </summary>
+    /// <param name="methodDecl">The method declaration.</param>
+    /// <returns>The mapping of generic type parameters.</returns>
+    public static Dictionary<string, GenericParameterCSName> GetGenericTypeMapping(MethodDecl methodDecl) =>
+        methodDecl.GenericParameters
+            .Select((param, i) => (param, i))
+            .ToDictionary(x => x.param, x => new GenericParameterCSName(
+                TypeName: $"T{x.i}",
+                MetadataName: $"T{x.i}Metadata",
+                PayloadName: $"T{x.i}Payload"
+            ));
+}

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -7,10 +7,10 @@ namespace BindingsGeneration;
 /// <summary>
 /// Represents a generic parameter name mapping.
 /// </summary>
-/// <param name="TypeName">The name of the generic type parameter e.g. T0.</param>
+/// <param name="PlaceholderName">The name of the generic type parameter e.g. T0.</param>
 /// <param name="MetadataName">The name of the metadata type parameter.</param>
 /// <param name="PayloadName">The name of the payload type parameter. </param>
-public record struct GenericParameterCSName(string TypeName, string MetadataName, string PayloadName);
+public record struct GenericParameterCSName(string PlaceholderName, string MetadataName, string PayloadName);
 
 /// <summary>
 /// Provides methods for generating names.
@@ -37,7 +37,7 @@ public static class NameProvider
         methodDecl.GenericParameters
             .Select((param, i) => (param, i))
             .ToDictionary(x => x.param.TypeName, x => new GenericParameterCSName(
-                TypeName: $"T{x.i}",
+                PlaceholderName: $"T{x.i}",
                 MetadataName: $"T{x.i}Metadata",
                 PayloadName: $"T{x.i}Payload"
             ));

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -36,7 +36,7 @@ public static class NameProvider
     public static Dictionary<string, GenericParameterCSName> GetGenericTypeMapping(MethodDecl methodDecl) =>
         methodDecl.GenericParameters
             .Select((param, i) => (param, i))
-            .ToDictionary(x => x.param, x => new GenericParameterCSName(
+            .ToDictionary(x => x.param.TypeName, x => new GenericParameterCSName(
                 TypeName: $"T{x.i}",
                 MetadataName: $"T{x.i}Metadata",
                 PayloadName: $"T{x.i}Payload"

--- a/src/Swift.Bindings/src/Model/TypeDecl/ArgumentDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ArgumentDecl.cs
@@ -10,7 +10,7 @@ namespace BindingsGeneration
     {
         /// <summary>
         /// Type of the argument
-        ///
+        /// <summary>
         public required TypeSpec SwiftTypeSpec { get; set; }
 
         /// <summary>
@@ -22,5 +22,10 @@ namespace BindingsGeneration
         /// Indicates the inout annotation of the argument.
         /// </summary>
         public required bool IsInOut { get; set; }
+
+        /// <summary>
+        /// Indicates if the argument is generic.
+        /// </summary>
+        public required bool IsGeneric { get; set; }
     }
 }

--- a/src/Swift.Bindings/src/Model/TypeDecl/BaseDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/BaseDecl.cs
@@ -11,7 +11,7 @@ namespace BindingsGeneration
         /// <summary>
         /// Name of the declaration.
         /// </summary>
-        public required string Name { get; set; }
+        public required string Name { get; set; } //TODO: Hide or remove this property. This might not contain a correct name.
 
         /// <summary>
         /// The fully qualified name of the declaration used for type registration.

--- a/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// Represents a generic argument declaration.
+/// </summary>
+/// <param name="TypeName">The name of the generic argument type</param>
+/// <param name="SugaredTypeName">The sugared name of the generic argument type</param>
+/// <param name="Constraints">The constraints of the generic argument type</param>
+public record GenericArgumentDecl(
+    string TypeName,
+    string SugaredTypeName,
+    List<Conformance> Constraints
+);
+
+/// <summary>
+/// Represents a generic argument declaration.
+/// </summary>
+/// <param name="TargetType">The target type of the conformance</param>
+/// <param name="ProtocolName">The protocol name of the conformance</param>
+public abstract record Conformance(
+    string TargetType,
+    string ProtocolName
+);
+
+/// <summary>
+/// Represents a protocol conformance.
+/// </summary>
+/// <param name="TargetType">The target type of the conformance</param>
+/// <param name="ProtocolName">The protocol name of the conformance</param>
+public record ProtocolConformance(
+    string TargetType,
+    string ProtocolName
+) : Conformance(TargetType, ProtocolName);
+
+/// <summary>
+/// Represents an associated type conformance.
+/// </summary>
+/// <param name="TargetType">The target type of the conformance</param>
+/// <param name="ProtocolName">The protocol name of the conformance</param>
+/// <param name="AssociatedTypeName">The associated type name of the conformance</param>
+public record AssociatedTypeConformance(
+    string TargetType,
+    string ProtocolName,
+    string AssociatedTypeName
+) : Conformance(TargetType, ProtocolName);

--- a/src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs
@@ -36,7 +36,7 @@ namespace BindingsGeneration
         /// <summary>
         /// Generic parameters of the method.
         /// </summary>
-        public required List<string> GenericParameters { get; set; }
+        public required List<GenericArgumentDecl> GenericParameters { get; set; }
 
         /// <summary>
         /// Indicates if the method is generic.

--- a/src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs
@@ -8,7 +8,6 @@ namespace BindingsGeneration
     /// </summary>
     public sealed record MethodDecl : BaseDecl
     {
- 
         /// <summary>
         /// Mangled name of the declaration.
         /// </summary>
@@ -29,10 +28,20 @@ namespace BindingsGeneration
         /// </summary>
         public required List<ArgumentDecl> CSSignature { get; set; }
 
-		/// <summary>
-		/// Indicates if method can throw an exception.
-		/// </summary>
-		public required bool Throws { get; set; }
+        /// <summary>
+        /// Indicates if method can throw an exception.
+        /// </summary>
+        public required bool Throws { get; set; }
+
+        /// <summary>
+        /// Generic parameters of the method.
+        /// </summary>
+        public required List<string> GenericParameters { get; set; }
+
+        /// <summary>
+        /// Indicates if the method is generic.
+        /// </summary>
+        public bool IsGeneric => GenericParameters.Count > 0;
     }
 
     /// <summary>

--- a/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
+++ b/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace BindingsGeneration;
+
+public class GenericSignatureParser
+{
+    /// <summary>
+    /// Parses a generic signature and its sugared signature into a list of GenericArgumentDecl.
+    /// </summary>
+    /// <param name="genericSignature">The generic signature to parse. </param>
+    /// <param name="sugaredSignature">The sugared signature to parse. </param>
+    /// <returns>A list of GenericArgumentDecl.</returns>
+    public static List<GenericArgumentDecl> ParseGenericSignature(string? genericSignature, string? sugaredSignature)
+    {
+        if (string.IsNullOrWhiteSpace(genericSignature) || string.IsNullOrWhiteSpace(sugaredSignature))
+            return [];
+
+        genericSignature = genericSignature[1..^1];
+        sugaredSignature = sugaredSignature[1..^1];
+
+        var genericParams = ExtractGenericParams(genericSignature);
+        var sugaredParams = ExtractGenericParams(sugaredSignature);
+
+        if (genericParams.Count != sugaredParams.Count)
+            throw new InvalidOperationException("Generic and sugared parameter counts do not match.");
+
+        var paramMap = genericParams.Zip(sugaredParams, (gen, sug) => (gen, sug)).ToDictionary(x => x.gen, x => x.sug);
+
+        var constraints = ExtractConstraints(genericSignature);
+
+        return genericParams.Select(typeName =>
+            new GenericArgumentDecl(
+                typeName,
+                paramMap[typeName],
+                constraints.Where(c => c.TargetType.StartsWith(typeName)).ToList()
+            )
+        ).ToList();
+    }
+
+    /// <summary>
+    /// Extracts the generic parameters from a generic signature.
+    /// </summary>
+    /// <param name="signature">The generic signature to extract parameters from.</param>
+    /// <returns>A list of generic parameters.</returns>
+    private static List<string> ExtractGenericParams(string signature)
+    {
+        var whereIndex = signature.IndexOf("where", StringComparison.OrdinalIgnoreCase);
+        if (whereIndex >= 0)
+            signature = signature[..whereIndex];
+
+        return signature.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+    }
+
+    /// <summary>
+    /// Extracts the constraints from a generic signature.
+    /// </summary>
+    /// <param name="signature">The generic signature to extract constraints from.</param>
+    /// <returns>A list of constraints.</returns>
+    private static List<Conformance> ExtractConstraints(string signature)
+    {
+        var whereIndex = signature.IndexOf("where", StringComparison.OrdinalIgnoreCase);
+        if (whereIndex == -1)
+            return new List<Conformance>();
+
+        return signature[(whereIndex + "where".Length)..].Split(',').Select(ParseConstraint).ToList();
+    }
+
+    /// <summary>
+    /// Parses a constraint clause into a Conformance object.
+    /// </summary>
+    /// <param name="clause">The constraint clause to parse.</param>
+    /// <returns>A Conformance object.</returns>
+    private static Conformance ParseConstraint(string clause)
+    {
+        var parts = clause.Split(new[] { ":", "==" }, StringSplitOptions.TrimEntries);
+        return parts[0].Contains('.')
+            ? new AssociatedTypeConformance(parts[0].Split('.')[0], parts[1], parts[0].Split('.')[1])
+            : new ProtocolConformance(parts[0], parts[1]);
+    }
+}

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -370,7 +370,7 @@ namespace BindingsGeneration
                 MethodType = node.@static ?? false ? MethodType.Static : MethodType.Instance,
                 IsConstructor = node.Kind == "Constructor",
                 CSSignature = new List<ArgumentDecl>(),
-                GenericParameters = GetGenericParams(node.GenericSig),
+                GenericParameters = GenericSignatureParser.ParseGenericSignature(node.GenericSig, node.sugared_genericSig),
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl,
                 Throws = node.throwing ?? false
@@ -400,15 +400,6 @@ namespace BindingsGeneration
             }
 
             return methodDecl;
-
-            List<string> GetGenericParams(string? genericSignature)
-            {
-                return genericSignature switch
-                {
-                    null => [],
-                    _ => [.. genericSignature[1..^1].Split(',').Select(s => s.Trim())]
-                };
-            }
         }
 
         /// <summary>

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -370,6 +370,7 @@ namespace BindingsGeneration
                 MethodType = node.@static ?? false ? MethodType.Static : MethodType.Instance,
                 IsConstructor = node.Kind == "Constructor",
                 CSSignature = new List<ArgumentDecl>(),
+                GenericParameters = GetGenericParams(node.GenericSig),
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl,
                 Throws = node.throwing ?? false
@@ -392,12 +393,22 @@ namespace BindingsGeneration
                     FullyQualifiedName = string.Empty,
                     PrivateName = string.Empty,
                     IsInOut = false,
+                    IsGeneric = node.Children.ElementAt(i).Name == "GenericTypeParam",
                     ParentDecl = methodDecl,
                     ModuleDecl = moduleDecl
                 });
             }
 
             return methodDecl;
+
+            List<string> GetGenericParams(string? genericSignature)
+            {
+                return genericSignature switch
+                {
+                    null => [],
+                    _ => [.. genericSignature[1..^1].Split(',').Select(s => s.Trim())]
+                };
+            }
         }
 
         /// <summary>

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+using Swift.GenericTests;
+using Swift.Runtime;
+
+namespace BindingsGeneration.FunctionalTests
+{
+    public class GenericsTests : IClassFixture<GenericsTests.TestFixture>
+    {
+        private readonly TestFixture _fixture;
+
+        public GenericsTests(TestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public class TestFixture
+        {
+            static TestFixture()
+            {
+                InitializeResources();
+            }
+
+            private static void InitializeResources()
+            {
+                // Initialize
+            }
+        }
+
+        [Fact]
+        public void TestFunctionTakesPrimitiveGenericParamsThrows()
+        {
+            nint a = 1;
+            double b = 2.3;
+            Assert.Throws<SwiftRuntimeException>(() => GenericTests.AcceptsGenericParametersAndThrows(a, b));
+        }
+
+        [Fact]
+        public void TestFunctionTakesPrimitiveGenericParams()
+        {
+            nint a = 1;
+            double b = 2.3;
+            var result = GenericTests.AcceptsGenericParameters(a, b);
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void TestFunctionTakesStructGenericParams()
+        {
+            var a = new FrozenStruct(1, 2);
+            var b = new NonFrozenStruct(3, 4);
+            var result = GenericTests.AcceptsGenericParameters(a, b);
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void TestFunctionTakesGenericPrimitiveAndReturnsOne()
+        {
+            nint a = 1;
+            var result = GenericTests.AcceptsGenericParameterAndReturnsGeneric(a);
+            Assert.Equal(a, result);
+
+            double b = 2.3;
+            var result2 = GenericTests.AcceptsGenericParameterAndReturnsGeneric(b);
+            Assert.Equal(b, result2);
+
+            float c = 3.4f;
+            var result3 = GenericTests.AcceptsGenericParameterAndReturnsGeneric(c);
+            Assert.Equal(c, result3);
+        }
+
+        [Fact]
+        public void TestFunctionTakesGenericStructAndReturnsOne()
+        {
+            var a = new FrozenStruct(1, 2);
+            var result = GenericTests.AcceptsGenericParameterAndReturnsGeneric(a);
+            Assert.Equal(a, result);
+
+            var b = new NonFrozenStruct(3, 4);
+            var result2 = GenericTests.AcceptsGenericParameterAndReturnsGeneric(b);
+            // No deep comparison for non-frozen structs yet
+        }
+    }
+}

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import Foundation
+
+@frozen
+public struct FrozenStruct
+{
+    public var x: Int
+    public var y: Int
+
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct NonFrozenStruct
+{
+    public var x: Int
+    public var y: Int
+
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public func AcceptsGenericParametersAndThrows<T, U> (a: T, b: U) throws -> Int {
+    throw NSError()
+}
+
+public func AcceptsGenericParameters<T, U> (a: T, b: U) throws -> Int {
+    if a is Int && b is Double {
+        return 0;
+    }
+
+    if a is FrozenStruct && b is NonFrozenStruct {
+        return 0;
+    }
+
+    throw NSError()
+}
+
+public func AcceptsGenericParameterAndReturnsGeneric<T>(a: T) -> T {
+    return a;
+}

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import Foundation
 
 @frozen

--- a/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using BindingsGeneration;
+using Xunit;
+
+#nullable enable
+
+namespace BindingsGeneration.Tests;
+
+public class GenericSignatureParserTests
+{
+    [Fact]
+    public void ParseGenericSignature_ReturnsEmpty_WhenEitherSignatureIsNullOrEmpty()
+    {
+        string? genericSig = null;
+        string? sugaredSig = null;
+
+        var result = GenericSignatureParser.ParseGenericSignature(genericSig, sugaredSig);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseGenericSignature_ParsesSingleParamNoConstraints()
+    {
+        var genericSig = "<τ_0_0>";
+        var sugaredSig = "<T>";
+
+        var result = GenericSignatureParser.ParseGenericSignature(genericSig, sugaredSig);
+
+        Assert.Single(result);
+        var decl = result[0];
+        Assert.Equal("τ_0_0", decl.TypeName);
+        Assert.Equal("T", decl.SugaredTypeName);
+        Assert.Empty(decl.Constraints);
+    }
+
+    [Fact]
+    public void ParseGenericSignature_ParsesMultipleParamsNoConstraints()
+    {
+        var genericSig = "<τ_0_0, τ_0_1>";
+        var sugaredSig = "<T, U>";
+
+        var result = GenericSignatureParser.ParseGenericSignature(genericSig, sugaredSig);
+
+        Assert.Equal(2, result.Count);
+
+        var first = result[0];
+        Assert.Equal("τ_0_0", first.TypeName);
+        Assert.Equal("T", first.SugaredTypeName);
+        Assert.Empty(first.Constraints);
+
+        var second = result[1];
+        Assert.Equal("τ_0_1", second.TypeName);
+        Assert.Equal("U", second.SugaredTypeName);
+        Assert.Empty(second.Constraints);
+    }
+
+    [Fact]
+    public void ParseGenericSignature_ParsesSingleParamWithConstraints()
+    {
+        var genericSig = "<τ_0_0 where τ_0_0 : Swift.Equatable>";
+        var sugaredSig = "<T where T : Swift.Equatable>";
+
+        var result = GenericSignatureParser.ParseGenericSignature(genericSig, sugaredSig);
+
+        Assert.Single(result);
+        var decl = result[0];
+        Assert.Equal("τ_0_0", decl.TypeName);
+        Assert.Equal("T", decl.SugaredTypeName);
+        Assert.Single(decl.Constraints);
+        var conformance = Assert.IsType<ProtocolConformance>(decl.Constraints[0]);
+        Assert.Equal("τ_0_0", conformance.TargetType);
+        Assert.Equal("Swift.Equatable", conformance.ProtocolName);
+    }
+
+    [Fact]
+    public void ParseGenericSignature_ParsesMultipleParamsWithConstraints()
+    {
+        var genericSig = "<τ_0_0, τ_0_1 where τ_0_0 : Swift.Equatable, τ_0_1 : Swift.Hashable>";
+        var sugaredSig = "<T, U where T : Swift.Equatable, U : Swift.Hashable>";
+
+        var result = GenericSignatureParser.ParseGenericSignature(genericSig, sugaredSig);
+
+        Assert.Equal(2, result.Count);
+
+        var first = result[0];
+        Assert.Equal("τ_0_0", first.TypeName);
+        Assert.Equal("T", first.SugaredTypeName);
+        Assert.Single(first.Constraints);
+        var firstConformance = Assert.IsType<ProtocolConformance>(first.Constraints[0]);
+        Assert.Equal("τ_0_0", firstConformance.TargetType);
+        Assert.Equal("Swift.Equatable", firstConformance.ProtocolName);
+
+        var second = result[1];
+        Assert.Equal("τ_0_1", second.TypeName);
+        Assert.Equal("U", second.SugaredTypeName);
+        Assert.Single(second.Constraints);
+        var secondConformance = Assert.IsType<ProtocolConformance>(second.Constraints[0]);
+        Assert.Equal("τ_0_1", secondConformance.TargetType);
+        Assert.Equal("Swift.Hashable", secondConformance.ProtocolName);
+    }
+
+    [Fact]
+    public void ParseGenericSignature_ParsesAssociatedTypeConstraints()
+    {
+        var genericSig = "<τ_0_0 where τ_0_0 : SomeProtocol, τ_0_0.ID == System.Guid>";
+        var sugaredSig = "<T where T : SomeProtocol, T.ID == System.Guid>";
+
+        var result = GenericSignatureParser.ParseGenericSignature(genericSig, sugaredSig);
+
+        Assert.Single(result);
+        var decl = result[0];
+        Assert.Equal("τ_0_0", decl.TypeName);
+        Assert.Equal("T", decl.SugaredTypeName);
+        Assert.Equal(2, decl.Constraints.Count);
+
+        var proto = Assert.IsType<ProtocolConformance>(decl.Constraints[0]);
+        Assert.Equal("τ_0_0", proto.TargetType);
+        Assert.Equal("SomeProtocol", proto.ProtocolName);
+
+        var assoc = Assert.IsType<AssociatedTypeConformance>(decl.Constraints[1]);
+        Assert.Equal("τ_0_0", assoc.TargetType);
+        Assert.Equal("System.Guid", assoc.ProtocolName);
+        Assert.Equal("ID", assoc.AssociatedTypeName);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtimelab/issues/2942

This PR:
- Brings basic support for generic methods. 
- Adds models for generic params and constraints
- Simplifies some code in the Emitter, removes unnecessary parameter passing, deletes redundant classes