### PR TITLE
[SwiftBindings] Revert bound generics special handling

### DIFF
--- a/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
+++ b/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
@@ -11,8 +11,7 @@ namespace BindingsGeneration
     /// Represents the result of processing a Swift module.
     /// </summary>
     /// <param name="ModuleDatabase">The module database containing type records.</param>
-    /// <param name="OutOfModuleTypeRecords"> Type records which look as if they belong to another module, e.g. closed generics.</param>
-    sealed record ModuleProcessingResult(ModuleTypeDatabase ModuleDatabase, IEnumerable<(string, TypeRecord)> OutOfModuleTypeRecords);
+    sealed record ModuleProcessingResult(ModuleTypeDatabase ModuleDatabase);
 
     /// <summary>
     /// Performs post-processing of types collected from the Swift ABI before generating bindings.
@@ -26,8 +25,6 @@ namespace BindingsGeneration
         private readonly ITypeDatabase _typeDatabase;
         private readonly ModuleTypeDatabase _moduleDatabase;
         private readonly Dictionary<NamedTypeSpec, TypeDecl> _typeDecls;
-        private readonly List<NamedTypeSpec> _boundGenericTypes; // TODO: Temporary solution for closed generics. Revise.
-        private readonly Dictionary<string, TypeRecord> _outOfModuleTypeRecords; // E.g. closed generics from other modules.
         private readonly int _verbosity;
 
         /// <summary>
@@ -36,14 +33,12 @@ namespace BindingsGeneration
         /// <param name="module">The name of the Swift module being processed.</param>
         /// <param name="dylibPath">The file path to the Swift dynamic library.</param>
         /// <param name="typeDecls">A dictionary mapping Swift type specs to their declarations.</param>
-        /// <param name="boundGenericTypes">A list of closed generic types encountered during method signature parsing.</param>
         /// <param name="typeDatabase">The global type database tracking processed types.</param>
         /// <param name="verbosity">The verbosity level for logging.</param>
         public ModuleProcessor(
             string module,
             string dylibPath,
             Dictionary<NamedTypeSpec, TypeDecl> typeDecls,
-            List<NamedTypeSpec> boundGenericTypes,
             ITypeDatabase typeDatabase,
             int verbosity)
         {
@@ -51,8 +46,6 @@ namespace BindingsGeneration
             _dylibPath = dylibPath;
             _typeDatabase = typeDatabase;
             _moduleDatabase = new ModuleTypeDatabase(module, dylibPath);
-            _boundGenericTypes = boundGenericTypes;
-            _outOfModuleTypeRecords = new Dictionary<string, TypeRecord>();
             _typeDecls = typeDecls;
             _verbosity = verbosity;
         }
@@ -74,12 +67,6 @@ namespace BindingsGeneration
                 return _moduleDatabase.TryGetTypeRecord(typeIdentifier, out record);
             }
 
-            // Next, check if the type is an out-of-module type (e.g., a closed generic).
-            if (_outOfModuleTypeRecords.TryGetValue($"{moduleName}.{typeIdentifier}", out record))
-            {
-                return true;
-            }
-
             // Otherwise, fall back to checking the global type database.
             return _typeDatabase.TryGetTypeRecord(moduleName, typeIdentifier, out record);
         }
@@ -96,13 +83,7 @@ namespace BindingsGeneration
                 ProcessTypeRecursively(typeSpec, typeDecl);
             }
 
-            // Placeholder for handling closed generics.
-            foreach (var closedGenericType in _boundGenericTypes)
-            {
-                ProcessGenericTypeSpec(closedGenericType);
-            }
-
-            return new ModuleProcessingResult(_moduleDatabase, _outOfModuleTypeRecords.Select(kv => (kv.Key, kv.Value)));
+            return new ModuleProcessingResult(_moduleDatabase);
         }
 
         /// <summary>
