### PR TITLE
[NativeAOT-LLVM] Start running the wasi library tests

### DIFF
--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -100,7 +100,7 @@ extends:
             nameSuffix: '_Smoke'
             extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
             shouldRunSmokeOnly: true
-            alwaysRun: ${{ variables.isRollingBuild }}
+            alwaysRun: true
             scenarios:
               - WasmTestOnWasmtime
 

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -88,6 +88,22 @@ extends:
                 - template: /eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
                   parameters:
                     librariesConfiguration: Debug
+        
+        #
+        # Build and test wasi library tests
+        #
+        - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+          parameters:
+            platforms:
+              - wasi_wasm
+              - wasi_wasm_win
+              - wasi_wasm_linux_x64_naot_llvm
+            nameSuffix: '_Smoke'
+            extraBuildArgs: /p:EnableAggressiveTrimming=true /p:RunWasmSamples=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+            shouldRunSmokeOnly: true
+            alwaysRun: ${{ variables.isRollingBuild }}
+            scenarios:
+              - WasmTestOnWasmtime
 
         #
         # Build and test with Release libraries and Release runtime

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -95,7 +95,6 @@ extends:
         - template: /eng/pipelines/common/templates/wasm-library-tests.yml
           parameters:
             platforms:
-              - wasi_wasm
               - wasi_wasm_win
               - wasi_wasm_linux_x64_naot_llvm
             nameSuffix: '_Smoke'


### PR DESCRIPTION
upstream stopped running the library tests for wasi with https://github.com/dotnet/runtime/pull/112716.  To ensure we still have coverage this adds them back on the branch here.

Note, I am not sure this will work as is.  Still figuring out the how the build system works. Any pointers welcome :-)

fyi @pavelsavara  