### PR TITLE
[SwiftBindings] Adds runtime support for protocol constraints

### DIFF
--- a/src/Swift.Bindings/src/DemangledSymbols.cs
+++ b/src/Swift.Bindings/src/DemangledSymbols.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using BindingsGeneration;
+using Xamarin;
+
+public readonly record struct DemangledSymbols
+{
+    public Dictionary<(NamedTypeSpec, NamedTypeSpec), string> ProtocolConformanceDescriptors { get; init; }
+
+    public DemangledSymbols(Dictionary<(NamedTypeSpec, NamedTypeSpec), string> descriptors)
+    {
+        ProtocolConformanceDescriptors = descriptors;
+    }
+}
+
+public sealed class DemangledSymbolsRegister
+{
+    private static readonly Lazy<DemangledSymbolsRegister> _instance = new(() => new DemangledSymbolsRegister());
+
+    private DemangledSymbols _symbols = new(new Dictionary<(NamedTypeSpec, NamedTypeSpec), string>());
+    private bool _isLoaded = false;
+
+    public static DemangledSymbolsRegister Instance => _instance.Value;
+
+    private DemangledSymbolsRegister() { }
+
+    public DemangledSymbols GetData(string dylibPath = "")
+    {
+        if (!_isLoaded)
+        {
+            if (string.IsNullOrEmpty(dylibPath))
+            {
+                throw new ArgumentException("dylibPath cannot be null or empty.");
+            }
+
+            Load(dylibPath);
+        }
+        return _symbols;
+    }
+
+    private void Load(string dylibPath)
+    {
+        try
+        {
+            var descriptors = DemanglingResults.FromFile(dylibPath, Abi.ARM64).ProtocolConformanceDescriptors;
+            var dictionary = new Dictionary<(NamedTypeSpec, NamedTypeSpec), string>();
+
+            foreach (var descriptor in descriptors)
+            {
+                dictionary[(descriptor.ImplementingType, descriptor.ProtocolType)] = descriptor.Symbol[1..];
+            }
+
+            _symbols = new DemangledSymbols(dictionary);
+            _isLoaded = true;
+        }
+        catch (Exception e)
+        {
+            // This happens if the dylib cannot be located on disk, which will be the case for Apple shipped dylibs. (e.g. Foundation, StoreKit, etc.)
+            Console.Error.WriteLine($"Error loading demangled symbols: {e.Message}");
+        }
+    }
+}

--- a/src/Swift.Bindings/src/DemangledSymbols.cs
+++ b/src/Swift.Bindings/src/DemangledSymbols.cs
@@ -43,7 +43,8 @@ public sealed class DemangledSymbolsRegister
     {
         try
         {
-            var descriptors = DemanglingResults.FromFile(dylibPath, Abi.ARM64).ProtocolConformanceDescriptors;
+            var abis = MachO.GetArchitectures(dylibPath);
+            var descriptors = DemanglingResults.FromFile(dylibPath, abis[0]).ProtocolConformanceDescriptors;
             var dictionary = new Dictionary<(NamedTypeSpec, NamedTypeSpec), string>();
 
             foreach (var descriptor in descriptors)

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -64,9 +64,9 @@ namespace BindingsGeneration
             var methodEnv = (MethodEnvironment)env;
             var signatureHandler = new SignatureHandler(methodEnv);
 
-            if (methodEnv.MethodDecl.GenericParameters.Any(x => x.Constraints.Count > 0))
+            if (methodEnv.MethodDecl.GenericParameters.Any(x => x.Constraints.OfType<AssociatedTypeConformance>().ToList().Count > 0))
             {
-                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported generic constraints");
+                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported PAT generic constraints");
                 return;
             }
 
@@ -292,6 +292,23 @@ namespace BindingsGeneration
         }
 
         /// <summary>
+        /// Handles the protocol conformances of the generic parameters of the method.
+        /// </summary>
+        public void HandleProtocolConformance()
+        {
+            foreach (var genericParameter in _env.MethodDecl.GenericParameters)
+            {
+                var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
+                foreach (var conformance in conformances)
+                {
+                    var protocolConformance = (ProtocolConformance)conformance;
+                    var pwtName = $"{_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName}_{protocolConformance.ProtocolSpec.NameWithoutModule}_pwt";
+                    AddParameter("ProtocolWitnessTable", pwtName);
+                }
+            }
+        }
+
+        /// <summary>
         /// Handles the SwiftSelf parameter of the method.
         /// </summary>
         public void HandleSwiftSelf()
@@ -376,6 +393,7 @@ namespace BindingsGeneration
                 pInvokeSignature.HandleSwiftAsync();
                 pInvokeSignature.HandleArguments();
                 pInvokeSignature.HandleGenericMetadata();
+                pInvokeSignature.HandleProtocolConformance();
                 pInvokeSignature.HandleSwiftSelf();
                 pInvokeSignature.HandleSwiftError();
                 _pInvokeSignature = pInvokeSignature.Build();
@@ -485,6 +503,7 @@ namespace BindingsGeneration
             EmitSwiftSelf(csWriter);
             EmitIndirectResultConstructor(csWriter);
             EmitGenericArguments(csWriter);
+            EmitProtocolWitnessTables(csWriter);
             EmitPInvokeCall(csWriter);
             EmitSwiftError(csWriter);
             EmitReturnConstructor(csWriter);
@@ -527,6 +546,7 @@ namespace BindingsGeneration
             EmitSwiftSelf(csWriter);
             EmitIndirectResultMethod(csWriter);
             EmitGenericArguments(csWriter);
+            EmitProtocolWitnessTables(csWriter);
             EmitPInvokeCall(csWriter);
             EmitSwiftError(csWriter);
             EmitReturnMethod(csWriter);
@@ -655,12 +675,31 @@ namespace BindingsGeneration
             foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
             {
                 var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+
                 var text = $$"""
                 var {{metadataName}} = TypeMetadata.GetTypeMetadataOrThrow<{{typeName}}>();
                 {{payloadName}} = (IntPtr)NativeMemory.Alloc({{metadataName}}.Size);
                 SwiftMarshal.MarshalToSwift({{argument.Name}}, {{payloadName}});
                 """;
                 csWriter.WriteLines(text);
+            }
+            csWriter.WriteLine();
+        }
+
+
+        private void EmitProtocolWitnessTables(CSharpWriter csWriter)
+        {
+            foreach (var genericParameter in _env.MethodDecl.GenericParameters)
+            {
+                var (placeholderName, _, _) = _env.GenericTypeMapping[genericParameter.TypeName];
+                var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
+                foreach (var conformance in conformances)
+                {
+                    var protocolConformance = (ProtocolConformance)conformance;
+                    var pwtName = $"{_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName}_{protocolConformance.ProtocolSpec.NameWithoutModule}_pwt";
+                    var protocolName = NameProvider.GetInterfaceName(protocolConformance.ProtocolSpec.NameWithoutModule);
+                    csWriter.WriteLine($"var {pwtName} = ProtocolWitnessTable.GetOrThrow<{placeholderName}, {protocolName}>();");
+                }
             }
             csWriter.WriteLine();
         }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -37,26 +37,17 @@ namespace BindingsGeneration
         {
         }
 
-        /// <summary>
-        /// Marshals the specified constructor.
-        /// </summary>
-        /// <param name="methodDecl">The method declaration.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
-        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        /// <inheritdoc/>
+        public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
         {
-            if (decl is not MethodDecl methodDecl)
+            if (baseDecl is not MethodDecl methodDecl)
             {
-                throw new ArgumentException("The provided decl must be a MethodDecl.", nameof(decl));
+                throw new ArgumentException("The provided decl must be a MethodDecl.", nameof(baseDecl));
             }
             return new MethodEnvironment(methodDecl, typeDatabase);
         }
 
-        /// <summary>
-        /// Emits the method declaration.
-        /// </summary>
-        /// <param name="csWriter">The IndentedTextWriter instance.</param>
-        /// <param name="env">The environment.</param>
-        /// <param name="conductor">The conductor instance.</param>
+        /// <inheritdoc/>
         public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
         {
             var methodEnv = (MethodEnvironment)env;
@@ -114,26 +105,17 @@ namespace BindingsGeneration
         {
         }
 
-        /// <summary>
-        /// Marshals the method declaration.
-        /// </summary>
-        /// <param name="methodDecl">The method declaration.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
-        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        /// <inheritdoc/>
+        public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
         {
-            if (decl is not MethodDecl methodDecl)
+            if (baseDecl is not MethodDecl methodDecl)
             {
-                throw new ArgumentException("The provided decl must be a MethodDecl.", nameof(decl));
+                throw new ArgumentException("The provided decl must be a MethodDecl.", nameof(baseDecl));
             }
             return new MethodEnvironment(methodDecl, typeDatabase);
         }
 
-        /// <summary>
-        /// Emits the method declaration.
-        /// </summary>
-        /// <param name="csWriter">The IndentedTextWriter instance.</param>
-        /// <param name="env">The environment.</param>
-        /// <param name="conductor">The conductor instance.</param>
+        /// <inheritdoc/>
         public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
         {
             var methodEnv = (MethodEnvironment)env;

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -5,6 +5,81 @@ using System.CodeDom.Compiler;
 
 namespace BindingsGeneration
 {
+    /// <summary>
+    /// Factory class for creating instances of ConstructorHandler.
+    /// </summary>
+    public class ConstructorHandlerFactory : IFactory<BaseDecl, IMethodHandler>
+    {
+        /// <summary>
+        /// Determines if the factory handles the specified declaration.
+        /// </summary>
+        /// <param name="decl">The base declaration.</param>
+        public bool Handles(BaseDecl decl)
+        {
+            return decl is MethodDecl methodDecl && methodDecl.IsConstructor;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of ConstructorHandler.
+        /// </summary>
+        public IMethodHandler Construct()
+        {
+            return new ConstructorHandler();
+        }
+    }
+
+    /// <summary>
+    /// Handler class for constructor declarations.
+    /// </summary>
+    public class ConstructorHandler : BaseHandler, IMethodHandler
+    {
+        public ConstructorHandler()
+        {
+        }
+
+        /// <summary>
+        /// Marshals the specified constructor.
+        /// </summary>
+        /// <param name="methodDecl">The method declaration.</param>
+        /// <param name="typeDatabase">The type database instance.</param>
+        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        {
+            if (decl is not MethodDecl methodDecl)
+            {
+                throw new ArgumentException("The provided decl must be a MethodDecl.", nameof(decl));
+            }
+            return new MethodEnvironment(methodDecl, typeDatabase);
+        }
+
+        /// <summary>
+        /// Emits the method declaration.
+        /// </summary>
+        /// <param name="csWriter">The IndentedTextWriter instance.</param>
+        /// <param name="env">The environment.</param>
+        /// <param name="conductor">The conductor instance.</param>
+        public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
+        {
+            var methodEnv = (MethodEnvironment)env;
+            var signatureHandler = new SignatureHandler(methodEnv);
+
+            if (methodEnv.MethodDecl.IsGeneric)
+            {
+                Console.WriteLine($"Constructor {methodEnv.MethodDecl.Name} has unsupported generic parameters");
+                return;
+            }
+
+            if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
+            {
+                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported signature: ({signatureHandler.GetWrapperSignature().ParametersString()}) -> {signatureHandler.GetWrapperSignature().ReturnType}");
+                return;
+            }
+
+            var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler);
+            wrapperEmitter.EmitConstructor(csWriter);
+            PInvokeEmitter.EmitPInvoke(csWriter, methodEnv, signatureHandler);
+            csWriter.WriteLine();
+        }
+    }
 
     /// <summary>
     /// Represents a method handler factory.
@@ -77,7 +152,7 @@ namespace BindingsGeneration
             }
 
             var wrapperEmitter = new WrapperEmitter(methodEnv, signatureHandler);
-            wrapperEmitter.Emit(csWriter, swiftWriter);
+            wrapperEmitter.EmitMethod(csWriter, swiftWriter);
             PInvokeEmitter.EmitPInvoke(csWriter, methodEnv, signatureHandler);
             csWriter.WriteLine();
         }
@@ -472,66 +547,38 @@ namespace BindingsGeneration
         }
 
         /// <summary>
