### PR TITLE
[Swift Bindings] Initialized static properties support

### DIFF
--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/PropertyHandler.cs
@@ -67,12 +67,6 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
             return;
         }
 
-        if (propertyDecl.IsStatic) // TODO: https://github.com/dotnet/runtimelab/issues/2995
-        {
-            Console.WriteLine($"PropertyHandler: Static properties are not supported. Skipping property {propertyDecl.Name}.");
-            return;
-        }
-
         var csTypeName = propertyEnv.BoundGenericsHandler.IsBoundGeneric(propertyDecl) switch
         {
             true => propertyEnv.BoundGenericsHandler.TranslateBoundGenericTypeToCSharp(propertyDecl),
@@ -97,9 +91,9 @@ public class PropertyHandler : BaseHandler, IPropertyHandler
                 throw new InvalidOperationException($"No handler found for properties accessor {accessor.Method.Name}");
             }
         }
-
+        var staticModifier = propertyDecl.IsStatic ? "static " : string.Empty;
         // Then emit the property
-        csWriter.WriteLine($"public {csTypeName} {propertyName}");
+        csWriter.WriteLine($"public {staticModifier}{csTypeName} {propertyName}");
         csWriter.WriteLine("{");
         csWriter.Indent++;
 

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -464,7 +464,7 @@ namespace BindingsGeneration
             {
                 Name = $"{fieldName}_Get",
                 MangledName = accessor.MangledName,
-                MethodType = MethodType.Instance,
+                MethodType = accessor.@static ?? false ? MethodType.Static : MethodType.Instance,
                 IsConstructor = false,
                 CSSignature = new List<ArgumentDecl>
                 {

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
@@ -292,6 +292,9 @@ namespace BindingsGeneration.FunctionalTests
         [Fact]
         public void TestFrozenStructProperties()
         {
+            var staticPropertyValue = PropertiesTestStruct.staticLetProperty;
+            Assert.Equal(42, staticPropertyValue);
+
             var struct1 = new PropertiesTestStruct(letValue: 10, varValue: 20, multiplier: 3);
 
             Assert.Equal(10, struct1.letProperty);
@@ -304,6 +307,9 @@ namespace BindingsGeneration.FunctionalTests
         [Fact]
         public void TestNonFrozenStructProperties()
         {
+            var staticPropertyValue = NonFrozenPropertiesTestStruct.staticLetProperty;
+            Assert.Equal(42, staticPropertyValue);
+
             var struct1 = new NonFrozenPropertiesTestStruct(letValue: 10, varValue: 20, multiplier: 3);
 
             Assert.Equal(10, struct1.letProperty);

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
@@ -224,6 +224,7 @@ public func createNonFrozenStruct(a: Int, b: Int) -> NonFrozenStruct
 
 @frozen
 public struct PropertiesTestStruct {
+    public static let staticLetProperty: Int32 = 42
     public let letProperty: Int32
     public var computedPropertyAmongStorageProperties: Double {
         return Double(letProperty) * Double(multiplier)
@@ -243,6 +244,7 @@ public struct PropertiesTestStruct {
 }
 
 public struct NonFrozenPropertiesTestStruct {
+    public static let staticLetProperty: Int32 = 42
     public let letProperty: Int32
     public var computedPropertyAmongStorageProperties: Double {
         return Double(letProperty) * Double(multiplier)

--- a/src/docs/binding-properties.md
+++ b/src/docs/binding-properties.md
@@ -100,7 +100,35 @@ public class NonFrozenPoint : IDisposable {
 
 ## Static Properties
 
-TODO
+Static properties should be bound as static properties in C#.
+
+```swift
+@frozen
+public struct SomeFrozenStruct {
+    public static var someStaticProperty: Int = 42
+}
+```
+
+```csharp
+public struct SomeStruct {
+    public static int SomeStaticProperty {
+        get => PInvoke_get_someStaticProperty();
+        set => PInvoke_set_someStaticProperty(value);
+    }
+}
+```
+
+On the ABI side the setter and getter are static functions. We can bind them in the same way as we bind static functions.
+
+```csharp
+[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+[DllImport("MySwiftModule", EntryPoint = "...")]
+private static extern nint PInvoke_get_someStaticProperty();
+
+[UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+[DllImport("MySwiftModule", EntryPoint = "...")]
+private static extern void PInvoke_set_someStaticProperty(nint value);
+```
 
 ## Async Properties
 


### PR DESCRIPTION
This PR add description of binding static properties and add projection support for generating static properties getters

Contributes to #2995 