### PR TITLE
[RuntimeAsync] Recognizing new overloads of Await related to the ConfigureAwait pattern.

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4847,6 +4847,8 @@ public:
 
     bool impMatchIsInstBooleanConversion(const BYTE* codeAddr, const BYTE* codeEndp, int* consumed);
 
+    bool impMatchAwaitPattern(const BYTE * codeAddr, const BYTE * codeEndp, int* configVal);
+
     GenTree* impCastClassOrIsInstToTree(
         GenTree* op1, GenTree* op2, CORINFO_RESOLVED_TOKEN* pResolvedToken, bool isCastClass, bool* booleanCheck, IL_OFFSET ilOffset);
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9013,11 +9013,18 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 if (opcode != CEE_CALLI)
                 {
                     bool isAwait = false;
-                    if (JitConfig.JitOptimizeAwait())
+                    // TODO: The configVal should be wired to the actual implementation
+                    //       that control the flow of sync context.
+                    //       We do not have that yet.
+                    int configVal= -1;  // -1 not congigured, 0/1 configured to false/true
+                    if (compIsAsync2() && JitConfig.JitOptimizeAwait())
                     {
                         // If we see the following code pattern in runtime async methods:
                         //
                         //    call[virt] <Method>
+                        //    [ OPTIONAL ]
+                        //       ldc.i4.0 / ldc.i4.1
+                        //       call[virt] <ConfigureAwait>
                         //    call       <Await>
                         //
                         //  we emit an eqivalent of
@@ -9031,7 +9038,36 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         //        replacing the pattern with a call to a thunk, which contains roughly the same code.
 
                         const BYTE* nextOpcode = codeAddr + sizeof(mdToken);
-                        if (compIsAsync2() && (nextOpcode + sizeof(mdToken) < codeEndp) &&
+                        // There must be enough space after ldc for {call + tk + call + tk}
+                        if (nextOpcode + 2 * (1 + sizeof(mdToken)) < codeEndp)
+                        {
+                            uint8_t nextOp = getU1LittleEndian(nextOpcode);
+                            uint8_t nextNextOp = getU1LittleEndian(nextOpcode + 1);
+                            if ((nextOp != CEE_LDC_I4_0 && nextOp != CEE_LDC_I4_1) ||
+                                (nextNextOp != CEE_CALL && nextNextOp != CEE_CALLVIRT))
+                            {
+                                goto checkForAwait;
+                            }
+
+                            // check if the token after {ldc, call[virt]} is ConfigAwait
+                            CORINFO_RESOLVED_TOKEN nextCallTok;
+                            impResolveToken(nextOpcode + 2, &nextCallTok, CORINFO_TOKENKIND_Method);
+
+                            if (!eeIsIntrinsic(nextCallTok.hMethod) ||
+                                lookupNamedIntrinsic(nextCallTok.hMethod) !=
+                                    NI_System_Threading_Tasks_Task_ConfigureAwait)
+                            {
+                                goto checkForAwait;
+                            }
+
+                            configVal = nextOp == CEE_LDC_I4_0 ? 0 : 1;
+                            // skip {ldc; call; <ConfigureAwait>}
+                            nextOpcode += 1 + 1 + sizeof(mdToken);
+                        }
+
+                    checkForAwait:
+
+                        if ((nextOpcode + sizeof(mdToken) < codeEndp) &&
                             (getU1LittleEndian(nextOpcode) == CEE_CALL))
                         {
                             // resolve the next token
@@ -9055,6 +9091,10 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         if (resolvedToken.hMethod != NULL)
                         {
                             // There is a runtime async variant that is implicitly awaitable, just call that.
+                            // if configured, skip {ldc call ConfigureAwait}
+                            if (configVal >= 0)
+                                codeAddr += 2 + sizeof(mdToken);
+
                             // Skip the call to `Await`
                             codeAddr += 1 + sizeof(mdToken);
                         }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5976,6 +5976,85 @@ bool Compiler::impBlockIsInALoop(BasicBlock* block)
            block->HasFlag(BBF_BACKWARD_JUMP);
 }
 
+//------------------------------------------------------------------------
+// impMatchAwaitPattern: check if a method call starts an Await pattern
+//                       that can be optimized for runtime async
+//
+// Arguments:
+//   codeAddr - IL after call[virt]
+//   codeEndp - End of IL code stream
+//   configVal - [out] set to 0 or 1, accordingly, if we saw ConfigureAwait(0|1)
+//
+// Returns:
+//    true if this is an Await that we can optimize
+//
+bool Compiler::impMatchAwaitPattern(const BYTE* codeAddr, const BYTE* codeEndp, int* configVal)
+{
+    // If we see the following code pattern in runtime async methods:
+    //
+    //    call[virt] <Method>
+    //    [ OPTIONAL ]
+    //       ldc.i4.0 / ldc.i4.1
+    //       call[virt] <ConfigureAwait>
+    //    call       <Await>
+    //
+    // We emit an eqivalent of:
+    //
+    //    call[virt] <RtMethod>
+    //
+    //    where "RtMethod" is the runtime-async counterpart of a Task-returning method.
+    //
+    //  NOTE: we could potentially check if Method is not a thunk and, in cases when we can tell,
+    //        bypass this optimization. Otherwise in a non-thunk case we would be
+    //        replacing the pattern with a call to a thunk, which contains roughly the same code.
+
+    const BYTE* nextOpcode = codeAddr + sizeof(mdToken);
+    // There must be enough space after ldc for {call + tk + call + tk}
+    if (nextOpcode + 2 * (1 + sizeof(mdToken)) < codeEndp)
+    {
+        uint8_t nextOp     = getU1LittleEndian(nextOpcode);
+        uint8_t nextNextOp = getU1LittleEndian(nextOpcode + 1);
+        if ((nextOp != CEE_LDC_I4_0 && nextOp != CEE_LDC_I4_1) ||
+            (nextNextOp != CEE_CALL && nextNextOp != CEE_CALLVIRT))
+        {
+            goto checkForAwait;
+        }
+
+        // check if the token after {ldc, call[virt]} is ConfigAwait
+        CORINFO_RESOLVED_TOKEN nextCallTok;
+        impResolveToken(nextOpcode + 2, &nextCallTok, CORINFO_TOKENKIND_Method);
+
+        if (!eeIsIntrinsic(nextCallTok.hMethod) ||
+            lookupNamedIntrinsic(nextCallTok.hMethod) != NI_System_Threading_Tasks_Task_ConfigureAwait)
+        {
+            goto checkForAwait;
+        }
+
+        *configVal = nextOp == CEE_LDC_I4_0 ? 0 : 1;
+        // skip {ldc; call; <ConfigureAwait>}
+        nextOpcode += 1 + 1 + sizeof(mdToken);
+    }
+
+checkForAwait:
+
+    if ((nextOpcode + sizeof(mdToken) < codeEndp) && (getU1LittleEndian(nextOpcode) == CEE_CALL))
+    {
+        // resolve the next token
+        CORINFO_RESOLVED_TOKEN nextCallTok;
+        impResolveToken(nextOpcode + 1, &nextCallTok, CORINFO_TOKENKIND_Method);
+
+        // check if it is an Await intrinsic
+        if (eeIsIntrinsic(nextCallTok.hMethod) &&
+            lookupNamedIntrinsic(nextCallTok.hMethod) == NI_System_Runtime_CompilerServices_RuntimeHelpers_Await)
+        {
+            // yes, this is an Await
+            return true;
+        }
+    }
+
+    return false;
+}
+
 #ifdef _PREFAST_
 #pragma warning(push)
 #pragma warning(disable : 21000) // Suppress PREFast warning about overly large function
@@ -9019,70 +9098,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     int configVal= -1;  // -1 not congigured, 0/1 configured to false/true
                     if (compIsAsync2() && JitConfig.JitOptimizeAwait())
                     {
-                        // If we see the following code pattern in runtime async methods:
-                        //
-                        //    call[virt] <Method>
-                        //    [ OPTIONAL ]
-                        //       ldc.i4.0 / ldc.i4.1
-                        //       call[virt] <ConfigureAwait>
-                        //    call       <Await>
-                        //
-                        //  we emit an eqivalent of
-                        //
-                        //    call[virt] <RtMethod>
-                        //
-                        //  where "RtMethod" is the runtime-async counterpart of a Task-returning method.
-                        //
-                        //  NOTE: we could potentially check if Method is not a thunk and, in cases when we can tell,
-                        //        bypass this optimization. Otherwise in a non-thunk case we would be
-                        //        replacing the pattern with a call to a thunk, which contains roughly the same code.
-
-                        const BYTE* nextOpcode = codeAddr + sizeof(mdToken);
-                        // There must be enough space after ldc for {call + tk + call + tk}
-                        if (nextOpcode + 2 * (1 + sizeof(mdToken)) < codeEndp)
-                        {
-                            uint8_t nextOp = getU1LittleEndian(nextOpcode);
-                            uint8_t nextNextOp = getU1LittleEndian(nextOpcode + 1);
-                            if ((nextOp != CEE_LDC_I4_0 && nextOp != CEE_LDC_I4_1) ||
-                                (nextNextOp != CEE_CALL && nextNextOp != CEE_CALLVIRT))
-                            {
-                                goto checkForAwait;
-                            }
-
-                            // check if the token after {ldc, call[virt]} is ConfigAwait
-                            CORINFO_RESOLVED_TOKEN nextCallTok;
-                            impResolveToken(nextOpcode + 2, &nextCallTok, CORINFO_TOKENKIND_Method);
-
-                            if (!eeIsIntrinsic(nextCallTok.hMethod) ||
-                                lookupNamedIntrinsic(nextCallTok.hMethod) !=
-                                    NI_System_Threading_Tasks_Task_ConfigureAwait)
-                            {
-                                goto checkForAwait;
-                            }
-
-                            configVal = nextOp == CEE_LDC_I4_0 ? 0 : 1;
-                            // skip {ldc; call; <ConfigureAwait>}
-                            nextOpcode += 1 + 1 + sizeof(mdToken);
-                        }
-
-                    checkForAwait:
-
-                        if ((nextOpcode + sizeof(mdToken) < codeEndp) &&
-                            (getU1LittleEndian(nextOpcode) == CEE_CALL))
-                        {
-                            // resolve the next token
-                            CORINFO_RESOLVED_TOKEN nextCallTok;
-                            impResolveToken(nextOpcode + 1, &nextCallTok, CORINFO_TOKENKIND_Method);
-
-                            // check if it is an Await intrinsic
-                            if (eeIsIntrinsic(nextCallTok.hMethod) &&
-                                lookupNamedIntrinsic(nextCallTok.hMethod) ==
-                                    NI_System_Runtime_CompilerServices_RuntimeHelpers_Await)
-                            {
-                                // yes, this is an Await
-                                isAwait = true;
-                            }
-                        }
+                        isAwait = impMatchAwaitPattern(codeAddr, codeEndp, &configVal);
                     }
 
                     if (isAwait)

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -11243,6 +11243,17 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                         }
                     }
                 }
