### PR TITLE
[Swift language feature] Implement generic parameters/types with generics in Swift async functions

### DIFF
--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -42,4 +42,4 @@ extends:
           enableSourceLinkValidation: true
           bindings:
             isBindingsBuild: true
-            scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --version 12.0 --framework StoreKit --experimental'
+            scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --version 16.0 --framework StoreKit --experimental'

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -59,7 +59,7 @@ stages:
           vmImage: 'macOS-latest'
         bindings:
           isBindingsBuild: true
-          scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --version 12.0 --framework StoreKit'
+          scriptArgs: '--platform MacOSX --arch x86_64-apple-macos --version 16.0 --framework StoreKit'
 
     - template: /eng/pipelines/common/templates/test-job.yml
       parameters:

--- a/generate.sh
+++ b/generate.sh
@@ -144,11 +144,11 @@ function CreateFramework {
     if [[ $platform == "MacOSX" ]]; then
         # MacCatalyst x86_64
         echo "Building ${framework} for MacCatalyst x86_64..."
-        swiftc -emit-library -target x86_64-apple-ios15.0-macabi -module-name ${framework} -o ${framework}-maccatalyst-x64.dylib *.swift -F /Applications/Xcode.app/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk/System/iOSSupport/System/Library/Frameworks
+        swiftc -emit-library -target x86_64-apple-ios18.1-macabi -module-name ${framework} -o ${framework}-maccatalyst-x64.dylib *.swift -F /Applications/Xcode.app/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk/System/iOSSupport/System/Library/Frameworks
 
         # MacCatalyst arm64
         echo "Building ${framework} for MacCatalyst arm64..."
-        swiftc -emit-library -target arm64-apple-ios15.0-macabi -module-name ${framework} -o ${framework}-maccatalyst-arm64.dylib *.swift -F /Applications/Xcode.app/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk/System/iOSSupport/System/Library/Frameworks
+        swiftc -emit-library -target arm64-apple-ios18.1-macabi -module-name ${framework} -o ${framework}-maccatalyst-arm64.dylib *.swift -F /Applications/Xcode.app/Contents/Developer/Platforms/${platform}.platform/Developer/SDKs/${platform}.sdk/System/iOSSupport/System/Library/Frameworks
     fi
 
     # Function to create a Swift framework

--- a/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
+++ b/src/Swift.Bindings/src/Demangler/Swift5Reducer.cs
@@ -117,6 +117,24 @@ internal class Swift5Reducer
             }
         },
         new MatchRule() {
+            Name = "FunctionType", NodeKindList = new List<NodeKind> () { NodeKind.FunctionType, NodeKind.NoEscapeFunctionType },
+            Reducer = ConvertFunctionTypeAsyncThrows,
+            ChildRules = new List<MatchRule> () {
+                new MatchRule () {
+                    Name = "ThrowsAnnotation", NodeKind = NodeKind.ThrowsAnnotation, Reducer = MatchRule.ErrorReducer
+                },
+                new MatchRule () {
+                    Name = "AsyncAnnotation", NodeKind = NodeKind.AsyncAnnotation, Reducer = MatchRule.ErrorReducer
+                },
+                new MatchRule () {
+                    Name = "Arguments", NodeKind = NodeKind.ArgumentTuple, Reducer = MatchRule.ErrorReducer
+                },
+                new MatchRule () {
+                    Name = "ReturnType", NodeKind = NodeKind.ReturnType, Reducer = MatchRule.ErrorReducer
+                },
+            }
+        },
+        new MatchRule() {
             Name = "Function", NodeKind = NodeKind.Function, Reducer = ConvertFunction,
             ChildRules = new List<MatchRule> () {
                 new MatchRule () {
@@ -340,7 +358,7 @@ internal class Swift5Reducer
     /// <param name="node">The node for a Tuple</param>
     /// <param name="mangledName">the mangled name that generated the Node</param>
     /// <returns>a TypeSpecReduction</returns>
-    /// 
+    ///
     static IReduction ConvertTuple(Node node, string mangledName)
     {
         // What to expect here:
@@ -453,7 +471,7 @@ internal class Swift5Reducer
         var argTuple = node.Children[0];
         var @return = node.Children[1];
 
-        return ConvertFunctionMaybeThrows(argTuple, @return, false, noEscaping, mangledName);
+        return ConvertFunctionAsyncThrows(argTuple, @return, false, false, noEscaping, mangledName);
 
         // var reduction = ConvertFirstChild (argTuple, mangledName);
         // if (reduction is ReductionError error)
@@ -467,7 +485,7 @@ internal class Swift5Reducer
         //         return new TypeSpecReduction () { Symbol = argsTypeSpecReduction.Symbol, TypeSpec = closure };
         //     } else {
         //         return ReductionErrorLow (ExpectedButGot ("TypeSpecReduction in function return type", reduction.GetType ().Name, mangledName), mangledName);
-        //     }            
+        //     }
         // } else {
         //     return ReductionErrorLow (ExpectedButGot ("TypeSpecReduction in argument tuple type", reduction.GetType ().Name, mangledName), mangledName);
         // }
@@ -486,7 +504,7 @@ internal class Swift5Reducer
         // ArgumentTuple
         // ReturnType
         var noEscaping = node.Kind == NodeKind.NoEscapeFunctionType;
-        return ConvertFunctionMaybeThrows(node.Children[1], node.Children[2], true, noEscaping, mangledName);
+        return ConvertFunctionAsyncThrows(node.Children[1], node.Children[2], false, true, noEscaping, mangledName);
     }
 
     /// <summary>
@@ -502,7 +520,18 @@ internal class Swift5Reducer
         // ArgumentTuple
         // ReturnType
         var noEscaping = node.Kind == NodeKind.NoEscapeFunctionType;
-        return ConvertFunctionAsync(node.Children[1], node.Children[2], true, noEscaping, mangledName);
+        return ConvertFunctionAsyncThrows(node.Children[1], node.Children[2], true, false, noEscaping, mangledName);
+    }
+
+    static IReduction ConvertFunctionTypeAsyncThrows(Node node, string mangledName)
+    {
+        // Expect:
+        // AsyncAnnotation
+        // ThrowsAnnotation
+        // ArgumentTuple
+        // ReturnType
+        var noEscaping = node.Kind == NodeKind.NoEscapeFunctionType;
+        return ConvertFunctionAsyncThrows(node.Children[2], node.Children[3], true, true, noEscaping, mangledName);
     }
 
     /// <summary>
@@ -510,11 +539,12 @@ internal class Swift5Reducer
     /// </summary>
     /// <param name="argTuple">The function arguments Node</param>
     /// <param name="return">The return type Node</param>
+    /// <param name="async">Whether or not the function is async</param>
     /// <param name="throws">Whether or not the function can throw</param>
     /// <param name="noEscaping">Whether or not the function can't escape</param>
     /// <param name="mangledName">the mangled name that generated the Node</param>
     /// <returns>A TypeSpecReduction containing a ClosureTypeSpec</returns>
-    static IReduction ConvertFunctionMaybeThrows(Node argTuple, Node @return, bool throws, bool noEscaping, string mangledName)
+    static IReduction ConvertFunctionAsyncThrows(Node argTuple, Node @return, bool async, bool throws, bool noEscaping, string mangledName)
     {
         var reduction = ConvertFirstChild(argTuple, mangledName);
         if (reduction is ReductionError error)
@@ -528,44 +558,7 @@ internal class Swift5Reducer
             {
                 var closure = new ClosureTypeSpec(argsTypeSpecReduction.TypeSpec, returnTypeSpecReduction.TypeSpec);
                 closure.Throws = throws;
-                if (!noEscaping)
-                    closure.Attributes.Add(new TypeSpecAttribute("escaping"));
-                return new TypeSpecReduction() { Symbol = argsTypeSpecReduction.Symbol, TypeSpec = closure };
-            }
-            else
-            {
-                return ReductionErrorLow(ExpectedButGot("TypeSpecReduction in function return type", reduction.GetType().Name, mangledName), mangledName);
-            }
-        }
-        else
-        {
-            return ReductionErrorLow(ExpectedButGot("TypeSpecReduction in argument tuple type", reduction.GetType().Name, mangledName), mangledName);
-        }
-    }
-
-    /// <summary>
-    /// Converts an argument tuple and return type to a TypeSpecReduction
-    /// </summary>
-    /// <param name="argTuple">The function arguments Node</param>
-    /// <param name="return">The return type Node</param>
-    /// <param name="isAsync">Whether or not the function is async</param>
-    /// <param name="noEscaping">Whether or not the function can't escape</param>
-    /// <param name="mangledName">the mangled name that generated the Node</param>
-    /// <returns>A TypeSpecReduction containing a ClosureTypeSpec</returns>
-    static IReduction ConvertFunctionAsync(Node argTuple, Node @return, bool isAsync, bool noEscaping, string mangledName)
-    {
-        var reduction = ConvertFirstChild(argTuple, mangledName);
-        if (reduction is ReductionError error)
-            return error;
-        else if (reduction is TypeSpecReduction argsTypeSpecReduction)
-        {
-            reduction = ConvertFirstChild(@return, mangledName);
-            if (reduction is ReductionError returnError)
-                return returnError;
-            else if (reduction is TypeSpecReduction returnTypeSpecReduction)
-            {
-                var closure = new ClosureTypeSpec(argsTypeSpecReduction.TypeSpec, returnTypeSpecReduction.TypeSpec);
-                closure.IsAsync = isAsync;
+                closure.IsAsync = async;
                 if (!noEscaping)
                     closure.Attributes.Add(new TypeSpecAttribute("escaping"));
                 return new TypeSpecReduction() { Symbol = argsTypeSpecReduction.Symbol, TypeSpec = closure };

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -391,7 +391,7 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var conformances = genericParameter.Constraints.OrderBy(c => c.Protocol.ModuleQualifiedName);
+                var conformances = genericParameter.GenericConformances.OrderBy(c => c.Protocol.ModuleQualifiedName);
                 foreach (var conformance in conformances)
                 {
                     var pwtName = NameProvider.GetProtocolWitnessTableName(_env.GenericTypeMapping[genericParameter.TypeName].TypeParameter, conformance.Protocol.Name);
@@ -532,7 +532,7 @@ namespace BindingsGeneration
 
             csWriter.WriteLine("[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]");
             csWriter.WriteLine($"[DllImport(\"{libPath}\", EntryPoint = \"{NameProvider.GetMangledName(methodDecl)}\")]");
-            csWriter.WriteLine($"private static extern {pInvokeSignature.ReturnType} {pInvokeName}({pInvokeSignature.ParametersString()});");
+            csWriter.WriteLine($"private static extern {(methodDecl.IsAsync ? "void" : pInvokeSignature.ReturnType)} {pInvokeName}({pInvokeSignature.ParametersString()});");
         }
     }
 
@@ -659,28 +659,62 @@ namespace BindingsGeneration
             GCHandle handle = GCHandle.Alloc(task, GCHandleType.Normal);
             """);
 
+            int genericIndex = 0;
             string parameters = string.Join(
                 ", ",
                 new[]
                 {
-                    $"callback: @escaping ({(isEmptyTuple ? "" : $"{_env.MethodDecl.CSSignature.First().SwiftTypeSpec}, ")}Int64) -> Void",
+                    $"callback: @escaping ({(isEmptyTuple ? "" : $"{(_env.MethodDecl.CSSignature.First().IsGeneric ? _env.MethodDecl.GenericParameters[0].SugaredTypeName : _env.MethodDecl.CSSignature.First().SwiftTypeSpec)}, ")}Int64) -> Void",
                     "task: Int64"
                 }.Concat(
                     _env.MethodDecl.CSSignature
                         .Skip(1)
-                        .Select(p => $"{p.Name}: {p.SwiftTypeSpec}")
+                        .Select(p => $"{p.Name}: {(p.IsGeneric ? _env.MethodDecl.GenericParameters[genericIndex++].SugaredTypeName : p.SwiftTypeSpec)}")
                 )
             );
 
+            var genericParams = _env.MethodDecl.IsGeneric switch
+            {
+                true => $"<{string.Join(", ", _env.MethodDecl.GenericParameters.Select(p => p.SugaredTypeName))}>",
+                false => ""
+            };
+
+            var whereClause = (_env.MethodDecl.IsGeneric && _env.MethodDecl.GenericParameters.Any(p => p.GenericConformances.Any() || p.TypeConformances.Any())) switch
+            {
+                true => " where " + string.Join(
+                    ", ",
+                    _env.MethodDecl.GenericParameters.Select(p =>
+                    {
+                        // Build conformances of the form "T : ProtocolName"
+                        var genericConformances = p.GenericConformances
+                            .Select(gc => $"{p.SugaredTypeName} : {gc.Protocol.Name}");
+
+                        // Build type conformances of the form "T.AssociatedType == ProtocolName"
+                        var typeConformances = p.TypeConformances
+                            .Select(tc =>
+                                $"{p.SugaredTypeName}.{string.Join(".", tc.GenericParameter.Split('.').Skip(1))} == {tc.Protocol.Name}"
+                            );
+
+                        return string.Join(", ", genericConformances.Concat(typeConformances));
+                    })
+                ),
+                false => ""
+            };
+
+
+            // TODO: Fix https://github.com/dotnet/runtimelab/issues/3020
+            var globalResult = $"public var result{_env.MethodDecl.Name}: {(_env.MethodDecl.CSSignature.First().IsGeneric ? "Any?" : ($"{_env.MethodDecl.CSSignature.First().SwiftTypeSpec} = {_env.MethodDecl.CSSignature.First().SwiftTypeSpec}()"))}";
+
             swiftWriter.WriteLine($$"""
+            {{(isEmptyTuple ? "" : globalResult)}}
             extension {{_env.ParentDecl.Name}} {
                 @_silgen_name("{{NameProvider.GetMangledName(_env.MethodDecl)}}")
-                public {{(_env.MethodDecl.MethodType == MethodType.Static ? "static " : "")}} func {{NameProvider.GetPInvokeName(_env.MethodDecl)}}({{parameters}}) {
+                public {{(_env.MethodDecl.MethodType == MethodType.Static ? "static " : "")}} func {{NameProvider.GetPInvokeName(_env.MethodDecl)}}{{genericParams}}({{parameters}}){{whereClause}}{
                     Task {
-                        {{(isEmptyTuple ? "" : "let result = ")}}await {{(_env.MethodDecl.MethodType == MethodType.Static ? $"{_env.ParentDecl.Name}." : "")}}{{_env.MethodDecl.Name}}(
-                            {{string.Join(", ", _env.MethodDecl.CSSignature.Skip(1).Select(p => p.Name + ": " + p.Name))}}
+                        {{(isEmptyTuple ? "" : $"result{_env.MethodDecl.Name} = ")}}try! await {{(_env.MethodDecl.MethodType == MethodType.Static ? $"{_env.ParentDecl.Name}." : "")}}{{_env.MethodDecl.Name}}(
+                            {{string.Join(", ", _env.MethodDecl.CSSignature.Skip(1).Select(p => (p.Name.First() == '_' ? p.Name.Remove(0, 1) : p.Name) + ": " + (p.Name)))}}
                         )
-                        callback({{(isEmptyTuple ? "" : "result, ")}}task)
+                        callback({{(isEmptyTuple ? "" : $"result{_env.MethodDecl.Name}{(_env.MethodDecl.CSSignature.First().IsGeneric ? $" as! {_env.MethodDecl.GenericParameters[0].SugaredTypeName}" : "")}, ")}}task);
                     }
                 }
             }
@@ -779,7 +813,7 @@ namespace BindingsGeneration
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
                 var csTypeParamName = _env.GenericTypeMapping[genericParameter.TypeName].TypeParameter;
-                var conformances = genericParameter.Constraints.OrderBy(c => c.Protocol.ModuleQualifiedName);
+                var conformances = genericParameter.GenericConformances.OrderBy(c => c.Protocol.ModuleQualifiedName);
                 foreach (var conformance in conformances)
                 {
                     var pwtName = NameProvider.GetProtocolWitnessTableName(csTypeParamName, conformance.Protocol.Name);
@@ -845,6 +879,12 @@ namespace BindingsGeneration
         {
             var returnArg = _env.MethodDecl.CSSignature.First();
 
+            if (_requiresSwiftAsync)
+            {
+                csWriter.WriteLine("return task.Task;");
+                return;
+            }
+
             if (_env.BoundGenericsHandler.RequiresBoundGenericMarshalling(returnArg))
             {
                 csWriter.WriteLine($"return SwiftMarshal.MarshalFromSwift<{_env.BoundGenericsHandler.TranslateBoundGenericTypeToCSharp(returnArg)}>((SwiftHandle)new IntPtr(&result));");
@@ -854,12 +894,6 @@ namespace BindingsGeneration
             if (_requiresIndirectResult)
             {
                 csWriter.WriteLine($"return SwiftMarshal.MarshalFromSwift<{_wrapperSignature.ReturnType}>((SwiftHandle)swiftIndirectResult.Value);");
-                return;
-            }
-
-            if (_requiresSwiftAsync)
-            {
-                csWriter.WriteLine("return task.Task;");
                 return;
             }
 
@@ -923,18 +957,28 @@ namespace BindingsGeneration
             if (!_requiresSwiftAsync)
                 return;
 
+            // if (_env.BoundGenericsHandler.IsBoundGeneric(argument))
+            // {
+            //     var csTypeParam = _env.BoundGenericsHandler.TranslateBoundGenericTypeToCSharp(argument);
+            //     SetReturnType(csTypeParam);
+            //     return;
+            // }
+
+            var voidReturn = _env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple;
+
             var text = $$"""
-                
-                        private static unsafe delegate* unmanaged[Cdecl]<{{(_env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple ? "" : $"{_wrapperSignature.ReturnType}, ")}}IntPtr, void> s_{{_env.MethodDecl.Name}}Callback = &{{_env.MethodDecl.Name}}OnComplete;
+                        private static unsafe delegate* unmanaged[Cdecl]<{{(voidReturn ? "" : $"{_pInvokeSignature.ReturnType}, ")}}IntPtr, void> s_{{_env.MethodDecl.Name}}Callback = &{{_env.MethodDecl.Name}}OnComplete;
                         [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-                        private static void {{_env.MethodDecl.Name}}OnComplete({{(_env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple ? "" : $"{_wrapperSignature.ReturnType} result, ")}}IntPtr task)
+                        private static void {{_env.MethodDecl.Name}}OnComplete({{(voidReturn ? "" : $"{_pInvokeSignature.ReturnType} rawResult, ")}}IntPtr task)
                         {
                             GCHandle handle = GCHandle.FromIntPtr(task);
                             try
                             {
-                                if (handle.Target is TaskCompletionSource{{(_env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple ? "" : $"<{_wrapperSignature.ReturnType}>")}} tcs)
+
+                                {{(voidReturn ? "" : $"var result = SwiftMarshal.MarshalFromSwift<{_wrapperSignature.ReturnType}>((SwiftHandle)new IntPtr(&rawResult));")}}
+                                if (handle.Target is TaskCompletionSource{{(voidReturn ? "" : $"<{_wrapperSignature.ReturnType}>")}} tcs)
                                 {
-                                    tcs.TrySetResult({{(_env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple ? "" : "result")}});
+                                    tcs.TrySetResult({{(voidReturn ? "" : "result")}});
                                 }
                             }
                             finally

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -318,6 +318,12 @@ namespace BindingsGeneration
                 return;
             }
 
+            if (_env.MethodDecl.IsAsync && !MarshallingHelpers.ArgumentIsMarshalledAsCSStruct(returnType, _env.TypeDatabase))
+            {
+                SetReturnType("IntPtr");
+                return;
+            }
+
             var returnTypeRecord = _env.TypeDatabase.GetTypeRecordOrThrow(returnType.SwiftTypeSpec);
             SetReturnType(returnTypeRecord.CSharpTypeName.FullyQualifiedName);
         }
@@ -712,7 +718,7 @@ namespace BindingsGeneration
                 @_silgen_name("{{NameProvider.GetMangledName(_env.MethodDecl)}}")
                 public {{(_env.MethodDecl.MethodType == MethodType.Static ? "static " : "")}} func {{NameProvider.GetPInvokeName(_env.MethodDecl)}}{{genericParams}}({{parameters}}){{whereClause}}{
                     Task {
-                        {{(isEmptyTuple ? "" : $"result{_env.MethodDecl.Name} = ")}}try! await {{(_env.MethodDecl.MethodType == MethodType.Static ? $"{_env.ParentDecl.Name}." : "")}}{{_env.MethodDecl.Name}}(
+                        {{(isEmptyTuple ? "" : $"result{_env.MethodDecl.Name} = ")}}try! await {{(_env.MethodDecl.MethodType == MethodType.Static ? $"{parentTypeName.ModuleQualifiedName}." : "")}}{{_env.MethodDecl.Name}}(
                             {{string.Join(", ", _env.MethodDecl.CSSignature.Skip(1).Select(p => (p.Name.First() == '_' ? p.Name.Remove(0, 1) : p.Name) + ": " + (p.Name)))}}
                         )
                         callback({{(isEmptyTuple ? "" : $"result{_env.MethodDecl.Name}{(_env.MethodDecl.CSSignature.First().IsGeneric ? $" as! {_env.MethodDecl.GenericParameters[0].SugaredTypeName}" : "")}, ")}}task);

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -707,18 +707,13 @@ namespace BindingsGeneration
                 false => ""
             };
 
-
-            // TODO: Fix https://github.com/dotnet/runtimelab/issues/3020
-            var globalResult = $"public var result{_env.MethodDecl.Name}: {(_env.MethodDecl.CSSignature.First().IsGeneric ? "Any?" : ($"{_env.MethodDecl.CSSignature.First().SwiftTypeSpec} = {_env.MethodDecl.CSSignature.First().SwiftTypeSpec}()"))}";
-
             var parentTypeName = (_env.ParentDecl as TypeDecl)!.SwiftTypeName;
             swiftWriter.WriteLine($$"""
-            {{(isEmptyTuple ? "" : globalResult)}}
             extension {{parentTypeName.ModuleQualifiedName}} {
                 @_silgen_name("{{NameProvider.GetMangledName(_env.MethodDecl)}}")
                 public {{(_env.MethodDecl.MethodType == MethodType.Static ? "static " : "")}} func {{NameProvider.GetPInvokeName(_env.MethodDecl)}}{{genericParams}}({{parameters}}){{whereClause}}{
                     Task {
-                        {{(isEmptyTuple ? "" : $"result{_env.MethodDecl.Name} = ")}}try! await {{(_env.MethodDecl.MethodType == MethodType.Static ? $"{parentTypeName.ModuleQualifiedName}." : "")}}{{_env.MethodDecl.Name}}(
+                        {{(isEmptyTuple ? "" : $"let result{_env.MethodDecl.Name} = ")}}try! await {{(_env.MethodDecl.MethodType == MethodType.Static ? $"{parentTypeName.ModuleQualifiedName}." : "")}}{{_env.MethodDecl.Name}}(
                             {{string.Join(", ", _env.MethodDecl.CSSignature.Skip(1).Select(p => (p.Name.First() == '_' ? p.Name.Remove(0, 1) : p.Name) + ": " + (p.Name)))}}
                         )
                         callback({{(isEmptyTuple ? "" : $"result{_env.MethodDecl.Name}{(_env.MethodDecl.CSSignature.First().IsGeneric ? $" as! {_env.MethodDecl.GenericParameters[0].SugaredTypeName}" : "")}, ")}}task);
@@ -964,7 +959,23 @@ namespace BindingsGeneration
             if (!_requiresSwiftAsync)
                 return;
 
-            var voidReturn = _env.MethodDecl.CSSignature.First().SwiftTypeSpec.IsEmptyTuple;
+            var returnType = _env.MethodDecl.CSSignature.First();
+            var voidReturn = returnType.SwiftTypeSpec.IsEmptyTuple;
+            var requiresInitWithCopy = !voidReturn && (!MarshallingHelpers.ArgumentIsMarshalledAsCSStruct(returnType, _env.TypeDatabase) || _env.BoundGenericsHandler.IsBoundGeneric(returnType));
+
+            var copyExpression = $$"""
+            IntPtr payload = IntPtr.Zero;
+            try
+            {
+                var metadata = SwiftObjectHelper<{{_wrapperSignature.ReturnType}}>.GetTypeMetadata();
+                payload = (IntPtr)NativeMemory.Alloc(metadata.Size);
+                SwiftMarshal.MarshalToSwift(result, payload);
+            }
+            finally
+            {
+                NativeMemory.Free((void*)payload);
+            }
+            """;
 
             var text = $$"""
                         private static unsafe delegate* unmanaged[Cdecl]<{{(voidReturn ? "" : $"{_pInvokeSignature.ReturnType}, ")}}IntPtr, void> s_{{_env.MethodDecl.Name}}Callback = &{{_env.MethodDecl.Name}}OnComplete;
@@ -974,8 +985,8 @@ namespace BindingsGeneration
                             GCHandle handle = GCHandle.FromIntPtr(task);
                             try
                             {
-
                                 {{(voidReturn ? "" : $"var result = SwiftMarshal.MarshalFromSwift<{_wrapperSignature.ReturnType}>((SwiftHandle)new IntPtr(&rawResult));")}}
+                                {{(requiresInitWithCopy ? copyExpression : "")}}
                                 if (handle.Target is TaskCompletionSource{{(voidReturn ? "" : $"<{_wrapperSignature.ReturnType}>")}} tcs)
                                 {
                                     tcs.TrySetResult({{(voidReturn ? "" : "result")}});

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -665,7 +665,6 @@ namespace BindingsGeneration
             GCHandle handle = GCHandle.Alloc(task, GCHandleType.Normal);
             """);
 
-            int genericIndex = 0;
             string parameters = string.Join(
                 ", ",
                 new[]
@@ -675,7 +674,7 @@ namespace BindingsGeneration
                 }.Concat(
                     _env.MethodDecl.CSSignature
                         .Skip(1)
-                        .Select(p => $"{p.Name}: {(p.IsGeneric ? _env.MethodDecl.GenericParameters[genericIndex++].SugaredTypeName : p.SwiftTypeSpec)}")
+                        .Select(p => $"{p.Name}: {(p.IsGeneric ? _env.MethodDecl.GenericParameters.Find(g => g.TypeName == p.SwiftTypeSpec.ToString())!.SugaredTypeName : p.SwiftTypeSpec)}")
                 )
             );
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/MethodHandler.cs
@@ -397,10 +397,10 @@ namespace BindingsGeneration
         {
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
-                var conformances = genericParameter.GenericConformances.OrderBy(c => c.Protocol.ModuleQualifiedName);
+                var conformances = genericParameter.GenericConformances.OrderBy(c => c.ConformanceTarget.ModuleQualifiedName);
                 foreach (var conformance in conformances)
                 {
-                    var pwtName = NameProvider.GetProtocolWitnessTableName(_env.GenericTypeMapping[genericParameter.TypeName].TypeParameter, conformance.Protocol.Name);
+                    var pwtName = NameProvider.GetProtocolWitnessTableName(_env.GenericTypeMapping[genericParameter.TypeName].TypeParameter, conformance.ConformanceTarget.Name);
                     AddParameter("ProtocolWitnessTable", pwtName);
                 }
             }
@@ -685,7 +685,7 @@ namespace BindingsGeneration
                 false => ""
             };
 
-            var whereClause = (_env.MethodDecl.IsGeneric && _env.MethodDecl.GenericParameters.Any(p => p.GenericConformances.Any() || p.TypeConformances.Any())) switch
+            var whereClause = (_env.MethodDecl.IsGeneric && _env.MethodDecl.GenericParameters.Any(p => p.GenericConformances.Any() || p.AssosiatedTypeConformances.Any())) switch
             {
                 true => " where " + string.Join(
                     ", ",
@@ -693,12 +693,12 @@ namespace BindingsGeneration
                     {
                         // Build conformances of the form "T : ProtocolName"
                         var genericConformances = p.GenericConformances
-                            .Select(gc => $"{p.SugaredTypeName} : {gc.Protocol.Name}");
+                            .Select(gc => $"{p.SugaredTypeName} : {gc.ConformanceTarget.Name}");
 
                         // Build type conformances of the form "T.AssociatedType == ProtocolName"
-                        var typeConformances = p.TypeConformances
+                        var typeConformances = p.AssosiatedTypeConformances
                             .Select(tc =>
-                                $"{p.SugaredTypeName}.{string.Join(".", tc.GenericParameter.Split('.').Skip(1))} == {tc.Protocol.Name}"
+                                $"{p.SugaredTypeName}.{string.Join(".", tc.Path.Skip(1))} == {tc.ConformanceTarget.Name}"
                             );
 
                         return string.Join(", ", genericConformances.Concat(typeConformances));
@@ -815,11 +815,11 @@ namespace BindingsGeneration
             foreach (var genericParameter in _env.MethodDecl.GenericParameters)
             {
                 var csTypeParamName = _env.GenericTypeMapping[genericParameter.TypeName].TypeParameter;
-                var conformances = genericParameter.GenericConformances.OrderBy(c => c.Protocol.ModuleQualifiedName);
+                var conformances = genericParameter.GenericConformances.OrderBy(c => c.ConformanceTarget.ModuleQualifiedName);
                 foreach (var conformance in conformances)
                 {
-                    var pwtName = NameProvider.GetProtocolWitnessTableName(csTypeParamName, conformance.Protocol.Name);
-                    var protocolName = NameProvider.GetInterfaceName(conformance.Protocol.Name);
+                    var pwtName = NameProvider.GetProtocolWitnessTableName(csTypeParamName, conformance.ConformanceTarget.Name);
+                    var protocolName = NameProvider.GetInterfaceName(conformance.ConformanceTarget.Name);
                     csWriter.WriteLine($"var {pwtName} = ProtocolWitnessTable.GetOrThrow<{csTypeParamName}, {protocolName}>();");
                 }
             }

--- a/src/Swift.Bindings/src/Marshaler/MarshallingHelpers.cs
+++ b/src/Swift.Bindings/src/Marshaler/MarshallingHelpers.cs
@@ -7,6 +7,8 @@ namespace BindingsGeneration
     {
         public static bool MethodRequiresIndirectResult(MethodEnvironment env)
         {
+            if (env.MethodDecl.IsAsync) return false;
+
             if (env.MethodDecl.IsConstructor && !(env.ParentDecl is StructDecl structDecl && StructIsMarshalledAsCSStruct(structDecl))) return true;
             var returnType = env.MethodDecl.CSSignature.First();
 

--- a/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
@@ -8,9 +8,11 @@ namespace BindingsGeneration;
 /// </summary>
 /// <param name="TypeName">The name of the generic argument type</param>
 /// <param name="SugaredTypeName">The sugared name of the generic argument type</param>
-/// <param name="Constraints">The constraints of the generic argument type</param>
+/// <param name="GenericConformances">The conformances of the generic argument type</param>
+/// <param name="TypeConformances">The conformances of the generic with associated types</param>
 public record GenericArgumentDecl(
     string TypeName,
     string SugaredTypeName,
-    List<GenericParameterConformance> Constraints
+    List<GenericParameterConformance> GenericConformances,
+    List<GenericParameterConformance> TypeConformances
 );

--- a/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/GenericArgumentDecl.cs
@@ -9,10 +9,10 @@ namespace BindingsGeneration;
 /// <param name="TypeName">The name of the generic argument type</param>
 /// <param name="SugaredTypeName">The sugared name of the generic argument type</param>
 /// <param name="GenericConformances">The conformances of the generic argument type</param>
-/// <param name="TypeConformances">The conformances of the generic with associated types</param>
+/// <param name="AssosiatedTypeConformances">The conformances of the associated types of the generic argument type</param>
 public record GenericArgumentDecl(
     string TypeName,
     string SugaredTypeName,
     List<GenericParameterConformance> GenericConformances,
-    List<GenericParameterConformance> TypeConformances
+    List<GenericParameterConformance> AssosiatedTypeConformances
 );

--- a/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
@@ -15,13 +15,22 @@ public record TypeConformance(
 );
 
 /// <summary>
+/// Represents the kind of conformance.
+/// </summary>
+public enum ConformanceKind
+{
+    Protocol,
+    ConcreteType
+}
+
+/// <summary>
 /// Represents a generic parameter conformance.
 /// </summary>
-/// <param name="GenericParameter">The generic parameter</param>
-/// <param name="Protocol">The protocol that the generic parameter conforms to</param>
-/// <param name="IsAssociatedType">Indicates if the conformance is on an associated type</param>
+/// <param name="path">The path to the generic parameter</param>
+/// <param name="ConformanceTarget">The type that conforms to the protocol</param>
+/// <param name="Kind">The kind of conformance</param>
 public record GenericParameterConformance(
-    string GenericParameter,
-    SwiftTypeName Protocol,
-    bool IsAssociatedType
+    string[] Path,
+    SwiftTypeName ConformanceTarget,
+    ConformanceKind Kind
 );

--- a/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
+++ b/src/Swift.Bindings/src/Model/TypeDecl/ProtocolConformance.cs
@@ -19,7 +19,9 @@ public record TypeConformance(
 /// </summary>
 /// <param name="GenericParameter">The generic parameter</param>
 /// <param name="Protocol">The protocol that the generic parameter conforms to</param>
+/// <param name="IsAssociatedType">Indicates if the conformance is on an associated type</param>
 public record GenericParameterConformance(
     string GenericParameter,
-    SwiftTypeName Protocol
+    SwiftTypeName Protocol,
+    bool IsAssociatedType
 );

--- a/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
+++ b/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
@@ -35,8 +35,8 @@ public class GenericSignatureParser
             new GenericArgumentDecl(
                 typeName,
                 paramMap[typeName],
-                constraints.Where(c => c.GenericParameter.Contains(typeName) && !c.IsAssociatedType).ToList(),
-                constraints.Where(c => c.GenericParameter.Contains(typeName) && c.IsAssociatedType).ToList()
+                constraints.Where(c => c.Path[0] == typeName && c.Path.Length == 1).ToList(),
+                constraints.Where(c => c.Path[0] == typeName && c.Path.Length > 1).ToList()
             )
         ).ToList();
     }
@@ -89,10 +89,10 @@ public class GenericSignatureParser
             throw new InvalidOperationException($"Invalid constraint clause: {clause}");
         }
 
-        var target = parts[0];
-        var protocol = parts[1];
+        var target = parts[0].Split('.');
+        var conformanceTarget = parts[1];
 
-        var isAssociatedType = target.Contains(".");
-        return new GenericParameterConformance(target, SwiftTypeName.FromModuleQualifiedName(protocol), isAssociatedType);
+        ConformanceKind kind = clause.Contains(":") ? ConformanceKind.Protocol : ConformanceKind.ConcreteType;
+        return new GenericParameterConformance(target, SwiftTypeName.FromModuleQualifiedName(conformanceTarget), kind);
     }
 }

--- a/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
+++ b/src/Swift.Bindings/src/Parser/GenericSignatureParser.cs
@@ -35,7 +35,8 @@ public class GenericSignatureParser
             new GenericArgumentDecl(
                 typeName,
                 paramMap[typeName],
-                constraints.Where(c => c.GenericParameter.Contains(typeName)).ToList()
+                constraints.Where(c => c.GenericParameter.Contains(typeName) && !c.IsAssociatedType).ToList(),
+                constraints.Where(c => c.GenericParameter.Contains(typeName) && c.IsAssociatedType).ToList()
             )
         ).ToList();
     }
@@ -70,7 +71,6 @@ public class GenericSignatureParser
 
         var parsedConstraints = constraints
             .Select(ParseConstraint)
-            .Where(constraint => constraint is not null)
             .Cast<GenericParameterConformance>();
 
         return [.. parsedConstraints];
@@ -92,8 +92,7 @@ public class GenericSignatureParser
         var target = parts[0];
         var protocol = parts[1];
 
-        if (!target.Contains(".")) return new GenericParameterConformance(target, SwiftTypeName.FromModuleQualifiedName(protocol));
-
-        return null;
+        var isAssociatedType = target.Contains(".");
+        return new GenericParameterConformance(target, SwiftTypeName.FromModuleQualifiedName(protocol), isAssociatedType);
     }
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Async/AsyncTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Async/AsyncTests.cs
@@ -142,6 +142,17 @@ namespace BindingsGeneration.FunctionalTests
             Assert.Equal(strings[0], stringsInstance[0]);
             Assert.Equal(strings[1], stringsInstance[1]);
             Assert.Equal(strings[2], stringsInstance[2]);
+
+
+            strings.Append(new SwiftString("four"));
+            stringsInstance = await myStruct.ArrayPassThrough(strings);
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+            Assert.Equal(4, stringsInstance.Count);
+            Assert.Equal(strings[0], stringsInstance[0]);
+            Assert.Equal(strings[1], stringsInstance[1]);
+            Assert.Equal(strings[2], stringsInstance[2]);
+            Assert.Equal(strings[3], stringsInstance[3]);
+
         }
 
         [Fact]

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Async/AsyncTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Async/AsyncTests.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Swift;
+using BindingsGeneration.Tests;
+using Swift;
+using Swift.Runtime;
+using Swift.Runtime.InteropServices;
+using Swift.StructsTests;
+using Xunit;
+
+using Bindings = Swift.AsyncTests;
+
+
+namespace BindingsGeneration.FunctionalTests
+{
+    public class AsyncTests : IClassFixture<AsyncTests.TestFixture>
+    {
+        private readonly TestFixture _fixture;
+
+        public AsyncTests(TestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public class TestFixture
+        {
+            static TestFixture()
+            {
+                InitializeResources();
+            }
+
+            private static void InitializeResources()
+            {
+                // Initialize
+            }
+        }
+
+        [Fact]
+        public async Task TestInstanceMethods()
+        {
+            var myStruct = new Bindings.AsyncStruct(42);
+
+            var stopwatch = Stopwatch.StartNew();
+            await myStruct.AsyncVoid();
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+
+            stopwatch.Restart();
+            ulong seconds = 2;
+            ulong result = await myStruct.AsyncNonVoid(seconds);
+            stopwatch.Stop();
+            Assert.Equal(seconds, result);
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= seconds);
+        }
+
+        [Fact]
+        public async Task TestStaticMethods()
+        {
+            var stopwatch = Stopwatch.StartNew();
+            await Bindings.AsyncStruct.AsyncVoidStatic();
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+
+            stopwatch.Restart();
+            ulong seconds = 2;
+            ulong result = await Bindings.AsyncStruct.AsyncNonVoidStatic(seconds);
+            stopwatch.Stop();
+            Assert.Equal(seconds, result);
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+        }
+
+        [Fact]
+        public async Task TestGenericUnconstrained()
+        {
+            var myStruct = new Bindings.AsyncStruct(42);
+
+            var stopwatch = Stopwatch.StartNew();
+            await myStruct.GenericUnconstrained(123);
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+
+            stopwatch.Restart();
+            await Bindings.AsyncStruct.GenericUnconstrainedStatic(123);
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+        }
+
+        [Fact]
+        public async Task TestGenericCollectionConstraint()
+        {
+            var myStruct = new Bindings.AsyncStruct(0);
+            var strings = new SwiftArray<SwiftString>();
+            strings.Append(new SwiftString("one"));
+            strings.Append(new SwiftString("two"));
+            strings.Append(new SwiftString("three"));
+
+            var stopwatch = Stopwatch.StartNew();
+            nint countInstance = await myStruct.GenericCollectionConstraint(strings);
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+            Assert.Equal(3, countInstance);
+
+            stopwatch.Restart();
+            nint countStatic = await Bindings.AsyncStruct.GenericCollectionConstraintStatic(strings);
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+            Assert.Equal(3, countStatic);
+
+            strings.Append(new SwiftString("error"));
+
+            stopwatch.Restart();
+            countInstance = await myStruct.GenericCollectionConstraint(strings);
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds < 1);
+            Assert.Equal(-1, countInstance);
+
+            stopwatch.Restart();
+            countStatic = await Bindings.AsyncStruct.GenericCollectionConstraintStatic(strings);
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds < 1);
+            Assert.Equal(-1, countStatic);
+        }
+
+        [Fact]
+        public async Task TestArray()
+        {
+            var myStruct = new Bindings.AsyncStruct(0);
+            var strings = new SwiftArray<SwiftString>();
+            strings.Append(new SwiftString("one"));
+            strings.Append(new SwiftString("two"));
+            strings.Append(new SwiftString("three"));
+
+            var stopwatch = Stopwatch.StartNew();
+            var stringsInstance = await myStruct.ArrayPassThrough(strings);
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+            Assert.Equal(3, stringsInstance.Count);
+            Assert.Equal(strings[0], stringsInstance[0]);
+            Assert.Equal(strings[1], stringsInstance[1]);
+            Assert.Equal(strings[2], stringsInstance[2]);
+        }
+
+        [Fact]
+        public async Task TestString()
+        {
+            var myStruct = new Bindings.AsyncStruct(0);
+            var str = new SwiftString("one");
+
+            var stopwatch = Stopwatch.StartNew();
+            var stringInstance = await myStruct.StringPassThrough(str);
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed.TotalSeconds >= 1);
+            Assert.Equal(str.Length, stringInstance.Length);
+            Assert.Equal(str, stringInstance);
+        }
+    }
+}

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Async/AsyncTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Async/AsyncTests.swift
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import Foundation
+
+public struct AsyncStruct {
+    public let storedValue: Int32
+
+    public init(_ storedValue: Int32) {
+        self.storedValue = storedValue
+    }
+
+    public func AsyncVoid() async {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+    }
+
+    public func AsyncNonVoid(seconds: UInt64) async -> UInt64 {
+        try? await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+        return seconds
+    }
+
+    public static func AsyncVoidStatic() async {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+    }
+
+    public static func AsyncNonVoidStatic(seconds: UInt64) async -> UInt64 {
+        try? await Task.sleep(nanoseconds: seconds * 1_000_000_000)
+        return seconds
+    }
+
+    public func GenericUnconstrained<T>(input: T) async {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+    }
+
+    public static func GenericUnconstrainedStatic<T>(input: T) async {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+    }
+
+    public func GenericCollectionConstraint<C>(input: C) async -> Int
+        where C: Collection, C.Element == String
+    {
+        for identifier in input {
+            if identifier == "error" {
+                return -1
+            }
+        }
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        return input.count
+    }
+
+    public static func GenericCollectionConstraintStatic<C>(input: C) async -> Int
+        where C: Collection, C.Element == String
+    {
+        for identifier in input {
+            if identifier == "error" {
+                return -1
+            }
+        }
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        return input.count
+    }
+
+    public func ArrayPassThrough(input: [String]) async -> [String] {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        return input
+    }
+
+    public func StringPassThrough(input: String) async -> String {
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        return input
+    }
+}
+

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
@@ -290,41 +290,6 @@ namespace BindingsGeneration.FunctionalTests
         }
 
         [Fact]
-        public async Task TestAsyncStruct()
-        {
-            int expectedValue = 42;
-            ulong seconds = 5;
-            TimerStruct timerStruct = new TimerStruct(expectedValue);
-            var tasks = new[]
-            {
-                timerStruct.waitFor(seconds - 1),
-                timerStruct.waitFor(seconds - 2),
-                timerStruct.waitFor(seconds - 3),
-                timerStruct.waitFor(seconds - 4),
-                timerStruct.waitFor(seconds - 5)
-            };
-            var stopwatch = Stopwatch.StartNew();
-            var results = await Task.WhenAll(tasks);
-            stopwatch.Stop();
-
-            foreach (var result in results)
-                Assert.Equal(expectedValue, result);
-
-            Assert.True(Math.Abs(stopwatch.Elapsed.TotalSeconds - seconds) <= 1);
-
-            var tasks2 = new[]
-            {
-                timerStruct.waitFor5Seconds(),
-                TimerStruct.waitFor5SecondsStatic()
-            };
-
-            stopwatch = Stopwatch.StartNew();
-            await Task.WhenAll(tasks2);
-            stopwatch.Stop();
-            Assert.True(Math.Abs(stopwatch.Elapsed.TotalSeconds - seconds) <= 1);
-        }
-
-        [Fact]
         public void TestFrozenStructProperties()
         {
             var struct1 = new PropertiesTestStruct(letValue: 10, varValue: 20, multiplier: 3);

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
@@ -222,32 +222,6 @@ public func createNonFrozenStruct(a: Int, b: Int) -> NonFrozenStruct
     return NonFrozenStruct(x: a, y: b)
 }
 
-public struct TimerStruct {
-    let returnValue: Int32
-
-    public init(returnValue: Int32) {
-        self.returnValue = returnValue
-    }
-
-    public func waitFor(seconds: UInt64) async -> Int32 {
-        do {
-            try await Task.sleep(nanoseconds: seconds * 1_000_000_000)
-        } catch {
-            print("Failed to sleep: \(error)")
-            return -1
-        }
-        return returnValue
-    }
-
-    public func waitFor5Seconds() async -> Void {
-        try? await Task.sleep(nanoseconds: 5_000_000_000)
-    }
-
-    public static func waitFor5SecondsStatic() async -> Void {
-        try? await Task.sleep(nanoseconds: 5_000_000_000)
-    }
-}
-
 @frozen
 public struct PropertiesTestStruct {
     public let letProperty: Int32
@@ -256,13 +230,13 @@ public struct PropertiesTestStruct {
     } // This property is added to make sure the layout is correct
     public var varProperty: Double
     private let multiplier: Float
-    
+
     public init(letValue: Int32, varValue: Double, multiplier: Float) {
         self.letProperty = letValue
         self.varProperty = varValue
         self.multiplier = multiplier
     }
-    
+
     public var computedProperty: Double {
         return Double(letProperty) * Double(multiplier)
     }
@@ -275,13 +249,13 @@ public struct NonFrozenPropertiesTestStruct {
     } // This property is added to make sure the layout is correct
     public var varProperty: Double
     private let multiplier: Float
-    
+
     public init(letValue: Int32, varValue: Double, multiplier: Float) {
         self.letProperty = letValue
         self.varProperty = varValue
         self.multiplier = multiplier
     }
-    
+
     public var computedProperty: Double {
         return Double(letProperty) * Double(multiplier)
     }

--- a/src/Swift.Bindings/tests/IntegrationTests/Swift.Bindings.Integration.Tests.csproj
+++ b/src/Swift.Bindings/tests/IntegrationTests/Swift.Bindings.Integration.Tests.csproj
@@ -28,7 +28,7 @@
     </ReadLinesFromFile>
 
     <ItemGroup>
-      <CMakeWarnings Include="@(CMakeOutputLines)" Condition="$([System.Text.RegularExpressions.Regex]::Match(%(Identity),'.*CMake Warning.*').Success)" />
+      <CMakeWarnings Include="@(CMakeOutputLines)" Condition="$([System.Text.RegularExpressions.Regex]::Match('%(Identity)','.*CMake Warning.*').Success)" />
     </ItemGroup>
 
     <Warning Text="%(CMakeWarnings.Identity)  (see: $(OutputPath)/cmake_output.log)" Condition="'%(Identity)' != ''"/>

--- a/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
@@ -71,8 +71,8 @@ public class GenericSignatureParserTests
         Assert.Equal("T", decl.SugaredTypeName);
         Assert.Single(decl.GenericConformances);
         var conformance = Assert.IsType<GenericParameterConformance>(decl.GenericConformances[0]);
-        Assert.Equal("τ_0_0", conformance.GenericParameter);
-        Assert.Equal("Swift.Equatable", conformance.Protocol.ModuleQualifiedName);
+        Assert.Equal("τ_0_0", conformance.Path[0]);
+        Assert.Equal("Swift.Equatable", conformance.ConformanceTarget.ModuleQualifiedName);
     }
 
     [Fact]
@@ -90,23 +90,23 @@ public class GenericSignatureParserTests
         Assert.Equal("T", first.SugaredTypeName);
         Assert.Single(first.GenericConformances);
         var firstConformance = Assert.IsType<GenericParameterConformance>(first.GenericConformances[0]);
-        Assert.Equal("τ_0_0", firstConformance.GenericParameter);
-        Assert.Equal("Swift.Equatable", firstConformance.Protocol.ModuleQualifiedName);
+        Assert.Equal("τ_0_0", firstConformance.Path[0]);
+        Assert.Equal("Swift.Equatable", firstConformance.ConformanceTarget.ModuleQualifiedName);
 
         var second = result[1];
         Assert.Equal("τ_0_1", second.TypeName);
         Assert.Equal("U", second.SugaredTypeName);
         Assert.Single(second.GenericConformances);
         var secondConformance = Assert.IsType<GenericParameterConformance>(second.GenericConformances[0]);
-        Assert.Equal("τ_0_1", secondConformance.GenericParameter);
-        Assert.Equal("Swift.Hashable", secondConformance.Protocol.ModuleQualifiedName);
+        Assert.Equal("τ_0_1", secondConformance.Path[0]);
+        Assert.Equal("Swift.Hashable", secondConformance.ConformanceTarget.ModuleQualifiedName);
     }
 
     [Fact]
     public void ParseGenericSignature_ParsesAssociatedTypeConstraints()
     {
-        var genericSig = "<τ_0_0 where τ_0_0 : SomeModule.SomeProtocol, τ_0_0.ID == System.Guid>";
-        var sugaredSig = "<T where T : SomeModule.SomeProtocol, T.ID == System.Guid>";
+        var genericSig = "<τ_0_0 where τ_0_0 : SomeModule.SomeProtocol, τ_0_0.ID == System.Guid, τ_0_0.ID : SomeModule.SomeProtocol>";
+        var sugaredSig = "<T where T : SomeModule.SomeProtocol, T.ID == System.Guid, T.ID : SomeModule.SomeProtocol>";
 
         var result = GenericSignatureParser.ParseGenericSignature(genericSig, sugaredSig);
 
@@ -115,16 +115,23 @@ public class GenericSignatureParserTests
         Assert.Equal("τ_0_0", decl.TypeName);
         Assert.Equal("T", decl.SugaredTypeName);
         Assert.Single(decl.GenericConformances);
-        Assert.Single(decl.TypeConformances);
+        Assert.Equal(2, decl.AssosiatedTypeConformances.Count);
 
         var proto = Assert.IsType<GenericParameterConformance>(decl.GenericConformances[0]);
-        Assert.Equal("τ_0_0", proto.GenericParameter);
-        Assert.Equal("SomeModule.SomeProtocol", proto.Protocol.ModuleQualifiedName);
-        Assert.False(proto.IsAssociatedType);
+        Assert.Equal("τ_0_0", proto.Path[0]);
+        Assert.Equal("SomeModule.SomeProtocol", proto.ConformanceTarget.ModuleQualifiedName);
+        Assert.Equal(ConformanceKind.Protocol, proto.Kind);
 
-        proto = Assert.IsType<GenericParameterConformance>(decl.TypeConformances[0]);
-        Assert.Equal("τ_0_0.ID", proto.GenericParameter);
-        Assert.Equal("System.Guid", proto.Protocol.ModuleQualifiedName);
-        Assert.True(proto.IsAssociatedType);
+        proto = Assert.IsType<GenericParameterConformance>(decl.AssosiatedTypeConformances[0]);
+        Assert.Equal("τ_0_0", proto.Path[0]);
+        Assert.Equal("ID", proto.Path[1]);
+        Assert.Equal("System.Guid", proto.ConformanceTarget.ModuleQualifiedName);
+        Assert.Equal(ConformanceKind.ConcreteType, proto.Kind);
+
+        proto = Assert.IsType<GenericParameterConformance>(decl.AssosiatedTypeConformances[1]);
+        Assert.Equal("τ_0_0", proto.Path[0]);
+        Assert.Equal("ID", proto.Path[1]);
+        Assert.Equal("SomeModule.SomeProtocol", proto.ConformanceTarget.ModuleQualifiedName);
+        Assert.Equal(ConformanceKind.Protocol, proto.Kind);
     }
 }

