### PR TITLE
[Swift language features] Bind property getters

### DIFF
--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -820,7 +820,8 @@ namespace BindingsGeneration
                 true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => _env.GenericTypeMapping[p.TypeName].TypeParameter))}>",
                 false => ""
             };
-            csWriter.WriteLine($"public {_env.ParentDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
+            var accessModifier = NameProvider.GetAccessModifier(_env.MethodDecl.Visibility);
+            csWriter.WriteLine($"{accessModifier} {_env.ParentDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
         }
 
         /// <summary>
@@ -844,7 +845,8 @@ namespace BindingsGeneration
                 returnType = $"Task{(_env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple ? "" : $"<{_wrapperSignature.ReturnType}>")}";
             }
 
-            csWriter.WriteLine($"public {staticKeyword}{unsafeKeyword}{returnType} {_env.MethodDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
+            var accessModifier = NameProvider.GetAccessModifier(_env.MethodDecl.Visibility);
+            csWriter.WriteLine($"{accessModifier} {staticKeyword}{unsafeKeyword}{returnType} {_env.MethodDecl.Name}{genericParams}({_wrapperSignature.ParametersString()})");
         }
 
         /// <summary>

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/ModuleHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/ModuleHandler.cs
@@ -68,18 +68,12 @@ namespace BindingsGeneration
             csWriter.WriteLine("{");
             csWriter.Indent++;
 