+                else if (strcmp(namespaceName, "Threading.Tasks") == 0)
+                {
+                    if (strcmp(methodName, "ConfigureAwait") == 0)
+                    {
+                        if (strcmp(className, "Task`1") == 0 || strcmp(className, "Task") == 0 ||
+                            strcmp(className, "ValuTask`1") == 0 || strcmp(className, "ValueTask") == 0)
+                        {
+                            result = NI_System_Threading_Tasks_Task_ConfigureAwait;
+                        }
+                    }
+                }
         }
     }
     else if (strcmp(namespaceName, "Internal.Runtime") == 0)

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -155,6 +155,8 @@ enum NamedIntrinsic : unsigned short
     NI_System_Threading_Interlocked_ExchangeAdd,
     NI_System_Threading_Interlocked_MemoryBarrier,
 
+    NI_System_Threading_Tasks_Task_ConfigureAwait,
+
     // These two are special marker IDs so that we still get the inlining profitability boost
     NI_System_Numerics_Intrinsic,
     NI_System_Runtime_Intrinsics_Intrinsic,

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -859,6 +859,18 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Runtime.CompilerServices.ConfiguredTaskAwaitable)</Target>
+    <Left>ref/net10.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net10.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable)</Target>
+    <Left>ref/net10.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net10.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.Task)</Target>
     <Left>ref/net10.0/System.Private.CoreLib.dll</Left>
     <Right>lib/net10.0/System.Private.CoreLib.dll</Right>
