### PR TITLE
[Swift ABI compatibility] Document memory ownership and handling at the Swift–C# boundary

### DIFF
--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -41,10 +41,17 @@ To define memory handling rules at the Swift and C# boundary, the following scen
 ### Code blocks
 
 When a value type is initialized within a block, it is stack-allocated. At the end of the block, all reference properties must be deallocated. For example:
+```swift
+public func TestBlock()
+{
+    var vtype = VType()
+}
+```
 ```
 %vtype = alloca %T6output5VTypeV, align 8
 ...
-%0 = call ptr @"outlined destroy of output.VType"(ptr %vtype), !dbg !156
+call swiftcc void @"output.VType.init() -> output.VType"(ptr noalias nocapture sret(%T6output5VTypeV) %vtype), !dbg !248
+%0 = call ptr @"outlined destroy of output.VType"(ptr %vtype), !dbg !250
 
 // VWT->Destroy
 define linkonce_odr hidden ptr @"outlined destroy of output.VType"(ptr %0) #8 !dbg !143 {
@@ -64,7 +71,6 @@ When a reference type or a value type containing a reference property is passed 
 var refType = RefType()
 var vtype = VType(refType: refType)
 ```
-
 ```
 %3 = call ptr @swift_retain(ptr returned %2) #4, !dbg !164
 store ptr %2, ptr %refType, align 8, !dbg !164
@@ -77,24 +83,40 @@ call void @swift_release(ptr %toDestroy) #1, !dbg !170
 
 When a reference type or a value type containing a reference property is passed as a parameter, a copy is made (reference counter is retained before the call) and released after:
 
+```swift
+public func TestParameter()
+{
+    var vtype = VType()
+    callByVal(vtype: vtype)
+}
+
+public func callByVal(vtype: VType) { }
 ```
-%1 = load ptr, ptr %vtype.refType, align 8, !dbg !154
-%2 = call ptr @swift_retain(ptr returned %1) #4, !dbg !154
-%.refType = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !156
-store ptr %1, ptr %.refType, align 8, !dbg !156
-call swiftcc void @"output.PassThrough(vtype: output.VType) -> ()"(ptr noalias nocapture dereferenceable(8) %0), !dbg !157
-%3 = call ptr @"outlined destroy of output.VType"(ptr %0), !dbg !158
+```
+%1 = load ptr, ptr %vtype.refType, align 8, !dbg !258
+%2 = call ptr @swift_retain(ptr returned %1) #5, !dbg !258
+%.refType = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !260
+store ptr %1, ptr %.refType, align 8, !dbg !260
+call swiftcc void @"output.callByVal(vtype: output.VType) -> ()"(ptr noalias nocapture dereferenceable(8) %0), !dbg !261
+%3 = call ptr @"outlined destroy of output.VType"(ptr %0), !dbg !262
 ```
 
 ### Parameters passed by reference (inout)
 
 When `inout` reference type or a value type containing a reference property is passed as a parameter, it is passed by reference, so no counters are updated.
+```swift
+public func TestInOutParameter()
+{
+    var vtype = VType()
+    callByRef(vtype: &vtype)
+}
+
+public func callByRef(vtype: inout VType) { }
 ```
-%vtype.debug = alloca ptr, align 8
-call void @llvm.dbg.declare(metadata ptr %vtype.debug, metadata !285, metadata !DIExpression(DW_OP_deref)), !dbg !286
-call void @llvm.memset.p0.i64(ptr align 8 %vtype.debug, i8 0, i64 8, i1 false)
-store ptr %0, ptr %vtype.debug, align 8, !dbg !287
-ret void, !dbg !288
+```
+%vtype = alloca %T6output5VTypeV, align 8
+...
+call swiftcc void @"output.callByRef(vtype: inout output.VType) -> ()"(ptr nocapture dereferenceable(8) %vtype), !dbg !280
 ```
 
 ### Return types
@@ -105,23 +127,44 @@ When a value type is returned from a function, the caller takes ownership of the
  - If an inout parameter is returned, a copy is created and returned
 
 Pass-through callee:
+```swift
+public func TestPassThrough()
+{
+    var vtype = VType()
+    var result = PassThrough(vtype: vtype)
+}
+
+public func PassThrough(vtype: VType) -> VType
+{
+    return vtype
+}
 ```
-%test.debug = alloca ptr, align 8
-call void @llvm.dbg.declare(metadata ptr %test.debug, metadata !265, metadata !DIExpression()), !dbg !266
-call void @llvm.memset.p0.i64(ptr align 8 %test.debug, i8 0, i64 8, i1 false)
-%.refType = getelementptr inbounds %T6output5VTypeV, ptr %1, i32 0, i32 0, !dbg !267
-%2 = load ptr, ptr %.refType, align 8, !dbg !267
-store ptr %2, ptr %test.debug, align 8, !dbg !269
-%3 = call ptr @swift_retain(ptr returned %2) #5, !dbg !270
-%.refType1 = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !270
-store ptr %2, ptr %.refType1, align 8, !dbg !270
-ret void, !dbg !271
+```
+%vtype.debug = alloca ptr, align 8
+%.refType = getelementptr inbounds %T6output5VTypeV, ptr %1, i32 0, i32 0, !dbg !314
+%2 = load ptr, ptr %.refType, align 8, !dbg !314
+store ptr %2, ptr %vtype.debug, align 8, !dbg !316
+%3 = call ptr @swift_retain(ptr returned %2) #5, !dbg !317
+%.refType1 = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !317
+store ptr %2, ptr %.refType1, align 8, !dbg !317
+ret void, !dbg !318
 ```
 
 New instance callee:
+```swift
+public func TestNewInstance()
+{
+    var result = NewInstance()
+}
+
+public func NewInstance() -> VType
+{
+    return VType()
+}
 ```
-call swiftcc void @"$s6output5VTypeVACycfC"(ptr noalias nocapture sret(%T6output5VTypeV) %0), !dbg !302
-ret void, !dbg !303
+```
+call swiftcc void @"output.VType.init() -> output.VType"(ptr noalias nocapture sret(%T6output5VTypeV) %0), !dbg !332
+ret void, !dbg !333
 ```
 
 ## Memory handling

--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -103,7 +103,7 @@ call swiftcc void @"output.callByVal(vtype: output.VType) -> ()"(ptr noalias noc
 
 ### Parameters passed by reference (inout)
 
-When `inout` reference type or a value type containing a reference property is passed as a parameter, it is passed by reference, so no counters are updated.
+When `inout` reference type or a value type containing a reference property is passed as a parameter, it is passed by reference, so no reference counters are updated.
 ```swift
 public func TestInOutParameter()
 {
@@ -177,5 +177,5 @@ To ensure correct memory handling:
  - When a type is marshalled to Swift as a function parameter, `InitWithCopy` should be invoked to create the copy
  - When a type is marshalled to Swift as an `inout` function parameters, an instance reference is passed
  - When a type is marshalled to Swift as a return paramter, `InitWithCopy` should be invoked to create the copy
- - When a type is marshalled from Swift as a return paramter, a created instance in a callee is consumed and counters are not updated
+ - When a type is marshalled from Swift as a return paramter, no reference counters are updated
  - When using a private "copy" constructor on the C# side for marshalling from Swift, `InitWithCopy` should be invoked

--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -169,7 +169,7 @@ ret void, !dbg !333
 
 ## Memory handling
 
-To handle native memory in the scenarios above, the projections should could use the value witness table to invoke `InitWithCopy` for copy operations and `Destroy` for finalization. These functions manage reference counts at any level of nesting.
+To handle native memory in the scenarios above, the projections should use the value witness table to invoke `InitWithCopy` for copy operations and `Destroy` for finalization. These functions manage reference counts at any level of nesting.
 
 To ensure correct memory handling:
  - Swift value types that contain reference properties should be projected as C# classes

--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -1,0 +1,103 @@
+# Memory management
+
+This section outlines the native memory management approach for projected value types, focusing on when and how to retain and release ref counters. The goal is to ensure that native memory is handled correctly across Swift and C# boundaries.
+
+## Requirements
+ - Projected types shall call the value witness table functions to retain and release owned ref types when required
+ - Projected types shall not invoke retain or release functions when implicit copies of ref types are created on the C# side
+
+## Memory ownership
+
+To identify scenarios that require explicit memory handling, consider the following Swift example:
+```swift
+public class RefType {
+    public init() { }
+
+    deinit { }
+}
+
+public struct VType {
+    public var refType: RefType
+
+    public init() {
+        refType = RefType()
+    }
+
+    public init(refType: RefType) {
+        self.refType = refType
+    }
+}
+
+To define memory handling rules at the Swift and C# boundary, the following scenarios are included:
+ - Code blocks
+ - Initializers
+ - Parameters
+ - Return types
+
+### Code blocks
+```
+When a value type is initialized within a block, it is stack-allocated. At the end of the block, all reference properties must be deallocated. For example:
+```
+%vtype = alloca %T6output5VTypeV, align 8
+...
+%0 = call ptr @"outlined destroy of output.VType"(ptr %vtype), !dbg !156
+
+// VWT->Destroy
+define linkonce_odr hidden ptr @"outlined destroy of output.VType"(ptr %0) #8 !dbg !143 {
+entry:
+  %.refType = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !144
+  %toDestroy = load ptr, ptr %.refType, align 8, !dbg !144
+  call void @swift_release(ptr %toDestroy) #1, !dbg !144
+  ret ptr %0, !dbg !144
+}
+```
+
+### Initializers
+
+When a reference type or a value type containing a reference property is passed as a parameter to a constructor, its reference count is retained before the call and released after:
+
+```swift
+var refType = RefType()
+var vtype = VType(refType: refType)
+```
+```
+%3 = call ptr @swift_retain(ptr returned %2) #4, !dbg !164
+store ptr %2, ptr %refType, align 8, !dbg !164
+call swiftcc void @"output.VType.init(refType: output.RefType) -> output.VType"(ptr noalias nocapture sret(%T6output5VTypeV) %vtype, ptr %2), !dbg !168
+%toDestroy = load ptr, ptr %refType, align 8, !dbg !170
+call void @swift_release(ptr %toDestroy) #1, !dbg !170
+```
+
+### Parameters
+
+When a reference type or a value type containing a reference property is passed as a parameter, its reference count is retained before the call and released after:
+
+```
+%1 = load ptr, ptr %vtype.refType, align 8, !dbg !154
+%2 = call ptr @swift_retain(ptr returned %1) #4, !dbg !154
+%.refType = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !156
+store ptr %1, ptr %.refType, align 8, !dbg !156
+call swiftcc void @"output.PassThrough(vtype: output.VType) -> ()"(ptr noalias nocapture dereferenceable(8) %0), !dbg !157
+%3 = call ptr @"outlined destroy of output.VType"(ptr %0), !dbg !158
+```
+
+### Return types
+
+When a value type is returned from a function, a new instance is created, and its reference count is retained before the return. The caller is responsible for releasing the reference:
+```
+%2 = load ptr, ptr %.refType, align 8, !dbg !173
+store ptr %2, ptr %vtype.debug, align 8, !dbg !175
+%3 = call ptr @swift_retain(ptr returned %2) #4, !dbg !176
+%.refType1 = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !176
+store ptr %2, ptr %.refType1, align 8, !dbg !176
+```
+
+## Memory handling
+
+To handle native memory in the scenarios above, the projections should could use the value witness table to invoke `InitWithCopy` for copy operations and `Destroy` for finalization. These functions manage reference counts at any level of nesting.
+
+To ensure correct memory handling:
+ - Value types that contain reference properties should be projected as C# classes with destructors that call `Destroy`
+ - When types are marshalled into Swift, `InitWithCopy` should be invoked to create the copy/ `Destroy` should be called on the copy at the end of the block
+ - When types are marshalled from Swift, `Destroy` should be called at the end of the block
+ - When using the "copy" constructor on the C# side, `InitWithCopy` should be invoked

--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -176,6 +176,6 @@ To ensure correct memory handling:
  - When a type goes out of the block the destructor/dispose should invoke `Destroy` function
  - When a type is marshalled to Swift as a function parameter, `InitWithCopy` should be invoked to create the copy
  - When a type is marshalled to Swift as an `inout` function parameters, an instance reference is passed
- - When a type is marshalled to Swift as a return paramter, `InitWithCopy` should be invoked to create the copy
+ - When a type is marshalled to Swift as a return parameter, `InitWithCopy` should be invoked to create the copy
  - When a type is marshalled from Swift as a return paramter, a created instance in a callee is consumed and counters are not updated
  - When using a private "copy" constructor on the C# side for marshalling from Swift, `InitWithCopy` should be invoked

--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -1,12 +1,14 @@
 # Memory management
 
-This section outlines the native memory management approach for projected value types, focusing on when and how to retain and release ref counters. The goal is to ensure that native memory is handled correctly across Swift and C# boundaries.
+This section outlines the native memory management approach for projected value types, focusing on when and how to retain and release reference counters. The goal is to ensure that native memory is handled correctly across Swift and C# boundaries.
 
 ## Requirements
- - Projected types shall call the value witness table functions to retain and release owned ref types when required
- - Projected types shall not invoke retain or release functions when implicit copies of ref types are created on the C# side
+ - Projected types shall call the value witness table functions to retain and release reference counters when required
+ - Projected types shall not invoke retain or release functions when implicit copies of value types with reference properties are created on the C# side
 
 ## Memory ownership
+
+The memory ownership rules described below apply exclusively to Swift and don't reflect on C# practices.
 
 To identify scenarios that require explicit memory handling, consider the following Swift example:
 ```swift
@@ -27,15 +29,17 @@ public struct VType {
         self.refType = refType
     }
 }
+```
 
 To define memory handling rules at the Swift and C# boundary, the following scenarios are included:
  - Code blocks
  - Initializers
- - Parameters
+ - Parameters passed by value
+ - Parameters passed by reference (inout)
  - Return types
 
 ### Code blocks
-```
+
 When a value type is initialized within a block, it is stack-allocated. At the end of the block, all reference properties must be deallocated. For example:
 ```
 %vtype = alloca %T6output5VTypeV, align 8
@@ -60,6 +64,7 @@ When a reference type or a value type containing a reference property is passed 
 var refType = RefType()
 var vtype = VType(refType: refType)
 ```
+
 ```
 %3 = call ptr @swift_retain(ptr returned %2) #4, !dbg !164
 store ptr %2, ptr %refType, align 8, !dbg !164
@@ -68,9 +73,9 @@ call swiftcc void @"output.VType.init(refType: output.RefType) -> output.VType"(
 call void @swift_release(ptr %toDestroy) #1, !dbg !170
 ```
 
-### Parameters
+### Parameters passed by value
 
-When a reference type or a value type containing a reference property is passed as a parameter, its reference count is retained before the call and released after:
+When a reference type or a value type containing a reference property is passed as a parameter, a copy is made (reference counter is retained before the call) and released after:
 
 ```
 %1 = load ptr, ptr %vtype.refType, align 8, !dbg !154
@@ -81,15 +86,42 @@ call swiftcc void @"output.PassThrough(vtype: output.VType) -> ()"(ptr noalias n
 %3 = call ptr @"outlined destroy of output.VType"(ptr %0), !dbg !158
 ```
 
+### Parameters passed by reference (inout)
+
+When `inout` reference type or a value type containing a reference property is passed as a parameter, it is passed by reference, so no counters are updated.
+```
+%vtype.debug = alloca ptr, align 8
+call void @llvm.dbg.declare(metadata ptr %vtype.debug, metadata !285, metadata !DIExpression(DW_OP_deref)), !dbg !286
+call void @llvm.memset.p0.i64(ptr align 8 %vtype.debug, i8 0, i64 8, i1 false)
+store ptr %0, ptr %vtype.debug, align 8, !dbg !287
+ret void, !dbg !288
+```
+
 ### Return types
 
-When a value type is returned from a function, a new instance is created, and its reference count is retained before the return. The caller is responsible for releasing the reference:
+When a value type is returned from a function, the caller takes ownership of the instance and is responsible for releasing it at the end of the block. In the callee:
+ - If a new instance is created, its counter is initialized to 1
+ - If an existing parameter is returned, its reference count is retained before returning
+ - If an inout parameter is returned, a copy is created and returned
+
+Pass-through callee:
 ```
-%2 = load ptr, ptr %.refType, align 8, !dbg !173
-store ptr %2, ptr %vtype.debug, align 8, !dbg !175
-%3 = call ptr @swift_retain(ptr returned %2) #4, !dbg !176
-%.refType1 = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !176
-store ptr %2, ptr %.refType1, align 8, !dbg !176
+%test.debug = alloca ptr, align 8
+call void @llvm.dbg.declare(metadata ptr %test.debug, metadata !265, metadata !DIExpression()), !dbg !266
+call void @llvm.memset.p0.i64(ptr align 8 %test.debug, i8 0, i64 8, i1 false)
+%.refType = getelementptr inbounds %T6output5VTypeV, ptr %1, i32 0, i32 0, !dbg !267
+%2 = load ptr, ptr %.refType, align 8, !dbg !267
+store ptr %2, ptr %test.debug, align 8, !dbg !269
+%3 = call ptr @swift_retain(ptr returned %2) #5, !dbg !270
+%.refType1 = getelementptr inbounds %T6output5VTypeV, ptr %0, i32 0, i32 0, !dbg !270
+store ptr %2, ptr %.refType1, align 8, !dbg !270
+ret void, !dbg !271
+```
+
+New instance callee:
+```
+call swiftcc void @"$s6output5VTypeVACycfC"(ptr noalias nocapture sret(%T6output5VTypeV) %0), !dbg !302
+ret void, !dbg !303
 ```
 
 ## Memory handling
@@ -97,7 +129,10 @@ store ptr %2, ptr %.refType1, align 8, !dbg !176
 To handle native memory in the scenarios above, the projections should could use the value witness table to invoke `InitWithCopy` for copy operations and `Destroy` for finalization. These functions manage reference counts at any level of nesting.
 
 To ensure correct memory handling:
- - Value types that contain reference properties should be projected as C# classes with destructors that call `Destroy`
- - When types are marshalled into Swift, `InitWithCopy` should be invoked to create the copy/ `Destroy` should be called on the copy at the end of the block
- - When types are marshalled from Swift, `Destroy` should be called at the end of the block
- - When using the "copy" constructor on the C# side, `InitWithCopy` should be invoked
+ - Swift value types that contain reference properties should be projected as C# classes
+ - When a type goes out of the block the destructor/dispose should invoke `Destroy` function
+ - When a type is marshalled to Swift as a function parameter, `InitWithCopy` should be invoked to create the copy
+ - When a type is marshalled to Swift as an `inout` function parameters, an instance reference is passed
+ - When a type is marshalled to Swift as a return paramter, `InitWithCopy` should be invoked to create the copy
+ - When a type is marshalled from Swift as a return paramter, a created instance in a callee is consumed and counters are not updated
+ - When using a private "copy" constructor on the C# side for marshalling from Swift, `InitWithCopy` should be invoked

--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -177,5 +177,5 @@ To ensure correct memory handling:
  - When a type is marshalled to Swift as a function parameter, `InitWithCopy` should be invoked to create the copy
  - When a type is marshalled to Swift as an `inout` function parameters, an instance reference is passed
  - When a type is marshalled to Swift as a return parameter, `InitWithCopy` should be invoked to create the copy
- - When a type is marshalled from Swift as a return paramter, a created instance in a callee is consumed and counters are not updated
+ - When a type is marshalled from Swift as a return parameter, a created instance in a callee is consumed and counters are not updated
  - When using a private "copy" constructor on the C# side for marshalling from Swift, `InitWithCopy` should be invoked

--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -175,7 +175,7 @@ To ensure correct memory handling:
  - Swift value types that contain reference properties should be projected as C# classes
  - When a type goes out of the block the finalizer/dispose should invoke `Destroy` function
  - When a type is marshalled to Swift as a function parameter, `InitWithCopy` should be invoked to create the copy
- - When a type is marshalled to Swift as an `inout` function parameters, an instance reference is passed
+ - When a type is marshalled to Swift as an `inout` function parameters, an instance reference is passed. If the projected Swift instance in C# remains in C# beyond the lifetime of the callee, `InitWithCopy` should be invoked to create the copy
  - When a type is marshalled to Swift as a return parameter, `InitWithCopy` should be invoked to create the copy
  - When a type is marshalled from Swift as a return paramter, no reference counters are updated
  - When using a private "copy" constructor on the C# side for marshalling from Swift, `InitWithCopy` should be invoked

--- a/src/docs/memory-management.md
+++ b/src/docs/memory-management.md
@@ -173,7 +173,7 @@ To handle native memory in the scenarios above, the projections should use the v
 
 To ensure correct memory handling:
  - Swift value types that contain reference properties should be projected as C# classes
- - When a type goes out of the block the destructor/dispose should invoke `Destroy` function
+ - When a type goes out of the block the finalizer/dispose should invoke `Destroy` function
  - When a type is marshalled to Swift as a function parameter, `InitWithCopy` should be invoked to create the copy
  - When a type is marshalled to Swift as an `inout` function parameters, an instance reference is passed
  - When a type is marshalled to Swift as a return parameter, `InitWithCopy` should be invoked to create the copy

--- a/src/docs/runtime-features-overview.md
+++ b/src/docs/runtime-features-overview.md
@@ -2,3 +2,5 @@
 
 [TypeMetadata](runtime-metadata.md) - a representation for Swift's type object
 [NominalTypeDescriptor](runtime-nominal-type-descriptor.md) - information about nominal types
+
+[Memory management](memory-management.md)


### PR DESCRIPTION
## Description
This PR adds documentation outlining the native memory management approach for projected value types. The scenarios included will be extended in future.

The goal is to validate the proposed approach and provide documentation.

## Out-of-scope

This PR doesn't include the handling of projected reference types; it only includes projected value types with reference properties. Additionally, generics are not included.

Contributes to https://github.com/dotnet/runtimelab/issues/2851