### PR TITLE
[Swift Bindings] Add support for Equality protocol

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -217,7 +217,7 @@ function CreateProject {
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/generate.sh
+++ b/generate.sh
@@ -217,7 +217,7 @@ function CreateProject {
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -59,6 +59,7 @@ namespace BindingsGeneration
             var typeRecord = env.TypeDatabase.GetTypeRecordOrThrow(structDecl.SwiftTypeName);
 
             var ISwiftObjectMethodWriter = new ISwiftObjectMethodWriter(csWriter, env.TypeDatabase, moduleDecl, structDecl);
+            var SwiftEquatableMethodWriter = new SwiftEquatableMethodWriter(csWriter, structDecl);
 
             SwiftTypeInfo? swiftTypeInfo = typeRecord?.SwiftTypeInfo;
 
@@ -106,6 +107,8 @@ namespace BindingsGeneration
             }
             csWriter.WriteLine();
 
+            // Add Equatable support if the struct conforms to Equatable
+            SwiftEquatableMethodWriter.WriteSwiftEquatableImplementation();
             ISwiftObjectMethodWriter.WriteFrozenStructImplementation();
 
             base.HandleBaseDecl(csWriter, swiftWriter, structDecl.Types, conductor, env.TypeDatabase);
@@ -167,6 +170,7 @@ namespace BindingsGeneration
             var moduleDecl = structDecl.ModuleDecl ?? throw new ArgumentNullException(nameof(structDecl.ModuleDecl));
 
             var ISwiftObjectMethodWriter = new ISwiftObjectMethodWriter(csWriter, env.TypeDatabase, moduleDecl, structDecl);
+            var SwiftEquatableMethodWriter = new SwiftEquatableMethodWriter(csWriter, structDecl);
 
             csWriter.WriteLine($"public unsafe class {structDecl.Name} : IDisposable, {typeof(ISwiftObject).Name}");
             csWriter.WriteLine("{");
@@ -189,6 +193,8 @@ namespace BindingsGeneration
             WritePayloadSize(csWriter);
             WritePayload(csWriter);
 
+            // Add Equatable support if the struct conforms to Equatable
+            SwiftEquatableMethodWriter.WriteSwiftEquatableImplementation();
             ISwiftObjectMethodWriter.WriteNonFrozenStructImplementation();
 
             csWriter.WriteLine();
@@ -530,12 +536,21 @@ namespace BindingsGeneration
 
         private string GenerateGetProtocolConformanceDictionaryEntries()
         {
+            var crossModuleSupportedProtocols = new HashSet<string> // TODO: Remove this once we process multiple modules
+            {
+                { "Swift.Equatable"},
+            };
             var libPath = _typeDatabase.GetLibraryPath(_moduleDecl.Name);
             var entries = new List<string>();
             var protocolConformanceDescriptors = DemangledSymbolsRegister.Instance.GetData(libPath).ProtocolConformanceDescriptors;
 
-            foreach (var conformance in _structDecl.Conformances.Where(c => c.Protocol.Module == _moduleDecl.Name)) // Process only protocol conformances from current module for now
+            foreach (var conformance in _structDecl.Conformances)
             {
+                if (conformance.Protocol.Module != _moduleDecl.Name && !crossModuleSupportedProtocols.Contains(conformance.Protocol.ModuleQualifiedName))
+                {
+                    continue;
+                }
+
                 var protocol = NameProvider.GetInterfaceName(conformance.Protocol.Name);
                 var typeRecord = _typeDatabase.GetTypeRecordOrThrow(_structDecl.SwiftTypeName);
                 var protocolConformanceSymbol = protocolConformanceDescriptors.GetValueOrDefault((_structDecl.SwiftTypeName, conformance.Protocol)); // TODO: Get rid of TypeSpec https://github.com/dotnet/runtimelab/issues/2889
@@ -544,6 +559,34 @@ namespace BindingsGeneration
             }
 
             return string.Join(",\n", entries);
+        }
+    }
+
+    public class SwiftEquatableMethodWriter
+    {
+        private readonly IndentedTextWriter _writer;
+        private readonly StructDecl _structDecl;
+
+        public SwiftEquatableMethodWriter(CSharpWriter csWriter, StructDecl structDecl)
+        {
+            _writer = csWriter;
+            _structDecl = structDecl;
+        }
+
+        public void WriteSwiftEquatableImplementation()
+        {
+            if (_structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable"))
+            {
+                var code = $$"""
+                public static bool SwiftEquals({{_structDecl.Name}} a, {{_structDecl.Name}} b)
+                {
+                    return Swift.Runtime.SwiftEquatable.Equals(a, b);
+                }
+                """;
+
+                _writer.WriteLines(code);
+                _writer.WriteLine();
+            }
         }
     }
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -74,8 +74,16 @@ namespace BindingsGeneration
                 }
             }
 
