### PR TITLE
[SwiftBindings] Skip test for invalid metadata due to cache issue

### DIFF
--- a/src/Swift.Runtime/tests/MetadataTests/TypeMetadataTests.cs
+++ b/src/Swift.Runtime/tests/MetadataTests/TypeMetadataTests.cs
@@ -127,7 +127,7 @@ public class TypeMetadataTests : IClassFixture<TypeMetadataTests.TestFixture>
         Assert.False(TypeMetadata.TryGetTypeMetadata<object>(out var md));
     }
 
-    [Fact]
+    [Fact(Skip = "Wrong value can be read from the cache: https://github.com/dotnet/runtimelab/issues/2966")]
     public static void FailsWhenMetadataIsNotValid()
     {
         Assert.False(TypeMetadata.TryGetTypeMetadata<AnyTypeMock>(out var md));


### PR DESCRIPTION
Disables a test introduced in the https://github.com/dotnet/runtimelab/pull/2958 as it breaks the CI. Created an issue to track the problem: https://github.com/dotnet/runtimelab/issues/2966