### PR TITLE
[NativeAOT-LLVM] Remove various file reading (Linux specific) paths

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1263,6 +1263,8 @@ uint64_t GetAvailablePhysicalMemory()
     sysctlbyname("vm.stats.vm.v_free_count", &free_count, &sz, NULL, 0);
 
     available = (inactive_count + laundry_count + free_count) * sysconf(_SC_PAGESIZE);
+#elif defined(TARGET_WASM)
+    available = sysconf(SYSCONF_PAGES) * sysconf(_SC_PAGE_SIZE);
 #else // Linux
     static volatile bool tryReadMemInfo = true;
 

--- a/src/coreclr/gc/wasm/gcenv.wasm.cpp
+++ b/src/coreclr/gc/wasm/gcenv.wasm.cpp
@@ -4,7 +4,6 @@
 #include "common.h"
 #include "gcenv.h"
 
-
 // Flush write buffers of processors that are executing threads of the current process - a NOP for Wasm
 void GCToOSInterface::FlushProcessWriteBuffers()
 {
@@ -117,4 +116,25 @@ bool GCToOSInterface::VirtualDecommit(void* address, size_t size)
 bool GCToOSInterface::VirtualReset(void* address, size_t size, bool unlock)
 {
     return false;
+}
+
+//
+// CPU and memory limits - not avaliable on WASM (yet).
+//
+void InitializeCGroup()
+{
+}
+
+void CleanupCGroup()
+{
+}
+
+size_t GetRestrictedPhysicalMemoryLimit()
+{
+    return 0; // 'Unlimited'.
+}
+
+bool GetPhysicalMemoryUsed(size_t* val)
+{
+    return false; // 'Unknown'.
 }

--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -163,12 +163,15 @@ else()
   )
 
   if (CLR_CMAKE_TARGET_ARCH_WASM)
+    list(REMOVE_ITEM COMMON_RUNTIME_SOURCES
+      ${GC_DIR}/unix/cgroup.cpp
+      unix/PalCreateDump.cpp
+    )
     list(APPEND COMMON_RUNTIME_SOURCES
       ${GC_DIR}/wasm/gcenv.wasm.cpp
       wasm/PalCreateDump.cpp
-      unix/cgroupcpu.cpp
+      wasm/cgroupcpu.cpp
     )