@@ -303,68 +284,6 @@ namespace BindingsGeneration
         private void ProcessClass(NamedTypeSpec namedTypeSpec, ClassDecl classDecl)
         {
             return;
-        }
-
-        /// <summary>
-        /// Processes a closed generic type specification by mapping open generic definitions
-        /// to specific instantiations (e.g., <c>MyGenericClass&lt;SomeType&gt;</c>).
-        /// </summary>
-        /// <param name="namedTypeSpec">The Swift type specification representing the closed generic.</param>
-        private void ProcessGenericTypeSpec(NamedTypeSpec namedTypeSpec)
-        {
-            // Attempt to retrieve the open generic type record (e.g., MyGenericClass`1).
-            if (!TryGetTypeRecord(namedTypeSpec.Module, $"{namedTypeSpec.NameWithoutModule}`{namedTypeSpec.GenericParameters.Count}", out var genericTypeRecord))
-            {
-                if (_verbosity > 1)
-                {
-                    Console.WriteLine($"Skipping generic '{namedTypeSpec}' from module '{namedTypeSpec.Module}'. " +
-                                      "Could not find open generic's type record.");
-                }
-                return;
-            }
-
-            // Build a C#-style generic type name based on the parameters.
-            var nameBuilder = new StringBuilder(genericTypeRecord.CSTypeIdentifier).Append("<");
-
-            foreach (var genericParameter in namedTypeSpec.GenericParameters)
-            {
-                if (genericParameter is not NamedTypeSpec namedGenericParameter)
-                    continue;
-
-                if (!TryGetTypeRecord(namedGenericParameter.Module, namedGenericParameter.NameWithoutModule, out var genericParameterRecord))
-                {
-                    if (_verbosity > 1)
-                    {
-                        Console.WriteLine($"Skipping generic '{namedTypeSpec}' from module '{namedTypeSpec.Module}'.");
-                    }
-                    return;
-                }
-                nameBuilder.Append(genericParameterRecord.CSTypeIdentifier);
-            }
-
-            nameBuilder.Append(">");
-
-            var typeRecord = new TypeRecord
-            {
-                ModuleName = namedTypeSpec.Module,
-                Namespace = namedTypeSpec.Module, // TODO: Correctly map to a .NET namespace
-                SwiftTypeIdentifier = namedTypeSpec.NameWithoutModuleWithGenericParameters,
-                CSTypeIdentifier = nameBuilder.ToString(),
-                MetadataAccessor = string.Empty, // TODO: Implement metadata accessor for closed generics
-                IsBlittable = true,
-                IsFrozen = true
-            };
-
-            // If the closed generic belongs to a different module, store it in out-of-module records.
-            if (namedTypeSpec.Module != _module)
-            {
-                _outOfModuleTypeRecords[$"{namedTypeSpec.Module}.{namedTypeSpec.NameWithoutModuleWithGenericParameters}"] = typeRecord;
-            }
-            // Otherwise, register it in the current module.
-            else
-            {
-                _moduleDatabase.RegisterType(namedTypeSpec.NameWithoutModuleWithGenericParameters, typeRecord);
-            }
         }
     }
 }

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -12,11 +12,7 @@ namespace BindingsGeneration
     /// </summary>
     /// <param name="ModuleDecl">The module declaration.</param>
     /// <param name="TypeDecls">The type declarations.</param>
-    /// <param name="BoundGenericTypes">The bound generic types.</param>
-    public sealed record ModuleParsingResult(
-    ModuleDecl ModuleDecl,
-    Dictionary<NamedTypeSpec, TypeDecl> TypeDecls,
-    List<NamedTypeSpec> BoundGenericTypes);
+    public sealed record ModuleParsingResult(ModuleDecl ModuleDecl, Dictionary<NamedTypeSpec, TypeDecl> TypeDecls);
 
     /// <summary>
     /// Represents the root node of the ABI.
@@ -116,11 +112,6 @@ namespace BindingsGeneration
         /// </summary>
         private readonly Swift5Demangler demangler = new();
 
-        /// <summary>
-        /// Closed generic types encountered during parsing method signatures.
-        /// </summary>
-        private readonly List<NamedTypeSpec> _boundGenericTypes = new();
-
         public SwiftABIParser(string filePath, ITypeDatabase typeDatabase, int verbose = 0)
         {
             _filePath = filePath;
@@ -174,7 +165,7 @@ namespace BindingsGeneration
                 _moduleTypes.Add(new NamedTypeSpec(type.FullyQualifiedName), type);
             }
 
-            return new ModuleParsingResult(moduleDecl, _moduleTypes, _boundGenericTypes);
+            return new ModuleParsingResult(moduleDecl, _moduleTypes);
         }
 
         /// <summary>