@@ -866,6 +878,18 @@
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.Await(System.Threading.Tasks.ValueTask)</Target>
+    <Left>ref/net10.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net10.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.Await``1(System.Runtime.CompilerServices.ConfiguredTaskAwaitable{``0})</Target>
+    <Left>ref/net10.0/System.Private.CoreLib.dll</Left>
+    <Right>lib/net10.0/System.Private.CoreLib.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.CompilerServices.RuntimeHelpers.Await``1(System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable{``0})</Target>
     <Left>ref/net10.0/System.Private.CoreLib.dll</Left>
     <Right>lib/net10.0/System.Private.CoreLib.dll</Right>
   </Suppression>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -271,6 +271,69 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
+        // Marked intrinsic since this needs to be
+        // recognized as an async2 call.
+        [Intrinsic]
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.Async)]
+        public static void Await(ConfiguredTaskAwaitable configuredAwaitable)
+        {
+            ConfiguredTaskAwaitable.ConfiguredTaskAwaiter awaiter = configuredAwaitable.GetAwaiter();
+            if (!awaiter.IsCompleted)
+            {
+                UnsafeAwaitAwaiterFromRuntimeAsync(awaiter);
+            }
+
+            awaiter.GetResult();
+        }
+
+        // Marked intrinsic since this needs to be
+        // recognized as an async2 call.
+        [Intrinsic]
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.Async)]
+        public static void Await(ConfiguredValueTaskAwaitable configuredAwaitable)
+        {
+            ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter awaiter = configuredAwaitable.GetAwaiter();
+            if (!awaiter.IsCompleted)
+            {
+                UnsafeAwaitAwaiterFromRuntimeAsync(awaiter);
+            }
+
+            awaiter.GetResult();
+        }
+
+        // Marked intrinsic since this needs to be
+        // recognized as an async2 call.
+        [Intrinsic]
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.Async)]
+        public static T Await<T>(ConfiguredTaskAwaitable<T> configuredAwaitable)
+        {
+            ConfiguredTaskAwaitable<T>.ConfiguredTaskAwaiter awaiter = configuredAwaitable.GetAwaiter();
+            if (!awaiter.IsCompleted)
+            {
+                UnsafeAwaitAwaiterFromRuntimeAsync(awaiter);
+            }
+
+            return awaiter.GetResult();
+        }
+
+        // Marked intrinsic since this needs to be
+        // recognized as an async2 call.
+        [Intrinsic]
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.Async)]
+        public static T Await<T>(ConfiguredValueTaskAwaitable<T> configuredAwaitable)
+        {
+            ConfiguredValueTaskAwaitable<T>.ConfiguredValueTaskAwaiter awaiter = configuredAwaitable.GetAwaiter();
+            if (!awaiter.IsCompleted)
+            {
+                UnsafeAwaitAwaiterFromRuntimeAsync(awaiter);
+            }
+
+            return awaiter.GetResult();
+        }
 #endif
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs
@@ -513,6 +513,7 @@ namespace System.Threading.Tasks
         /// true to attempt to marshal the continuation back to the original context captured; otherwise, false.
         /// </param>
         /// <returns>An object used to await this task.</returns>