-            // Emit top-level fields and pinvokes
-            if (moduleDecl.Methods.Any() || moduleDecl.Fields.Any())
+            // Emit top-level methods
+            if (moduleDecl.Methods.Any())
             {
                 csWriter.WriteLine($"public class {moduleDecl.Name}");
                 csWriter.WriteLine("{");
                 csWriter.Indent++;
-                foreach (FieldDecl fieldDecl in moduleDecl.Fields)
-                {
-                    string accessModifier = fieldDecl.Visibility == Visibility.Public ? "public" : "private";
-                    var fieldTypeRecord = moduleEnv.TypeDatabase.GetTypeRecordOrThrow(fieldDecl.SwiftTypeSpec);
-                    csWriter.WriteLine($"{accessModifier} {fieldTypeRecord.CSTypeIdentifier} {fieldDecl.Name};");
-                }
                 csWriter.WriteLine();
                 foreach (MethodDecl methodDecl in moduleDecl.Methods)
                 {

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CodeDom.Compiler;
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// Factory class for creating instances of PropertyHandler.
+/// </summary>
+public class PropertyHandlerFactory : IFactory<BaseDecl, IPropertyHandler>
+{
+    public bool Handles(BaseDecl decl)
+    {
+        return decl is PropertyDecl propertyDecl && propertyDecl.Accessors.Any();
+    }
+
+    public IPropertyHandler Construct()
+    {
+        return new PropertyHandler();
+    }
+}
+
+/// <summary>
+/// Handler class for property declarations that generates the binding code for Swift properties.
+/// </summary> 
+public class PropertyHandler : BaseHandler, IPropertyHandler
+{
+    private readonly MethodHandler _methodHandler = new();
+
+    /// <inheritdoc/>
+    public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
+    {
+        if (baseDecl is not PropertyDecl propertyDecl)
+        {
+            throw new ArgumentException("The provided decl must be a PropertyDecl.", nameof(baseDecl));
+        }
+        return new PropertyEnvironment(propertyDecl, typeDatabase);
+    }
+
+    /// <inheritdoc/>
+    public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
+    {
+        var propertyEnv = (PropertyEnvironment)env;
+        var propertyDecl = propertyEnv.PropertyDecl;
+
+        var typeRecord = propertyEnv.TypeDatabase.GetTypeRecordOrThrow(propertyDecl.SwiftTypeSpec);
+
+        var staticModifier = propertyDecl.IsStatic ? "static " : "";
+        var csTypeName = typeRecord.CSTypeIdentifier;
+
+
+        // First emit the accessor methods using MethodHandler
+        foreach (var accessor in propertyDecl.Accessors)
+        {
+            var accessorEnv = new MethodEnvironment(accessor.Method, propertyEnv.TypeDatabase);
+            _methodHandler.Emit(csWriter, swiftWriter, accessorEnv, conductor);
+        }
+
+        // Then emit the property
+        csWriter.WriteLine($"public {staticModifier}{csTypeName} {propertyDecl.Name}");
+        csWriter.WriteLine("{");
+        csWriter.Indent++;
+
+        var getter = propertyDecl.Accessors.OfType<GetAccessorDecl>().FirstOrDefault();
+        if (getter != null)
+        {
+            EmitGetter(csWriter, getter);
+        }
+
+        csWriter.Indent--;
+        csWriter.WriteLine("}");
+        csWriter.WriteLine();
+    }
+
+    /// <summary>
+    /// Emits the getter implementation for a property.
+    /// </summary>
+    /// <param name="csWriter">The C# code writer to emit to</param>
+    /// <param name="getter">The getter accessor declaration</param>
+    private void EmitGetter(CSharpWriter csWriter, GetAccessorDecl getter)
+    {
+        csWriter.WriteLine($"get => {getter.Method.Name}();");
+    }
+}
+

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -28,6 +28,13 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
 {
     private readonly MethodHandler _methodHandler = new();
 
+    // Dictionary of Swift property names that need to be renamed in C#
+    // Temporary workaround for https://github.com/dotnet/runtimelab/issues/2997 to keep StoreKit tests passing
+    private static readonly Dictionary<string, string> PropertyNameMappings = new()
+    {
+        { "isEligibleForIntroOffer", "isEligibleForIntroOfferProperty" },
+    };
+
     /// <inheritdoc/>
     public IEnvironment Marshal(BaseDecl baseDecl, ITypeDatabase typeDatabase)
     {
@@ -64,14 +71,14 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
             return;
         }
 
-        if (propertyDecl.Accessors.Any(a => a.Method.IsAsync)) // TODO: https://github.com/dotnet/runtimelab/issues/2996
-        {
-            Console.WriteLine($"PropertyHandler: Async properties are not supported. Skipping property {propertyDecl.Name}.");
-            return;
-        }
-
+        // TODO Detect and skip / Handle async properties https://github.com/dotnet/runtimelab/issues/2996
         var csTypeName = typeRecord!.CSTypeIdentifier;
 
+        // Get the C# property name, using the mapping dictionary if necessary
+        // Temporary workaround for https://github.com/dotnet/runtimelab/issues/2997 to keep StoreKit tests passing
+        var propertyName = PropertyNameMappings.TryGetValue(propertyDecl.Name, out var mappedName)
+            ? mappedName
+            : propertyDecl.Name;
 
         // First emit the accessor methods using MethodHandler
         foreach (var accessor in propertyDecl.Accessors)
@@ -81,7 +88,7 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
         }
 
         // Then emit the property
-        csWriter.WriteLine($"public {csTypeName} {propertyDecl.Name}");
+        csWriter.WriteLine($"public {csTypeName} {propertyName}");
         csWriter.WriteLine("{");
         csWriter.Indent++;
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -48,6 +48,12 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
     /// <inheritdoc/>
     public void Emit(CSharpWriter csWriter, SwiftWriter swiftWriter, IEnvironment env, Conductor conductor)
     {
+        // This will emit the C# equivalent of the Swift property.
+        // To achieve this, the process is divided into the following steps:
+        // 1. Emit Accessor Methods: Generate the C# methods that correspond to the Swift property's accessors (getter, setter, etc.).
+        // 2. Emit Property Definition: Define the C# property itself, including its type, name, and accessors.
+        //    This step utilizes the previously generated accessor methods to implement the property's behavior.
+
         var propertyEnv = (PropertyEnvironment)env;
         var propertyDecl = propertyEnv.PropertyDecl;
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -26,7 +26,6 @@ public class PropertyHandlerFactory : IFactory<BaseDecl, IPropertyHandler>
 /// </summary> 
 public class PropertyHandler : BaseHandler, IPropertyHandler
 {
-    private readonly MethodHandler _methodHandler = new();
 
     // Dictionary of Swift property names that need to be renamed in C#
     // Temporary workaround for https://github.com/dotnet/runtimelab/issues/2997 to keep StoreKit tests passing
@@ -89,8 +88,15 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
         // First emit the accessor methods using MethodHandler
         foreach (var accessor in propertyDecl.Accessors)
         {
-            var accessorEnv = new MethodEnvironment(accessor.Method, propertyEnv.TypeDatabase);
-            _methodHandler.Emit(csWriter, swiftWriter, accessorEnv, conductor);
+            if (conductor.TryGetMethodHandler(accessor.Method, out var methodHandler))
+            {
+                var accessorEnv = methodHandler.Marshal(accessor.Method, propertyEnv.TypeDatabase);
+                methodHandler.Emit(csWriter, swiftWriter, accessorEnv, conductor);
+            }
+            else
+            {
+                throw new InvalidOperationException($"No handler found for properties accessor {accessor.Method.Name}");
+            }
         }
 
         // Then emit the property

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -12,7 +12,7 @@ public class PropertyHandlerFactory : IFactory<BaseDecl, IPropertyHandler>
 {
     public bool Handles(BaseDecl decl)
     {
-        return decl is PropertyDecl propertyDecl && propertyDecl.Accessors.Any();
+        return decl is PropertyDecl;
     }
 
     public IPropertyHandler Construct()
@@ -46,7 +46,16 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
 
         var typeRecord = propertyEnv.TypeDatabase.GetTypeRecordOrThrow(propertyDecl.SwiftTypeSpec);
 
-        var staticModifier = propertyDecl.IsStatic ? "static " : "";
+        if (propertyDecl.Accessors.Count == 0)
+        {
+            // No public accessors, so we don't need to emit anything
+            return;
+        }
+
+        if (propertyDecl.IsStatic)
+        {
+            throw new NotImplementedException("Static properties are not supported yet.");
+        }
         var csTypeName = typeRecord.CSTypeIdentifier;
 
 
@@ -58,7 +67,7 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
         }
 
         // Then emit the property
-        csWriter.WriteLine($"public {staticModifier}{csTypeName} {propertyDecl.Name}");
+        csWriter.WriteLine($"public {csTypeName} {propertyDecl.Name}");
         csWriter.WriteLine("{");
         csWriter.Indent++;
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -26,9 +26,6 @@ public class PropertyHandlerFactory : IFactory<BaseDecl, IPropertyHandler>
 /// </summary> 
 public class PropertyHandler : BaseHandler, IPropertyHandler
 {
-
-    // Dictionary of Swift property names that need to be renamed in C#
-    // Temporary workaround for https://github.com/dotnet/runtimelab/issues/2997 to keep StoreKit tests passing
     private static readonly Dictionary<string, string> PropertyNameMappings = new()
     {
         { "isEligibleForIntroOffer", "isEligibleForIntroOfferProperty" },
@@ -79,11 +76,8 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
         // TODO Detect and skip / Handle async properties https://github.com/dotnet/runtimelab/issues/2996
         var csTypeName = typeRecord!.CSTypeIdentifier;
 
-        // Get the C# property name, using the mapping dictionary if necessary
-        // Temporary workaround for https://github.com/dotnet/runtimelab/issues/2997 to keep StoreKit tests passing
-        var propertyName = PropertyNameMappings.TryGetValue(propertyDecl.Name, out var mappedName)
-            ? mappedName
-            : propertyDecl.Name;
+        // Get the C# property name, handling reserved keywords and special cases
+        var propertyName = NameProvider.GetPropertyName(propertyDecl.Name);
 
         // First emit the accessor methods using MethodHandler
         foreach (var accessor in propertyDecl.Accessors)

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -44,7 +44,13 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
         var propertyEnv = (PropertyEnvironment)env;
         var propertyDecl = propertyEnv.PropertyDecl;
 
-        var typeRecord = propertyEnv.TypeDatabase.GetTypeRecordOrThrow(propertyDecl.SwiftTypeSpec);
+        bool processed = propertyEnv.TypeDatabase.TryGetTypeRecord(propertyDecl.SwiftTypeSpec, out var typeRecord);
+
+        if (!processed)
+        {
+            Console.WriteLine($"PropertyHandler: Couldn't process property {propertyDecl.Name} of type {propertyDecl.SwiftTypeSpec}. Skipping.");
+            return;
+        }
 
         if (propertyDecl.Accessors.Count == 0)
         {
@@ -54,9 +60,10 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
 
         if (propertyDecl.IsStatic)
         {
-            throw new NotImplementedException("Static properties are not supported yet.");
+            Console.WriteLine($"PropertyHandler: Static properties are not supported. Skipping property {propertyDecl.Name}.");
+            return;
         }
-        var csTypeName = typeRecord.CSTypeIdentifier;
+        var csTypeName = typeRecord!.CSTypeIdentifier;
 
 
         // First emit the accessor methods using MethodHandler

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -58,11 +58,18 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
             return;
         }
 
-        if (propertyDecl.IsStatic)
+        if (propertyDecl.IsStatic) // TODO: https://github.com/dotnet/runtimelab/issues/2995
         {
             Console.WriteLine($"PropertyHandler: Static properties are not supported. Skipping property {propertyDecl.Name}.");
             return;
         }
+
+        if (propertyDecl.Accessors.Any(a => a.Method.IsAsync)) // TODO: https://github.com/dotnet/runtimelab/issues/2996
+        {
+            Console.WriteLine($"PropertyHandler: Async properties are not supported. Skipping property {propertyDecl.Name}.");
+            return;
+        }
+
         var csTypeName = typeRecord!.CSTypeIdentifier;
 
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -74,12 +74,22 @@ namespace BindingsGeneration
             csWriter.WriteLine($"public unsafe struct {structDecl.Name} : {typeof(ISwiftObject).Name} {{");
             csWriter.Indent++;
 
+            // For frozen structs, we need to emit fields that match the Swift struct's memory layout exactly.
+            // These backing fields are required for proper memory layout and marshalling, even though they
+            // are never directly accessed from C# code. The actual value access happens through Swift's
+            // accessor methods.
+            //
+            // Important: Direct access to these fields from C# will not provide the correct value - always
+            // use the generated property accessors which call into Swift.
             foreach (PropertyDecl propertyDecl in structDecl.Properties)
             {
                 if (conductor.TryGetPropertyHandler(propertyDecl, out var propertyHandler))
                 {
-                    var fieldRecord = env.TypeDatabase.GetTypeRecordOrThrow(propertyDecl.SwiftTypeSpec);
-                    csWriter.WriteLine($"private {fieldRecord.CSTypeIdentifier} {propertyDecl.Name}_;");
+                    if (propertyDecl.HasStorage)
+                    {
+                        var fieldRecord = env.TypeDatabase.GetTypeRecordOrThrow(propertyDecl.SwiftTypeSpec);
+                        csWriter.WriteLine($"private {fieldRecord.CSTypeIdentifier} {propertyDecl.Name}_;  // Note: Do not access this field directly - use the property accessors");
+                    }
 
                     var propertyEnv = propertyHandler.Marshal(propertyDecl, env.TypeDatabase);
                     propertyHandler.Emit(csWriter, swiftWriter, propertyEnv, conductor);

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -74,23 +74,28 @@ namespace BindingsGeneration
             csWriter.WriteLine($"public unsafe struct {structDecl.Name} : {typeof(ISwiftObject).Name} {{");
             csWriter.Indent++;
 
+            csWriter.WriteLine(@"
             // For frozen structs, we need to emit fields that match the Swift struct's memory layout exactly.
             // These backing fields are required for proper memory layout and marshalling, even though they
             // are never directly accessed from C# code. The actual value access happens through Swift's
             // accessor methods.
             //
             // Important: Direct access to these fields from C# will not provide the correct value - always
-            // use the generated property accessors which call into Swift.
+            // use the generated property accessors which call into Swift.");
+
+            foreach (PropertyDecl propertyDecl in structDecl.Properties)
+            {
+                if (propertyDecl.HasStorage)
+                {
+                    var fieldRecord = env.TypeDatabase.GetTypeRecordOrThrow(propertyDecl.SwiftTypeSpec);
+                    csWriter.WriteLine($"private {fieldRecord.CSTypeIdentifier} {propertyDecl.Name}_;  // Note: Do not access this field directly - use the property accessors");
+                }
+            }
+
             foreach (PropertyDecl propertyDecl in structDecl.Properties)
             {
                 if (conductor.TryGetPropertyHandler(propertyDecl, out var propertyHandler))
                 {
-                    if (propertyDecl.HasStorage)
-                    {
-                        var fieldRecord = env.TypeDatabase.GetTypeRecordOrThrow(propertyDecl.SwiftTypeSpec);
-                        csWriter.WriteLine($"private {fieldRecord.CSTypeIdentifier} {propertyDecl.Name}_;  // Note: Do not access this field directly - use the property accessors");
-                    }
-
                     var propertyEnv = propertyHandler.Marshal(propertyDecl, env.TypeDatabase);
                     propertyHandler.Emit(csWriter, swiftWriter, propertyEnv, conductor);
                 }

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -100,7 +100,9 @@ namespace BindingsGeneration
                     propertyHandler.Emit(csWriter, swiftWriter, propertyEnv, conductor);
                 }
                 else
-                    Console.WriteLine($"No handler found for property {propertyDecl.Name}");
+                {
+                    throw new InvalidOperationException($"No handler found for property {propertyDecl.Name}");
+                }
             }
             csWriter.WriteLine();
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -74,19 +74,18 @@ namespace BindingsGeneration
             csWriter.WriteLine($"public unsafe struct {structDecl.Name} : {typeof(ISwiftObject).Name} {{");
             csWriter.Indent++;
 
-            // Emit each field in the struct
-            foreach (var fieldDecl in structDecl.Fields)
+            foreach (PropertyDecl propertyDecl in structDecl.Properties)
             {
-                string accessModifier = fieldDecl.Visibility == Visibility.Public ? "public" : "private";
-                var fieldRecord = env.TypeDatabase.GetTypeRecordOrThrow(fieldDecl.SwiftTypeSpec);
-                csWriter.WriteLine($"{accessModifier} {fieldRecord.CSTypeIdentifier} {fieldDecl.Name};");
+                if (conductor.TryGetPropertyHandler(propertyDecl, out var propertyHandler))
+                {
+                    var fieldRecord = env.TypeDatabase.GetTypeRecordOrThrow(propertyDecl.SwiftTypeSpec);
+                    csWriter.WriteLine($"private {fieldRecord.CSTypeIdentifier} {propertyDecl.Name}_;");
 
-                // TODO: Fix memory access violation
-                // // Verify field against Swift type information
-                // if (swiftTypeInfo.HasValue && !VerifyFieldRecord(swiftTypeInfo.Value, structDecl.Fields.IndexOf(fieldDecl), fieldDecl))
-                // {
-                //     Console.WriteLine("Field record does not match the field declaration");
-                // }
+                    var propertyEnv = propertyHandler.Marshal(propertyDecl, env.TypeDatabase);
+                    propertyHandler.Emit(csWriter, swiftWriter, propertyEnv, conductor);
+                }
+                else
+                    Console.WriteLine($"No handler found for property {propertyDecl.Name}");
             }
             csWriter.WriteLine();
 
@@ -98,35 +97,8 @@ namespace BindingsGeneration
             csWriter.Indent--;
             csWriter.WriteLine("}");
         }
-
-        /// <summary>
-        /// Verify field record with the Swift type information.
-        /// </summary>
-        private unsafe bool VerifyFieldRecord(SwiftTypeInfo swiftTypeInfo, int fieldIndex, FieldDecl fieldDecl)
-        {
-            // Access the field descriptor using pointer arithmetic
-            FieldDescriptor* desc = (FieldDescriptor*)IntPtr.Add(
-                (IntPtr)(((StructDescriptor*)swiftTypeInfo.Metadata->TypeDescriptor))->NominalType.FieldsPtr.Target,
-                IntPtr.Size * fieldIndex
-            );
-
-            // Ensure the field number is within bounds
-            if (desc->NumFields <= fieldIndex)
-            {
-                return false;
-            }
-
-            FieldRecord* fieldRecord = desc->GetFieldRecord(fieldIndex);
-
-            // Check field name
-            if ((System.Runtime.InteropServices.Marshal.PtrToStringAnsi((IntPtr)fieldRecord->Name.Target) ?? string.Empty) != fieldDecl.Name)
-            {
-                return false;
-            }
-
-            return true;
-        }
     }
+
 
     /// <summary>
     /// Factory class for creating instances of NonFrozenStructHandler.
@@ -183,6 +155,17 @@ namespace BindingsGeneration
             csWriter.WriteLine($"public unsafe class {structDecl.Name} : IDisposable, {typeof(ISwiftObject).Name}");
             csWriter.WriteLine("{");
             csWriter.Indent++;
+
+            foreach (PropertyDecl propertyDecl in structDecl.Properties)
+            {
+                if (conductor.TryGetPropertyHandler(propertyDecl, out var propertyHandler))
+                {
+                    var propertyEnv = propertyHandler.Marshal(propertyDecl, env.TypeDatabase);
+                    propertyHandler.Emit(csWriter, swiftWriter, propertyEnv, conductor);
+                }
+                else
+                    Console.WriteLine($"No handler found for field {propertyDecl.Name}");
+            }
 
             WritePrivateFields(csWriter, structDecl);
             WriteDisposeMethod(csWriter);

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -109,7 +109,6 @@ namespace BindingsGeneration
         }
     }
 
-
     /// <summary>
     /// Factory class for creating instances of NonFrozenStructHandler.
     /// </summary>

--- a/src/Swift.Bindings/src/Marshaler/Conductor.cs
+++ b/src/Swift.Bindings/src/Marshaler/Conductor.cs
@@ -6,9 +6,9 @@ using System.Diagnostics.CodeAnalysis;
 namespace BindingsGeneration
 {
     using IArgumentHandlerFactory = IFactory<BaseDecl, IArgumentHandler>;
-    using IPropertyHandlerFactory = IFactory<BaseDecl, IPropertyHandler>;
     using IMethodHandlerFactory = IFactory<BaseDecl, IMethodHandler>;
     using IModuleHandlerFactory = IFactory<BaseDecl, IModuleHandler>;
+    using IPropertyHandlerFactory = IFactory<BaseDecl, IPropertyHandler>;
     using ITypeHandlerFactory = IFactory<BaseDecl, ITypeHandler>;
 
     /// <summary>

--- a/src/Swift.Bindings/src/Marshaler/Conductor.cs
+++ b/src/Swift.Bindings/src/Marshaler/Conductor.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 
 namespace BindingsGeneration
 {
     using IArgumentHandlerFactory = IFactory<BaseDecl, IArgumentHandler>;
-    using IFieldHandlerFactory = IFactory<BaseDecl, IFieldHandler>;
+    using IPropertyHandlerFactory = IFactory<BaseDecl, IPropertyHandler>;
     using IMethodHandlerFactory = IFactory<BaseDecl, IMethodHandler>;
     using IModuleHandlerFactory = IFactory<BaseDecl, IModuleHandler>;
     using ITypeHandlerFactory = IFactory<BaseDecl, ITypeHandler>;
@@ -27,7 +26,9 @@ namespace BindingsGeneration
             new ProtocolHandlerFactory(),
             new ClassHandlerFactory(),
         ];
-        private readonly List<IFieldHandlerFactory> _fieldHandlerFactories = [];
+        private readonly List<IPropertyHandlerFactory> _propertyHandlerFactories = [
+            new PropertyHandlerFactory(),
+        ];
         private readonly List<IMethodHandlerFactory> _methodHandlerFactories = [
             new ConstructorHandlerFactory(),
             new MethodHandlerFactory(),
@@ -84,6 +85,17 @@ namespace BindingsGeneration
         public bool TryGetArgumentHandler(ArgumentDecl argumentDecl, [NotNullWhen(returnValue: true)] out IArgumentHandler? handler)
         {
             return TryGetFooHandler(argumentDecl, out handler, _argumentHandlerFactories);
+        }
+
+        /// <summary>
+        /// Tries to get a property handler for a given PropertyDecl.
+        /// </summary>
+        /// <param name="propertyDecl">The property declaration to get the handler for.</param>
+        /// <param name="handler">The handler found for the given declaration.</param>
+        /// <returns>True if a handler is found, otherwise false.</returns>
+        public bool TryGetPropertyHandler(PropertyDecl propertyDecl, [NotNullWhen(returnValue: true)] out IPropertyHandler? handler)
+        {
+            return TryGetFooHandler(propertyDecl, out handler, _propertyHandlerFactories);
         }
 
         /// <summary>

--- a/src/Swift.Bindings/src/Marshaler/IEnvironment.cs
+++ b/src/Swift.Bindings/src/Marshaler/IEnvironment.cs
@@ -88,4 +88,25 @@ namespace BindingsGeneration
         /// </summary>
         public Dictionary<string, GenericParameterCSName> GenericTypeMapping { get; } = NameProvider.GetGenericTypeMapping(methodDecl);
     }
+
+    /// <summary>
+    /// Represents a property environment.
+    /// </summary>
+    /// <remarks>
+    /// Initializes a new instance of the PropertyEnvironment class.
+    /// </remarks>
+    /// <param name="propertyDecl">The property declaration.</param>
+    /// <param name="typeDatabase">The type database instance.</param>
+    public class PropertyEnvironment(PropertyDecl propertyDecl, ITypeDatabase typeDatabase) : IEnvironment
+    {
+        /// <summary>
+        /// Gets the property declaration.
+        /// </summary>
+        public PropertyDecl PropertyDecl { get; private set; } = propertyDecl;
+
+        /// <summary>
+        /// Gets the TypeDatabase
+        /// </summary>
+        public ITypeDatabase TypeDatabase { get; } = typeDatabase;
+    }
 }

--- a/src/Swift.Bindings/src/Marshaler/IHandler.cs
+++ b/src/Swift.Bindings/src/Marshaler/IHandler.cs
@@ -44,13 +44,6 @@ namespace BindingsGeneration
     }
 
     /// <summary>
-    /// Interface for handling field declarations.
-    /// </summary>
-    public interface IFieldHandler : IHandler
-    {
-    }
-
-    /// <summary>
     /// Interface for handling method declarations.
     /// </summary>
     public interface IMethodHandler : IHandler

--- a/src/Swift.Bindings/src/Marshaler/IHandler.cs
+++ b/src/Swift.Bindings/src/Marshaler/IHandler.cs
@@ -65,6 +65,13 @@ namespace BindingsGeneration
     }
 
     /// <summary>
+    /// Interface for handling property declarations.
+    /// </summary>
+    public interface IPropertyHandler : IHandler
+    {
+    }
+
+    /// <summary>
     /// Base class for handling declarations.
     /// </summary>
     public class BaseHandler

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -65,4 +65,14 @@ public static class NameProvider
     public static string GetMetadataName(string typeName) => $"{typeName}Metadata";
     public static string GetPayloadName(string argumentName) => $"{argumentName}Payload";
     public static string GetProtocolWitnessTableName(string typeName, string protocolName) => $"{typeName}{protocolName}PWT";
+
+    /// <summary>
+    /// Maps visibility to C# access modifier keyword.
+    /// </summary>
+    public static string GetAccessModifier(Visibility visibility) => visibility switch
+    {
+        Visibility.Public => "public",
+        Visibility.Private => "private",
+        _ => throw new ArgumentException($"Unknown visibility: {visibility}")
+    };
 }

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -16,6 +16,13 @@ public record struct GenericParameterCSName(string TypeParameter);
 /// 
 public static class NameProvider
 {
+    // Dictionary of Swift property names that need to be renamed in C#
+    // Temporary workaround for https://github.com/dotnet/runtimelab/issues/2997 to keep StoreKit tests passing
+    private static readonly Dictionary<string, string> PropertyNameMappings = new()
+    {
+        { "isEligibleForIntroOffer", "isEligibleForIntroOfferProperty" },
+    };
+
     /// <summary>
     /// Provides the name of the PInvoke method.
     /// </summary>
@@ -75,4 +82,14 @@ public static class NameProvider
         Visibility.Private => "private",
         _ => throw new ArgumentException($"Unknown visibility: {visibility}")
     };
+
+    /// <summary>
+    /// Gets the C# property name for a given Swift property name, handling reserved keywords and special cases.
+    /// </summary>
+    /// <param name="swiftPropertyName">The original Swift property name.</param>
+    /// <returns>The appropriate C# property name.</returns>
+    public static string GetPropertyName(string swiftPropertyName) =>
+        PropertyNameMappings.TryGetValue(swiftPropertyName, out var mappedName)
+            ? mappedName
+            : swiftPropertyName;
 }

