### PR TITLE
[Swift shipping] Add `Swift.Bindings.Experimental` nuget to `dotnet-experimental` for device tests

### DIFF
--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -2,6 +2,9 @@ parameters:
   PublishRidAgnosticPackagesFromPlatform: ''
   isOfficialBuild: false
   logArtifactName: 'Logs-PrepareSignedArtifacts_Attempt$(System.JobAttempt)'
+  bindings:
+    isBindingsBuild: false
+    scriptArgs: ''
 
 jobs:
 - template: /eng/common/templates-official/job/job.yml
@@ -54,12 +57,23 @@ jobs:
         /p:DotNetSignType=$(_SignType)
         /p:DotNetPublishUsingPipelines=true
         /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
-      displayName: Prepare artifacts and upload to build
+      displayName: Prepare tooling artifacts and upload to build
 
-    - script: |
-        ./generate.sh --configuration Release --platform MacOSX --arch x86_64-apple-macos --framework StoreKit
-        ./dotnet.sh pack GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj /p:Configuration=Release /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }} /p:OfficialBuildId=$(Build.BuildNumber) /p:SignType=$(_SignType) /p:DotNetSignType=$(_SignType) /p:DotNetPublishUsingPipelines=true
-      displayName: Generate bindings and upload to build
+    - ${{ if and(eq(parameters.bindings.isBindingsBuild, true), ne(parameters.osGroup, 'Windows_NT')) }}:
+      - script: >-
+          ./generate.sh --configuration Release ${{ parameters.bindings.scriptArgs }}
+        displayName: Generate bindings
+
+      - script: >-
+          ./dotnet.sh pack
+          GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj
+          /p:Configuration=Release
+          /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
+          /p:OfficialBuildId=$(Build.BuildNumber)
+          /p:SignType=$(_SignType)
+          /p:DotNetSignType=$(_SignType)
+          /p:DotNetPublishUsingPipelines=true
+        displayName: Prepare bindings artifacts and upload to build
 
     - task: CopyFiles@2
       displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -53,7 +53,7 @@ jobs:
           -publish
           -pack
           -configuration Release
-          --projects $(pwd)/GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj
+          --projects $(pwd)/GeneratedBindings/Swift.Bindings.Experimental.csproj
           /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
           /p:OfficialBuildId=$(Build.BuildNumber)
           /p:SignType=$(_SignType)

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -29,36 +29,7 @@ jobs:
       - name: '_SignType'
         value: $[ coalesce(variables.OfficialSignType, 'real') ]
 
-    templateContext:
-      inputs:
-      - input: checkout
-        repository: self
-        clean: true
-        fetchDepth: 20
-      - input: pipelineArtifact
-        artifactName: IntermediateArtifacts
-        targetPath: $(Build.SourcesDirectory)\artifacts\PackageDownload\IntermediateArtifacts
-      outputs:
-      - output: pipelineArtifact
-        displayName: 'Publish BuildLogs'
-        condition: succeededOrFailed()
-        targetPath: '$(Build.StagingDirectory)\BuildLogs'
-        artifactName: ${{ parameters.logArtifactName }}
-
     steps:
-    - script: >-
-        ./build.sh -ci
-        -publish
-        -pack
-        -configuration Release
-        /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
-        /p:OfficialBuildId=$(Build.BuildNumber)
-        /p:SignType=$(_SignType)
-        /p:DotNetSignType=$(_SignType)
-        /p:DotNetPublishUsingPipelines=true
-        /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
-      displayName: Prepare tooling artifacts and upload to build
-
     - ${{ if and(eq(parameters.bindings.isBindingsBuild, true), ne(parameters.osGroup, 'Windows_NT')) }}:
       - script: >-
           ./generate.sh --configuration Release ${{ parameters.bindings.scriptArgs }}
@@ -74,6 +45,19 @@ jobs:
           /p:DotNetSignType=$(_SignType)
           /p:DotNetPublishUsingPipelines=true
         displayName: Prepare bindings artifacts and upload to build