--- a/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
+++ b/src/Swift.Bindings/tests/UnitTests/ParserTests/GenericSignatureParserTests.cs
@@ -33,7 +33,7 @@ public class GenericSignatureParserTests
         var decl = result[0];
         Assert.Equal("τ_0_0", decl.TypeName);
         Assert.Equal("T", decl.SugaredTypeName);
-        Assert.Empty(decl.Constraints);
+        Assert.Empty(decl.GenericConformances);
     }
 
     [Fact]
@@ -49,12 +49,12 @@ public class GenericSignatureParserTests
         var first = result[0];
         Assert.Equal("τ_0_0", first.TypeName);
         Assert.Equal("T", first.SugaredTypeName);
-        Assert.Empty(first.Constraints);
+        Assert.Empty(first.GenericConformances);
 
         var second = result[1];
         Assert.Equal("τ_0_1", second.TypeName);
         Assert.Equal("U", second.SugaredTypeName);
-        Assert.Empty(second.Constraints);
+        Assert.Empty(second.GenericConformances);
     }
 
     [Fact]
@@ -69,8 +69,8 @@ public class GenericSignatureParserTests
         var decl = result[0];
         Assert.Equal("τ_0_0", decl.TypeName);
         Assert.Equal("T", decl.SugaredTypeName);