--- a/src/Swift.Bindings/src/Model/TypeDecl/AccessorDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/AccessorDecl.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration;
+
+/// <summary>
+/// Base class for property accessor declarations in Swift.
+/// </summary>
+public abstract record AccessorDecl
+{
+    /// <summary>
+    /// Gets or sets the method that implements this accessor.
+    /// </summary>
+    public required MethodDecl Method { get; init; }
+}
+
+/// <summary>
+/// Represents a getter accessor declaration for a Swift property.
+/// </summary>
+public record GetAccessorDecl : AccessorDecl { }
+

--- a/src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/MethodDecl.cs
@@ -47,6 +47,11 @@ namespace BindingsGeneration
         /// Indicates if the method is generic.
         /// </summary>
         public bool IsGeneric => GenericParameters.Count > 0;
+
+        /// <summary>
+        /// Gets or sets the visibility of the method.
+        /// </summary>
+        public required Visibility Visibility { get; set; } = Visibility.Public;
     }
 
     /// <summary>

--- a/src/Swift.Bindings/src/Model/TypeDecl/ModuleDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ModuleDecl.cs
@@ -9,9 +9,9 @@ namespace BindingsGeneration
     public sealed record ModuleDecl : BaseDecl
     {
         /// <summary>
-        /// The module's fields.
+        /// The module's properties.
         /// </summary>
-        public required List<FieldDecl> Fields { get; set; }
+        public required List<PropertyDecl> Properties { get; set; }
 
         /// <summary>
         /// The module's methods.

--- a/src/Swift.Bindings/src/Model/TypeDecl/PropertyDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/PropertyDecl.cs
@@ -23,20 +23,4 @@ namespace BindingsGeneration
         /// </summary>
         public required IReadOnlyList<AccessorDecl> Accessors { get; init; }
     }
