### PR TITLE
[RuntimeAsync] Turn off the assert and enable test scenario for struct method thunks

### DIFF
--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1843,8 +1843,6 @@ void MethodDesc::EmitJitStateMachineBasedRuntimeAsyncThunk(MethodDesc* pAsyncOth
             DWORD localArg = 0;
             if (thunkMsig.HasThis())
             {
-                // Struct async thunks not yet implemented
-                _ASSERTE(!this->GetMethodTable()->IsValueType());
                 pCode->EmitLDARG(localArg++);
             }
 

--- a/src/tests/async/struct.cs
+++ b/src/tests/async/struct.cs
@@ -14,9 +14,17 @@ public class Async2Struct
     public static void TestEntryPoint()
     {
         Async().Wait();
+        Async2().Wait();
     }
 
-    private static async2 Task Async()
+    private static async Task Async()
+    {
+        S s = new S(100);
+        await s.Test();
+        AssertEqual(100, s.Value);
+    }
+
+    private static async2 Task Async2()
     {
         S s = new S(100);
         await s.Test();


### PR DESCRIPTION
Fixes:  https://github.com/dotnet/runtimelab/issues/3011

The change basically removes an assert and adds a test scenario. It looks like thunks for struct methods do not require anything special - we transparently call the async2 variant with exactly same args and then finalize the result into Task.  
(maybe they required something special in previous variation of spec for struct async methods and thus we had the assert).