+        [Intrinsic]
         public new ConfiguredTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext)
         {
             return new ConfiguredTaskAwaitable<TResult>(this, continueOnCapturedContext ? ConfigureAwaitOptions.ContinueOnCapturedContext : ConfigureAwaitOptions.None);
@@ -522,6 +523,7 @@ namespace System.Threading.Tasks
         /// <param name="options">Options used to configure how awaits on this task are performed.</param>
         /// <returns>An object used to await this task.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="options"/> argument specifies an invalid value.</exception>
+        [Intrinsic]
         public new ConfiguredTaskAwaitable<TResult> ConfigureAwait(ConfigureAwaitOptions options)
         {
             if ((options & ~(ConfigureAwaitOptions.ContinueOnCapturedContext |

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2448,6 +2448,7 @@ namespace System.Threading.Tasks
         /// true to attempt to marshal the continuation back to the original context captured; otherwise, false.
         /// </param>
         /// <returns>An object used to await this task.</returns>
+        [Intrinsic]
         public ConfiguredTaskAwaitable ConfigureAwait(bool continueOnCapturedContext)
         {
             return new ConfiguredTaskAwaitable(this, continueOnCapturedContext ? ConfigureAwaitOptions.ContinueOnCapturedContext : ConfigureAwaitOptions.None);
@@ -2457,6 +2458,7 @@ namespace System.Threading.Tasks
         /// <param name="options">Options used to configure how awaits on this task are performed.</param>
         /// <returns>An object used to await this task.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The <paramref name="options"/> argument specifies an invalid value.</exception>
+        [Intrinsic]
         public ConfiguredTaskAwaitable ConfigureAwait(ConfigureAwaitOptions options)
         {
             if ((options & ~(ConfigureAwaitOptions.ContinueOnCapturedContext |

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -425,6 +425,7 @@ namespace System.Threading.Tasks
         /// <param name="continueOnCapturedContext">
         /// true to attempt to marshal the continuation back to the captured context; otherwise, false.
         /// </param>
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ConfiguredValueTaskAwaitable ConfigureAwait(bool continueOnCapturedContext) =>
             new ConfiguredValueTaskAwaitable(new ValueTask(_obj, _token, continueOnCapturedContext));
@@ -825,6 +826,7 @@ namespace System.Threading.Tasks
         /// <param name="continueOnCapturedContext">
         /// true to attempt to marshal the continuation back to the captured context; otherwise, false.
         /// </param>
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ConfiguredValueTaskAwaitable<TResult> ConfigureAwait(bool continueOnCapturedContext) =>
             new ConfiguredValueTaskAwaitable<TResult>(new ValueTask<TResult>(_obj, _result, _token, continueOnCapturedContext));

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13757,6 +13757,10 @@ namespace System.Runtime.CompilerServices
         public static T Await<T>(System.Threading.Tasks.Task<T> task) { throw null; }
         public static void Await(System.Threading.Tasks.ValueTask task) { throw null; }
         public static T Await<T>(System.Threading.Tasks.ValueTask<T> task) { throw null; }
+        public static void Await(System.Runtime.CompilerServices.ConfiguredTaskAwaitable configuredAwaitable) { throw null; }
+        public static void Await(System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable configuredAwaitable) { throw null; }
+        public static T Await<T>(System.Runtime.CompilerServices.ConfiguredTaskAwaitable<T> configuredAwaitable) { throw null; }
+        public static T Await<T>(System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<T> configuredAwaitable) { throw null; }
     }
     public sealed partial class RuntimeWrappedException : System.Exception
     {

--- a/src/tests/async/fibonacci-without-yields-config-await.cs
+++ b/src/tests/async/fibonacci-without-yields-config-await.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 public class Async2FibonacciWithYields
 {
-    const int iterations = 10;
+    const int iterations = 3;
     const bool doYields = false;
 
     [Fact]

--- a/src/tests/async/fibonacci-without-yields-config-await.cs
+++ b/src/tests/async/fibonacci-without-yields-config-await.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+public class Async2FibonacciWithYields
+{
+    const int iterations = 10;
+    const bool doYields = false;
+
+    [Fact]
+    public static void Test()
+    {
+        long allocated = GC.GetTotalAllocatedBytes(precise: true);
+
+        AsyncEntry().GetAwaiter().GetResult();
+
+        allocated = GC.GetTotalAllocatedBytes(precise: true) - allocated;
+        System.Console.WriteLine("allocated: " + allocated);
+    }
+
+    public static async2 Task AsyncEntry()
+    {
+        for (int i = 0; i < iterations; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            int result = RuntimeHelpers.Await(Fib(30).ConfigureAwait(false));
+            sw.Stop();
+
+            Console.WriteLine($"{sw.ElapsedMilliseconds} ms result={result}");
+        }
+    }
+
+    static async2 Task<int> Fib(int i)
+    {
+        if (i <= 1)
+        {
+            if (doYields)
+            {
+                await Task.Yield();
+            }
+
+            return 1;
+        }
+
+        int i1 = RuntimeHelpers.Await(Fib(i - 1).ConfigureAwait(false));
+        int i2 = RuntimeHelpers.Await(Fib(i - 2).ConfigureAwait(false));
+
+        return i1 + i2;
+    }
+}

--- a/src/tests/async/fibonacci-without-yields-config-await.cs
+++ b/src/tests/async/fibonacci-without-yields-config-await.cs
@@ -49,7 +49,7 @@ public class Async2FibonacciWithYields
             return 1;
         }
 
-        int i1 = RuntimeHelpers.Await(Fib(i - 1).ConfigureAwait(false));
+        int i1 = RuntimeHelpers.Await(Fib(i - 1).ConfigureAwait(true));
         int i2 = RuntimeHelpers.Await(Fib(i - 2).ConfigureAwait(false));
 
         return i1 + i2;

--- a/src/tests/async/fibonacci-without-yields-config-await.csproj
+++ b/src/tests/async/fibonacci-without-yields-config-await.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Adds overloads of Await as specified in  
 https://github.com/dotnet/runtime/pull/113675 and JIT logic to recognise them

The  true/false arguments to ConfigureAwait are recognised, but not passed further and have no effect yet as we do not have the actual mechanism to flow (or not) the execution context. 
We can, though, recognize and optimize the pattern that is emitted by `await SomethingAsync().ConfigureAwait(false/true)`

- Adds a test.