-
-    /// <summary>
-    /// Represents the visibility of a declaration.
-    /// </summary>
-    public enum Visibility
-    {
-        /// <summary>
-        /// Public visibility.
-        /// </summary>
-        Public,
-
-        /// <summary>
-        /// Private visibility.
-        /// </summary>
-        Private
-    }
 }

--- a/src/Swift.Bindings/src/Model/TypeDecl/PropertyDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/PropertyDecl.cs
@@ -14,6 +14,11 @@ namespace BindingsGeneration
         public required TypeSpec SwiftTypeSpec { get; set; }
 
         /// <summary>
+        /// Indicates if the property has a backing field
+        /// </summary>
+        public required bool HasStorage { get; set; }
+
+        /// <summary>
         /// Indicates if the declaration is static.
         /// </summary>
         public required bool IsStatic { get; set; }

--- a/src/Swift.Bindings/src/Model/TypeDecl/PropertyDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/PropertyDecl.cs
@@ -4,9 +4,9 @@
 namespace BindingsGeneration
 {
     /// <summary>
-    /// Represents a field declaration.
+    /// Represents a property declaration.
     /// </summary>
-    public record FieldDecl : BaseDecl
+    public record PropertyDecl : BaseDecl
     {
         /// <summary>
         /// The TypeSpec of the declaration
@@ -14,14 +14,14 @@ namespace BindingsGeneration
         public required TypeSpec SwiftTypeSpec { get; set; }
 
         /// <summary>
-        /// Indicates the visibility of the declaration.
-        /// </summary>
-        public Visibility? Visibility { get; set; }
-
-        /// <summary>
         /// Indicates if the declaration is static.
         /// </summary>
         public required bool IsStatic { get; set; }
+
+        /// <summary>
+        /// The accessors available for this field.
+        /// </summary>
+        public required IReadOnlyList<AccessorDecl> Accessors { get; init; }
     }
 
     /// <summary>

--- a/src/Swift.Bindings/src/Model/TypeDecl/TypeDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/TypeDecl.cs
@@ -19,9 +19,9 @@ namespace BindingsGeneration
         public required string MangledName { get; set; }
 
         /// <summary>
-        /// Type fields.
+        /// Type properties.
         /// </summary>
-        public required List<FieldDecl> Fields { get; set; }
+        public required List<PropertyDecl> Properties { get; set; }
 
         /// <summary>
         /// Methods within the base declaration.

--- a/src/Swift.Bindings/src/Model/TypeDecl/Visibility.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/Visibility.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace BindingsGeneration;
+
+
+/// <summary>
+/// Represents the visibility of a declaration.
+/// </summary>
+public enum Visibility
+{
+    /// <summary>
+    /// Public visibility.
+    /// </summary>
+    Public,
+
+    /// <summary>
+    /// Private visibility.
+    /// </summary>
+    Private
+}

--- a/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
+++ b/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
@@ -156,9 +156,9 @@ namespace BindingsGeneration
         /// </exception>
         private void ProcessStructFields(StructDecl structDecl)
         {
-            foreach (var fieldDecl in structDecl.Fields)
+            foreach (var propertyDecl in structDecl.Properties)
             {
-                if (fieldDecl.SwiftTypeSpec is not NamedTypeSpec namedFieldType || fieldDecl.IsStatic)
+                if (propertyDecl.SwiftTypeSpec is not NamedTypeSpec namedFieldType || propertyDecl.IsStatic)
                     continue;
 
                 // If the field is from a different module, ensure that type is already processed.
@@ -169,7 +169,7 @@ namespace BindingsGeneration
                         if (_verbosity > 1)
                         {
                             Console.WriteLine(
-                                $"Skipping field '{fieldDecl.Name}' of type '{namedFieldType.NameWithoutModule}' " +
+                                $"Skipping field '{propertyDecl.Name}' of type '{namedFieldType.NameWithoutModule}' " +
                                 $"from module '{namedFieldType.Module}'. Type should have been processed " +
                                 "in a previous module but was not found.");
                         }
@@ -184,7 +184,7 @@ namespace BindingsGeneration
                         if (_verbosity > 1)
                         {
                             Console.WriteLine(
-                                $"Skipping field '{fieldDecl.Name}' of type '{namedFieldType.NameWithoutModule}' " +
+                                $"Skipping field '{propertyDecl.Name}' of type '{namedFieldType.NameWithoutModule}' " +
                                 $"from module '{namedFieldType.Module}'. Not found in type declarations.");
                         }
                         continue;
@@ -206,9 +206,9 @@ namespace BindingsGeneration
                 return false;
 
             // If any field is not frozen, the struct cannot be frozen.
-            foreach (var fieldDecl in structDecl.Fields)
+            foreach (var propertyDecl in structDecl.Properties)
             {
-                if (fieldDecl.SwiftTypeSpec is not NamedTypeSpec namedFieldType)
+                if (propertyDecl.SwiftTypeSpec is not NamedTypeSpec namedFieldType)
                     continue;
 
                 if (!TryGetTypeRecord(namedFieldType, out var fieldRecord))

--- a/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
+++ b/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
@@ -129,8 +129,8 @@ namespace BindingsGeneration
         /// <param name="structDecl">The struct declaration.</param>
         private void ProcessStruct(NamedTypeSpec namedTypeSpec, StructDecl structDecl)
         {
-            // Ensure that all fields are processed or known in the database.
-            ProcessStructFields(structDecl);
+            // Ensure that all properties are processed or known in the database.
+            ProcessStructProperties(structDecl);
 
             // TODO: Remove loading dylib
             IntPtr metadataPtr = DynamicLibraryLoader.invoke(_dylibPath, $"{structDecl.MangledName}Ma");
@@ -141,62 +141,62 @@ namespace BindingsGeneration
 
             RegisterStructType(namedTypeSpec, structDecl, swiftTypeInfo, isFrozen, isBlittable);
 
-            // Update the struct declaration in memory so future passes see these fields.
+            // Update the struct declaration in memory so future passes see these properties.
             structDecl.IsBlittable = isBlittable;
             structDecl.IsFrozen = isFrozen;
         }
 
         /// <summary>
-        /// Ensures that each field in the struct is either from an already processed type
+        /// Ensures that each property in the struct is either from an already processed type
         /// or is recursively processed in this module.
         /// </summary>
         /// <param name="structDecl">The struct declaration.</param>
         /// <exception cref="Exception">
-        /// Thrown if a field type cannot be found or processed.
+        /// Thrown if a property type cannot be found or processed.
         /// </exception>
-        private void ProcessStructFields(StructDecl structDecl)
+        private void ProcessStructProperties(StructDecl structDecl)
         {
             foreach (var propertyDecl in structDecl.Properties)
             {
-                if (propertyDecl.SwiftTypeSpec is not NamedTypeSpec namedFieldType || propertyDecl.IsStatic)
+                if (propertyDecl.SwiftTypeSpec is not NamedTypeSpec namedPropertyType || propertyDecl.IsStatic)
                     continue;
 
-                // If the field is from a different module, ensure that type is already processed.
-                if (namedFieldType.Module != _module)
+                // If the property is from a different module, ensure that type is already processed.
+                if (namedPropertyType.Module != _module)
                 {
-                    if (!_typeDatabase.IsTypeProcessed(namedFieldType))
+                    if (!_typeDatabase.IsTypeProcessed(namedPropertyType))
                     {
                         if (_verbosity > 1)
                         {
                             Console.WriteLine(
-                                $"Skipping field '{propertyDecl.Name}' of type '{namedFieldType.NameWithoutModule}' " +
-                                $"from module '{namedFieldType.Module}'. Type should have been processed " +
+                                $"Skipping property '{propertyDecl.Name}' of type '{namedPropertyType.NameWithoutModule}' " +
+                                $"from module '{namedPropertyType.Module}'. Type should have been processed " +
                                 "in a previous module but was not found.");
                         }
                         continue;
                     }
                 }
-                // If the field is in the same module, process it recursively.
+                // If the property is in the same module, process it recursively.
                 else
                 {
-                    if (!_typeDecls.TryGetValue(namedFieldType, out var nestedDecl))
+                    if (!_typeDecls.TryGetValue(namedPropertyType, out var nestedDecl))
                     {
                         if (_verbosity > 1)
                         {
                             Console.WriteLine(
-                                $"Skipping field '{propertyDecl.Name}' of type '{namedFieldType.NameWithoutModule}' " +
-                                $"from module '{namedFieldType.Module}'. Not found in type declarations.");
+                                $"Skipping property '{propertyDecl.Name}' of type '{namedPropertyType.NameWithoutModule}' " +
+                                $"from module '{namedPropertyType.Module}'. Not found in type declarations.");
                         }
                         continue;
                     }
-                    ProcessTypeRecursively(namedFieldType, nestedDecl);
+                    ProcessTypeRecursively(namedPropertyType, nestedDecl);
                 }
             }
         }
 
         /// <summary>
         /// Determines whether a struct is truly frozen. The struct itself must be marked frozen
-        /// and all of its fields must also be from frozen types.
+        /// and all of its properties must also be from frozen types.
         /// </summary>
         /// <param name="structDecl">The struct declaration.</param>
         /// <returns><c>true</c> if the struct is frozen; otherwise, <c>false</c>.</returns>
@@ -205,18 +205,18 @@ namespace BindingsGeneration
             if (!structDecl.IsFrozen)
                 return false;
 
-            // If any field is not frozen, the struct cannot be frozen.
+            // If any property is not frozen, the struct cannot be frozen.
             foreach (var propertyDecl in structDecl.Properties)
             {
-                if (propertyDecl.SwiftTypeSpec is not NamedTypeSpec namedFieldType)
+                if (propertyDecl.SwiftTypeSpec is not NamedTypeSpec namedPropertyType)
                     continue;
 
-                if (!TryGetTypeRecord(namedFieldType, out var fieldRecord))
+                if (!TryGetTypeRecord(namedPropertyType, out var propertyRecord))
                 {
-                    throw new Exception($"Type not found in the database: {namedFieldType}");
+                    throw new Exception($"Type not found in the database: {namedPropertyType}");
                 }
 
-                if (!fieldRecord.IsFrozen)
+                if (!propertyRecord.IsFrozen)
                     return false;
             }
 

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -415,7 +415,8 @@ namespace BindingsGeneration
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl,
                 Throws = node.throwing ?? false,
-                IsAsync = functionReduction?.Function?.IsAsync ?? false
+                IsAsync = functionReduction?.Function?.IsAsync ?? false,
+                Visibility = Visibility.Public,
             };
 
             for (int i = 0; i < node.Children.Count(); i++)
@@ -482,7 +483,8 @@ namespace BindingsGeneration
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl,
                 Throws = false,
-                IsAsync = false
+                IsAsync = false,
+                Visibility = Visibility.Private,
             };
 
             return new GetAccessorDecl { Method = methodDecl };

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -50,8 +50,10 @@ namespace BindingsGeneration
         public required string? GenericSig { get; set; }
         public required string? sugared_genericSig { get; set; }
         public required bool? throwing { get; set; }
+        public required string? AccessorKind { get; set; }
         public required IEnumerable<Node> Children { get; set; } = Enumerable.Empty<Node>();
         public required IEnumerable<Node> Conformances { get; set; } = Enumerable.Empty<Node>();
+        public required IEnumerable<Node> Accessors { get; set; } = Enumerable.Empty<Node>();
     }
 
     /// <summary>