-        /// Emits the wrapper.
-        /// </summary>
-        /// <param name="writer"></param>
-        internal void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter)
-        {
-            if (_env.MethodDecl.IsConstructor)
-            {
-                EmitConstructor(csWriter);
-            }
-            else
-            {
-                EmitMethod(csWriter, swiftWriter);
-            }
-        }
-
-        /// <summary>
         /// Emits the constructor wrapper.
         /// </summary>
         /// <param name="writer">The IndentedTextWriter instance.</param>
-        private void EmitConstructor(CSharpWriter csWriter)
+        internal void EmitConstructor(CSharpWriter csWriter)
         {
             EmitSignatureConstructor(csWriter);
             EmitBodyStart(csWriter);
 
-            EmitDeclarationsForAllocations(csWriter);
+            // EmitDeclarationsForAllocations(csWriter);
 
-            EmitTryBlockStart(csWriter);
+            // EmitTryBlockStart(csWriter);
 
             EmitSwiftSelf(csWriter);
             EmitIndirectResultConstructor(csWriter);
-            EmitGenericArguments(csWriter);
-            EmitProtocolWitnessTables(csWriter);
+            // EmitGenericArguments(csWriter);
+            // EmitProtocolWitnessTables(csWriter); TODO: Add support for generic arguments and protocol witness tables in constructors
             EmitPInvokeCall(csWriter);
             EmitSwiftError(csWriter);
             EmitReturnConstructor(csWriter);
 
-            EmitTryBlockEnd(csWriter);
+            // EmitTryBlockEnd(csWriter);
 
-            EmitFinally(csWriter);
+            // EmitFinally(csWriter);
 
             EmitBodyEnd(csWriter);
-        }
-
-        /// <summary>
-        /// Emits the declarations for allocations.
-        /// </summary>
-        private void EmitDeclarationsForAllocations(CSharpWriter csWriter)
-        {
-            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
-            {
-                var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
-                csWriter.WriteLine($"IntPtr {payloadName} = IntPtr.Zero;");
-            }
         }
 
         /// <summary>
         /// Emits the method wrapper.
         /// </summary>
         /// <param name="writer">The IndentedTextWriter instance.</param>
-        private void EmitMethod(CSharpWriter csWriter, SwiftWriter swiftWriter)
+        internal void EmitMethod(CSharpWriter csWriter, SwiftWriter swiftWriter)
         {
             EmitAsyncWrapper(csWriter);
 
@@ -556,6 +603,18 @@ namespace BindingsGeneration
             EmitFinally(csWriter);
 
             EmitBodyEnd(csWriter);
+        }
+
+        /// <summary>
+        /// Emits the declarations for allocations.
+        /// </summary>
+        private void EmitDeclarationsForAllocations(CSharpWriter csWriter)
+        {
+            foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
+            {
+                var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                csWriter.WriteLine($"IntPtr {payloadName} = IntPtr.Zero;");
+            }
         }
 
         /// <summary>

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -139,12 +139,6 @@ namespace BindingsGeneration
             var methodEnv = (MethodEnvironment)env;
             var signatureHandler = new SignatureHandler(methodEnv);
 
-            if (methodEnv.MethodDecl.GenericParameters.Any(x => x.Constraints.OfType<AssociatedTypeConformance>().ToList().Count > 0))
-            {
-                Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported PAT generic constraints");
-                return;
-            }
-
             if (signatureHandler.GetWrapperSignature().ContainsPlaceholder)
             {
                 Console.WriteLine($"Method {methodEnv.MethodDecl.Name} has unsupported signature: ({signatureHandler.GetWrapperSignature().ParametersString()}) -> {signatureHandler.GetWrapperSignature().ReturnType}");
@@ -376,8 +370,7 @@ namespace BindingsGeneration
                 var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
                 foreach (var conformance in conformances)
                 {
-                    var protocolConformance = (ProtocolConformance)conformance;
-                    var pwtName = $"{_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName}_{protocolConformance.ProtocolSpec.NameWithoutModule}_pwt";
+                    var pwtName = $"{_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName}_{conformance.ProtocolSpec.NameWithoutModule}_pwt";
                     AddParameter("ProtocolWitnessTable", pwtName);
                 }
             }
@@ -754,9 +747,8 @@ namespace BindingsGeneration
                 var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
                 foreach (var conformance in conformances)
                 {
-                    var protocolConformance = (ProtocolConformance)conformance;
-                    var pwtName = $"{_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName}_{protocolConformance.ProtocolSpec.NameWithoutModule}_pwt";
-                    var protocolName = NameProvider.GetInterfaceName(protocolConformance.ProtocolSpec.NameWithoutModule);
+                    var pwtName = $"{_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName}_{conformance.ProtocolSpec.NameWithoutModule}_pwt";
+                    var protocolName = NameProvider.GetInterfaceName(conformance.ProtocolSpec.NameWithoutModule);
                     csWriter.WriteLine($"var {pwtName} = ProtocolWitnessTable.GetOrThrow<{placeholderName}, {protocolName}>();");
                 }
             }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -333,7 +333,7 @@ namespace BindingsGeneration
             {
                 if (argument.IsGeneric)
                 {
-                    var payloadName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].PayloadName;
+                    var payloadName = NameProvider.GetPayloadName(argument.Name);
                     AddParameter("IntPtr", payloadName);
                 }
                 else if (MarshallingHelpers.ArgumentIsMarshalledAsCSStruct(argument, _env.TypeDatabase))
@@ -355,7 +355,7 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var metadataName = _env.GenericTypeMapping[genericParameter.TypeName].MetadataName;
+                var metadataName = NameProvider.GetMetadataName(_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName);
                 AddParameter("TypeMetadata", metadataName);
             }
         }
@@ -605,7 +605,7 @@ namespace BindingsGeneration
         {
             foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
             {
-                var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                var payloadName = NameProvider.GetPayloadName(argument.Name);
                 csWriter.WriteLine($"IntPtr {payloadName} = IntPtr.Zero;");
             }
         }
@@ -724,12 +724,21 @@ namespace BindingsGeneration
         /// </summary>
         private void EmitGenericArguments(CSharpWriter csWriter)
         {
+            foreach (var genericParameter in _env.MethodDecl.GenericParameters)
+            {
+                var placeholderName = _env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName;
+                var metadataName = NameProvider.GetMetadataName(placeholderName);
+
+                csWriter.WriteLine($"var {metadataName} = TypeMetadata.GetTypeMetadataOrThrow<{placeholderName}>();");
+            }
+
             foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
             {
-                var (typeName, metadataName, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                var placeholderName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].PlaceholderName;
+                var metadataName = NameProvider.GetMetadataName(placeholderName);
+                var payloadName = NameProvider.GetPayloadName(argument.Name);
 
                 var text = $$"""
-                var {{metadataName}} = TypeMetadata.GetTypeMetadataOrThrow<{{typeName}}>();
                 {{payloadName}} = (IntPtr)NativeMemory.Alloc({{metadataName}}.Size);
                 SwiftMarshal.MarshalToSwift({{argument.Name}}, {{payloadName}});
                 """;
@@ -743,7 +752,7 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var (placeholderName, _, _) = _env.GenericTypeMapping[genericParameter.TypeName];
+                var placeholderName = _env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName;
                 var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
                 foreach (var conformance in conformances)
                 {
@@ -908,7 +917,7 @@ namespace BindingsGeneration
 
             foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
             {
-                var (_, _, payloadName) = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()];
+                var payloadName = NameProvider.GetPayloadName(argument.Name);
                 csWriter.WriteLine($"NativeMemory.Free((void*){payloadName});");
             }
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -547,23 +547,11 @@ namespace BindingsGeneration
         {
             EmitSignatureConstructor(csWriter);
             EmitBodyStart(csWriter);
-
-            // EmitDeclarationsForAllocations(csWriter);
-
-            // EmitTryBlockStart(csWriter);
-
             EmitSwiftSelf(csWriter);
             EmitIndirectResultConstructor(csWriter);
-            // EmitGenericArguments(csWriter);
-            // EmitProtocolWitnessTables(csWriter); TODO: Add support for generic arguments and protocol witness tables in constructors
             EmitPInvokeCall(csWriter);
             EmitSwiftError(csWriter);
             EmitReturnConstructor(csWriter);
-
-            // EmitTryBlockEnd(csWriter);
-
-            // EmitFinally(csWriter);
-
             EmitBodyEnd(csWriter);
         }
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -55,6 +55,7 @@ namespace BindingsGeneration
 
             if (methodEnv.MethodDecl.IsGeneric)
             {
+                // TODO: This should revert writing the entire struct: https://github.com/dotnet/runtimelab/issues/2890
                 Console.WriteLine($"Constructor {methodEnv.MethodDecl.Name} has unsupported generic parameters");
                 return;
             }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -370,7 +370,7 @@ namespace BindingsGeneration
                 var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
                 foreach (var conformance in conformances)
                 {
-                    var pwtName = $"{_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName}_{conformance.ProtocolSpec.NameWithoutModule}_pwt";
+                    var pwtName = NameProvider.GetProtocolWitnessTableName(_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName, conformance.ProtocolSpec.NameWithoutModule);
                     AddParameter("ProtocolWitnessTable", pwtName);
                 }
             }
@@ -756,7 +756,7 @@ namespace BindingsGeneration
                 var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
                 foreach (var conformance in conformances)
                 {
-                    var pwtName = $"{_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName}_{conformance.ProtocolSpec.NameWithoutModule}_pwt";
+                    var pwtName = NameProvider.GetProtocolWitnessTableName(placeholderName, conformance.ProtocolSpec.NameWithoutModule);
                     var protocolName = NameProvider.GetInterfaceName(conformance.ProtocolSpec.NameWithoutModule);
                     csWriter.WriteLine($"var {pwtName} = ProtocolWitnessTable.GetOrThrow<{placeholderName}, {protocolName}>();");
                 }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -214,8 +214,8 @@ namespace BindingsGeneration
             var argument = _env.MethodDecl.CSSignature.First();
             if (argument.IsGeneric)
             {
-                var placeholderName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].PlaceholderName;
-                SetReturnType(placeholderName);
+                var csTypeParamName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].TypeParameter;
+                SetReturnType(csTypeParamName);
             }
             else
             {
@@ -233,8 +233,8 @@ namespace BindingsGeneration
             {
                 if (argument.IsGeneric)
                 {
-                    var placeholderName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].PlaceholderName;
-                    AddParameter(placeholderName, argument.Name);
+                    var csTypeParamName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].TypeParameter;
+                    AddParameter(csTypeParamName, argument.Name);
                 }
                 else
                 {
@@ -355,7 +355,7 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var metadataName = NameProvider.GetMetadataName(_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName);
+                var metadataName = NameProvider.GetMetadataName(_env.GenericTypeMapping[genericParameter.TypeName].TypeParameter);
                 AddParameter("TypeMetadata", metadataName);
             }
         }