+
+    - script: >-
+        ./build.sh -ci
+        -publish
+        -pack
+        -configuration Release
+        /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
+        /p:OfficialBuildId=$(Build.BuildNumber)
+        /p:SignType=$(_SignType)
+        /p:DotNetSignType=$(_SignType)
+        /p:DotNetPublishUsingPipelines=true
+        /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+      displayName: Prepare tooling artifacts and upload to build
 
     - task: CopyFiles@2
       displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -10,8 +10,9 @@ jobs:
     displayName: 'Prepare Signed Artifacts'
 
     pool:
-      name: $(DncEngInternalBuildPool)
-      demands: ImageOverride -equals 1es-windows-2022
+      name: Azure Pipelines
+      image: macos-latest
+      os: macOS
 
     # Double the default timeout.
     timeoutInMinutes: 240
@@ -24,7 +25,7 @@ jobs:
     variables:
       - name: '_SignType'
         value: $[ coalesce(variables.OfficialSignType, 'real') ]
-      
+
     templateContext:
       inputs:
       - input: checkout
@@ -40,10 +41,10 @@ jobs:
         condition: succeededOrFailed()
         targetPath: '$(Build.StagingDirectory)\BuildLogs'
         artifactName: ${{ parameters.logArtifactName }}
-    
+
     steps:
     - script: >-
-        build.cmd -ci
+        build.sh -ci
         -publish
         -pack
         -configuration Release
@@ -54,7 +55,12 @@ jobs:
         /p:DotNetPublishUsingPipelines=true
         /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
       displayName: Prepare artifacts and upload to build
-    
+
+    - script: |
+        ./generate.sh --configuration Release --platform MacOSX --arch x86_64-apple-macos --framework StoreKit
+        ./dotnet.sh pack GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj -configuration Release /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }} p:OfficialBuildId=$(Build.BuildNumber) /p:SignType=$(_SignType) /p:DotNetSignType=$(_SignType) /p:DotNetPublishUsingPipelines=true
+      displayName: Generate bindings and upload to build
+
     - task: CopyFiles@2
       displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs
       inputs:

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -30,22 +30,6 @@ jobs:
         value: $[ coalesce(variables.OfficialSignType, 'real') ]
 
     steps:
-    - ${{ if and(eq(parameters.bindings.isBindingsBuild, true), ne(parameters.osGroup, 'Windows_NT')) }}:
-      - script: >-
-          ./generate.sh --configuration Release ${{ parameters.bindings.scriptArgs }}
-        displayName: Generate bindings
-
-      - script: >-
-          ./dotnet.sh pack
-          GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj
-          /p:Configuration=Release
-          /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
-          /p:OfficialBuildId=$(Build.BuildNumber)
-          /p:SignType=$(_SignType)
-          /p:DotNetSignType=$(_SignType)
-          /p:DotNetPublishUsingPipelines=true
-        displayName: Prepare bindings artifacts and upload to build
-
     - script: >-
         ./build.sh -ci
         -publish
@@ -58,6 +42,25 @@ jobs:
         /p:DotNetPublishUsingPipelines=true
         /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
       displayName: Prepare tooling artifacts and upload to build
+
+    - ${{ if eq(parameters.bindings.isBindingsBuild, true)) }}:
+      - script: >-
+          ./generate.sh --configuration Release ${{ parameters.bindings.scriptArgs }}
+        displayName: Generate bindings
+
+      - script: >-
+          ./build.sh -ci
+          -publish
+          -pack
+          -configuration Release
+          --projects $(pwd)/GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj
+          /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
+          /p:OfficialBuildId=$(Build.BuildNumber)
+          /p:SignType=$(_SignType)
+          /p:DotNetSignType=$(_SignType)
+          /p:DotNetPublishUsingPipelines=true
+          /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+        displayName: Prepare bindings artifacts and upload to build
 
     - task: CopyFiles@2
       displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -43,7 +43,7 @@ jobs:
         /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
       displayName: Prepare tooling artifacts and upload to build
 