@@ -142,7 +144,7 @@ namespace BindingsGeneration
             var moduleDecl = new ModuleDecl
             {
                 Name = ExtractUniqueName(moduleName),
-                Fields = new List<FieldDecl>(),
+                Properties = new List<PropertyDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
                 Dependencies = dependencies,
@@ -154,7 +156,7 @@ namespace BindingsGeneration
 
             dependencies.Remove(moduleName);
 
-            moduleDecl.Fields = decls.OfType<FieldDecl>().ToList();
+            moduleDecl.Properties = decls.OfType<PropertyDecl>().ToList();
             moduleDecl.Methods = decls.OfType<MethodDecl>().ToList();
             moduleDecl.Types = decls.OfType<TypeDecl>().ToList();
             moduleDecl.Dependencies = dependencies;
@@ -209,9 +211,7 @@ namespace BindingsGeneration
                         result = IsOperator(node.Name) ? null : CreateMethodDecl(node, parentDecl, moduleDecl);
                         break;
                     case "Var":
-                        // TODO: Implement computed properties
-                        if (node.DeclAttributes is not null && Array.IndexOf(node.DeclAttributes, "HasStorage") != -1)
-                            result = CreateFieldDecl(node, parentDecl, moduleDecl);
+                        result = CreatePropertyDecl(node, parentDecl, moduleDecl);
                         break;
                     case "Import":
                         break;
@@ -288,7 +288,7 @@ namespace BindingsGeneration
             if (decl is not null)
             {
                 var childDecls = CollectDeclarations(node.Children, decl, moduleDecl);
-                decl.Fields.AddRange(childDecls.OfType<FieldDecl>());
+                decl.Properties.AddRange(childDecls.OfType<PropertyDecl>());
                 decl.Methods.AddRange(childDecls.OfType<MethodDecl>());
                 decl.Types.AddRange(childDecls.OfType<TypeDecl>());
 
@@ -328,7 +328,7 @@ namespace BindingsGeneration
                 Name = ExtractUniqueName(node.Name),
                 SwiftTypeName = GetSwiftTypeName(parentDecl, node.Name),
                 MangledName = node.MangledName,
-                Fields = new List<FieldDecl>(),
+                Properties = new List<PropertyDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
                 Conformances = [.. node.Conformances.Select(x => HandleConformance(x, swiftTypeName))],
@@ -354,7 +354,7 @@ namespace BindingsGeneration
                 Name = ExtractUniqueName(node.Name),
                 SwiftTypeName = swiftTypeName,
                 MangledName = node.MangledName,
-                Fields = new List<FieldDecl>(),
+                Properties = new List<PropertyDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
                 Conformances = [.. node.Conformances.Select(x => HandleConformance(x, swiftTypeName))],
@@ -377,7 +377,7 @@ namespace BindingsGeneration
                 Name = ExtractUniqueName(node.Name),
                 SwiftTypeName = GetSwiftTypeName(parentDecl, node.Name),
                 MangledName = node.MangledName,
-                Fields = new List<FieldDecl>(),
+                Properties = new List<PropertyDecl>(),
                 Methods = new List<MethodDecl>(),
                 Types = new List<TypeDecl>(),
                 ParentDecl = parentDecl,
@@ -437,27 +437,70 @@ namespace BindingsGeneration
             return methodDecl;
         }
 
-        /// <summary>
-        /// Creates a field declaration from a given node.
-        /// </summary>
-        /// <param name="node">The node representing the field declaration.</param>
-        /// <param name="parentDecl">The parent declaration.</param>
-        /// <param name="moduleDecl">The module declaration.</param>
-        /// <returns>The field declaration.</returns>
-        private FieldDecl CreateFieldDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
+        private List<AccessorDecl> HandleAccessors(IEnumerable<Node> accessors, string fieldName, BaseDecl parentDecl, ModuleDecl moduleDecl)
+        {
+            var result = new List<AccessorDecl>();
+
+            foreach (var accessor in accessors)
+            {
+                switch (accessor.AccessorKind)
+                {
+                    case "get":
+                        result.Add(CreateGetAccessor(accessor, fieldName, parentDecl, moduleDecl));
+                        break;
+                    default:
+                        Console.WriteLine($"Unsupported accessor kind '{accessor.AccessorKind}' encountered.");
+                        break;
+                }
+            }
+
+            return result;
+        }
+
+        private GetAccessorDecl CreateGetAccessor(Node accessor, string fieldName, BaseDecl parentDecl, ModuleDecl moduleDecl)
+        {
+            var methodDecl = new MethodDecl
+            {
+                Name = $"{fieldName}_Get",
+                MangledName = accessor.MangledName,
+                MethodType = MethodType.Instance,
+                IsConstructor = false,
+                CSSignature = new List<ArgumentDecl>
+                {
+                    new ArgumentDecl
+                    {
+                        SwiftTypeSpec = CreateTypeSpec(accessor.Children.ElementAt(0)),
+                        Name = string.Empty,
+                        PrivateName = string.Empty,
+                        IsInOut = false,
+                        IsGeneric = false,
+                        ParentDecl = parentDecl,
+                        ModuleDecl = moduleDecl
+                    }
+                },
+                GenericParameters = new List<GenericArgumentDecl>(),
+                ParentDecl = parentDecl,
+                ModuleDecl = moduleDecl,
+                Throws = false,
+                IsAsync = false
+            };
+
+            return new GetAccessorDecl { Method = methodDecl };
+        }
+
+        private PropertyDecl CreatePropertyDecl(Node node, BaseDecl parentDecl, ModuleDecl moduleDecl)
         {
             var typeSpec = CreateTypeSpec(node.Children.ElementAt(0));
-            var fieldDecl = new FieldDecl
+
+            return new PropertyDecl
             {
                 SwiftTypeSpec = typeSpec,
                 Name = node.Name,
-                Visibility = node.IsInternal ?? false ? Visibility.Private : Visibility.Public,
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl,
-                IsStatic = node.@static ?? false
+                IsStatic = node.@static ?? false,
+                Accessors = HandleAccessors(node.Accessors, node.Name, parentDecl, moduleDecl)
             };
-
-            return fieldDecl;
         }
 
         /// <summary>

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -501,6 +501,7 @@ namespace BindingsGeneration
                 ParentDecl = parentDecl,
                 ModuleDecl = moduleDecl,
                 IsStatic = node.@static ?? false,
+                HasStorage = node.DeclAttributes is not null && Array.IndexOf(node.DeclAttributes, "HasStorage") != -1,
                 Accessors = HandleAccessors(node.Accessors, node.Name, parentDecl, moduleDecl)
             };
         }