-            string interfaces = implementsEquatable ? $", ISwiftEquatable, IEquatable<{structDecl.Name}>" : "";
-            csWriter.WriteLine($"public unsafe struct {structDecl.Name} : {typeof(ISwiftObject).Name}{interfaces} {{");
+            var interfaces = new List<string> {
+                typeof(ISwiftObject).Name,
+            };
+            if (implementsEquatable)
+            {
+                interfaces.Add($"IEquatable<{structDecl.Name}>");
+            }
+
+            csWriter.WriteLine($"public unsafe struct {structDecl.Name} : {string.Join(", ", interfaces)}");
+            csWriter.WriteLine("{");
             csWriter.Indent++;
 
             csWriter.WriteLine(@"
@@ -176,8 +184,15 @@ namespace BindingsGeneration
             var SwiftEquatableMethodWriter = new EqualityMethodsWriter(csWriter, structDecl);
             bool implementsEquatable = structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable");
 
-            string interfaces = implementsEquatable ? $", ISwiftEquatable, IEquatable<{structDecl.Name}>" : "";
-            csWriter.WriteLine($"public unsafe class {structDecl.Name} : IDisposable, {typeof(ISwiftObject).Name}{interfaces}");
+            var interfaces = new List<string> {
+                typeof(ISwiftObject).Name,
+                typeof(IDisposable).Name
+            };
+            if (implementsEquatable)
+            {
+                interfaces.Add($"IEquatable<{structDecl.Name}>");
+            }
+            csWriter.WriteLine($"public unsafe class {structDecl.Name} : {string.Join(", ", interfaces)}");
             csWriter.WriteLine("{");
             csWriter.Indent++;
 
@@ -556,7 +571,7 @@ namespace BindingsGeneration
                     continue;
                 }
 
-                var protocol = NameProvider.GetInterfaceName(conformance.Protocol.Name);
+                var protocol = NameProvider.GetInterfaceName(conformance.Protocol.Name, _structDecl.Name);
                 var typeRecord = _typeDatabase.GetTypeRecordOrThrow(_structDecl.SwiftTypeName);
                 var protocolConformanceSymbol = protocolConformanceDescriptors.GetValueOrDefault((_structDecl.SwiftTypeName, conformance.Protocol)); // TODO: Get rid of TypeSpec https://github.com/dotnet/runtimelab/issues/2889
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -59,7 +59,8 @@ namespace BindingsGeneration
             var typeRecord = env.TypeDatabase.GetTypeRecordOrThrow(structDecl.SwiftTypeName);
 
             var ISwiftObjectMethodWriter = new ISwiftObjectMethodWriter(csWriter, env.TypeDatabase, moduleDecl, structDecl);
-            var SwiftEquatableMethodWriter = new SwiftEquatableMethodWriter(csWriter, structDecl);
+            var SwiftEquatableMethodWriter = new EqualityMethodsWriter(csWriter, structDecl);
+            bool implementsEquatable = structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable");
 
             SwiftTypeInfo? swiftTypeInfo = typeRecord?.SwiftTypeInfo;
 
@@ -72,7 +73,9 @@ namespace BindingsGeneration
                     csWriter.WriteLine($"[StructLayout(LayoutKind.Sequential, Size = {swiftTypeInfo.Value.ValueWitnessTable->Size})]");
                 }
             }