-        Assert.Single(decl.Constraints);
-        var conformance = Assert.IsType<GenericParameterConformance>(decl.Constraints[0]);
+        Assert.Single(decl.GenericConformances);
+        var conformance = Assert.IsType<GenericParameterConformance>(decl.GenericConformances[0]);
         Assert.Equal("τ_0_0", conformance.GenericParameter);
         Assert.Equal("Swift.Equatable", conformance.Protocol.ModuleQualifiedName);
     }
@@ -88,16 +88,16 @@ public class GenericSignatureParserTests
         var first = result[0];
         Assert.Equal("τ_0_0", first.TypeName);
         Assert.Equal("T", first.SugaredTypeName);
-        Assert.Single(first.Constraints);
-        var firstConformance = Assert.IsType<GenericParameterConformance>(first.Constraints[0]);
+        Assert.Single(first.GenericConformances);
+        var firstConformance = Assert.IsType<GenericParameterConformance>(first.GenericConformances[0]);
         Assert.Equal("τ_0_0", firstConformance.GenericParameter);
         Assert.Equal("Swift.Equatable", firstConformance.Protocol.ModuleQualifiedName);
 
         var second = result[1];
         Assert.Equal("τ_0_1", second.TypeName);
         Assert.Equal("U", second.SugaredTypeName);