--- a/src/Swift.Bindings/src/TypeDatabase/TypeDatabaseExtensions.cs
+++ b/src/Swift.Bindings/src/TypeDatabase/TypeDatabaseExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace BindingsGeneration;
 
 // TODO: TypeDatabase should hold only nominal types (represented by NamedTypeSpec). Specifically tuples, closures etc. should not reside inside TypeDatabase.
@@ -78,6 +80,37 @@ public static class TypeDatabaseExtensions
             TupleTypeSpec { IsEmptyTuple: true } => VoidType,
             _ => throw new ArgumentException($"Attempted to read TypeRecord of unsupported type spec: {typeSpec}")
         };
+    }
+
+    /// <summary>
+    /// Tries to get the type record for the specified Swift type.
+    /// </summary>
+    /// <param name="typeDatabase">The type database.</param>
+    /// <param name="typeSpec">The Swift type specification.</param>
+    /// <param name="record">The type record.</param>
+    /// <returns>True if the type record was found; otherwise, false.</returns>
+    public static bool TryGetTypeRecord(this ITypeDatabase typeDatabase, TypeSpec typeSpec, [NotNullWhen(returnValue: true)] out TypeRecord? record)
+    {
+        record = null;
+        return typeSpec switch
+        {
+            NamedTypeSpec namedTypeSpec => typeDatabase.TryGetTypeRecord(namedTypeSpec, out record),
+            TupleTypeSpec { IsEmptyTuple: true } => false,
+            _ => false
+        };
+    }
+
+    /// <summary>
+    /// Tries to get the type record for the specified Swift type.
+    /// </summary>
+    /// <param name="typeDatabase">The type database.</param>
+    /// <param name="typeSpec">The Swift type specification.</param>
+    /// <param name="record">The type record.</param>
+    /// <returns>True if the type record was found; otherwise, false.</returns>
+    public static bool TryGetTypeRecord(this ITypeDatabase typeDatabase, NamedTypeSpec typeSpec, [NotNullWhen(returnValue: true)] out TypeRecord? record)
+    {
+        var typeName = SwiftTypeNameConverter.ConvertWithGenericParameters(typeSpec);
+        return typeDatabase.TryGetTypeRecord(typeName, out record);
     }
 
     /// <summary>

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
@@ -395,25 +395,21 @@ namespace BindingsGeneration.FunctionalTests
         [Fact]
         public void TestFrozenStructProperties()
         {
-            var struct1 = new PropertiesTestStruct(letValue: 10, varValue: 20, multiplier: 3);
+            var struct1 = new PropertiesTestStruct(letValue: 10, varValue: 20.5, multiplier: 3.0f);
 
             Assert.Equal(10, struct1.letProperty);
-
-            Assert.Equal(20, struct1.varProperty);
-
-            Assert.Equal(30, struct1.computedProperty);
+            Assert.Equal(20.5, struct1.varProperty);
+            Assert.Equal(30.0, struct1.computedProperty);
         }
 
         [Fact]
         public void TestNonFrozenStructProperties()
         {
-            var struct1 = new NonFrozenPropertiesTestStruct(letValue: 10, varValue: 20, multiplier: 3);
+            var struct1 = new NonFrozenPropertiesTestStruct(letValue: 10, varValue: 20.5, multiplier: 3.0f);
 
             Assert.Equal(10, struct1.letProperty);
-
-            Assert.Equal(20, struct1.varProperty);
-
-            Assert.Equal(30, struct1.computedProperty);
+            Assert.Equal(20.5, struct1.varProperty);
+            Assert.Equal(30.0, struct1.computedProperty);
         }
     }
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
@@ -392,6 +392,28 @@ namespace BindingsGeneration.FunctionalTests
         [DllImport("Structs/libStructsTests.dylib", EntryPoint = "$s12StructsTests8sumArray5arrays5Int32VSayAEG_tF")]
         private static extern int PInvoke_SumSet(Variant array);
 
