### PR TITLE
[SwiftBindings] Add array support

### DIFF
--- a/src/Swift.Runtime/src/Swift/SwiftArray.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftArray.cs
@@ -1,0 +1,361 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Swift;
+using Swift.Runtime;
+using Swift.Runtime.InteropServices;
+
+namespace Swift;
+
+/// <summary>
+/// Represents a Swift array
+/// </summary>
+/// <typeparam name="T">the element type</typeparam>
+public sealed class SwiftArray<T> : ISwiftObject, IList<T>
+{
+
+    SwiftHandle handle;
+
+    /// <summary>
+    /// Constructs a new SwiftArray from the given handle to a Swift array
+    /// </summary>
+    public SwiftArray(SwiftHandle handle)
+    {
+        this.handle = handle;
+    }
+
+
+    /// <summary>
+    /// Constructs a new empty SwiftArray
+    /// </summary>
+    public SwiftArray()
+        : this(PInvokesForSwiftArray.Init(ElementTypeMetadata))
+    {
+    }
+
+    /// <summary>
+    /// Constructs a new SwiftArray and populates it with the given list
+    /// </summary>
+    /// <param name="list">a list of items to populate the array</param>
+    public SwiftArray(IList<T> list)
+        : this()
+    {
+        AddRange(list);
+    }
+
+    /// <summary>
+    /// Constructs a new SwiftArray and populates it with the enumeration
+    /// </summary>
+    /// <param name="collection">an enumeration of items to populate the array</param>
+    public SwiftArray(IEnumerable<T> collection)
+        : this()
+    {
+        AddRange(collection);
+    }
+
+    /// <summary>
+    /// Constructs a new SwiftArray and populates it with the given array
+    /// </summary>
+    /// <param name="items">an array of items to populate the array</param>
+    public SwiftArray(params T[] items)
+        : this()
+    {
+        AddRange(items);
+    }
+
+    /// <summary>
+    /// Returns the type metadata for the element
+    /// </summary>
+    static TypeMetadata ElementTypeMetadata
+    {
+        get => TypeMetadata.GetTypeMetadataOrThrow<T>();
+    }
+
+    /// <summary>
+    /// Returns the size of the element in bytes
+    /// </summary>
+    static unsafe nuint ElementSize
+    {
+        get => ElementTypeMetadata.ValueWitnessTable->Size;
+    }
+
+    /// <inheritdoc/>
+    static TypeMetadata ISwiftObject.GetTypeMetadata()
+    {
+        return TypeMetadata.Cache.GetOrAdd(typeof(SwiftArray<T>), _ =>
+                PInvokesForSwiftArray._MetadataAccessor(TypeMetadataRequest.Complete, ElementTypeMetadata));
+    }
+
+    /// <inheritdoc/>
+    static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle payload)
+    {
+        return new SwiftArray<T>(payload);
+    }
+
+    /// <inheritdoc/>
+    IntPtr ISwiftObject.MarshalToSwift(IntPtr swiftDest)
+    {
+        var metadata = SwiftObjectHelper<SwiftArray<T>>.GetTypeMetadata();
+        unsafe
+        {
+            metadata.ValueWitnessTable->InitializeWithCopy((void*)swiftDest, (void*)handle, metadata);
+        }
+        return swiftDest;
+    }
+
+    /// <inheritdoc/>
+    public T this[int index]
+    {
+        get
+        {
+            if (index < 0 || index >= Count)
+                throw new IndexOutOfRangeException();
+
+            unsafe
+            {
+                var payload = stackalloc byte[(int)ElementSize];
+                PInvokesForSwiftArray.Get(new SwiftIndirectResult(payload), (nint)index, handle, ElementTypeMetadata);
+                return SwiftMarshal.MarshalFromSwift<T>(new SwiftHandle((IntPtr)payload));
+            }
+        }
+        set
+        {
+            if (index < 0 || index >= Count)
+                throw new IndexOutOfRangeException();
+
+            var metadata = SwiftObjectHelper<SwiftArray<T>>.GetTypeMetadata();
+            unsafe
+            {
+                var payload = stackalloc byte[(int)ElementSize];
+                SwiftMarshal.MarshalToSwift(value, (IntPtr)payload);
+
+                var localHandle = handle;
+                var localHandlePtr = &localHandle;
+
+                PInvokesForSwiftArray.Set(new SwiftSelf(localHandlePtr), new SwiftHandle((IntPtr)payload), (nint)index, metadata);
+                handle = localHandle;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public int Count
+    {
+        get
+        {
+            unsafe
+            {
+                return (int)PInvokesForSwiftArray.Count(handle, ElementTypeMetadata);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<T> GetEnumerator()
+    {
+        int count = Count;
+        for (int i = 0; i < count; i++)
+        {
+            yield return this[i];
+        }
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    public void Add(T item)
+    {
+        unsafe
+        {
+            var elementMetadata = ElementTypeMetadata;
+            var payload = stackalloc byte[(int)ElementSize];
+            SwiftMarshal.MarshalToSwift(item, (IntPtr)payload);
+
+            var localHandle = handle;
+            void* localHandlePtr = &localHandle;
+            var metadata = SwiftObjectHelper<SwiftArray<T>>.GetTypeMetadata();
+            PInvokesForSwiftArray.Append(new SwiftSelf(localHandlePtr), new SwiftHandle((IntPtr)payload), metadata);
+            handle = localHandle;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void AddRange(IList<T> list)
+    {
+        for (int i = 0; i < list.Count; i++)
+            Add(list[i]);
+    }
+
+    /// <inheritdoc/>
+    public void AddRange(IEnumerable<T> collection)
+    {
+        foreach (T elem in collection)
+        {
+            Add(elem);
+        }
+    }
+
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        unsafe
+        {
+            var localHandle = handle;
+            var localHandlePtr = &localHandle;
+            var metadata = SwiftObjectHelper<SwiftArray<T>>.GetTypeMetadata();
+            PInvokesForSwiftArray.RemoveAll(new SwiftSelf(localHandlePtr), 1, metadata);
+            handle = localHandle;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(T item)
+    {
+        foreach (T thing in this)
+        {
+            if (Equals(thing, item))
+                return true;
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        if (array == null)
+            throw new ArgumentNullException(nameof(array));
+
+        if (arrayIndex < 0)
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+
+        if (Count > array.Length - arrayIndex)
+            throw new ArgumentException("Destination array was not long enough.");
+
+        foreach (T thing in this)
+        {
+            array[arrayIndex++] = thing;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(T item)
+    {
+        int i = 0;
+        foreach (T thing in this)
+        {
+            if (Equals(thing, item))
+            {
+                RemoveAt(i);
+                return true;
+            }
+            i++;
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public int IndexOf(T item)
+    {
+        int i = 0;
+        foreach (T thing in this)
+        {
+            if (Equals(thing, item))
+                return i;
+            i++;
+        }
+        return -1;
+    }
+
+    /// <inheritdoc/>
+    public void Insert(int index, T item)
+    {
+        if (index < 0 || index >= Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        unsafe
+        {
+            var payload = stackalloc byte[(int)ElementSize];
+            SwiftMarshal.MarshalToSwift(item, (IntPtr)payload);
+
+            var localHandle = handle;
+            var localHandlePtr = &localHandle;
+            var metadata = SwiftObjectHelper<SwiftArray<T>>.GetTypeMetadata();
+            PInvokesForSwiftArray.Insert(new SwiftSelf(localHandlePtr), new SwiftHandle((IntPtr)payload), (nint)index, metadata);
+            handle = localHandle;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        if (index < 0 || index >= Count)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        unsafe
+        {
+            var payload = stackalloc byte[(int)ElementSize];
+            var localHandle = handle;
+            var localHandlePtr = &localHandle;
+            var metadata = SwiftObjectHelper<SwiftArray<T>>.GetTypeMetadata();
+            PInvokesForSwiftArray.RemoveAt(new SwiftIndirectResult(payload), new SwiftSelf(localHandlePtr), (nint)index, metadata);
+            var witness = ElementTypeMetadata.ValueWitnessTable;
+            witness->Destroy((void*)payload, witness);
+            handle = localHandle;
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool IsReadOnly
+    {
+        get
+        {
+            return false;
+        }
+    }
+}
+
+internal static class PInvokesForSwiftArray
+{
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSaMa")]
+    public static extern TypeMetadata _MetadataAccessor(TypeMetadataRequest request, TypeMetadata typeMetadata);
+
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sS2ayxGycfC")]
+    public static extern SwiftHandle Init(TypeMetadata typeMetadata);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSayxSicig")]
+    public static unsafe extern void Get(SwiftIndirectResult result, nint index, SwiftHandle handle, TypeMetadata elementMetadata);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSayxSicis")]
+    public static unsafe extern void Set(SwiftSelf self, SwiftHandle value, nint index, TypeMetadata elementMetadata);
+
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSa5countSivg")]
+    public static extern nint Count(SwiftHandle handle, TypeMetadata elementMetadata);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSa6appendyyxnF")]
+    public static unsafe extern void Append(SwiftSelf self, SwiftHandle value, TypeMetadata metadata);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSa9removeAll15keepingCapacityySb_tF")]
+    public static unsafe extern void RemoveAll(SwiftSelf self, byte keepCapacity, TypeMetadata metadata);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSa6remove2atxSi_tF")]
+    public static unsafe extern void RemoveAt(SwiftIndirectResult result, SwiftSelf self, nint index, TypeMetadata metadata);
+
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSa6insert_2atyxn_SitF")]
+    public static unsafe extern void Insert(SwiftSelf self, SwiftHandle value, nint index, TypeMetadata metadata);
+}

--- a/src/Swift.Runtime/tests/LibraryTests/SwiftArrayTests.cs
+++ b/src/Swift.Runtime/tests/LibraryTests/SwiftArrayTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+using Swift;
+using Swift.Runtime;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace BindingsGeneration.Tests;
+
+public class SwiftArrayTests : IClassFixture<SwiftArrayTests.TestFixture>
+{
+    private readonly TestFixture _fixture;
+
+    public SwiftArrayTests(TestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public class TestFixture
+    {
+        static TestFixture()
+        {
+        }
+
+        private static void InitializeResources()
+        {
+        }
+    }
+
+    [Fact]
+    static void ArraySizeExpected()
+    {
+        var metadata = TypeMetadata.GetTypeMetadataOrThrow<SwiftArray<int>>();
+        Assert.Equal((nuint)8, metadata.Size);
+    }
+
+    [Fact]
+    static void SmokeTest()
+    {
+        var array = new SwiftArray<int>();
+        Assert.Empty(array);
+    }
+
+    [Fact]
+    static void AddsElements()
+    {
+        var array = new SwiftArray<int>();
+        array.Add(42);
+        array.Add(17);
+        var c = array.Count;
+        Assert.Equal(2, c);
+        Assert.Equal(17, array[1]);
+    }
+
+    [Fact]
+    static void ReplacesElement()
+    {
+        var array = new SwiftArray<int>();
+        array.Add(42);
+        array.Add(17);
+        var c = array.Count;
+        Assert.Equal(2, c);
+        Assert.Equal(17, array[1]);
+        array[1] = 99;
+        Assert.Equal(99, array[1]);
+    }
+
+    [Fact]
+    static void Clears()
+    {
+        var array = new SwiftArray<int>();
+        array.Add(42);
+        array.Add(17);
+        var c = array.Count;
+        Assert.Equal(2, c);
+        array.Clear();
+        c = array.Count;
+        Assert.Equal(0, c);
+    }
+
+    [Fact]
+    static void RemovesElement()
+    {
+        var array = new SwiftArray<int>();
+        array.Add(42);
+        array.Add(17);
+        var c = array.Count;
+        Assert.Equal(2, c);
+        array.RemoveAt(0);
+        c = array.Count;
+        Assert.Equal(1, c);
+        Assert.Equal(17, array[0]);
+    }
+
+    [Fact]
+    static void InsertsElement()
+    {
+        var array = new SwiftArray<int>();
+        array.Add(42);
+        array.Add(17);
+        var c = array.Count;
+        Assert.Equal(2, c);
+        array.Insert(1, 99);
+        c = array.Count;
+        Assert.Equal(3, c);
+        Assert.Equal(17, array[2]);
+    }
+}


### PR DESCRIPTION
This pull request adds a binding for `Swift.Array`.

This binding demonstrates a fundamental difference between the design of core types in Swift vs. .NET.
Swift uses consistent "copy on write" semantics for pretty much everything. This means that if you write this in Swift:
```swift
var a1:[Int] = [1, 2, 3]
var a2:[Int] = a1
a2[0] = 17
print(a1[0])
print(a2[0])
```
you will see
```
1
17
```

This is clearly not what a C# developer would expect and as such this binding doesn't reflect that. Any operation that mutates an instance of the array will effectively throw away the old instance which isn't precisely ideal, but here we are.

This is another example of a generic binding but this is different from `SwiftOptional` in that there are two types of methods: non-mutating (ie, normal methods) and mutating methods. These have very different calling conventions.

For non-mutating methods, the instance gets passed in as the first argument (not using the self register) and the type metadata of the generic **parameter** gets passed in.
For mutating methods, a pointer to a copy of the instance gets passed in in the self register and the type metadata of the **array** gets passed in.

Like many Swift primitives, this type is...unusual. I think it's technically a value type (it sure is acting like one), but under the hood the actual implementation may be one of several types. As a default, it looks like it's an `NSArray` for most cases.

Question: should I include an `IDisposable` implementation here or do we want to put that into a common base class?