-    - ${{ if eq(parameters.bindings.isBindingsBuild, true)) }}:
+    - ${{ if eq(parameters.bindings.isBindingsBuild, true) }}:
       - script: >-
           ./generate.sh --configuration Release ${{ parameters.bindings.scriptArgs }}
         displayName: Generate bindings

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -58,7 +58,7 @@ jobs:
 
     - script: |
         ./generate.sh --configuration Release --platform MacOSX --arch x86_64-apple-macos --framework StoreKit
-        ./dotnet.sh pack GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj /p:Configuration=Release /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }} p:OfficialBuildId=$(Build.BuildNumber) /p:SignType=$(_SignType) /p:DotNetSignType=$(_SignType) /p:DotNetPublishUsingPipelines=true
+        ./dotnet.sh pack GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj /p:Configuration=Release /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }} /p:OfficialBuildId=$(Build.BuildNumber) /p:SignType=$(_SignType) /p:DotNetSignType=$(_SignType) /p:DotNetPublishUsingPipelines=true
       displayName: Generate bindings and upload to build
 
     - task: CopyFiles@2

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -30,22 +30,6 @@ jobs:
         value: $[ coalesce(variables.OfficialSignType, 'real') ]
 
     steps:
-    - ${{ if and(eq(parameters.bindings.isBindingsBuild, true), ne(parameters.osGroup, 'Windows_NT')) }}:
-      - script: >-
-          ./generate.sh --configuration Release ${{ parameters.bindings.scriptArgs }}
-        displayName: Generate bindings
-
-      - script: >-
-          ./dotnet.sh pack
-          GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj
-          /p:Configuration=Release
-          /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
-          /p:OfficialBuildId=$(Build.BuildNumber)
-          /p:SignType=$(_SignType)
-          /p:DotNetSignType=$(_SignType)
-          /p:DotNetPublishUsingPipelines=true
-        displayName: Prepare bindings artifacts and upload to build
-
     - script: >-
         ./build.sh -ci
         -publish
@@ -58,6 +42,25 @@ jobs:
         /p:DotNetPublishUsingPipelines=true
         /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
       displayName: Prepare tooling artifacts and upload to build
+
+    - ${{ if and(eq(parameters.bindings.isBindingsBuild, true), ne(parameters.osGroup, 'Windows_NT')) }}:
+      - script: >-
+          ./generate.sh --configuration Release ${{ parameters.bindings.scriptArgs }}
+        displayName: Generate bindings
+
+      - script: >-
+          ./build.sh -ci
+          -publish
+          -pack
+          -configuration Release
+          --projects $(pwd)/GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj
+          /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
+          /p:OfficialBuildId=$(Build.BuildNumber)
+          /p:SignType=$(_SignType)
+          /p:DotNetSignType=$(_SignType)
+          /p:DotNetPublishUsingPipelines=true
+          /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
+        displayName: Prepare bindings artifacts and upload to build
 
     - task: CopyFiles@2
       displayName: Copy Files to $(Build.StagingDirectory)\BuildLogs

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -58,7 +58,7 @@ jobs:
 
     - script: |
         ./generate.sh --configuration Release --platform MacOSX --arch x86_64-apple-macos --framework StoreKit
-        ./dotnet.sh pack GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj -configuration Release /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }} p:OfficialBuildId=$(Build.BuildNumber) /p:SignType=$(_SignType) /p:DotNetSignType=$(_SignType) /p:DotNetPublishUsingPipelines=true
+        ./dotnet.sh pack GeneratedBindings/Swift.Bindings.MacOSX.Experimental.csproj /p:Configuration=Release /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }} p:OfficialBuildId=$(Build.BuildNumber) /p:SignType=$(_SignType) /p:DotNetSignType=$(_SignType) /p:DotNetPublishUsingPipelines=true
       displayName: Generate bindings and upload to build
 
     - task: CopyFiles@2

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - script: >-
-        build.sh -ci
+        ./build.sh -ci
         -publish
         -pack
         -configuration Release