@@ -432,12 +423,6 @@ namespace BindingsGeneration
             for (int i = 0; i < node.Children.Count(); i++)
             {
                 var typeSpec = CreateTypeSpec(node.Children.ElementAt(i));
-
-                //TODO: Make sure that the generics are actually bound
-                if (!_typeDatabase.IsTypeProcessed(typeSpec) && typeSpec is NamedTypeSpec namedTypeSpec && namedTypeSpec.GenericParameters.Count > 0)
-                {
-                    _boundGenericTypes.Add(namedTypeSpec);
-                }
 
                 methodDecl.CSSignature.Add(new ArgumentDecl
                 {

--- a/src/Swift.Bindings/src/Program.cs
+++ b/src/Swift.Bindings/src/Program.cs
@@ -95,12 +95,11 @@ namespace BindingsGeneration
             if (!typeDatabase.IsModuleProcessed(moduleName))
             {
                 // Parse the Swift ABI file and generate declarations
-                var (decl, moduleTypes, boundGenericTypes) = swiftParser.ParseModule();
+                var (decl, moduleTypes) = swiftParser.ParseModule();
 
-                var moduleProcessor = new ModuleProcessor(moduleName, dylibPath, moduleTypes, boundGenericTypes, typeDatabase, verbose);
-                var (moduleDatabase, outOfModuleTypeRecords) = moduleProcessor.FinalizeTypeProcessingAndCreateModuleDatabase();
+                var moduleProcessor = new ModuleProcessor(moduleName, dylibPath, moduleTypes, typeDatabase, verbose);
+                var moduleDatabase = moduleProcessor.FinalizeTypeProcessingAndCreateModuleDatabase().ModuleDatabase;
                 typeDatabase.AddModuleDatabase(moduleDatabase);
-                typeDatabase.AddOutOfModuleTypes(outOfModuleTypeRecords);
 
                 if (verbose > 1)
                     Console.WriteLine("Parsed Swift ABI file successfully.");

--- a/src/Swift.Runtime/src/Swift/FoundationDatabase.xml
+++ b/src/Swift.Runtime/src/Swift/FoundationDatabase.xml
@@ -41,10 +41,10 @@
             <typedeclaration kind="struct" name="Bool" module="Swift" mangledName="$sSb" frozen="true" blittable ="true" />
         </entity>
         <entity managedNameSpace="Swift" managedTypeName="UnsafePointer">
-            <typedeclaration kind="struct" name="UnsafePointer`1" module="Swift" mangledName="sSP" frozen="false" blittable ="false" />
+            <typedeclaration kind="struct" name="UnsafePointer" module="Swift" mangledName="sSP" frozen="false" blittable ="false" />
         </entity>
         <entity managedNameSpace="Swift" managedTypeName="UnsafeMutablePointer">
-            <typedeclaration kind="struct" name="UnsafeMutablePointer`1" module="Swift" mangledName="sSp" frozen="false" blittable ="false" />
+            <typedeclaration kind="struct" name="UnsafeMutablePointer" module="Swift" mangledName="sSp" frozen="false" blittable ="false" />
         </entity>
         <entity managedNameSpace="Swift" managedTypeName="UnsafeRawPointer">
             <typedeclaration kind="struct" name="UnsafeRawPointer" module="Swift" mangledName="sSV" frozen="true" blittable ="true"/>
@@ -53,16 +53,22 @@
             <typedeclaration kind="struct" name="UnsafeMutableRawPointer" module="Swift" mangledName="sSv" frozen="true" blittable ="true"/>
         </entity>
         <entity managedNameSpace="Swift" managedTypeName="UnsafeBufferPointer">
-            <typedeclaration kind="struct" name="UnsafeBufferPointer`1" module="Swift" mangledName="sSR" frozen="false" blittable ="false"/>
+            <typedeclaration kind="struct" name="UnsafeBufferPointer" module="Swift" mangledName="sSR" frozen="false" blittable ="false"/>
         </entity>
         <entity managedNameSpace="Swift" managedTypeName="UnsafeMutableBufferPointer">
-            <typedeclaration kind="struct" name="UnsafeMutableBufferPointer`1" module="Swift" mangledName="sSr" frozen="false" blittable ="false"/>
+            <typedeclaration kind="struct" name="UnsafeMutableBufferPointer" module="Swift" mangledName="sSr" frozen="false" blittable ="false"/>
         </entity>
         <entity managedNameSpace="Swift" managedTypeName="UnsafeRawBufferPointer">
             <typedeclaration kind="struct" name="UnsafeRawBufferPointer" module="Swift" mangledName="sSW" frozen="true" blittable ="true"/>
         </entity>
         <entity managedNameSpace="Swift" managedTypeName="UnsafeMutableRawBufferPointer">
             <typedeclaration kind="struct" name="UnsafeMutableRawBufferPointer" module="Swift" mangledName="sSw" frozen="true" blittable ="true"/>
+        </entity>
+        <entity managedNameSpace="Swift" managedTypeName="UnsafeMutablePointer&lt;System.Byte&gt;">
+            <typedeclaration kind="struct" name="UnsafeMutablePointer&lt;Swift.UInt8&gt;" module="Swift" mangledName="sSp" frozen="true" blittable="true"/>
+        </entity>
+        <entity managedNameSpace="Swift" managedTypeName="UnsafeMutableBufferPointer&lt;System.Byte&gt;">
+            <typedeclaration kind="struct" name="UnsafeMutableBufferPointer&lt;Swift.UInt8&gt;" module="Swift" mangledName="sSr" frozen="true" blittable="true"/>
         </entity>
     </entities>
 </swifttypedatabase>


### PR DESCRIPTION
Fixes #2976 

https://github.com/dotnet/runtimelab/pull/2919 introduced a special path for some bound generics to be projected. The special case was intended to handle generic pointer types, which are frozen and do not need explicit size information. This special case might lead to generating wrong projections for other bound generics.

This PR reverts those changes. The temporary workaround is to add the two bound generic types to database until we have a proper solution.