-    list(REMOVE_ITEM COMMON_RUNTIME_SOURCES unix/PalCreateDump.cpp)
   endif()
 
   list(APPEND FULL_RUNTIME_SOURCES

--- a/src/coreclr/nativeaot/Runtime/wasm/cgroupcpu.cpp
+++ b/src/coreclr/nativeaot/Runtime/wasm/cgroupcpu.cpp
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <cstdint>
+
+//
+// No CPU or memory limits on WASM as yet.
+//
+void InitializeCpuCGroup()
+{
+}
+
+bool GetCpuLimit(uint32_t* val)
+{
+    return false;
+}

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -27,7 +27,7 @@
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\SharedLibrary\SharedLibrary.csproj" />
 
       <!-- Only automated on WASI with LLDB, which we don't have on Windows CI machines. -->
-      <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\HelloWasm\WasmDebugging.csproj" Condition="'$(TargetOS)' == 'browser' or '$(OS)' == 'Windows_NT'" />
+      <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\HelloWasm\WasmDebugging.csproj" Condition="'$(TargetOS)' == 'browser' or '$(OS)' == 'Windows_NT' or '$(Configuration)' != 'Debug'" />
       <DisabledProjects Include="$(TestRoot)readytorun\**\*.csproj" Condition="'$(TestBuildMode)' == 'nativeaot'" />
     </ItemGroup>
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.csproj
@@ -5,9 +5,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
-
-    <!-- Only works without optimizations for now. -->
-    <CLRTestTargetUnsupported Condition="'$(Configuration)' != 'Debug'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsWasi)' == 'true'">

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
@@ -50,6 +50,7 @@ if ($ShowHelp)
     Write-Host " further inspected using tools like git-diff."
     Write-Host ""
     Write-Host " -Analyze depends on https://github.com/WebAssembly/wabt tools being available in PATH."
+    Write-Host " -Analyze for WASI depends on https://github.com/bytecodealliance/wasm-tools being available in PATH."
     Write-Host " -Llvm depends on llvm-dis being available in PATH."
     Write-Host ""
     return
@@ -203,6 +204,29 @@ if ($Analyze -or $Summary)
     }
     else
     {
+        function WasmObjDump($Options, $Path)
+        {
+            if ($OS -eq "wasi")
+            {
+                $UnbundlePath = "$([IO.Path]::GetDirectoryName($Path))/wasmjit-diff"
+                if (!(Test-Path $UnbundlePath))
+                {
+                    mkdir $UnbundlePath > $null | Write-Verbose
+                }
+                $CoreModulePath = "$UnbundlePath/unbundled-module0.wasm"
+                $ComponentTimeStamp = (Get-ChildItem $Path).LastAccessTime
+                $CoreModuleTimeStamp = (Get-ChildItem $CoreModulePath -ErrorAction Ignore).LastAccessTime
+                if ($ComponentTimeStamp -gt $CoreModuleTimeStamp)
+                {
+                    # Component newer than our cached core module, update the latter.
+                    Write-Host "Unbundling $Path as $CoreModulePath"
+                    wasm-tools component unbundle $Path --module-dir $UnbundlePath > $null
+                }
+                $Path = $CoreModulePath
+            }
+            return wasm-objdump @Options $Path
+        }
+
         $WasmSummaryLineRegex = [Regex]::New(" - func\[(\d+)\] size=(\d+) <(.*)>", "Compiled")
         function ParseWasmSummary($RawSummary, $SummaryName)
         {
@@ -243,8 +267,8 @@ if ($Analyze -or $Summary)
             return $SummaryList, $TotalCodeSize
         }
 
-        $BaseSummaryRaw = wasm-objdump -x -j Code $TestProjectBaseWasmOutput
-        $DiffSummaryRaw = wasm-objdump -x -j Code $TestProjectWasmOutput
+        $BaseSummaryRaw = WasmObjDump @("-x", "-j", "Code") $TestProjectBaseWasmOutput
+        $DiffSummaryRaw = WasmObjDump @("-x", "-j", "Code") $TestProjectWasmOutput
 
         $BaseSummary, $TotalBaseCodeSize = ParseWasmSummary $BaseSummaryRaw "base"
         $DiffSummary, $TotalDiffCodeSize = ParseWasmSummary $DiffSummaryRaw "diff"
@@ -357,9 +381,9 @@ if ($Analyze -or $Summary)
             else
             {
                 Write-Host "Collecting full disassembly for the base..."
-                $BaseWat = wasm-objdump -d $TestProjectBaseWasmOutput
+                $BaseWat = WasmObjDump @("-d") $TestProjectBaseWasmOutput
                 Write-Host "Collecting full disassembly for the diff..."
-                $DiffWat = wasm-objdump -d $TestProjectWasmOutput
+                $DiffWat = WasmObjDump @("-d") $TestProjectWasmOutput
 
                 function CreateWatIndex($Wat)
                 {


### PR DESCRIPTION
Fixes #2947. Includes a `wasmjit-diff.ps1` change that makes it work with components.

Diffs (WasmDebugging):
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 772104
Total bytes of diff: 752689
Total bytes of delta: -19415 (-2.51% % of base)
Average relative delta: -5.53%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
          15 ( 5.70% of base) : 1002.dasm - GCToOSInterface::GetMemoryStatus(unsigned long long, unsigned int*, unsigned long long*, unsigned long long*)

Top method improvements (percentages):
        -658 (-99.70% of base) : 1003.dasm - InitializeCGroup()
        -263 (-98.50% of base) : 1004.dasm - GetPhysicalMemoryUsed(unsigned long*)
         -17 (-89.47% of base) : 1005.dasm - InitializeCpuCGroup()

Top methods only present in base:
          -3 (-100.00% of base) : 1000.dasm - undefined_weak:__wasilibc_find_relpath_alloc
         -52 (-100.00% of base) : 1027.dasm - __ofl_add
         -55 (-100.00% of base) : 1028.dasm - sscanf
         -36 (-100.00% of base) : 1029.dasm - fputs
        -174 (-100.00% of base) : 1030.dasm - scalbn
        -538 (-100.00% of base) : 1031.dasm - fmod
       -4811 (-100.00% of base) : 1032.dasm - __floatscan
       -1403 (-100.00% of base) : 1033.dasm - hexfloat
        -595 (-100.00% of base) : 1034.dasm - scanexp
        -402 (-100.00% of base) : 1035.dasm - mbrtowc
         -18 (-100.00% of base) : 1036.dasm - mbsinit
         -16 (-100.00% of base) : 1026.dasm - getline
       -3081 (-100.00% of base) : 1037.dasm - vfscanf
         -88 (-100.00% of base) : 1039.dasm - vsscanf
         -93 (-100.00% of base) : 1040.dasm - string_read
        -370 (-100.00% of base) : 1041.dasm - memchr
         -73 (-100.00% of base) : 1042.dasm - memcmp
         -24 (-100.00% of base) : 1043.dasm - strcat
         -29 (-100.00% of base) : 1044.dasm - strchr
        -360 (-100.00% of base) : 1045.dasm - strstr
        -178 (-100.00% of base) : 1046.dasm - fourbyte_strstr
       -1002 (-100.00% of base) : 1047.dasm - twoway_strstr
        -247 (-100.00% of base) : 1048.dasm - strspn
         -28 (-100.00% of base) : 1038.dasm - long_double_not_supported
        -240 (-100.00% of base) : 1049.dasm - strcspn
        -585 (-100.00% of base) : 1025.dasm - getdelim
        -389 (-100.00% of base) : 1023.dasm - __fdopen
        -404 (-100.00% of base) : 1001.dasm - GetAvailablePhysicalMemory()
        -267 (-100.00% of base) : 1006.dasm - CGroup::FindCGroupPath(bool (*)(char const*))
        -557 (-100.00% of base) : 1007.dasm - CGroup::FindHierarchyMount(bool (*)(char const*), char**, char**)
        -209 (-100.00% of base) : 1008.dasm - CGroup::FindCGroupPathForSubsystem(bool (*)(char const*))
        -112 (-100.00% of base) : 1009.dasm - read
         -17 (-100.00% of base) : 1010.dasm - __wasi_fd_fdstat_set_flags
        -101 (-100.00% of base) : 1024.dasm - fopen
         -37 (-100.00% of base) : 1012.dasm - __wasi_path_open
        -281 (-100.00% of base) : 1013.dasm - __wasilibc_nocwd_openat_nomode
         -21 (-100.00% of base) : 1011.dasm - __wasi_fd_read
         -93 (-100.00% of base) : 1015.dasm - __wasilibc_find_relpath
        -342 (-100.00% of base) : 1016.dasm - __wasilibc_find_abspath
          -2 (-100.00% of base) : 1017.dasm - dummy
        -151 (-100.00% of base) : 1018.dasm - fclose
        -101 (-100.00% of base) : 1019.dasm - __fmodeflags
        -274 (-100.00% of base) : 1020.dasm - fcntl
        -113 (-100.00% of base) : 1021.dasm - readv
        -252 (-100.00% of base) : 1022.dasm - __stdio_read
        -161 (-100.00% of base) : 1014.dasm - __wasilibc_open_nomode
        -107 (-100.00% of base) : 1050.dasm - strtok_r

51 total methods with Code Size differences (50 improved, 1 regressed)
```