--- a/eng/pipelines/common/templates/publish.yml
+++ b/eng/pipelines/common/templates/publish.yml
@@ -1,5 +1,5 @@
 parameters:
-  PublishRidAgnosticPackagesFromPlatform: windows_x64
+  PublishRidAgnosticPackagesFromPlatform: macos_x64
   publishingInfraVersion: 3
   enableSigningValidation: false
   enableNugetValidation: false

--- a/eng/pipelines/common/templates/publish.yml
+++ b/eng/pipelines/common/templates/publish.yml
@@ -4,6 +4,9 @@ parameters:
   enableSigningValidation: false
   enableNugetValidation: false
   enableSourceLinkValidation: false
+  bindings:
+    isBindingsBuild: false
+    scriptArgs: ''
 
 stages:
 
@@ -16,6 +19,7 @@ stages:
   - template: /eng/pipelines/common/jobs/prepare-signed-artifacts.yml
     parameters:
       PublishRidAgnosticPackagesFromPlatform: ${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
+      bindings: ${{ parameters.bindings }}
 
   # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
   - template: /eng/common/templates-official/job/publish-build-assets.yml

--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -42,4 +42,4 @@ extends:
           enableSourceLinkValidation: true
           bindings:
             isBindingsBuild: true
-            scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --version 12.0 --framework StoreKit'
+            scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --version 12.0 --framework StoreKit --experimental'

--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -35,24 +35,11 @@ extends:
   template: /eng/pipelines/common/templates/template1es.yml@self
   parameters:
     stages:
-    - stage: Build
-      jobs:
-      - template: /eng/pipelines/common/templates/build-job.yml
-        parameters:
-          osGroup: OSX
-          archType: x64
-          isOfficialBuild: true
-          runTests: false
-          pool:
-            name: Azure Pipelines
-            image: macos-latest
-            os: macOS
-          bindings:
-            isBindingsBuild: true
-            scriptArgs: '--platform MacOSX --arch arm64e-apple-macos --framework StoreKit --experimental'
-
     - ${{ if eq(variables.isOfficialBuild, true) }}:
       - template: /eng/pipelines/common/templates/publish.yml
         parameters:
           isOfficialBuild: true
           enableSourceLinkValidation: true
+          bindings:
+            isBindingsBuild: true
+            scriptArgs: '--platform MacOSX --arch arm64e-apple-macos --framework StoreKit --experimental'

--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -42,4 +42,4 @@ extends:
           enableSourceLinkValidation: true
           bindings:
             isBindingsBuild: true
-            scriptArgs: '--platform MacOSX --arch arm64e-apple-macos --framework StoreKit --experimental'
+            scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --version 12.0 --framework StoreKit'

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -59,7 +59,7 @@ stages:
           vmImage: 'macOS-latest'
         bindings:
           isBindingsBuild: true
-          scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --framework StoreKit'
+          scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --version 12.0 --framework StoreKit'
 
     - template: /eng/pipelines/common/templates/test-job.yml
       parameters:

--- a/generate.sh
+++ b/generate.sh
@@ -111,8 +111,8 @@ function InvokeProjectionTooling {
     fi
 }
 
-# Function to generate NuGet package
-function PackNuGet {
+# Function to generate project
+function CreateProject {
     local project_file="./Swift.Bindings.${platform}.Experimental.csproj"
 
     cat <<EOL > "$project_file"
@@ -129,7 +129,7 @@ function PackNuGet {
 </Project>
 EOL
 
-    $scriptroot/dotnet.sh pack "$project_file"
+    $scriptroot/dotnet.sh build "$project_file"
 }
 
 function Generate {
@@ -144,7 +144,7 @@ function Generate {
         fi
     done
 
-    PackNuGet
+    CreateProject
 
     echo "Process completed."
 }

--- a/generate.sh
+++ b/generate.sh
@@ -6,14 +6,13 @@ usage()
 {
   echo "Common settings:"
   echo "  --platform <value>         Platform: MacOSX, iPhoneOS, iPhoneSimulator, AppleTVOS, AppleTVSimulator"
+  echo "  --version <value>          Version of the SDK"
   echo "  --arch <value>             Architecture: arm64e-apple-macos, x86_64-apple-macos"
   echo "  --framework <value>        Framework to generate bindings for"
   echo "  --configuration <value>    Configuration: Debug, Release"
+  echo "  --experimental             Generates only Runtime.Swift namespace when bindings for frameworks are not complete"
   echo "  --help                     Print help and exit (short: -h)"
   echo ""
-
-  echo "Actions:"
-  echo "  --experimental             Generates only Runtime.Swift namespace when bindings for frameworks are not complete"
 }
 
 source="${BASH_SOURCE[0]}"
@@ -31,6 +30,7 @@ done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
 platform=''
+version=''
 arch=''
 frameworks=()
 configuration='Debug'
@@ -50,6 +50,10 @@ while [[ $# > 0 ]]; do
       ;;
     -platform)
       platform=$2
+      shift
+      ;;
+    -version)
+      version=$2
       shift
       ;;
     -arch)
@@ -101,6 +105,10 @@ function InvokeProjectionTooling {
 
     $scriptroot/dotnet.sh $scriptroot/artifacts/bin/Swift.Bindings/$configuration/net9.0/Swift.Bindings.dll -a "./$framework.abi.json" -d "/System/Library/Frameworks/$framework.framework/$framework" -o "./"
 
+    # Patch library name in generated C# code for async methods
+    local frameworkPath="/System/Library/Frameworks/${framework}.framework/${framework}"
+    sed -i '' "/_async/ s|${frameworkPath}|SwiftBindings|g" "./Swift.$framework.cs"
+
     echo ""
     echo "C# source code for Swift.$framework.cs:"
     cat "./Swift.$framework.cs"
@@ -108,12 +116,101 @@ function InvokeProjectionTooling {
 
     if $experimental; then
         rm -rf "./Swift.$framework.cs"
+        rm -rf "./Swift.$framework.swift"
     fi
+
+    if [ -f "Swift.${framework}.swift" ]; then
+        echo "import ${framework}" | cat - Swift.${framework}.swift > temp && mv temp Swift.${framework}.swift
+    fi
+}
+
+# Function to create a Swift xcframework
+function CreateFramework {
+    framework="SwiftBindings"
+
+    if ! ls *.swift 1> /dev/null 2>&1; then
+        echo "No Swift files found to build. Skipping..."
+        return
+    fi
+
+    # x86_64
+    echo "Building ${framework} for ${platform} x86_64..."
+    swiftc -emit-library -target x86_64-apple-$(echo "$platform" | tr '[:upper:]' '[:lower:]')${version} -module-name ${framework} -o ${framework}-${platform}-x64.dylib *.swift -F /Applications/Xcode.app/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk/System/Library/Frameworks/
+
+    # arm64
+    echo "Building ${framework} for ${platform} arm64..."
+    swiftc -emit-library -target arm64-apple-$(echo "$platform" | tr '[:upper:]' '[:lower:]')${version} -module-name ${framework} -o ${framework}-${platform}-arm64.dylib *.swift -F /Applications/Xcode.app/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk/System/Library/Frameworks/
+
+    if [[ $platform == "MacOSX" ]]; then
+        # MacCatalyst x86_64
+        echo "Building ${framework} for MacCatalyst x86_64..."
+        swiftc -emit-library -target x86_64-apple-ios15.0-macabi -module-name ${framework} -o ${framework}-maccatalyst-x64.dylib *.swift -F /Applications/Xcode.app/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk/System/iOSSupport/System/Library/Frameworks
+
+        # MacCatalyst arm64
+        echo "Building ${framework} for MacCatalyst arm64..."
+        swiftc -emit-library -target arm64-apple-ios15.0-macabi -module-name ${framework} -o ${framework}-maccatalyst-arm64.dylib *.swift -F /Applications/Xcode.app/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk/System/iOSSupport/System/Library/Frameworks
+    fi
+
+    # Function to create a Swift framework
+    create_framework() {
+        variant=$1
+        dylib="${framework}-${variant}.dylib"
+        framework_dir="${variant}/${framework}.framework"
+
+        echo "Creating framework bundle for ${variant}..."
+        rm -rf "${framework_dir}"
+        mkdir -p "${framework_dir}/Versions/A"
+
+        cp "${dylib}" "${framework_dir}/Versions/A/${framework}"
+        ln -s "Versions/A/${framework}" "${framework_dir}/${framework}"
+
+        cat > "${framework_dir}/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.yourcompany.${framework}</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+</dict>
+</plist>
+EOF
+
+        mkdir -p ${framework_dir}/Modules
+        cat > ${framework_dir}/Modules/module.modulemap <<EOF
+framework module MySwiftFramework {
+    umbrella header "MySwiftFramework.h"
+    export *
+    module * { export * }
+}
+EOF
+
+        echo "// Header file" > ${framework_dir}/${framework}.h
+    }
+
+    create_framework "$platform-x64"
+    create_framework "$platform-arm64"
+    args_x64=(-framework "$platform-x64/${framework}.framework")
+    args_arm64=(-framework "$platform-x64/${framework}.framework")
+    if [[ $platform == "MacOSX" ]]; then
+        create_framework "maccatalyst-x64"
+        create_framework "maccatalyst-arm64"
+        args_x64+=(-framework "maccatalyst-x64/${framework}.framework")
+        args_arm64+=(-framework "maccatalyst-arm64/${framework}.framework")
+    fi
+
+    args_x64+=(-output "${framework}_x64.xcframework")
+    args_arm64+=(-output "${framework}_arm64.xcframework")
+    xcodebuild -create-xcframework "${args_x64[@]}"
+    xcodebuild -create-xcframework "${args_arm64[@]}"
 }
 
 # Function to generate project
 function CreateProject {
-    local project_file="./Swift.Bindings.${platform}.Experimental.csproj"
+    local project_file="./Swift.Bindings.Experimental.csproj"
 
     cat <<EOL > "$project_file"
 <Project Sdk="Microsoft.NET.Sdk">
@@ -126,6 +223,24 @@ function CreateProject {
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
+  <ItemGroup>
+    <Content Include="./SwiftBindings_arm64.xcframework/macos-arm64/**">
+        <PackagePath>runtimes/osx-arm64/native/</PackagePath>
+        <Pack>true</Pack>
+    </Content>
+    <Content Include="./SwiftBindings_x64.xcframework/macos-64/**">
+        <PackagePath>runtimes/osx-x64/native/</PackagePath>
+        <Pack>true</Pack>
+    </Content>
+    <Content Include="./SwiftBindings_arm64.xcframework/ios-arm64-maccatalyst/**">
+        <PackagePath>runtimes/maccatalyst-arm64/native/</PackagePath>
+        <Pack>true</Pack>
+    </Content>
+    <Content Include="./SwiftBindings_x64.xcframework/ios-x64-maccatalyst/**">
+        <PackagePath>runtimes/maccatalyst-x64/native/</PackagePath>
+        <Pack>true</Pack>
+    </Content>
+  </ItemGroup>
 </Project>
 EOL
 
@@ -144,6 +259,7 @@ function Generate {
         fi
     done
 
+    CreateFramework
     CreateProject
 
     echo "Process completed."

--- a/src/Dynamo/src/Dynamo.csproj
+++ b/src/Dynamo/src/Dynamo.csproj
@@ -6,5 +6,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IsAotCompatible>true</IsAotCompatible>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 </Project>

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -633,13 +633,14 @@ namespace BindingsGeneration
                 )
             );
 
+            var parentTypeName = (_env.ParentDecl as TypeDecl)!.SwiftTypeName;
             swiftWriter.WriteLine($$"""
-            extension {{_env.ParentDecl.Name}} {
+            extension {{parentTypeName.ModuleQualifiedName}} {
                 @_silgen_name("{{NameProvider.GetMangledName(_env.MethodDecl)}}")
                 public {{(_env.MethodDecl.MethodType == MethodType.Static ? "static " : "")}} func {{NameProvider.GetPInvokeName(_env.MethodDecl)}}({{parameters}}) {
                     Task {
-                        {{(isEmptyTuple ? "" : "let result = ")}}await {{(_env.MethodDecl.MethodType == MethodType.Static ? $"{_env.ParentDecl.Name}." : "")}}{{_env.MethodDecl.Name}}(
-                            {{string.Join(", ", _env.MethodDecl.CSSignature.Skip(1).Select(p => p.Name + ": " + p.Name))}}
+                        {{(isEmptyTuple ? "" : "let result = ")}}await {{(_env.MethodDecl.MethodType == MethodType.Static ? $"{parentTypeName.ModuleQualifiedName}." : "")}}{{_env.MethodDecl.Name}}(
+                            {{string.Join(", ", _env.MethodDecl.CSSignature.Skip(1).Select(p => (p.Name.First() == '_' ? p.Name.Remove(0, 1) : p.Name) + ": " + p.Name))}}
                         )
                         callback({{(isEmptyTuple ? "" : "result, ")}}task)
                     }
@@ -859,7 +860,6 @@ namespace BindingsGeneration
                 return;
 
             var text = $$"""
-                
                         private static unsafe delegate* unmanaged[Cdecl]<{{(_env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple ? "" : $"{_wrapperSignature.ReturnType}, ")}}IntPtr, void> s_{{_env.MethodDecl.Name}}Callback = &{{_env.MethodDecl.Name}}OnComplete;
                         [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
                         private static void {{_env.MethodDecl.Name}}OnComplete({{(_env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple ? "" : $"{_wrapperSignature.ReturnType} result, ")}}IntPtr task)

--- a/src/samples/HikingApp/HikingApp.MacCatalyst/HikingApp.MacCatalyst.csproj
+++ b/src/samples/HikingApp/HikingApp.MacCatalyst/HikingApp.MacCatalyst.csproj
@@ -27,9 +27,9 @@
     </ImageAsset>
   </ItemGroup>
 
-  <!-- Reference Swift.Bindings.MacOSX.Experimental NuGet package locally -->
+  <!-- Reference Swift.Bindings.Experimental NuGet package locally -->
   <!-- <ItemGroup>
-    <PackageReference Include="Swift.Bindings.MacOSX.Experimental" />
+    <PackageReference Include="Swift.Bindings.Experimental" />
   </ItemGroup> -->
 
   <!-- Notes about the values set below:


### PR DESCRIPTION
## Description

This PR adds the `Swift.Bindings.Experimental` nuget package to the `dotnet-experimental` feed for device testing. The package provides both C# and Swift bindings for selected frameworks. 

It will be used on Helix for testing `StoreKit` scenarios and other frameworks in the future.

## Changes
The `generate.sh` script is updated to generate an `.xcframework` that contains platform and architecture specific bindings. The publish job is updated to upload `Swift.Bindings.Experimental` artifacts to the storage.

## Testing
Internal build for the `dotnet-experimental` feed.

## Out-of-scope
The bindings are generated with the `--experimental` flag and currently contain only the `Swift.Runtime` namespace. Once the package is produced and validated locally from the `feature/swift-bindings`, the flag will be removed and the bindings will be updated to include `StoreKit` bindings.

Fixes https://github.com/dotnet/runtimelab/issues/2849
Contributes to https://github.com/dotnet/runtimelab/issues/2850