### PR TITLE
[Swift Bindings] Propagate cmake warnings and fix existing warnings

### DIFF
--- a/src/Swift.Bindings/tests/IntegrationTests/CMakeLists.txt
+++ b/src/Swift.Bindings/tests/IntegrationTests/CMakeLists.txt
@@ -16,6 +16,8 @@ if (NOT SWIFT_COMPILER_TARGET)
     set(SWIFT_COMPILER_TARGET "${CMAKE_OSX_ARCHITECTURES}-apple-${SWIFT_PLATFORM}${SWIFT_DEPLOYMENT_TARGET}")
 endif()
 
+set(TARGETS)
+
 foreach(SOURCE_FILE ${SOURCES})
     get_filename_component(SOURCE_DIR ${SOURCE_FILE} DIRECTORY)
     get_filename_component(PARENT_DIR_NAME ${SOURCE_DIR} NAME)
@@ -24,9 +26,8 @@ foreach(SOURCE_FILE ${SOURCES})
     message(STATUS "Generating ${OUTPUT_DIR} library")
     file(MAKE_DIRECTORY ${OUTPUT_DIR})
 
-    add_custom_target(${SOURCE_BASE_NAME} ALL
+    add_custom_target(${SOURCE_BASE_NAME}
         COMMAND xcrun swiftc -target ${SWIFT_COMPILER_TARGET} -emit-module -emit-library -enable-library-evolution -emit-module-interface ${SOURCE_FILE} -o ${OUTPUT_DIR}/lib${SOURCE_BASE_NAME}.dylib
-        DEPENDS ${SOURCE_FILE}
         COMMENT "Generating ${SOURCE_BASE_NAME} library"
     )
 
@@ -51,7 +52,10 @@ foreach(SOURCE_FILE ${SOURCES})
 
     add_custom_command(TARGET ${SOURCE_BASE_NAME} POST_BUILD
         COMMAND xcrun swiftc -target ${SWIFT_COMPILER_TARGET} -emit-module -emit-library -enable-library-evolution -emit-module-interface ${SOURCE_FILE} "${OUTPUT_DIR}/*.swift" -o ${OUTPUT_DIR}/lib${SOURCE_BASE_NAME}.dylib
-        DEPENDS ${SOURCE_FILE}
         COMMENT "Generating final ${SOURCE_BASE_NAME} library"
     )
+
+    list(APPEND TARGETS ${SOURCE_BASE_NAME})
 endforeach()
+
+add_custom_target(build_all ALL DEPENDS ${TARGETS})

--- a/src/Swift.Bindings/tests/IntegrationTests/Swift.Bindings.Integration.Tests.csproj
+++ b/src/Swift.Bindings/tests/IntegrationTests/Swift.Bindings.Integration.Tests.csproj
@@ -6,8 +6,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <PreTestCommand>cd $(OutputPath)$(TargetFramework) &amp;&amp; cmake $(MSBuildThisFileDirectory) &amp;&amp; make</PreTestCommand>
+    <PreTestCommand>cd $(OutputPath)$(TargetFramework) &amp;&amp; cmake $(MSBuildThisFileDirectory) &gt; cmake_output.log 2&gt;&amp;1 &amp;&amp; make &gt;&gt; cmake_output.log 2&gt;&amp;1</PreTestCommand>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
@@ -20,6 +21,17 @@
   <Target Name="CompileNativeLibs" AfterTargets="ResolveReferences">
     <!-- Generate Swift libraries and projection tooling bindings -->
     <Exec Command="$(PreTestCommand)" />
+
+    <!-- Parse cmake output log for warnings and report them -->
+    <ReadLinesFromFile File="$(OutputPath)/cmake_output.log">
+      <Output TaskParameter="Lines" ItemName="CMakeOutputLines" />
+    </ReadLinesFromFile>
+
+    <ItemGroup>
+      <CMakeWarnings Include="@(CMakeOutputLines)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'.*CMake Warning.*').Success)" />
+    </ItemGroup>
+
+    <Warning Text="%(CMakeWarnings.Identity)  (see: $(OutputPath)/cmake_output.log)" Condition="'%(Identity)' != ''"/>
 
     <!-- Compile generated bindings with tests -->
     <ItemGroup>


### PR DESCRIPTION
Show cmake warnings when building swift files.
Also fixes cmake warnings which were present.