@@ -370,7 +370,7 @@ namespace BindingsGeneration
                 var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
                 foreach (var conformance in conformances)
                 {
-                    var pwtName = NameProvider.GetProtocolWitnessTableName(_env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName, conformance.ProtocolSpec.NameWithoutModule);
+                    var pwtName = NameProvider.GetProtocolWitnessTableName(_env.GenericTypeMapping[genericParameter.TypeName].TypeParameter, conformance.ProtocolSpec.NameWithoutModule);
                     AddParameter("ProtocolWitnessTable", pwtName);
                 }
             }
@@ -714,16 +714,16 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var placeholderName = _env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName;
-                var metadataName = NameProvider.GetMetadataName(placeholderName);
+                var csTypeParamName = _env.GenericTypeMapping[genericParameter.TypeName].TypeParameter;
+                var metadataName = NameProvider.GetMetadataName(csTypeParamName);
 
-                csWriter.WriteLine($"var {metadataName} = TypeMetadata.GetTypeMetadataOrThrow<{placeholderName}>();");
+                csWriter.WriteLine($"var {metadataName} = TypeMetadata.GetTypeMetadataOrThrow<{csTypeParamName}>();");
             }
 
             foreach (var argument in _env.MethodDecl.CSSignature.Skip(1).Where(a => a.IsGeneric))
             {
-                var placeholderName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].PlaceholderName;
-                var metadataName = NameProvider.GetMetadataName(placeholderName);
+                var csTypeParamName = _env.GenericTypeMapping[argument.SwiftTypeSpec.ToString()].TypeParameter;
+                var metadataName = NameProvider.GetMetadataName(csTypeParamName);
                 var payloadName = NameProvider.GetPayloadName(argument.Name);
 
                 var text = $$"""
@@ -740,13 +740,13 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var placeholderName = _env.GenericTypeMapping[genericParameter.TypeName].PlaceholderName;
+                var csTypeParamName = _env.GenericTypeMapping[genericParameter.TypeName].TypeParameter;
                 var conformances = genericParameter.Constraints.Where(c => c is ProtocolConformance).OrderBy(c => c.ProtocolSpec.NameWithoutModule);
                 foreach (var conformance in conformances)
                 {
-                    var pwtName = NameProvider.GetProtocolWitnessTableName(placeholderName, conformance.ProtocolSpec.NameWithoutModule);
+                    var pwtName = NameProvider.GetProtocolWitnessTableName(csTypeParamName, conformance.ProtocolSpec.NameWithoutModule);
                     var protocolName = NameProvider.GetInterfaceName(conformance.ProtocolSpec.NameWithoutModule);
-                    csWriter.WriteLine($"var {pwtName} = ProtocolWitnessTable.GetOrThrow<{placeholderName}, {protocolName}>();");
+                    csWriter.WriteLine($"var {pwtName} = ProtocolWitnessTable.GetOrThrow<{csTypeParamName}, {protocolName}>();");
                 }
             }
             csWriter.WriteLine();
@@ -833,7 +833,7 @@ namespace BindingsGeneration
         {
             var genericParams = _env.MethodDecl.IsGeneric switch
             {
-                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].PlaceholderName))}>",
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].TypeParameter))}>",
                 false => ""
             };
             csWriter.WriteLine($"public {_env.ParentDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
@@ -847,7 +847,7 @@ namespace BindingsGeneration
         {
             var genericParams = _env.MethodDecl.IsGeneric switch
             {
-                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].PlaceholderName))}>",
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].TypeParameter))}>",
                 false => ""
             };
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/ModuleHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/ModuleHandler.cs
@@ -38,27 +38,17 @@ namespace BindingsGeneration
         {
         }
 
-        /// <summary>
-        /// Marshals the module declaration.
-        /// </summary>
-        /// <param name="moduleDecl">The module declaration.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
-        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        /// <inheritdoc/>
+        public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
         {
-            if (decl is not ModuleDecl moduleDecl)
+            if (baseDecl is not ModuleDecl moduleDecl)
             {
-                throw new ArgumentException("The provided decl must be a ModuleDecl.", nameof(decl));
+                throw new ArgumentException("The provided decl must be a ModuleDecl.", nameof(baseDecl));
             }
             return new ModuleEnvironment(moduleDecl, typeDatabase);
         }
 
-        /// <summary>
-        /// Emits the code for the specified environment.
-        /// </summary>
-        /// <param name="csWriter">The IndentedTextWriter instance.</param>
-        /// <param name="env">The environment.</param>
-        /// <param name="conductor">The conductor instance.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
+        /// <inheritdoc/>
         public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
         {
             var moduleEnv = (ModuleEnvironment)env;

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -549,7 +549,7 @@ namespace BindingsGeneration
             var entries = new List<string>();
             var protocolConformanceDescriptors = DemangledSymbolsRegister.Instance.GetData(libPath).ProtocolConformanceDescriptors;
 
-            foreach (var conformance in _structDecl.Conformances.OfType<ProtocolConformance>().Where(c => c.ProtocolSpec.Module == _moduleDecl.Name)) // Process only protocol conformances from current module for now
+            foreach (var conformance in _structDecl.Conformances.Where(c => c.ProtocolSpec.Module == _moduleDecl.Name)) // Process only protocol conformances from current module for now
             {
                 var protocol = NameProvider.GetInterfaceName(conformance.ProtocolSpec.NameWithoutModule);
                 var typeRecord = _typeDatabase.GetTypeRecordOrThrow(_moduleDecl.Name, _structDecl.FullyQualifiedNameWithoutModule);

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -519,16 +519,46 @@ namespace BindingsGeneration
         /// </summary>
         private void WriteGetProtocolConformanceDescriptor()
         {
+            var libPath = _typeDatabase.GetLibraryPath(_moduleDecl.Name);
             var text = $$"""