-            csWriter.WriteLine($"public unsafe struct {structDecl.Name} : {typeof(ISwiftObject).Name} {{");
+
+            string interfaces = implementsEquatable ? $", ISwiftEquatable, IEquatable<{structDecl.Name}>" : "";
+            csWriter.WriteLine($"public unsafe struct {structDecl.Name} : {typeof(ISwiftObject).Name}{interfaces} {{");
             csWriter.Indent++;
 
             csWriter.WriteLine(@"
@@ -170,9 +173,11 @@ namespace BindingsGeneration
             var moduleDecl = structDecl.ModuleDecl ?? throw new ArgumentNullException(nameof(structDecl.ModuleDecl));
 
             var ISwiftObjectMethodWriter = new ISwiftObjectMethodWriter(csWriter, env.TypeDatabase, moduleDecl, structDecl);
-            var SwiftEquatableMethodWriter = new SwiftEquatableMethodWriter(csWriter, structDecl);
+            var SwiftEquatableMethodWriter = new EqualityMethodsWriter(csWriter, structDecl);
+            bool implementsEquatable = structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable");
 
-            csWriter.WriteLine($"public unsafe class {structDecl.Name} : IDisposable, {typeof(ISwiftObject).Name}");
+            string interfaces = implementsEquatable ? $", ISwiftEquatable, IEquatable<{structDecl.Name}>" : "";
+            csWriter.WriteLine($"public unsafe class {structDecl.Name} : IDisposable, {typeof(ISwiftObject).Name}{interfaces}");
             csWriter.WriteLine("{");
             csWriter.Indent++;
 
@@ -562,31 +567,94 @@ namespace BindingsGeneration
         }
     }
 
