### PR TITLE
[SwiftBindings] Document properties bindings

### DIFF
--- a/src/docs/binding-properties.md
+++ b/src/docs/binding-properties.md
@@ -53,21 +53,10 @@ public struct FrozenPoint {
 
     private unsafe void Set_x(nint value)
     {
-        void* payload;
-        try 
+        fixed (FrozenPoint* p = &this)
         {
-            var metadata = ...;
-            payload = (SwiftHandle)NativeMemory.Alloc(returnMetadata.Size);
-            SwiftMarshal.MarshalToSwift(this, (IntPtr)payload);
-            var self = new SwiftSelf(payload);
-
+            var self = new SwiftSelf(p);
             PInvoke_set_x(value, self);
-
-            this = SwiftMarshal.MarshalFromSwift<FrozenPoint>(payload);
-        }
-        finally
-        {
-            NativeMemory.Free(payload);
         }
     }
 

--- a/src/docs/binding-properties.md
+++ b/src/docs/binding-properties.md
@@ -101,3 +101,7 @@ public class NonFrozenPoint : IDisposable {
 ## Static Properties
 
 TODO
+
+## Async Properties
+
+TODO

--- a/src/docs/binding-properties.md
+++ b/src/docs/binding-properties.md
@@ -1,0 +1,114 @@
+# Properties
+
+## Simple Properties on Swift Structs
+
+Properties in Swift structs have different calling conventions depending on whether the struct is frozen or not, and whether it's a getter or setter:
+
+- Getters:
+  - For frozen structs: Take the struct value lowered into registers
+  - For non-frozen structs: Take a pointer to the struct instance
+  
+- Setters:
+  - For both frozen and non-frozen structs: Always take a pointer to self and a value to set
+  - The pointer to self is required because setters need to modify the struct's memory in-place
+
+This means that when binding properties to C#, we need to handle these different cases appropriately:
+
+- For frozen struct getters, we can pass `SwiftSelf<T>`.
+- For non-frozen struct getters, we need to pass `SwiftSelf` pointer.
+- For all setters, we must always pass the new value and `SwiftSelf` pointer.
+
+Example of how this affects the binding:
+
+```swift
+@frozen public struct FrozenPoint {
+    public var x: Int
+}
+
+public struct NonFrozenPoint {
+    public var x: Int
+}
+```
+
+The generated C# binding needs to handle the different calling conventions:
+
+```csharp
+[StructLayout(LayoutKind.Sequential)]
+public struct FrozenPoint {
+    nint x;
+
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+    [DllImport("MySwiftModule", EntryPoint = "...")]
+    private static extern nint PInvoke_get_x(SwiftSelf<FrozenPoint> self);
+    
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+    [DllImport("MySwiftModule", EntryPoint = "...")]
+    private static extern void PInvoke_set_x(nint value, SwiftSelf self);
+
+    private unsafe nint Get_x()
+    {
+        var self = new SwiftSelf<FrozenPoint>(instance);
+        return PInvoke_get_x(self);
+    }
+
+    private unsafe void Set_x(nint value)
+    {
+        IntPtr payload;
+        try 
+        {
+            var metadata = ...;
+            payload = (SwiftHandle)NativeMemory.Alloc(returnMetadata.Size);
+            SwiftMarshal.MarshalToSwift(instance, payload);
+            var self = new SwiftSelf((void*)_payload);
+
+            PInvoke_set_x(value, self);
+
+            this = SwiftMarshal.MarshalFromSwift<FrozenPoint>(payload);
+        }
+        finally
+        {
+            NativeMemory.Free((void*)payload);
+        }
+    }
+
+    public int X
+    {
+        get => Get_x();
+        set => Set_x(nint value);
+    }
+}
+
+public class NonFrozenPoint : IDisposable {
+    private SwiftHandle _payload;
+
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+    [DllImport("MySwiftModule", EntryPoint = "...")]
+    private static extern nint PInvoke_get_x(SwiftSelf self);
+    
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+    [DllImport("MySwiftModule", EntryPoint = "...")]
+    private static extern void PInvoke_set_x(nint value, SwiftSelf self);
+
+    private unsafe nint Get_x()
+    {
+        var self = new SwiftSelf((void*)_payload);
+        return PInvoke_get_x(self);
+    }
+
+    private unsafe void Set_x(nint value)
+    {
+        var self = new SwiftSelf((void*)_payload);
+        PInvoke_set_x(value, self);
+    }
+
+    public int X
+    {
+        get => Get_x();
+        set => Set_x(value);
+    }
+}
+```
+
+## Static Properties
+
+TODO

--- a/src/docs/binding-properties.md
+++ b/src/docs/binding-properties.md
@@ -53,13 +53,13 @@ public struct FrozenPoint {
 
     private unsafe void Set_x(nint value)
     {
-        IntPtr payload;
+        void* payload;
         try 
         {
             var metadata = ...;
             payload = (SwiftHandle)NativeMemory.Alloc(returnMetadata.Size);
-            SwiftMarshal.MarshalToSwift(instance, payload);
-            var self = new SwiftSelf((void*)_payload);
+            SwiftMarshal.MarshalToSwift(this, (IntPtr)payload);
+            var self = new SwiftSelf(payload);
 
             PInvoke_set_x(value, self);
 
@@ -67,7 +67,7 @@ public struct FrozenPoint {
         }
         finally
         {
-            NativeMemory.Free((void*)payload);
+            NativeMemory.Free(payload);
         }
     }
 


### PR DESCRIPTION
Adds a proposal on how to handle instance properties bindings for Swift structs. While getters are simple - they have the same calling convention as as regular instance function which accesses data on a struct, the setters are complex. They accepts the struct using the `SwiftSelf` pointer and modify it inplace.

Contributes to https://github.com/dotnet/runtimelab/issues/2971