-            static ProtocolConformanceDescriptor ISwiftObject.GetProtocolConformanceDescriptor<U>()
+            static ProtocolConformanceDescriptor ISwiftObject.GetProtocolConformanceDescriptor<TProtocol>()
+                where TProtocol : class
             {
-                throw new NotImplementedException();
+                var dispatch = new Dictionary<Type, string>
+                {
+                    {{GenerateGetProtocolConformanceDictionaryEntries()}}
+                };
+
+                if (!dispatch.ContainsKey(typeof(TProtocol)))
+                {
+                    throw new SwiftRuntimeException($"Attempted to retrieve protocol conformance descriptor for type {{_structDecl.Name}} and protocol {typeof(TProtocol).Name}, but no conformance was found.");
+                }
+
+                return ProtocolConformanceDescriptor.LoadFromSymbol("{{libPath}}", dispatch[typeof(TProtocol)]);
             }
             """;
 
             _writer.WriteLines(text);
             _writer.WriteLine();
 
+        }
+
+        private string GenerateGetProtocolConformanceDictionaryEntries()
+        {
+            var libPath = _typeDatabase.GetLibraryPath(_moduleDecl.Name);
+            var entries = new List<string>();
+            var protocolConformanceDescriptors = DemangledSymbolsRegister.Instance.GetData(libPath).ProtocolConformanceDescriptors;
+
+            foreach (var conformance in _structDecl.Conformances.OfType<ProtocolConformance>().Where(c => c.ProtocolSpec.Module == _moduleDecl.Name)) // Process only protocol conformances from current module for now
+            {
+                var protocol = NameProvider.GetInterfaceName(conformance.ProtocolSpec.NameWithoutModule);
+                var typeRecord = _typeDatabase.GetTypeRecordOrThrow(_moduleDecl.Name, _structDecl.FullyQualifiedNameWithoutModule);
+                var protocolConformanceSymbol = protocolConformanceDescriptors[(new NamedTypeSpec(_structDecl.FullyQualifiedName), conformance.ProtocolSpec)]; // TODO: Get rid of TypeSpec https://github.com/dotnet/runtimelab/issues/2889
+
+                entries.Add($"{{typeof({protocol}), \"{protocolConformanceSymbol}\"}}");
+            }
+
+            return string.Join(",\n", entries);
         }
     }
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -38,27 +38,17 @@ namespace BindingsGeneration
         {
         }
 
-        /// <summary>
-        /// Marshals the specified struct declaration.
-        /// </summary>
-        /// <param name="structDecl">The struct declaration.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
-        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        /// <inheritdoc/>
+        public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
         {
-            if (decl is not StructDecl structDecl)
+            if (baseDecl is not StructDecl structDecl)
             {
-                throw new ArgumentException("The provided decl must be a StructDecl.", nameof(decl));
+                throw new ArgumentException("The provided decl must be a StructDecl.", nameof(baseDecl));
             }
             return new TypeEnvironment(structDecl, typeDatabase);
         }
 
-        /// <summary>
-        /// Emits the code for the specified environment.
-        /// </summary>
-        /// <param name="csWriter">The IndentedTextWriter instance.</param>
-        /// <param name="env">The environment.</param>
-        /// <param name="conductor">The conductor instance.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
+        /// <inheritdoc/>
         public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
         {
             var structEnv = (TypeEnvironment)env;
@@ -170,28 +160,18 @@ namespace BindingsGeneration
         {
         }
 
-        /// <summary>
-        /// Marshals the specified struct declaration.
-        /// </summary>
-        /// <param name="structDecl">The struct declaration.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
-        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        /// <inheritdoc/>
+        public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
         {
-            if (decl is not StructDecl structDecl)
+            if (baseDecl is not StructDecl structDecl)
             {
-                throw new ArgumentException("The provided decl must be a StructDecl.", nameof(decl));
+                throw new ArgumentException("The provided decl must be a StructDecl.", nameof(baseDecl));
 
             }
             return new TypeEnvironment(structDecl, typeDatabase);
         }
 
-        /// <summary>
-        /// Emits the code for the specified environment.
-        /// </summary>
-        /// <param name="csWriter">The IndentedTextWriter instance.</param>
-        /// <param name="env">The environment.</param>
-        /// <param name="conductor">The conductor instance.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
+        /// <inheritdoc/>
         public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
         {
             var structEnv = (TypeEnvironment)env;
@@ -323,27 +303,17 @@ namespace BindingsGeneration
         {
         }
 
-        /// <summary>
-        /// Marshals the specified class declaration.
-        /// </summary>
-        /// <param name="classDecl">The class declaration.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
-        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        /// <inheritdoc/>
+        public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
         {
-            if (decl is not ClassDecl classDecl)
+            if (baseDecl is not ClassDecl classDecl)
             {
-                throw new ArgumentException("The provided decl must be a ClassDecl.", nameof(decl));
+                throw new ArgumentException("The provided decl must be a ClassDecl.", nameof(baseDecl));
             }
             return new TypeEnvironment(classDecl, typeDatabase);
         }
 
-        /// <summary>
-        /// Emits the necessary code for the specified environment.
-        /// </summary>
-        /// <param name="csWriter">The IndentedTextWriter instance.</param>
-        /// <param name="env">The environment.</param>
-        /// <param name="conductor">The conductor instance.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
+        /// <inheritdoc/>
         public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
         {
             var classEnv = (TypeEnvironment)env;
@@ -610,27 +580,17 @@ namespace BindingsGeneration
         {
         }
 
-        /// <summary>
-        /// Marshals the specified protocol declaration.
-        /// </summary>
-        /// <param name="protocolDecl">The protocol declaration.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
-        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        /// <inheritdoc/>
+        public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
         {
-            if (decl is not ProtocolDecl protocolDecl)
+            if (baseDecl is not ProtocolDecl protocolDecl)
             {
-                throw new ArgumentException("The provided decl must be a ProtocolDecl.", nameof(decl));
+                throw new ArgumentException("The provided decl must be a ProtocolDecl.", nameof(baseDecl));
             }
             return new TypeEnvironment(protocolDecl, typeDatabase);
         }
 
-        /// <summary>
-        /// Emits the code for the specified environment.
-        /// </summary>
-        /// <param name="writer">The IndentedTextWriter instance.</param>
-        /// <param name="env">The environment.</param>
-        /// <param name="conductor">The conductor instance.</param>
-        /// <param name="typeDatabase">The type database instance.</param>
+        /// <inheritdoc/>
         public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
         {
             var protocolEnv = (TypeEnvironment)env;

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -531,4 +531,78 @@ namespace BindingsGeneration
 
         }
     }
+
+    /// <summary>
+    /// Factory class for creating instances of ProtocolHandler.
+    /// </summary>
+    public class ProtocolHandlerFactory : IFactory<BaseDecl, ITypeHandler>
+    {
+        /// <summary>
+        /// Determines if the factory handles the specified declaration.
+        /// </summary>
+        /// <param name="decl">The base declaration.</param>
+        public bool Handles(BaseDecl decl)
+        {
+            return decl is ProtocolDecl;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of ProtocolHandler.
+        /// </summary>
+        public ITypeHandler Construct()
+        {
+            return new ProtocolHandler();
+        }
+    }
+
+    /// <summary>
+    /// Handler class for protocol declarations.
+    /// </summary>
+    public class ProtocolHandler : BaseHandler, ITypeHandler
+    {
+        public ProtocolHandler()
+        {
+        }
+
+        /// <summary>
+        /// Marshals the specified protocol declaration.
+        /// </summary>
+        /// <param name="protocolDecl">The protocol declaration.</param>
+        /// <param name="typeDatabase">The type database instance.</param>
+        public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
+        {
+            if (decl is not ProtocolDecl structDecl)
+            {
+                throw new ArgumentException("The provided decl must be a ProtocolDecl.", nameof(decl));
+            }
+            return new TypeEnvironment(structDecl, typeDatabase);
+        }
+
+        /// <summary>
+        /// Emits the code for the specified environment.
+        /// </summary>
+        /// <param name="writer">The IndentedTextWriter instance.</param>
+        /// <param name="env">The environment.</param>
+        /// <param name="conductor">The conductor instance.</param>
+        /// <param name="typeDatabase">The type database instance.</param>
+        public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
+        {
+            var protocolEnv = (TypeEnvironment)env;
+            var protocolDecl = (ProtocolDecl)protocolEnv.TypeDecl;
+
+            var interfaceName = NameProvider.GetInterfaceName(protocolDecl.Name);
+
+            csWriter.WriteLine($"public interface {interfaceName}");
+            csWriter.WriteLine("{");
+            csWriter.Indent++;
+
+            // TODO: Implement protocol methods and properties
+            // base.HandleBaseDecl(writer, protocolDecl.Types, conductor, env.TypeDatabase);
+            // base.HandleBaseDecl(writer, protocolDecl.Methods, conductor, env.TypeDatabase);
+
+            csWriter.Indent--;
+            csWriter.WriteLine("}");
+            csWriter.WriteLine();
+        }
+    }
 }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -553,7 +553,7 @@ namespace BindingsGeneration
             {
                 var protocol = NameProvider.GetInterfaceName(conformance.ProtocolSpec.NameWithoutModule);
                 var typeRecord = _typeDatabase.GetTypeRecordOrThrow(_moduleDecl.Name, _structDecl.FullyQualifiedNameWithoutModule);
-                var protocolConformanceSymbol = protocolConformanceDescriptors[(new NamedTypeSpec(_structDecl.FullyQualifiedName), conformance.ProtocolSpec)]; // TODO: Get rid of TypeSpec https://github.com/dotnet/runtimelab/issues/2889
+                var protocolConformanceSymbol = protocolConformanceDescriptors.GetValueOrDefault((new NamedTypeSpec(_structDecl.FullyQualifiedName), conformance.ProtocolSpec)); // TODO: Get rid of TypeSpec https://github.com/dotnet/runtimelab/issues/2889
 
                 entries.Add($"{{typeof({protocol}), \"{protocolConformanceSymbol}\"}}");
             }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -601,11 +601,11 @@ namespace BindingsGeneration
         /// <param name="typeDatabase">The type database instance.</param>
         public IEnvironment Marshal(BaseDecl decl, ITypeDatabase typeDatabase)
         {
-            if (decl is not ProtocolDecl structDecl)
+            if (decl is not ProtocolDecl protocolDecl)
             {
                 throw new ArgumentException("The provided decl must be a ProtocolDecl.", nameof(decl));
             }
-            return new TypeEnvironment(structDecl, typeDatabase);
+            return new TypeEnvironment(protocolDecl, typeDatabase);
         }
 
         /// <summary>

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -519,28 +519,44 @@ namespace BindingsGeneration
         /// </summary>
         private void WriteGetProtocolConformanceDescriptor()
         {
+            WriteStaticConstructor();
             var libPath = _typeDatabase.GetLibraryPath(_moduleDecl.Name);
             var text = $$"""
             static ProtocolConformanceDescriptor ISwiftObject.GetProtocolConformanceDescriptor<TProtocol>()
                 where TProtocol : class
             {
-                var dispatch = new Dictionary<Type, string>
-                {
-                    {{GenerateGetProtocolConformanceDictionaryEntries()}}
-                };
-
-                if (!dispatch.ContainsKey(typeof(TProtocol)))
+                if (!_protocolConformanceSymbols.TryGetValue(typeof(TProtocol), out var symbolName))
                 {
                     throw new SwiftRuntimeException($"Attempted to retrieve protocol conformance descriptor for type {{_structDecl.Name}} and protocol {typeof(TProtocol).Name}, but no conformance was found.");
                 }
 
-                return ProtocolConformanceDescriptor.LoadFromSymbol("{{libPath}}", dispatch[typeof(TProtocol)]);
+                return ProtocolConformanceDescriptor.LoadFromSymbol("{{libPath}}", symbolName);
             }
             """;
 
             _writer.WriteLines(text);
             _writer.WriteLine();
+        }
 
+        /// <summary>
+        /// Writes the static constructor for the struct.
+        /// </summary>
+        private void WriteStaticConstructor()
+        {
+            var text = $$"""
+            private static Dictionary<Type, string> _protocolConformanceSymbols;
+
+            static {{_structDecl.Name}}()
+            {
+                _protocolConformanceSymbols = new Dictionary<Type, string>
+                {
+                    {{GenerateGetProtocolConformanceDictionaryEntries()}}
+                };
+            }
+            """;
+
+            _writer.WriteLines(text);
+            _writer.WriteLine();
         }
 
         private string GenerateGetProtocolConformanceDictionaryEntries()

--- a/src/Swift.Bindings/src/Marshaler/Conductor.cs
+++ b/src/Swift.Bindings/src/Marshaler/Conductor.cs
@@ -24,6 +24,7 @@ namespace BindingsGeneration
         private readonly List<ITypeHandlerFactory> _typeHandlerFactories = [
             new NonFrozenStructHandlerFactory(),
             new FrozenStructHandlerFactory(),
+            new ProtocolHandlerFactory(),
             new ClassHandlerFactory(),
         ];
         private readonly List<IFieldHandlerFactory> _fieldHandlerFactories = [];

--- a/src/Swift.Bindings/src/Marshaler/Conductor.cs
+++ b/src/Swift.Bindings/src/Marshaler/Conductor.cs
@@ -29,6 +29,7 @@ namespace BindingsGeneration
         ];
         private readonly List<IFieldHandlerFactory> _fieldHandlerFactories = [];
         private readonly List<IMethodHandlerFactory> _methodHandlerFactories = [
+            new ConstructorHandlerFactory(),
             new MethodHandlerFactory(),
         ];
         private readonly List<IArgumentHandlerFactory> _argumentHandlerFactories = [];

--- a/src/Swift.Bindings/src/Marshaler/IHandler.cs
+++ b/src/Swift.Bindings/src/Marshaler/IHandler.cs
@@ -102,6 +102,18 @@ namespace BindingsGeneration
                         Console.WriteLine($"No handler found for method {classDecl.Name}");
                     }
                 }
+                else if (baseDecl is ProtocolDecl protocolDecl)
+                {
+                    if (conductor.TryGetTypeHandler(protocolDecl, out var handler))
+                    {
+                        var env = handler.Marshal(protocolDecl, typeDatabase);
+                        handler.Emit(csWriter, swiftWriter, env, conductor);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"No handler found for method {protocolDecl.Name}");
+                    }
+                }
                 else if (baseDecl is MethodDecl methodDecl)
                 {
                     if (conductor.TryGetMethodHandler(methodDecl, out var handler))

--- a/src/Swift.Bindings/src/Marshaler/IHandler.cs
+++ b/src/Swift.Bindings/src/Marshaler/IHandler.cs
@@ -15,13 +15,15 @@ namespace BindingsGeneration
         /// Marshals the specified base declaration.
         /// </summary>
         /// <param name="baseDecl">The base declaration.</param>
+        /// <param name="typeDatabase">The type database instance.</param>
         /// <returns>The environment corresponding to the base declaration.</returns>
         IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase);
 
         /// <summary>
         /// Emits the necessary code for the specified environment.
         /// </summary>
-        /// <param name="writer">The IndentedTextWriter instance.</param>
+        /// <param name="csWriter">The csWriter instance.</param>
+        /// <param name="swiftWriter">The swiftWriter instance.</param>
         /// <param name="env">The environment.</param>
         /// <param name="conductor">The conductor instance.</param>
         void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor);

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -43,6 +43,16 @@ public static class NameProvider
     }
 
     /// <summary>
+    /// Provides the name of the interface based on a protocol name.
+    /// </summary>
+    /// <param name="protocolName">The protocol name.</param>
+    /// <returns>The name of the interface.</returns>
+    public static string GetInterfaceName(string protocolName)
+    {
+        return $"ISwift{protocolName}";
+    }
+
+    /// <summary>
     /// Provides the mapping of generic type parameters.
     /// </summary>
     /// <param name="methodDecl">The method declaration.</param>

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -10,7 +10,7 @@ namespace BindingsGeneration;
 /// <param name="PlaceholderName">The name of the generic type parameter e.g. T0.</param>
 /// <param name="MetadataName">The name of the metadata type parameter.</param>
 /// <param name="PayloadName">The name of the payload type parameter. </param>
-public record struct GenericParameterCSName(string PlaceholderName, string MetadataName, string PayloadName);
+public record struct GenericParameterCSName(string PlaceholderName);
 
 /// <summary>
 /// Provides methods for generating names.
@@ -61,8 +61,10 @@ public static class NameProvider
         methodDecl.GenericParameters
             .Select((param, i) => (param, i))
             .ToDictionary(x => x.param.TypeName, x => new GenericParameterCSName(
-                PlaceholderName: $"T{x.i}",
-                MetadataName: $"T{x.i}Metadata",
-                PayloadName: $"T{x.i}Payload"
+                PlaceholderName: $"T{x.i}"
             ));
+
+    public static string GetMetadataName(string typeName) => $"{typeName}Metadata";
+    public static string GetPayloadName(string argumentName) => $"{argumentName}Payload";
+    public static string GetProtocolWitnessTableName(string typeName, string protocolName) => $"{typeName}{protocolName}PWT";
 }

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -8,8 +8,6 @@ namespace BindingsGeneration;
 /// Represents a generic parameter name mapping.
 /// </summary>
 /// <param name="TypeParameter">The name of the generic type parameter e.g. T0.</param>
-/// <param name="MetadataName">The name of the metadata type parameter.</param>
-/// <param name="PayloadName">The name of the payload type parameter. </param>
 public record struct GenericParameterCSName(string TypeParameter);
 
 /// <summary>

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -7,10 +7,10 @@ namespace BindingsGeneration;
 /// <summary>
 /// Represents a generic parameter name mapping.
 /// </summary>
-/// <param name="PlaceholderName">The name of the generic type parameter e.g. T0.</param>
+/// <param name="TypeParameter">The name of the generic type parameter e.g. T0.</param>
 /// <param name="MetadataName">The name of the metadata type parameter.</param>
 /// <param name="PayloadName">The name of the payload type parameter. </param>
-public record struct GenericParameterCSName(string PlaceholderName);
+public record struct GenericParameterCSName(string TypeParameter);
 
 /// <summary>
 /// Provides methods for generating names.
@@ -61,7 +61,7 @@ public static class NameProvider
         methodDecl.GenericParameters
             .Select((param, i) => (param, i))
             .ToDictionary(x => x.param.TypeName, x => new GenericParameterCSName(
-                PlaceholderName: $"T{x.i}"
+                TypeParameter: $"T{x.i}"
             ));
 
     public static string GetMetadataName(string typeName) => $"{typeName}Metadata";

--- a/src/Swift.Bindings/src/Model/TypeDecl/ClassDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ClassDecl.cs
@@ -11,6 +11,6 @@ namespace BindingsGeneration
         /// <summary>
         /// Protocol conformances.
         /// </summary>
-        public required List<Conformance> Conformances { get; set; }
+        public required List<ProtocolConformance> Conformances { get; set; }
     }
 }

--- a/src/Swift.Bindings/src/Model/TypeDecl/ClassDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ClassDecl.cs
@@ -8,5 +8,9 @@ namespace BindingsGeneration
     /// </summary>
     public sealed record ClassDecl : TypeDecl
     {
+        /// <summary>
+        /// Protocol conformances.
+        /// </summary>
+        public required List<Conformance> Conformances { get; set; }
     }
 }

--- a/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
@@ -12,5 +12,5 @@ namespace BindingsGeneration;
 public record GenericArgumentDecl(
     string TypeName,
     string SugaredTypeName,
-    List<Conformance> Constraints
+    List<ProtocolConformance> Constraints
 );

--- a/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
@@ -14,35 +14,3 @@ public record GenericArgumentDecl(
     string SugaredTypeName,
     List<Conformance> Constraints
 );
-
-/// <summary>
-/// Represents a generic argument declaration.
-/// </summary>
-/// <param name="TargetType">The target type of the conformance</param>
-/// <param name="ProtocolName">The protocol name of the conformance</param>
-public abstract record Conformance(
-    string TargetType,
-    string ProtocolName
-);
-
-/// <summary>
-/// Represents a protocol conformance.
-/// </summary>
-/// <param name="TargetType">The target type of the conformance</param>
-/// <param name="ProtocolName">The protocol name of the conformance</param>
-public record ProtocolConformance(
-    string TargetType,
-    string ProtocolName
-) : Conformance(TargetType, ProtocolName);
-
-/// <summary>
-/// Represents an associated type conformance.
-/// </summary>
-/// <param name="TargetType">The target type of the conformance</param>
-/// <param name="ProtocolName">The protocol name of the conformance</param>
-/// <param name="AssociatedTypeName">The associated type name of the conformance</param>
-public record AssociatedTypeConformance(
-    string TargetType,
-    string ProtocolName,
-    string AssociatedTypeName
-) : Conformance(TargetType, ProtocolName);

--- a/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
@@ -4,30 +4,28 @@ namespace BindingsGeneration;
 /// Represents a generic argument declaration.
 /// </summary>
 /// <param name="TargetType">The target type of the conformance</param>
-/// <param name="ProtocolName">The protocol name of the conformance</param>
+/// <param name="ProtocolSpec">The protocol spec of the conformance</param>
 public abstract record Conformance(
     string TargetType,
-    string ProtocolName
+    NamedTypeSpec ProtocolSpec
 );
 
 /// <summary>
 /// Represents a protocol conformance.
 /// </summary>
 /// <param name="TargetType">The target type of the conformance</param>
-/// <param name="ProtocolName">The protocol name of the conformance</param>
+/// <param name="ProtocolSpec">The protocol spec of the conformance</param>
 public record ProtocolConformance(
     string TargetType,
-    string ProtocolName
-) : Conformance(TargetType, ProtocolName);
+    NamedTypeSpec ProtocolSpec
+) : Conformance(TargetType, ProtocolSpec);
 
 /// <summary>
 /// Represents an associated type conformance.
 /// </summary>
-/// <param name="TargetType">The target type of the conformance</param>
-/// <param name="ProtocolName">The protocol name of the conformance</param>
-/// <param name="AssociatedTypeName">The associated type name of the conformance</param>
+/// <param name="Path">The path to the associated type</param>
+/// <param name="ProtocolSpec">The protocol spec of the conformance</param>
 public record AssociatedTypeConformance(
-    string TargetType,
-    string ProtocolName,
-    string AssociatedTypeName
-) : Conformance(TargetType, ProtocolName);
+    string Path,
+    NamedTypeSpec ProtocolSpec
+) : Conformance(Path, ProtocolSpec);

--- a/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
@@ -1,0 +1,33 @@
+namespace BindingsGeneration;
+
+/// <summary>
+/// Represents a generic argument declaration.
+/// </summary>
+/// <param name="TargetType">The target type of the conformance</param>
+/// <param name="ProtocolName">The protocol name of the conformance</param>
+public abstract record Conformance(
+    string TargetType,
+    string ProtocolName
+);
+
+/// <summary>
+/// Represents a protocol conformance.
+/// </summary>
+/// <param name="TargetType">The target type of the conformance</param>
+/// <param name="ProtocolName">The protocol name of the conformance</param>
+public record ProtocolConformance(
+    string TargetType,
+    string ProtocolName
+) : Conformance(TargetType, ProtocolName);
+
+/// <summary>
+/// Represents an associated type conformance.
+/// </summary>
+/// <param name="TargetType">The target type of the conformance</param>
+/// <param name="ProtocolName">The protocol name of the conformance</param>
+/// <param name="AssociatedTypeName">The associated type name of the conformance</param>
+public record AssociatedTypeConformance(
+    string TargetType,
+    string ProtocolName,
+    string AssociatedTypeName
+) : Conformance(TargetType, ProtocolName);

--- a/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
@@ -1,31 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace BindingsGeneration;
 
-/// <summary>
-/// Represents a generic argument declaration.
-/// </summary>
-/// <param name="TargetType">The target type of the conformance</param>
-/// <param name="ProtocolSpec">The protocol spec of the conformance</param>
-public abstract record Conformance(
-    string TargetType,
-    NamedTypeSpec ProtocolSpec
-);
 
 /// <summary>
 /// Represents a protocol conformance.
 /// </summary>
-/// <param name="TargetType">The target type of the conformance</param>
+/// <param name="TargetType">The type spec of the target type of the conformance</param>
 /// <param name="ProtocolSpec">The protocol spec of the conformance</param>
 public record ProtocolConformance(
-    string TargetType,
+    NamedTypeSpec TargetType,
     NamedTypeSpec ProtocolSpec
-) : Conformance(TargetType, ProtocolSpec);
-
-/// <summary>
-/// Represents an associated type conformance.
-/// </summary>
-/// <param name="Path">The path to the associated type</param>
-/// <param name="ProtocolSpec">The protocol spec of the conformance</param>
-public record AssociatedTypeConformance(
-    string Path,
-    NamedTypeSpec ProtocolSpec
-) : Conformance(Path, ProtocolSpec);
+);

--- a/src/Swift.Bindings/src/Model/TypeDecl/ProtocolDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ProtocolDecl.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration;
+
+public sealed record ProtocolDecl : TypeDecl
+{
+}

--- a/src/Swift.Bindings/src/Model/TypeDecl/StructDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/StructDecl.cs
@@ -11,5 +11,10 @@ namespace BindingsGeneration
         public required bool IsBlittable { get; set; }
 
         public required bool IsFrozen { get; set; }
+
+        /// <summary>
+        /// Protocol conformances.
+        /// </summary>
+        public required List<Conformance> Conformances { get; set; }
     }
 }

--- a/src/Swift.Bindings/src/Model/TypeDecl/StructDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/StructDecl.cs
@@ -15,6 +15,6 @@ namespace BindingsGeneration
         /// <summary>
         /// Protocol conformances.
         /// </summary>
-        public required List<Conformance> Conformances { get; set; }
+        public required List<ProtocolConformance> Conformances { get; set; }
     }
 }

--- a/src/Swift.Bindings/src/Model/TypeDecl/TypeDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/TypeDecl.cs
@@ -27,10 +27,5 @@ namespace BindingsGeneration
         /// Types declarations within the base declaration.
         /// </summary>
         public required List<TypeDecl> Types { get; set; }
-
-        /// <summary>
-        /// Protocol conformances.
-        /// </summary>
-        public required List<Conformance> Conformances { get; set; }
     }
 }

--- a/src/Swift.Bindings/src/Model/TypeDecl/TypeDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/TypeDecl.cs
@@ -27,5 +27,10 @@ namespace BindingsGeneration
         /// Types declarations within the base declaration.
         /// </summary>
         public required List<TypeDecl> Types { get; set; }
+
+        /// <summary>
+        /// Protocol conformances.
+        /// </summary>
+        public required List<Conformance> Conformances { get; set; }
     }
 }

--- a/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
+++ b/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
@@ -72,7 +72,7 @@ public class GenericSignatureParser
     /// Parses a constraint clause into a Conformance object.
     /// </summary>
     /// <param name="clause">The constraint clause to parse.</param>
-    /// <returns>A Conformance object.</returns>
+    /// <returns>A Conformance object. Null if the constraint refers to the associated type.</returns>
     private static ProtocolConformance? ParseConstraint(string clause)
     {
         var parts = clause.Split(new[] { ":", "==" }, StringSplitOptions.TrimEntries);

--- a/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
+++ b/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
@@ -35,7 +35,7 @@ public class GenericSignatureParser
             new GenericArgumentDecl(
                 typeName,
                 paramMap[typeName],
-                constraints.Where(c => c.TargetType.StartsWith(typeName)).ToList()
+                constraints.Where(c => c.TargetType.NameWithoutModule.StartsWith(typeName)).ToList()
             )
         ).ToList();
     }
@@ -59,13 +59,13 @@ public class GenericSignatureParser
     /// </summary>
     /// <param name="signature">The generic signature to extract constraints from.</param>
     /// <returns>A list of constraints.</returns>
-    private static List<Conformance> ExtractConstraints(string signature)
+    private static List<ProtocolConformance> ExtractConstraints(string signature)
     {
         var whereIndex = signature.IndexOf("where", StringComparison.OrdinalIgnoreCase);
         if (whereIndex == -1)
-            return new List<Conformance>();
+            return new List<ProtocolConformance>();
 
-        return signature[(whereIndex + "where".Length)..].Split(',').Select(ParseConstraint).ToList();
+        return [.. signature[(whereIndex + "where".Length)..].Split(',').Select(ParseConstraint).Where(c => c is not null).Cast<ProtocolConformance>()];
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ public class GenericSignatureParser
     /// </summary>
     /// <param name="clause">The constraint clause to parse.</param>
     /// <returns>A Conformance object.</returns>
-    private static Conformance ParseConstraint(string clause)
+    private static ProtocolConformance? ParseConstraint(string clause)
     {
         var parts = clause.Split(new[] { ":", "==" }, StringSplitOptions.TrimEntries);
         if (parts.Length != 2)
@@ -84,6 +84,8 @@ public class GenericSignatureParser
         var target = parts[0];
         var protocol = parts[1];
 
-        return target.Contains('.') ? new AssociatedTypeConformance(target, new NamedTypeSpec(protocol)) : new ProtocolConformance(target, new NamedTypeSpec(protocol));
+        if (!target.Contains(".")) return new ProtocolConformance(new NamedTypeSpec(target), new NamedTypeSpec(protocol));
+
+        return null;
     }
 }

--- a/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
+++ b/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
@@ -76,8 +76,14 @@ public class GenericSignatureParser
     private static Conformance ParseConstraint(string clause)
     {
         var parts = clause.Split(new[] { ":", "==" }, StringSplitOptions.TrimEntries);
-        return parts[0].Contains('.')
-            ? new AssociatedTypeConformance(parts[0].Split('.')[0], parts[1], parts[0].Split('.')[1])
-            : new ProtocolConformance(parts[0], parts[1]);
+        if (parts.Length != 2)
+        {
+            throw new InvalidOperationException($"Invalid constraint clause: {clause}");
+        }
+
+        var target = parts[0];
+        var protocol = parts[1];
+
+        return target.Contains('.') ? new AssociatedTypeConformance(target, new NamedTypeSpec(protocol)) : new ProtocolConformance(target, new NamedTypeSpec(protocol));
     }
 }

--- a/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
+++ b/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
@@ -65,7 +65,15 @@ public class GenericSignatureParser
         if (whereIndex == -1)
             return new List<ProtocolConformance>();
 
-        return [.. signature[(whereIndex + "where".Length)..].Split(',').Select(ParseConstraint).Where(c => c is not null).Cast<ProtocolConformance>()];
+        var constraintsSection = signature[(whereIndex + "where".Length)..];
+        var constraints = constraintsSection.Split(',');
+
+        var parsedConstraints = constraints
+            .Select(ParseConstraint)
+            .Where(constraint => constraint is not null)
+            .Cast<ProtocolConformance>();
+
+        return [.. parsedConstraints];
     }
 
     /// <summary>

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -362,7 +362,7 @@ namespace BindingsGeneration
             return new ClassDecl
             {
                 Name = ExtractUniqueName(node.Name),
-                FullyQualifiedName = ExtractFullyQualifiedName(parentDecl.FullyQualifiedName, node.Name),
+                FullyQualifiedName = fullyQualifiedName,
                 MangledName = node.MangledName,
                 Fields = new List<FieldDecl>(),
                 Methods = new List<MethodDecl>(),

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -390,7 +390,6 @@ namespace BindingsGeneration
                 Fields = new List<FieldDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
-                Conformances = new List<Conformance>(),
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl
             };

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -286,6 +286,10 @@ namespace BindingsGeneration
                     decl = CreateClassDecl(node, parentDecl, moduleDecl);
                     break;
 
+                case "Protocol":
+                    decl = CreateProtocolDecl(node, parentDecl, moduleDecl);
+                    break;
+
                 default:
                     if (_verbose > 1)
                         Console.WriteLine($"Unsupported declaration type '{node.DeclKind} {node.Name}' encountered.");
@@ -342,6 +346,28 @@ namespace BindingsGeneration
         private ClassDecl CreateClassDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
             return new ClassDecl
+            {
+                Name = ExtractUniqueName(node.Name),
+                FullyQualifiedName = ExtractFullyQualifiedName(parentDecl.FullyQualifiedName, node.Name),
+                MangledName = node.MangledName,
+                Fields = new List<FieldDecl>(),
+                Methods = new List<MethodDecl>(),
+                Types = new List<TypeDecl>(),
+                ParentDecl = parentDecl,
+                ModuleDecl = moduleDecl
+            };
+        }
+
+        /// <summary>
+        /// Creates a protocol declaration from a node.
+        /// </summary>
+        /// <param name="node">The node representing the protocol declaration.</param>
+        /// <param name="parentDecl">The parent declaration.</param>
+        /// <param name="moduleDecl">The module declaration.</param>
+        /// <returns>The protocol declaration.</returns>
+        private ProtocolDecl CreateProtocolDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
+        {
+            return new ProtocolDecl
             {
                 Name = ExtractUniqueName(node.Name),
                 FullyQualifiedName = ExtractFullyQualifiedName(parentDecl.FullyQualifiedName, node.Name),

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -55,6 +55,7 @@ namespace BindingsGeneration
         public required string? sugared_genericSig { get; set; }
         public required bool? throwing { get; set; }
         public required IEnumerable<Node> Children { get; set; } = Enumerable.Empty<Node>();
+        public required IEnumerable<Node> Conformances { get; set; } = Enumerable.Empty<Node>();
     }
 
     /// <summary>
@@ -312,6 +313,21 @@ namespace BindingsGeneration
             return decl;
         }
 
+        private Conformance? HandleConformance(Node node, string typeName)
+        {
+            if (node.Children.Count() > 0)
+            {
+                Console.WriteLine($"Protocols with associated types not supported. Skipping.");
+            }
+
+            var reduction = demangler.Run(node.MangledName) as TypeSpecReduction ?? throw new InvalidOperationException($"Invalid demangling result for '{node.MangledName}'.");
+            var protocolTypeSpec = reduction.TypeSpec as NamedTypeSpec ?? throw new InvalidOperationException($"TypeSpec '{reduction.TypeSpec}' is not a NamedTypeSpec");
+
+            var conformance = new ProtocolConformance(typeName, protocolTypeSpec.Name);
+
+            return conformance;
+        }
+
         /// <summary>
         /// Creates a struct declaration from a node.
         /// </summary>
@@ -321,14 +337,16 @@ namespace BindingsGeneration
         /// <returns>The struct declaration.</returns>
         private StructDecl CreateStructDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl, bool hasFrozenAttribute)
         {
+            var fullyQualifiedName = ExtractFullyQualifiedName(parentDecl.FullyQualifiedName, node.Name);
             return new StructDecl
             {
                 Name = ExtractUniqueName(node.Name),
-                FullyQualifiedName = ExtractFullyQualifiedName(parentDecl.FullyQualifiedName, node.Name),
+                FullyQualifiedName = fullyQualifiedName,
                 MangledName = node.MangledName,
                 Fields = new List<FieldDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
+                Conformances = [.. node.Conformances.Select(x => HandleConformance(x, fullyQualifiedName)).Where(x => x is not null).Cast<Conformance>()],
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl,
                 IsFrozen = hasFrozenAttribute,
@@ -345,6 +363,7 @@ namespace BindingsGeneration
         /// <returns>The class declaration.</returns>
         private ClassDecl CreateClassDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
+            var fullyQualifiedName = ExtractFullyQualifiedName(parentDecl.FullyQualifiedName, node.Name);
             return new ClassDecl
             {
                 Name = ExtractUniqueName(node.Name),
@@ -353,6 +372,7 @@ namespace BindingsGeneration
                 Fields = new List<FieldDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
+                Conformances = [.. node.Conformances.Select(x => HandleConformance(x, fullyQualifiedName)).Where(x => x is not null).Cast<Conformance>()],
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl
             };
@@ -375,6 +395,7 @@ namespace BindingsGeneration
                 Fields = new List<FieldDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
+                Conformances = new List<Conformance>(),
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl
             };

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -313,13 +313,8 @@ namespace BindingsGeneration
             return decl;
         }
 
-        private Conformance? HandleConformance(Node node, string typeName)
+        private Conformance HandleConformance(Node node, string typeName)
         {
-            if (node.Children.Count() > 0)
-            {
-                Console.WriteLine($"Protocols with associated types not supported. Skipping.");
-            }
-
             var reduction = demangler.Run(node.MangledName) as TypeSpecReduction ?? throw new InvalidOperationException($"Invalid demangling result for '{node.MangledName}'.");
             var protocolTypeSpec = reduction.TypeSpec as NamedTypeSpec ?? throw new InvalidOperationException($"TypeSpec '{reduction.TypeSpec}' is not a NamedTypeSpec");
 
@@ -346,7 +341,7 @@ namespace BindingsGeneration
                 Fields = new List<FieldDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
-                Conformances = [.. node.Conformances.Select(x => HandleConformance(x, fullyQualifiedName)).Where(x => x is not null).Cast<Conformance>()],
+                Conformances = [.. node.Conformances.Select(x => HandleConformance(x, fullyQualifiedName))],
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl,
                 IsFrozen = hasFrozenAttribute,
@@ -372,7 +367,7 @@ namespace BindingsGeneration
                 Fields = new List<FieldDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
-                Conformances = [.. node.Conformances.Select(x => HandleConformance(x, fullyQualifiedName)).Where(x => x is not null).Cast<Conformance>()],
+                Conformances = [.. node.Conformances.Select(x => HandleConformance(x, fullyQualifiedName))],
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl
             };

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -323,7 +323,7 @@ namespace BindingsGeneration
             var reduction = demangler.Run(node.MangledName) as TypeSpecReduction ?? throw new InvalidOperationException($"Invalid demangling result for '{node.MangledName}'.");
             var protocolTypeSpec = reduction.TypeSpec as NamedTypeSpec ?? throw new InvalidOperationException($"TypeSpec '{reduction.TypeSpec}' is not a NamedTypeSpec");
 
-            var conformance = new ProtocolConformance(typeName, protocolTypeSpec.Name);
+            var conformance = new ProtocolConformance(typeName, protocolTypeSpec);
 
             return conformance;
         }

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -313,12 +313,12 @@ namespace BindingsGeneration
             return decl;
         }
 
-        private Conformance HandleConformance(Node node, string typeName)
+        private ProtocolConformance HandleConformance(Node node, string typeName)
         {
             var reduction = demangler.Run(node.MangledName) as TypeSpecReduction ?? throw new InvalidOperationException($"Invalid demangling result for '{node.MangledName}'.");
             var protocolTypeSpec = reduction.TypeSpec as NamedTypeSpec ?? throw new InvalidOperationException($"TypeSpec '{reduction.TypeSpec}' is not a NamedTypeSpec");
 
-            var conformance = new ProtocolConformance(typeName, protocolTypeSpec);
+            var conformance = new ProtocolConformance(new NamedTypeSpec(typeName), protocolTypeSpec);
 
             return conformance;
         }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
@@ -107,5 +107,17 @@ namespace BindingsGeneration.FunctionalTests
             var result = GenericTests.AcceptsMultipleGenericParamsWithProtocols(a, b);
             Assert.Equal((43 + 177) + (43 * 177) + (531 - 133) + (531 / 133), result);
         }
+
+        [Fact]
+        public void TestFunctionWithGenericParamConstrainedToPAT()
+        {
+            var a = new IntContainer1(42);
+            var result = GenericTests.AcceptsIntContainer(a);
+            Assert.Equal(42 * 2, result);
+
+            var b = new IntContainer2(42);
+            var result2 = GenericTests.AcceptsIntContainer(b);
+            Assert.Equal(42 * 4, result2);
+        }
     }
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
@@ -82,5 +82,30 @@ namespace BindingsGeneration.FunctionalTests
             var result2 = GenericTests.AcceptsGenericParameterAndReturnsGeneric(b);
             // No deep comparison for non-frozen structs yet
         }
+
+        [Fact]
+        public void TestFunctionTakesGenericParameterConstrainedToProtocol()
+        {
+            var a = new SummableStruct(2, 40);
+            var result = GenericTests.AcceptsSummable(a);
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public void TestFunctionTakesGenericParameterConstrainedToMultipleProtocols()
+        {
+            var a = new StructWithMultipleProtocols(43, 177);
+            var result = GenericTests.AcceptsMultipleProtocols(a);
+            Assert.Equal(43 + 177 + 43 - 177 + 43 * 177, result);
+        }
+
+        [Fact]
+        public void TestFunctionTakesMultipleGenericParametersConstrainedToMultipleProtocols()
+        {
+            var a = new StructWithMultipleProtocols(43, 177);
+            var b = new StructWithMultipleProtocols(531, 133);
+            var result = GenericTests.AcceptsMultipleGenericParamsWithProtocols(a, b);
+            Assert.Equal((43 + 177) + (43 * 177) + (531 - 133) + (531 / 133), result);
+        }
     }
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
@@ -127,6 +127,15 @@ namespace BindingsGeneration.FunctionalTests
         }
 
         [Fact]
+        public void TestFunctionTakesMultipleGenericParametersOfDifferentTypesConstrainedByTheSameProtocol()
+        {
+            var a = new SummableStruct(2, 40);
+            var b = new AnotherSummableStruct(3, 39);
+            var result = GenericTests.AcceptsMultipleGenericParamsOfDifferentTypesConstrainedByTheSameProtocol(a, b);
+            Assert.Equal(42 + 42, result);
+        }
+
+        [Fact]
         public void TestFunctionWithGenericParamConstrainedToPAT()
         {
             var a = new IntContainer1(42);

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
@@ -84,11 +84,29 @@ namespace BindingsGeneration.FunctionalTests
         }
 
         [Fact]
+        public void TestFunctionTakesMultipleGenericParametersOfSameType()
+        {
+            var a = new FrozenStruct(1, 2);
+            var b = new FrozenStruct(3, 4);
+            var result = GenericTests.AcceptsTwoValuesOfTheSameGenericType(a, b);
+            Assert.Equal(a, result);
+        }
+
+        [Fact]
         public void TestFunctionTakesGenericParameterConstrainedToProtocol()
         {
             var a = new SummableStruct(2, 40);
             var result = GenericTests.AcceptsSummable(a);
             Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public void TestFunctionTakesMultipleGenericParametersOfSameTypeConstrainedToProtocol()
+        {
+            var a = new SummableStruct(2, 40);
+            var b = new SummableStruct(3, 39);
+            var result = GenericTests.AcceptsMultipleGenericParamsOfTheSameTypeConstrainedByProtocol(a, b);
+            Assert.Equal(42 + 42, result);
         }
 
         [Fact]

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
@@ -171,18 +171,6 @@ public struct IntContainer2: Container {
     }
 }
 
-public struct DoubleContainer: Container {
-    public var value: Double
-
-    public init(value: Double) {
-        self.value = value
-    }
-
-    public func increase() -> Double {
-        return value * 2
-    }
-}
-
 public func AcceptsIntContainer<T: Container>(a: T) -> Int where T.Element == Int {
     return a.increase()
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
@@ -114,3 +114,48 @@ public func AcceptsMultipleProtocols<T: Summable & Subtractable & Multiplicable>
 public func AcceptsMultipleGenericParamsWithProtocols<T: Summable & Multiplicable, U: Subtractable & Dividable>(a: T, b: U) -> Int {
     return a.sum() + a.multiply() + b.subtract() + b.divide()
 }
+
+public protocol Container {
+    associatedtype Element
+    func increase() -> Element
+}
+
+public struct IntContainer1: Container {
+    public var value: Int
+
+    public init(value: Int) {
+        self.value = value
+    }
+
+    public func increase() -> Int {
+        return value * 2
+    }
+}
+
+public struct IntContainer2: Container {
+    public var value: Int
+
+    public init(value: Int) {
+        self.value = value
+    }
+
+    public func increase() -> Int {
+        return value * 4
+    }
+}
+
+public struct DoubleContainer: Container {
+    public var value: Double
+
+    public init(value: Double) {
+        self.value = value
+    }
+
+    public func increase() -> Double {
+        return value * 2
+    }
+}
+
+public func AcceptsIntContainer<T: Container>(a: T) -> Int where T.Element == Int {
+    return a.increase()
+}

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
@@ -81,11 +81,30 @@ public struct SummableStruct: Summable {
     }
 }
 
+@frozen 
+public struct AnotherSummableStruct: Summable {
+    public var x: Int
+    public var y: Int
+
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+
+    public func sum() -> Int {
+        return x + y
+    }
+}
+
 public func AcceptsSummable<T: Summable>(a: T) -> Int {
     return a.sum()
 }
 
 public func AcceptsMultipleGenericParamsOfTheSameTypeConstrainedByProtocol<T: Summable>(a: T, b: T) -> Int {
+    return a.sum() + b.sum()
+}
+
+public func AcceptsMultipleGenericParamsOfDifferentTypesConstrainedByTheSameProtocol<T: Summable, U: Summable>(a: T, b: U) -> Int {
     return a.sum() + b.sum()
 }
 

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
@@ -46,6 +46,10 @@ public func AcceptsGenericParameterAndReturnsGeneric<T>(a: T) -> T {
     return a;
 }
 
+public func AcceptsTwoValuesOfTheSameGenericType<T>(a: T, b: T) -> T {
+    return a;
+}
+
 public protocol Summable {
     func sum() -> Int
 }
@@ -79,6 +83,10 @@ public struct SummableStruct: Summable {
 
 public func AcceptsSummable<T: Summable>(a: T) -> Int {
     return a.sum()
+}
+
+public func AcceptsMultipleGenericParamsOfTheSameTypeConstrainedByProtocol<T: Summable>(a: T, b: T) -> Int {
+    return a.sum() + b.sum()
 }
 
 public struct StructWithMultipleProtocols: Summable, Subtractable, Multiplicable, Dividable {

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.swift
@@ -45,3 +45,72 @@ public func AcceptsGenericParameters<T, U> (a: T, b: U) throws -> Int {
 public func AcceptsGenericParameterAndReturnsGeneric<T>(a: T) -> T {
     return a;
 }
+
+public protocol Summable {
+    func sum() -> Int
+}
+
+public protocol Subtractable {
+    func subtract() -> Int
+}
+
+public protocol Multiplicable {
+    func multiply() -> Int
+}
+
+public protocol Dividable {
+    func divide() -> Int
+}
+
+@frozen
+public struct SummableStruct: Summable {
+    public var x: Int
+    public var y: Int
+
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+
+    public func sum() -> Int {
+        return x + y
+    }
+}
+
+public func AcceptsSummable<T: Summable>(a: T) -> Int {
+    return a.sum()
+}
+
+public struct StructWithMultipleProtocols: Summable, Subtractable, Multiplicable, Dividable {
+    public var x: Int
+    public var y: Int
+
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+
+    public func sum() -> Int {
+        return x + y
+    }
+
+    public func subtract() -> Int {
+        return x - y
+    }
+
+    public func multiply() -> Int {
+        return x * y
+    }
+
+    public func divide() -> Int {
+        return x / y
+    }
+}
+
+public func AcceptsMultipleProtocols<T: Summable & Subtractable & Multiplicable>(a: T) -> Int {
+    return a.sum() + a.subtract() + a.multiply()
+}
+
+public func AcceptsMultipleGenericParamsWithProtocols<T: Summable & Multiplicable, U: Subtractable & Dividable>(a: T, b: U) -> Int {
+    return a.sum() + a.multiply() + b.subtract() + b.divide()
+}

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Protocols/ProtocolsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Protocols/ProtocolsTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Swift.ProtocolsTests;
+using Xunit;
+
+namespace BindingsGeneration.FunctionalTests
+{
+    public class ProtocolsTests : IClassFixture<ProtocolsTests.TestFixture>
+    {
+        private readonly TestFixture _fixture;
+
+        public ProtocolsTests(TestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public class TestFixture
+        {
+            static TestFixture()
+            {
+                InitializeResources();
+            }
+
+            private static void InitializeResources()
+            {
+                // Initialize
+            }
+        }
+
+        [Fact]
+        public void ProtocolIsProjected()
+        {
+            // This test is to ensure that the protocol is projected, it just needs to compile
+            Assert.NotNull(typeof(ISwiftPrintable));
+        }
+    }
+}

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Protocols/ProtocolsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Protocols/ProtocolsTests.cs
@@ -32,7 +32,7 @@ namespace BindingsGeneration.FunctionalTests
         public void ProtocolIsProjected()
         {
             // This test is to ensure that the protocol is projected, it just needs to compile
-            Assert.NotNull(typeof(ISwiftPrintable));
+            Assert.True(typeof(ISwiftPrintable).IsInterface);
         }
     }
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Protocols/ProtocolsTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Protocols/ProtocolsTests.swift
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import Foundation
+
+public protocol Printable {
+    func print()
+}

--- a/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
@@ -71,7 +71,7 @@ public class GenericSignatureParserTests
         Assert.Equal("T", decl.SugaredTypeName);
         Assert.Single(decl.Constraints);
         var conformance = Assert.IsType<ProtocolConformance>(decl.Constraints[0]);
-        Assert.Equal("τ_0_0", conformance.TargetType);
+        Assert.Equal("τ_0_0", conformance.TargetType.Name);
         Assert.Equal("Swift.Equatable", conformance.ProtocolSpec.Name);
     }
 
@@ -90,7 +90,7 @@ public class GenericSignatureParserTests
         Assert.Equal("T", first.SugaredTypeName);
         Assert.Single(first.Constraints);
         var firstConformance = Assert.IsType<ProtocolConformance>(first.Constraints[0]);
-        Assert.Equal("τ_0_0", firstConformance.TargetType);
+        Assert.Equal("τ_0_0", firstConformance.TargetType.Name);
         Assert.Equal("Swift.Equatable", firstConformance.ProtocolSpec.Name);
 
         var second = result[1];
@@ -98,7 +98,7 @@ public class GenericSignatureParserTests
         Assert.Equal("U", second.SugaredTypeName);
         Assert.Single(second.Constraints);
         var secondConformance = Assert.IsType<ProtocolConformance>(second.Constraints[0]);
-        Assert.Equal("τ_0_1", secondConformance.TargetType);
+        Assert.Equal("τ_0_1", secondConformance.TargetType.Name);
         Assert.Equal("Swift.Hashable", secondConformance.ProtocolSpec.Name);
     }
 
@@ -114,14 +114,10 @@ public class GenericSignatureParserTests
         var decl = result[0];
         Assert.Equal("τ_0_0", decl.TypeName);
         Assert.Equal("T", decl.SugaredTypeName);
-        Assert.Equal(2, decl.Constraints.Count);
+        Assert.Single(decl.Constraints);
 
         var proto = Assert.IsType<ProtocolConformance>(decl.Constraints[0]);
-        Assert.Equal("τ_0_0", proto.TargetType);
+        Assert.Equal("τ_0_0", proto.TargetType.Name);
         Assert.Equal("SomeProtocol", proto.ProtocolSpec.Name);
-
-        var assoc = Assert.IsType<AssociatedTypeConformance>(decl.Constraints[1]);
-        Assert.Equal("τ_0_0.ID", assoc.TargetType);
-        Assert.Equal("System.Guid", assoc.ProtocolSpec.Name);
     }
 }

--- a/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
@@ -72,7 +72,7 @@ public class GenericSignatureParserTests
         Assert.Single(decl.Constraints);
         var conformance = Assert.IsType<ProtocolConformance>(decl.Constraints[0]);
         Assert.Equal("τ_0_0", conformance.TargetType);
-        Assert.Equal("Swift.Equatable", conformance.ProtocolName);
+        Assert.Equal("Swift.Equatable", conformance.ProtocolSpec.Name);
     }
 
     [Fact]
@@ -91,7 +91,7 @@ public class GenericSignatureParserTests
         Assert.Single(first.Constraints);
         var firstConformance = Assert.IsType<ProtocolConformance>(first.Constraints[0]);
         Assert.Equal("τ_0_0", firstConformance.TargetType);
-        Assert.Equal("Swift.Equatable", firstConformance.ProtocolName);
+        Assert.Equal("Swift.Equatable", firstConformance.ProtocolSpec.Name);
 
         var second = result[1];
         Assert.Equal("τ_0_1", second.TypeName);
@@ -99,7 +99,7 @@ public class GenericSignatureParserTests
         Assert.Single(second.Constraints);
         var secondConformance = Assert.IsType<ProtocolConformance>(second.Constraints[0]);
         Assert.Equal("τ_0_1", secondConformance.TargetType);
-        Assert.Equal("Swift.Hashable", secondConformance.ProtocolName);
+        Assert.Equal("Swift.Hashable", secondConformance.ProtocolSpec.Name);
     }
 
     [Fact]
@@ -118,11 +118,10 @@ public class GenericSignatureParserTests
 
         var proto = Assert.IsType<ProtocolConformance>(decl.Constraints[0]);
         Assert.Equal("τ_0_0", proto.TargetType);
-        Assert.Equal("SomeProtocol", proto.ProtocolName);
+        Assert.Equal("SomeProtocol", proto.ProtocolSpec.Name);
 
         var assoc = Assert.IsType<AssociatedTypeConformance>(decl.Constraints[1]);
-        Assert.Equal("τ_0_0", assoc.TargetType);
-        Assert.Equal("System.Guid", assoc.ProtocolName);
-        Assert.Equal("ID", assoc.AssociatedTypeName);
+        Assert.Equal("τ_0_0.ID", assoc.TargetType);
+        Assert.Equal("System.Guid", assoc.ProtocolSpec.Name);
     }
 }


### PR DESCRIPTION
Fixes #2943 and #2944. This PR adds runtime support for protocol constraints. Those enable to call Swift generic functions which have protocol and PAT constraints on the generic argument. 

As discussed on weekly meeting we are currently not exposing Swift generic constraints to C# on type system level.

The changes include:
- Adding trivial projections of protocols
- Adding support for conformances in type declarations
- Population of `GetProtocolConformanceDescriptor` method on `ISwiftObject`
- Adding pwt retrieval and passing to pinvokes

In order to make the symbol population work I did create a mock interface for using `MachO`. I did put all of the logic into one file so that it can be easily modified / removed when https://github.com/dotnet/runtimelab/issues/2918 is implemented. 

While working on the PR I noticed several issues coming from previous PRs:
- Handling of generic paramaters in constructor calls. The logic was straight wrong. I reverted the changes removing `ConstructorHandler` so that Swift init methods with generic signatures are not handled.
- Handling of functions with multiple arguments having same generic type e.g. `foo<T>(a: T, b: T)`. Fixed the logic so that the projection is correct