-    public class SwiftEquatableMethodWriter
+    public class EqualityMethodsWriter
     {
         private readonly IndentedTextWriter _writer;
         private readonly StructDecl _structDecl;
+        private readonly bool _implementsEquatable;
 
-        public SwiftEquatableMethodWriter(CSharpWriter csWriter, StructDecl structDecl)
+        public EqualityMethodsWriter(CSharpWriter csWriter, StructDecl structDecl)
         {
             _writer = csWriter;
             _structDecl = structDecl;
+            _implementsEquatable = _structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable");
         }
 
         public void WriteSwiftEquatableImplementation()
         {
-            if (_structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable"))
+            if (_implementsEquatable)
             {
-                var code = $$"""
-                public static bool SwiftEquals({{_structDecl.Name}} a, {{_structDecl.Name}} b)
-                {
-                    return Swift.Runtime.SwiftEquatable.Equals(a, b);
-                }
-                """;
-
-                _writer.WriteLines(code);
-                _writer.WriteLine();
+                WriteSwiftEquatableImplementationWithSwiftEquals();
             }
+            else
+            {
+                WriteDefaultEquatableImplementation();
+            }
+        }
+
+        private void WriteSwiftEquatableImplementationWithSwiftEquals()
+        {
+            var code = $$"""
+            public override bool Equals(object obj)
+            {
+                return obj is {{_structDecl.Name}} other && Swift.Runtime.SwiftEquatable.Equals(this, other);
+            }
+
+            public override int GetHashCode()
+            {
+                throw new InvalidOperationException("Type {{_structDecl.Name}} does not implement Swift's Hashable protocol, so GetHashCode() is not supported.");
+            }
+
+            public static bool operator ==({{_structDecl.Name}} left, {{_structDecl.Name}} right)
+            {
+                return Swift.Runtime.SwiftEquatable.Equals(left, right);
+            }
+
+            public static bool operator !=({{_structDecl.Name}} left, {{_structDecl.Name}} right)
+            {
+                return !Swift.Runtime.SwiftEquatable.Equals(left, right);
+            }
+
+            public bool Equals({{_structDecl.Name}} other)
+            {
+                return Swift.Runtime.SwiftEquatable.Equals(this, other);
+            }
+            """;
+
+            _writer.WriteLines(code);
+            _writer.WriteLine();
+        }
+
+        private void WriteDefaultEquatableImplementation()
+        {
+            var code = $$"""
+            // Swift structs cannot be compared using .NET's default equality semantics,
+            // since Swift's equality is defined by the Equatable protocol.
+            // This type does not implement Swift's Equatable protocol.
+
+            public override bool Equals(object obj)
+            {
+                throw new InvalidOperationException("Type {{_structDecl.Name}} does not implement Swift's Equatable protocol, so equality comparison is not supported.");
+            }
+
+            public override int GetHashCode()
+            {
+                throw new InvalidOperationException("Type {{_structDecl.Name}} does not implement Swift's Equatable protocol, so GetHashCode() is not supported.");
+            }
+
+            public static bool operator ==({{_structDecl.Name}} left, {{_structDecl.Name}} right)
+            {
+                throw new InvalidOperationException("Type {{_structDecl.Name}} does not implement Swift's Equatable protocol, so equality comparison is not supported.");
+            }
+
+            public static bool operator !=({{_structDecl.Name}} left, {{_structDecl.Name}} right)
+            {
+                throw new InvalidOperationException("Type {{_structDecl.Name}} does not implement Swift's Equatable protocol, so equality comparison is not supported.");
+            }
+            """;
+
+            _writer.WriteLines(code);
+            _writer.WriteLine();
         }
     }
 

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/Handler/TypeHandler.cs
@@ -59,7 +59,7 @@ namespace BindingsGeneration
             var typeRecord = env.TypeDatabase.GetTypeRecordOrThrow(structDecl.SwiftTypeName);
 
             var ISwiftObjectMethodWriter = new ISwiftObjectMethodWriter(csWriter, env.TypeDatabase, moduleDecl, structDecl);
-            var SwiftEquatableMethodWriter = new EqualityMethodsWriter(csWriter, structDecl);
+            var SwiftEquatableMethodWriter = new EqualityMethodsWriter(csWriter, structDecl, false);
             bool implementsEquatable = structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable");
 
             SwiftTypeInfo? swiftTypeInfo = typeRecord?.SwiftTypeInfo;
@@ -181,7 +181,7 @@ namespace BindingsGeneration
             var moduleDecl = structDecl.ModuleDecl ?? throw new ArgumentNullException(nameof(structDecl.ModuleDecl));
 
             var ISwiftObjectMethodWriter = new ISwiftObjectMethodWriter(csWriter, env.TypeDatabase, moduleDecl, structDecl);
-            var SwiftEquatableMethodWriter = new EqualityMethodsWriter(csWriter, structDecl);
+            var SwiftEquatableMethodWriter = new EqualityMethodsWriter(csWriter, structDecl, true);
             bool implementsEquatable = structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable");
 
             var interfaces = new List<string> {
@@ -587,19 +587,21 @@ namespace BindingsGeneration
         private readonly IndentedTextWriter _writer;
         private readonly StructDecl _structDecl;
         private readonly bool _implementsEquatable;
+        private readonly bool _isRefType;
 
-        public EqualityMethodsWriter(CSharpWriter csWriter, StructDecl structDecl)
+        public EqualityMethodsWriter(CSharpWriter csWriter, StructDecl structDecl, bool refType)
         {
             _writer = csWriter;
             _structDecl = structDecl;
             _implementsEquatable = _structDecl.Conformances.Any(c => c.Protocol.Name == "Equatable");
+            _isRefType = refType;
         }
 
         public void WriteSwiftEquatableImplementation()
         {
             if (_implementsEquatable)
             {
-                WriteSwiftEquatableImplementationWithSwiftEquals();
+                WriteSwiftEquatableImplementationWithSwiftEquals(_isRefType);
             }
             else
             {
@@ -607,10 +609,10 @@ namespace BindingsGeneration
             }
         }
 
-        private void WriteSwiftEquatableImplementationWithSwiftEquals()
+        private void WriteSwiftEquatableImplementationWithSwiftEquals(bool refType)
         {
             var code = $$"""
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is {{_structDecl.Name}} other && Swift.Runtime.SwiftEquatable.Equals(this, other);
             }
@@ -630,7 +632,7 @@ namespace BindingsGeneration
                 return !Swift.Runtime.SwiftEquatable.Equals(left, right);
             }
 
-            public bool Equals({{_structDecl.Name}} other)
+            public bool Equals({{_structDecl.Name}}{{(refType == true ? "?" : "")}} other)
             {
                 return Swift.Runtime.SwiftEquatable.Equals(this, other);
             }
@@ -647,7 +649,7 @@ namespace BindingsGeneration
             // since Swift's equality is defined by the Equatable protocol.
             // This type does not implement Swift's Equatable protocol.
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 throw new InvalidOperationException("Type {{_structDecl.Name}} does not implement Swift's Equatable protocol, so equality comparison is not supported.");
             }

--- a/src/Swift.Bindings/src/Marshaler/NameProvider.cs
+++ b/src/Swift.Bindings/src/Marshaler/NameProvider.cs
@@ -53,8 +53,16 @@ public static class NameProvider
     /// </summary>
     /// <param name="protocolName">The protocol name.</param>
     /// <returns>The name of the interface.</returns>
-    public static string GetInterfaceName(string protocolName)
+    public static string GetInterfaceName(string protocolName, string typeName = "")
     {
+        var specialCases = new Dictionary<string, string>
+        {
+            { "Equatable", $"IEquatable<{typeName}>" },
+        };
+
+        if (specialCases.TryGetValue(protocolName, out var specialCase))
+            return specialCase;
+
         return $"ISwift{protocolName}";
     }
 

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Generics/GenericTests.cs
@@ -76,7 +76,8 @@ namespace BindingsGeneration.FunctionalTests
         {
             var a = new FrozenStruct(1, 2);
             var result = GenericTests.AcceptsGenericParameterAndReturnsGeneric(a);
-            Assert.Equal(a, result);
+            Assert.Equal(a.x, result.x);
+            Assert.Equal(a.y, result.y);
 
             var b = new NonFrozenStruct(3, 4);
             var result2 = GenericTests.AcceptsGenericParameterAndReturnsGeneric(b);
@@ -89,7 +90,8 @@ namespace BindingsGeneration.FunctionalTests
             var a = new FrozenStruct(1, 2);
             var b = new FrozenStruct(3, 4);
             var result = GenericTests.AcceptsTwoValuesOfTheSameGenericType(a, b);
-            Assert.Equal(a, result);
+            Assert.Equal(a.x, result.x);
+            Assert.Equal(a.y, result.y);
         }
 
         [Fact]

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
@@ -318,5 +318,47 @@ namespace BindingsGeneration.FunctionalTests
 
             Assert.Equal(30, struct1.computedProperty);
         }
+
+        [Fact]
+        public void TestFrozenEquatableStruct()
+        {
+            var struct1 = new FrozenEquatableStruct(10, 20);
+            var struct2 = new FrozenEquatableStruct(10, 20);
+            var struct3 = new FrozenEquatableStruct(30, 40);
+
+            // Verify that two identical structs are equal
+            Assert.True(FrozenEquatableStruct.SwiftEquals(struct1, struct2));
+
+            // Verify that two different structs are not equal
+            Assert.False(FrozenEquatableStruct.SwiftEquals(struct1, struct3));
+        }
+
+        [Fact]
+        public void TestNonFrozenEquatableStruct()
+        {
+            var struct1 = new NonFrozenEquatableStruct(10, 20);
+            var struct2 = new NonFrozenEquatableStruct(10, 20);
+            var struct3 = new NonFrozenEquatableStruct(30, 40);
+
+            // Verify that two identical structs are equal
+            Assert.True(NonFrozenEquatableStruct.SwiftEquals(struct1, struct2));
+
+            // Verify that two different structs are not equal
+            Assert.False(NonFrozenEquatableStruct.SwiftEquals(struct1, struct3));
+        }
+
+        [Fact]
+        public void TestCustomEquatableStruct()
+        {
+            var struct1 = new CustomEquatableStruct(10);
+            var struct2 = new CustomEquatableStruct(13);
+            var struct3 = new CustomEquatableStruct(30);
+
+            // Verify that two structures with absolute difference less than 5 are equal
+            Assert.True(CustomEquatableStruct.SwiftEquals(struct1, struct2));
+
+            // Verify that two structures with absolute difference greater than 5 are not equal
+            Assert.False(CustomEquatableStruct.SwiftEquals(struct1, struct3));
+        }
     }
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.cs
@@ -327,10 +327,10 @@ namespace BindingsGeneration.FunctionalTests
             var struct3 = new FrozenEquatableStruct(30, 40);
 
             // Verify that two identical structs are equal
-            Assert.True(FrozenEquatableStruct.SwiftEquals(struct1, struct2));
+            Assert.Equal(struct1, struct2);
 
             // Verify that two different structs are not equal
-            Assert.False(FrozenEquatableStruct.SwiftEquals(struct1, struct3));
+            Assert.NotEqual(struct1, struct3);
         }
 
         [Fact]
@@ -341,10 +341,10 @@ namespace BindingsGeneration.FunctionalTests
             var struct3 = new NonFrozenEquatableStruct(30, 40);
 
             // Verify that two identical structs are equal
-            Assert.True(NonFrozenEquatableStruct.SwiftEquals(struct1, struct2));
+            Assert.Equal(struct1, struct2);
 
             // Verify that two different structs are not equal
-            Assert.False(NonFrozenEquatableStruct.SwiftEquals(struct1, struct3));
+            Assert.NotEqual(struct1, struct3);
         }
 
         [Fact]
@@ -355,10 +355,10 @@ namespace BindingsGeneration.FunctionalTests
             var struct3 = new CustomEquatableStruct(30);
 
             // Verify that two structures with absolute difference less than 5 are equal
-            Assert.True(CustomEquatableStruct.SwiftEquals(struct1, struct2));
+            Assert.Equal(struct1, struct2);
 
             // Verify that two structures with absolute difference greater than 5 are not equal
-            Assert.False(CustomEquatableStruct.SwiftEquals(struct1, struct3));
+            Assert.NotEqual(struct1, struct3);
         }
     }
 }

--- a/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
+++ b/src/Swift.Bindings/tests/IntegrationTests/FunctionalTests/Structs/StructsTests.swift
@@ -262,3 +262,37 @@ public struct NonFrozenPropertiesTestStruct {
         return Double(letProperty) * Double(multiplier)
     }
 }
+
+@frozen
+public struct FrozenEquatableStruct: Equatable {
+    public var x: Int
+    public var y: Int
+    
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public struct NonFrozenEquatableStruct: Equatable {
+    public var x: Int
+    public var y: Int
+    
+    public init(x: Int, y: Int) {
+        self.x = x
+        self.y = y
+    }
+}
+
+@frozen
+public struct CustomEquatableStruct: Equatable {
+    public var value: Int
+    
+    public init(value: Int) {
+        self.value = value
+    }
+    
+    public static func == (lhs: CustomEquatableStruct, rhs: CustomEquatableStruct) -> Bool {
+        return abs(lhs.value - rhs.value) <= 5
+    }
+}

--- a/src/Swift.Bindings/tests/IntegrationTests/Swift.Bindings.Integration.Tests.csproj
+++ b/src/Swift.Bindings/tests/IntegrationTests/Swift.Bindings.Integration.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/src/Swift.Runtime/src/Swift/Runtime/TypeMetadata.cs
+++ b/src/Swift.Runtime/src/Swift/Runtime/TypeMetadata.cs
@@ -142,8 +142,8 @@ public enum TypeMetadataRequest
 /// </summary>
 public readonly struct TypeMetadata : IEquatable<TypeMetadata>
 {
-    readonly IntPtr handle;
-
+    private readonly IntPtr handle;
+    public IntPtr Handle => handle;
     static TypeMetadata()
     {
         // TODO - add metadata for common built-in types like scalars and strings

--- a/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
@@ -10,7 +10,23 @@ namespace Swift.Runtime
 {
     public interface ISwiftEquatable
     {
-        // This interface is intentionally left empty. It serves as a marker for types that implement Swift's Equatable protocol.
+        /// <summary>
+        /// Compares the current instance with another object of the same type.
+        /// </summary>
+        /// <param name="other">The other object to compare with.</param>
+        /// <returns>True if the objects are equal; otherwise, false.</returns>
+        bool Equals(object other)
+        {
+            if (other == null)
+                return false;
+
+            if (other is ISwiftEquatable otherSwift)
+            {
+                return SwiftEquatable.Equals(this, otherSwift);
+            }
+
+            return false;
+        }
     }
 
     /// <summary>
@@ -31,7 +47,7 @@ namespace Swift.Runtime
         /// <summary>
         /// Compares two objects using Swift's Equatable protocol.
         /// </summary>
-        /// <typeparam name="T">Type that implements IEquatable&lt;T&gt;</typeparam>
+        /// <typeparam name="T">Type that implements ISwiftEquatable</typeparam>
         /// <param name="lhs">Left-hand side object</param>
         /// <param name="rhs">Right-hand side object</param>
         /// <returns>True if the objects are equal according to Swift's equality</returns>

--- a/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.Swift;
+using Swift.Runtime.InteropServices;
+
+namespace Swift.Runtime
+{
+    public interface ISwiftEquatable
+    {
+        // This interface is intentionally left empty. It serves as a marker for types that implement Swift's Equatable protocol.
+    }
+
+    /// <summary>
+    /// Provides functionality to use Swift's Equatable protocol for equality comparison.
+    /// </summary>
+    public static class SwiftEquatable
+    {
+        // P/Invoke declaration for Swift's Equatable protocol equality operator
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+        [DllImport(KnownLibraries.SwiftCore, EntryPoint = "$sSQ2eeoiySbx_xtFZTj")]
+        private static extern bool PInvoke_SwiftEquals(
+            IntPtr lhs,
+            IntPtr rhs,
+            SwiftSelf typeMetadataInSwiftSelf,
+            TypeMetadata typeMetadata,
+            ProtocolWitnessTable equatableProtocolWitnessTable);
+
+        /// <summary>
+        /// Compares two objects using Swift's Equatable protocol.
+        /// </summary>
+        /// <typeparam name="T">Type that implements IEquatable&lt;T&gt;</typeparam>
+        /// <param name="lhs">Left-hand side object</param>
+        /// <param name="rhs">Right-hand side object</param>
+        /// <returns>True if the objects are equal according to Swift's equality</returns>
+        public static unsafe bool Equals<T>(T lhs, T rhs)
+        {
+            if (lhs == null)
+                throw new ArgumentNullException(nameof(lhs));
+            if (rhs == null)
+                throw new ArgumentNullException(nameof(rhs));
+
+            var metadata = TypeMetadata.GetTypeMetadataOrThrow<T>();
+            var equatablePwt = ProtocolWitnessTable.GetOrThrow<T, ISwiftEquatable>();
+
+            IntPtr lhsPayload = IntPtr.Zero;
+            IntPtr rhsPayload = IntPtr.Zero;
+
+            try
+            {
+                lhsPayload = (IntPtr)NativeMemory.Alloc(metadata.Size);
+                rhsPayload = (IntPtr)NativeMemory.Alloc(metadata.Size);
+
+                SwiftMarshal.MarshalToSwift(lhs, lhsPayload);
+                SwiftMarshal.MarshalToSwift(rhs, rhsPayload);
+
+                return PInvoke_SwiftEquals(
+                    lhsPayload,
+                    rhsPayload,
+                    new SwiftSelf((void*)metadata.Handle),
+                    metadata,
+                    equatablePwt);
+            }
+            finally
+            {
+                if (lhsPayload != IntPtr.Zero)
+                    NativeMemory.Free((void*)lhsPayload);
+                if (rhsPayload != IntPtr.Zero)
+                    NativeMemory.Free((void*)rhsPayload);
+            }
+        }
+    }
+}

--- a/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Swift;
 using Swift.Runtime.InteropServices;
 

--- a/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
@@ -10,23 +10,7 @@ namespace Swift.Runtime
 {
     public interface ISwiftEquatable
     {
-        /// <summary>
-        /// Compares the current instance with another object of the same type.
-        /// </summary>
-        /// <param name="other">The other object to compare with.</param>
-        /// <returns>True if the objects are equal; otherwise, false.</returns>
-        bool Equals(object other)
-        {
-            if (other == null)
-                return false;
 
-            if (other is ISwiftEquatable otherSwift)
-            {
-                return SwiftEquatable.Equals(this, otherSwift);
-            }
-
-            return false;
-        }
     }
 
     /// <summary>

--- a/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
+++ b/src/Swift.Runtime/src/Swift/SwiftEquatable.cs
@@ -8,11 +8,6 @@ using Swift.Runtime.InteropServices;
 
 namespace Swift.Runtime
 {
-    public interface ISwiftEquatable
-    {
-
-    }
-
     /// <summary>
     /// Provides functionality to use Swift's Equatable protocol for equality comparison.
     /// </summary>
@@ -43,7 +38,7 @@ namespace Swift.Runtime
                 throw new ArgumentNullException(nameof(rhs));
 
             var metadata = TypeMetadata.GetTypeMetadataOrThrow<T>();
-            var equatablePwt = ProtocolWitnessTable.GetOrThrow<T, ISwiftEquatable>();
+            var equatablePwt = ProtocolWitnessTable.GetOrThrow<T, IEquatable<T>>();
 
             IntPtr lhsPayload = IntPtr.Zero;
             IntPtr rhsPayload = IntPtr.Zero;

--- a/src/Swift.Runtime/tests/LibraryTests/SwiftEquatableTests.cs
+++ b/src/Swift.Runtime/tests/LibraryTests/SwiftEquatableTests.cs
@@ -1,0 +1,24 @@
+using BindingsGeneration.Tests;
+using Swift.Runtime;
+using Xunit;
+
+namespace LibraryTests
+{
+    public class SwiftEquatableTests
+    {
+        [Fact]
+        public void SwiftIntMock_Equals_ShouldWork()
+        {
+            var intMock1 = new SwiftIntMock(42);
+            var intMock2 = new SwiftIntMock(42);
+            var intMock3 = new SwiftIntMock(100);
+
+            bool equalsResult1 = SwiftEquatable.Equals(intMock1, intMock2);
+            bool equalsResult2 = SwiftEquatable.Equals(intMock1, intMock3);
+
+
+            Assert.True(equalsResult1, "Two SwiftIntMock instances with the same value should be equal");
+            Assert.False(equalsResult2, "Two SwiftIntMock instances with different values should not be equal");
+        }
+    }
+}

--- a/src/Swift.Runtime/tests/MetadataTests/TestTypes.cs
+++ b/src/Swift.Runtime/tests/MetadataTests/TestTypes.cs
@@ -7,11 +7,19 @@ struct TypeNotImplementingAnyProtocols { }
 
 struct SwiftIntMock : ISwiftObject
 {
+    public int Value { get; set; }
+
+    public SwiftIntMock(int value)
+    {
+        Value = value;
+    }
+
     static ProtocolConformanceDescriptor ISwiftObject.GetProtocolConformanceDescriptor<TProtocol>() where TProtocol : class
     {
         var dic = new Dictionary<Type, string>
             {
-                { typeof(ISwiftHashable), "$sSiSHsMc"} // protocol conformance descriptor for Swift.Int : Swift.Hashable in Swift
+                { typeof(ISwiftHashable), "$sSiSHsMc"}, // protocol conformance descriptor for Swift.Int : Swift.Hashable in Swift
+                { typeof(ISwiftEquatable), "$sSiSQsMc"}, // protocol conformance descriptor for Swift.Int : Swift.Equatable in Swift
             };
 
         if (!dic.ContainsKey(typeof(TProtocol)))
@@ -29,12 +37,16 @@ struct SwiftIntMock : ISwiftObject
 
     static ISwiftObject ISwiftObject.NewFromPayload(SwiftHandle payload)
     {
-        throw new NotImplementedException();
+        return new SwiftIntMock((int)payload.Handle);
     }
 
     nint ISwiftObject.MarshalToSwift(nint swiftDest)
     {
-        throw new NotImplementedException();
+        unsafe
+        {
+            *(int*)swiftDest = Value;
+        }
+        return swiftDest;
     }
 }
 

--- a/src/Swift.Runtime/tests/MetadataTests/TestTypes.cs
+++ b/src/Swift.Runtime/tests/MetadataTests/TestTypes.cs
@@ -19,7 +19,7 @@ struct SwiftIntMock : ISwiftObject
         var dic = new Dictionary<Type, string>
             {
                 { typeof(ISwiftHashable), "$sSiSHsMc"}, // protocol conformance descriptor for Swift.Int : Swift.Hashable in Swift
-                { typeof(ISwiftEquatable), "$sSiSQsMc"}, // protocol conformance descriptor for Swift.Int : Swift.Equatable in Swift
+                { typeof(IEquatable<SwiftIntMock>), "$sSiSQsMc"}, // protocol conformance descriptor for Swift.Int : Swift.Equatable in Swift
             };
 
         if (!dic.ContainsKey(typeof(TProtocol)))


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtimelab/issues/3029

This pull request introduces Equatable support for Swift structs and includes corresponding tests to ensure functionality. The key changes involve adding a new method writer for Equatable implementations, updating the protocol conformance handling, and adding tests for various struct types.

Currently the equality method is surfaced as a separate `SwiftEquals` static method. We should consider whether we should override `.Equals` and `==` in c#.