+        [Fact]
+        public void TestFrozenStructProperties()
+        {
+            var struct1 = new PropertiesTestStruct(letValue: 10, varValue: 20, multiplier: 3);
 
+            Assert.Equal(10, struct1.letProperty);
+
+            Assert.Equal(20, struct1.varProperty);
+
+            Assert.Equal(30, struct1.computedProperty);
+        }
+
+        [Fact]
+        public void TestNonFrozenStructProperties()
+        {
+            var struct1 = new NonFrozenPropertiesTestStruct(letValue: 10, varValue: 20, multiplier: 3);
+
+            Assert.Equal(10, struct1.letProperty);
+
+            Assert.Equal(20, struct1.varProperty);
+
+            Assert.Equal(30, struct1.computedProperty);
+        }
     }
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
@@ -257,3 +257,36 @@ public func sumArray(array: Array<Int32>) -> Int32
 {
     return array.reduce(0, +)
 }
+
+@frozen
+public struct PropertiesTestStruct {
+    public let letProperty: Int
+    public var varProperty: Int
+    private let multiplier: Int
+    
+    public init(letValue: Int, varValue: Int, multiplier: Int) {
+        self.letProperty = letValue
+        self.varProperty = varValue
+        self.multiplier = multiplier
+    }
+    
+    public var computedProperty: Int {
+        return letProperty * multiplier
+    }
+}
+
+public struct NonFrozenPropertiesTestStruct {
+    public let letProperty: Int
+    public var varProperty: Int
+    private let multiplier: Int
+    
+    public init(letValue: Int, varValue: Int, multiplier: Int) {
+        self.letProperty = letValue
+        self.varProperty = varValue
+        self.multiplier = multiplier
+    }
+    
+    public var computedProperty: Int {
+        return letProperty * multiplier
+    }
+}

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
@@ -260,33 +260,39 @@ public func sumArray(array: Array<Int32>) -> Int32
 
 @frozen
 public struct PropertiesTestStruct {
-    public let letProperty: Int
-    public var varProperty: Int
-    private let multiplier: Int
+    public let letProperty: Int32
+    public var computedPropertyAmongStorageProperties: Double {
+        return Double(letProperty) * Double(multiplier)
+    } // This property is added to make sure the layout is correct
+    public var varProperty: Double
+    private let multiplier: Float
     
-    public init(letValue: Int, varValue: Int, multiplier: Int) {
+    public init(letValue: Int32, varValue: Double, multiplier: Float) {
         self.letProperty = letValue
         self.varProperty = varValue
         self.multiplier = multiplier
     }
     
-    public var computedProperty: Int {
-        return letProperty * multiplier
+    public var computedProperty: Double {
+        return Double(letProperty) * Double(multiplier)
     }
 }
 
 public struct NonFrozenPropertiesTestStruct {
-    public let letProperty: Int
-    public var varProperty: Int
-    private let multiplier: Int
+    public let letProperty: Int32
+    public var computedPropertyAmongStorageProperties: Double {
+        return Double(letProperty) * Double(multiplier)
+    } // This property is added to make sure the layout is correct
+    public var varProperty: Double
+    private let multiplier: Float
     
-    public init(letValue: Int, varValue: Int, multiplier: Int) {
+    public init(letValue: Int32, varValue: Double, multiplier: Float) {
         self.letProperty = letValue
         self.varProperty = varValue
         self.multiplier = multiplier
     }
     
-    public var computedProperty: Int {
-        return letProperty * multiplier
+    public var computedProperty: Double {
+        return Double(letProperty) * Double(multiplier)
     }
 }


### PR DESCRIPTION
Adds support for property getters. An appropriate property getter is generated on csharp side. All fields used for lowering of frozen structs are made private.

Fixes #2986 