-        Assert.Single(second.Constraints);
-        var secondConformance = Assert.IsType<GenericParameterConformance>(second.Constraints[0]);
+        Assert.Single(second.GenericConformances);
+        var secondConformance = Assert.IsType<GenericParameterConformance>(second.GenericConformances[0]);
         Assert.Equal("τ_0_1", secondConformance.GenericParameter);
         Assert.Equal("Swift.Hashable", secondConformance.Protocol.ModuleQualifiedName);
     }
@@ -114,10 +114,17 @@ public class GenericSignatureParserTests
         var decl = result[0];
         Assert.Equal("τ_0_0", decl.TypeName);
         Assert.Equal("T", decl.SugaredTypeName);
-        Assert.Single(decl.Constraints);
+        Assert.Single(decl.GenericConformances);
+        Assert.Single(decl.TypeConformances);
 
-        var proto = Assert.IsType<GenericParameterConformance>(decl.Constraints[0]);
+        var proto = Assert.IsType<GenericParameterConformance>(decl.GenericConformances[0]);
         Assert.Equal("τ_0_0", proto.GenericParameter);
         Assert.Equal("SomeModule.SomeProtocol", proto.Protocol.ModuleQualifiedName);
+        Assert.False(proto.IsAssociatedType);
+
+        proto = Assert.IsType<GenericParameterConformance>(decl.TypeConformances[0]);
+        Assert.Equal("τ_0_0.ID", proto.GenericParameter);
+        Assert.Equal("System.Guid", proto.Protocol.ModuleQualifiedName);
+        Assert.True(proto.IsAssociatedType);
     }
 }


### PR DESCRIPTION
## Description

This PR implements generic parameters/types with generics in Swift async functions. This is needed to correctly project StoreKit examples:
- https://developer.apple.com/documentation/storekit/product/products(for:)
- https://developer.apple.com/documentation/storekit/product/purchase(options:)

## Changes
 - In addition to the generic parameters, the ABI parser collects associated type conformances. They are needed to correctly invoke Swift async functions from the Swift wrappers and aren't used in the C# bindings
 - C# callback is updated to correctly marshal results at the ABI boundary
 - Async integration tests are expanded and moved to the separate file

## Out-of-scope

Generic return types in Swift async functions are not supported yet. Tracking issue https://github.com/dotnet/runtimelab/issues/3022

Fixes https://github.com/dotnet/runtimelab/issues/2960
Fixes https://github.com/dotnet/runtimelab/issues/3020