### PR TITLE
[Swift projection tooling] Initial support for Logger

### DIFF
--- a/src/Swift.Bindings/src/Demangler/DemanglingResults.cs
+++ b/src/Swift.Bindings/src/Demangler/DemanglingResults.cs
@@ -1,5 +1,5 @@
-using Utils.Logging;
 using TbdParsing;
+using Utils.Logging;
 
 namespace BindingsGeneration.Demangling;
 

--- a/src/Swift.Bindings/src/Demangler/DemanglingResults.cs
+++ b/src/Swift.Bindings/src/Demangler/DemanglingResults.cs
@@ -1,3 +1,4 @@
+using Utils.Logging;
 using TbdParsing;
 
 namespace BindingsGeneration.Demangling;
@@ -59,11 +60,11 @@ public class DemanglingResults
     /// <summary>
     /// Factory method to generate a suite of demangling results from the given TBD file.
     /// </summary>
-    /// <param name="path">Path to the TBD file</param>
+    /// <param name="path">Path to the TBD file.</param>
+    /// <param name="logger">Logger.</param>
     /// <returns>A set of demangling results</returns>
-    public static DemanglingResults FromTbd(string path)
+    public static DemanglingResults FromTbd(string path, ILogger logger)
     {
-        var logger = new TbdParsing.Logging.ConsoleLogger { MinimumLevel = TbdParsing.Logging.LogLevel.Debug };
         var tbdParser = new TbdParser(logger);
         var tbdFile = tbdParser.ParseFile(path);
 

--- a/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/JsonTbdFormatParser.cs
+++ b/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/JsonTbdFormatParser.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using Utils.Logging;
 using TbdParsing.Models;
+using Utils.Logging;
 
 namespace TbdParsing.Parsing
 {

--- a/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/JsonTbdFormatParser.cs
+++ b/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/JsonTbdFormatParser.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using TbdParsing.Logging;
+using Utils.Logging;
 using TbdParsing.Models;
 
 namespace TbdParsing.Parsing

--- a/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/TbdFormatParserBase.cs
+++ b/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/TbdFormatParserBase.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using TbdParsing.Logging;
+using Utils.Logging;
 using TbdParsing.Models;
 
 namespace TbdParsing.Parsing

--- a/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/TbdFormatParserBase.cs
+++ b/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/TbdFormatParserBase.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Utils.Logging;
 using TbdParsing.Models;
+using Utils.Logging;
 
 namespace TbdParsing.Parsing
 {

--- a/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/YamlLikeTbdFormatParser.cs
+++ b/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/YamlLikeTbdFormatParser.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Utils.Logging;
 using TbdParsing.Models;
+using Utils.Logging;
 
 namespace TbdParsing.Parsing
 {

--- a/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/YamlLikeTbdFormatParser.cs
+++ b/src/Swift.Bindings/src/Demangler/TbdParser/Parsing/YamlLikeTbdFormatParser.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using TbdParsing.Logging;
+using Utils.Logging;
 using TbdParsing.Models;
 
 namespace TbdParsing.Parsing

--- a/src/Swift.Bindings/src/Demangler/TbdParser/TbdParser.cs
+++ b/src/Swift.Bindings/src/Demangler/TbdParser/TbdParser.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using TbdParsing.Logging;
+using Utils.Logging;
 using TbdParsing.Models;
 using TbdParsing.Parsing;
 

--- a/src/Swift.Bindings/src/Demangler/TbdParser/TbdParser.cs
+++ b/src/Swift.Bindings/src/Demangler/TbdParser/TbdParser.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Utils.Logging;
 using TbdParsing.Models;
 using TbdParsing.Parsing;
+using Utils.Logging;
 
 namespace TbdParsing
 {

--- a/src/Swift.Bindings/src/Emitter/StringEmitter/ModuleEmitter.cs
+++ b/src/Swift.Bindings/src/Emitter/StringEmitter/ModuleEmitter.cs
@@ -3,6 +3,7 @@
 
 using System.CodeDom.Compiler;
 using Swift.Runtime;
+using Utils.Logging;
 
 namespace BindingsGeneration
 {
@@ -14,17 +15,17 @@ namespace BindingsGeneration
         // Private properties
         private readonly string _outputDirectory;
         private readonly ITypeDatabase _typeDatabase;
-        private readonly int _verbose;
+        private readonly ILogger _logger;
         private readonly Conductor _conductor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StringEmitter"/> class.
         /// </summary>
-        public StringEmitter(string outputDirectory, ITypeDatabase typeDatabase, int verbose = 0)
+        public StringEmitter(string outputDirectory, ITypeDatabase typeDatabase, ILogger logger)
         {
             _outputDirectory = outputDirectory;
             _typeDatabase = typeDatabase;
-            _verbose = verbose;
+            _logger = logger;
             _conductor = new Conductor();
         }
 
@@ -58,8 +59,7 @@ namespace BindingsGeneration
             }
             else
             {
-                if (_verbose > 0)
-                    Console.WriteLine($"No module handler found for {moduleDecl.Name}");
+                _logger.Warning($"No module handler found for {moduleDecl.Name}");
             }
         }
     }

--- a/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
+++ b/src/Swift.Bindings/src/Parser/ModuleProcessor.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Swift.Runtime;
+using Utils.Logging;
 
 namespace BindingsGeneration
 {
@@ -25,7 +26,7 @@ namespace BindingsGeneration
         private readonly ITypeDatabase _typeDatabase;
         private readonly ModuleTypeDatabase _moduleDatabase;
         private readonly Dictionary<NamedTypeSpec, TypeDecl> _typeDecls;
-        private readonly int _verbosity;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ModuleProcessor"/> class.
@@ -34,20 +35,20 @@ namespace BindingsGeneration
         /// <param name="dylibPath">The file path to the Swift dynamic library.</param>
         /// <param name="typeDecls">A dictionary mapping Swift type specs to their declarations.</param>
         /// <param name="typeDatabase">The global type database tracking processed types.</param>
-        /// <param name="verbosity">The verbosity level for logging.</param>
+        /// <param name="logger">Logger.</param>
         public ModuleProcessor(
             string module,
             string dylibPath,
             Dictionary<NamedTypeSpec, TypeDecl> typeDecls,
             ITypeDatabase typeDatabase,
-            int verbosity)
+            ILogger logger)
         {
             _module = module;
             _dylibPath = dylibPath;
             _typeDatabase = typeDatabase;
             _moduleDatabase = new ModuleTypeDatabase(module, dylibPath);
             _typeDecls = typeDecls;
-            _verbosity = verbosity;
+            _logger = logger;
         }
 
         /// <summary>
@@ -117,10 +118,7 @@ namespace BindingsGeneration
                     break;
 
                 default:
-                    if (_verbosity > 1)
-                    {
-                        Console.WriteLine($"Skipping unknown type declaration '{typeDecl.GetType().Name}'.");
-                    }
+                    _logger.Warning($"Skipping unknown type declaration '{typeDecl.GetType().Name}'.");
                     break;
             }
         }
@@ -169,13 +167,10 @@ namespace BindingsGeneration
                 {
                     if (!_typeDatabase.IsTypeProcessed(namedPropertyType))
                     {
-                        if (_verbosity > 1)
-                        {
-                            Console.WriteLine(
+                        _logger.Warning(
                                 $"Skipping property '{propertyDecl.Name}' of type '{namedPropertyType.NameWithoutModule}' " +
                                 $"from module '{namedPropertyType.Module}'. Type should have been processed " +
                                 "in a previous module but was not found.");
-                        }
                         continue;
                     }
                 }
@@ -184,12 +179,9 @@ namespace BindingsGeneration
                 {
                     if (!_typeDecls.TryGetValue(namedPropertyType, out var nestedDecl))
                     {
-                        if (_verbosity > 1)
-                        {
-                            Console.WriteLine(
+                        _logger.Warning(
                                 $"Skipping property '{propertyDecl.Name}' of type '{namedPropertyType.NameWithoutModule}' " +
                                 $"from module '{namedPropertyType.Module}'. Not found in type declarations.");
-                        }
                         continue;
                     }
                     ProcessTypeRecursively(namedPropertyType, nestedDecl);

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -472,7 +472,7 @@ namespace BindingsGeneration
                         result.Add(CreateGetAccessor(accessor, fieldName, parentDecl, moduleDecl));
                         break;
                     default:
-                        Console.WriteLine($"Unsupported accessor kind '{accessor.AccessorKind}' encountered.");
+                        _logger.Warning($"Unsupported accessor kind '{accessor.AccessorKind}' encountered.");
                         break;
                 }
             }

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using BindingsGeneration.Demangling;
 using Microsoft.CodeAnalysis.CSharp;
 using Newtonsoft.Json;
+using BindingsGeneration.Demangling;
+using Utils.Logging;
 
 namespace BindingsGeneration
 {
@@ -101,9 +102,9 @@ namespace BindingsGeneration
 
 
         /// <summary>
-        /// The verbosity level.
+        /// Logger.
         /// </summary>
-        private readonly int _verbose;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// The module root node.
@@ -124,12 +125,12 @@ namespace BindingsGeneration
             string filePath,
             ITypeDatabase typeDatabase,
             DemanglingResults demangledTbd,
-            int verbose = 0)
+            ILogger logger)
         {
             _filePath = filePath;
             _typeDatabase = typeDatabase;
             _demangledTbd = demangledTbd;
-            _verbose = verbose;
+            _logger = logger;
 
             string jsonContent = File.ReadAllText(_filePath);
             _moduleRoot = JsonConvert.DeserializeObject<ABIRootNode>(jsonContent) ?? throw new InvalidOperationException("Invalid ABI structure.");
@@ -234,13 +235,11 @@ namespace BindingsGeneration
             }
             catch (NotImplementedException e)
             {
-                if (_verbose > 1)
-                    Console.WriteLine($"Not implemented '{node.Name}' ({node.MangledName}): {e.Message}");
+                _logger.Warning($"Not implemented '{node.Name}' ({node.MangledName}): {e.Message}");
             }
             catch (Exception e)
             {
-                if (_verbose > 0)
-                    Console.WriteLine($"Error while processing node '{node.Name} ({node.MangledName})': {e.Message}");
+                _logger.Warning($"Error while processing node '{node.Name} ({node.MangledName})': {e.Message}");
             }
 
             return result;
@@ -263,8 +262,7 @@ namespace BindingsGeneration
 
             if (string.IsNullOrEmpty(node.MangledName))
             {
-                if (_verbose > 1)
-                    Console.WriteLine($"Type '{node.Name}' has no mangled name. Skipping.");
+                _logger.Warning($"Type '{node.Name}' has no mangled name. Skipping.");
                 return null;
             }
 
@@ -272,8 +270,7 @@ namespace BindingsGeneration
 
             if (node.GenericSig is not null)
             {
-                if (_verbose > 1)
-                    Console.WriteLine($"Generic type '{node.Name}' not supported. Skipping.");
+                _logger.Warning($"Generic type '{node.Name}' not supported. Skipping.");
                 return null;
             }
 
@@ -293,8 +290,7 @@ namespace BindingsGeneration
                     break;
 
                 default:
-                    if (_verbose > 1)
-                        Console.WriteLine($"Unsupported declaration type '{node.DeclKind} {node.Name}' encountered.");
+                    _logger.Warning($"Unsupported declaration type '{node.DeclKind} {node.Name}' encountered.");
                     return null;
             }
 
@@ -329,8 +325,7 @@ namespace BindingsGeneration
             {
                 // TODO: Some types conform to protocols inherently, i.e., they are not explicitly declared.
                 // These conformances are specified in the ABI.json but the descriptors are not present in the TBD.
-                if (_verbose > 0)
-                    Console.WriteLine($"Error while getting protocol conformance descriptor for '{typeName}' and protocol '{protocolName}': {e.Message}");
+                _logger.Warning($"Error while getting protocol conformance descriptor for '{typeName}' and protocol '{protocolName}': {e.Message}");
             }
 
             var conformance = new TypeConformance(typeName, protocolName, protocolConformanceDescriptor);

--- a/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
+++ b/src/Swift.Bindings/src/Parser/SwiftABIParser.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using BindingsGeneration.Demangling;
 using Microsoft.CodeAnalysis.CSharp;
 using Newtonsoft.Json;
-using BindingsGeneration.Demangling;
 using Utils.Logging;
 
 namespace BindingsGeneration

--- a/src/Swift.Bindings/src/Program.cs
+++ b/src/Swift.Bindings/src/Program.cs
@@ -119,7 +119,7 @@ namespace BindingsGeneration
                 // Parse the Swift ABI file and generate declarations
                 var (decl, moduleTypes) = swiftParser.ParseModule();
 
-                var moduleProcessor = new ModuleProcessor(moduleName, dylibPath, moduleTypes, typeDatabase, 2);
+                var moduleProcessor = new ModuleProcessor(moduleName, dylibPath, moduleTypes, typeDatabase, logger);
                 var moduleDatabase = moduleProcessor.FinalizeTypeProcessingAndCreateModuleDatabase().ModuleDatabase;
                 typeDatabase.AddModuleDatabase(moduleDatabase);
 

--- a/src/Swift.Bindings/src/Program.cs
+++ b/src/Swift.Bindings/src/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
+using Utils.Logging;
 
 namespace BindingsGeneration
 {
@@ -19,7 +20,10 @@ namespace BindingsGeneration
             Option<string> dylibOption = new(aliases: new[] { "-d", "--dylib" }, "Path to the dynamic library.") { IsRequired = true };
             Option<string> tbdOption = new(aliases: new[] { "-t", "--tbd" }, "Path to the TBD file.") { IsRequired = true };
             Option<string> outputDirectoryOption = new(aliases: new[] { "-o", "--output" }, "Output directory for generated bindings.") { IsRequired = true };
-            Option<int> verboseOption = new(aliases: new[] { "-v", "--verbose" }, "Verbosity level.");
+            Option<int> verboseOption = new(
+                aliases: new[] { "-v", "--verbose" }, 
+                description: "Verbosity level. 0 = No logging, 1 = Error, 2 = Warning, 3 = Info, 4 = Debug. (default: 3)", 
+                getDefaultValue: () => 3);
             Option<bool> helpOption = new(aliases: new[] { "-h", "--help" }, "Display a help message.");
 
             RootCommand rootCommand = new(description: "Swift bindings generator.")
@@ -44,31 +48,33 @@ namespace BindingsGeneration
                     return;
                 }
 
+                ILogger logger = LoggerFactory.Create(verbose);
+
                 if (string.IsNullOrWhiteSpace(swiftAbiPath) || !File.Exists(swiftAbiPath))
                 {
-                    Console.Error.WriteLine("Error: Valid Swift ABI file is required.");
+                    logger.Error("Error: Valid Swift ABI file is required.");
                     return;
                 }
 
                 if (string.IsNullOrWhiteSpace(dylibPath) || !File.Exists(dylibPath))
                 {
-                    Console.Error.WriteLine("Error: Valid dynamic library is required.");
+                    logger.Error("Error: Valid dynamic library is required.");
                     return;
                 }
 
                 if (string.IsNullOrWhiteSpace(tbdPath) || !File.Exists(tbdPath))
                 {
-                    Console.Error.WriteLine("Error: Valid TBD file is required.");
+                    logger.Error("Error: Valid TBD file is required.");
                     return;
                 }
 
                 if (string.IsNullOrWhiteSpace(outputDirectory) || !Directory.Exists(outputDirectory))
                 {
-                    Console.Error.WriteLine("Error: Valid output directory is required.");
+                    logger.Error("Error: Valid output directory is required.");
                     return;
                 }
 
-                GenerateBindings(swiftAbiPath, dylibPath, tbdPath, outputDirectory, verbose);
+                GenerateBindings(swiftAbiPath, dylibPath, tbdPath, outputDirectory, logger);
             },
             swiftAbiOption,
             dylibOption,
@@ -87,8 +93,8 @@ namespace BindingsGeneration
         /// <param name="swiftAbiPath">Path to the Swift ABI file.</param>
         /// <param name="dylibPath">Path to the dynamic library.</param>
         /// <param name="outputDirectory">Output directory for generated bindings.</param>
-        /// <param name="verbose">Verbosity level.</param>
-        public static void GenerateBindings(string swiftAbiPath, string dylibPath, string tbdPath, string outputDirectory, int verbose = 2)
+        /// <param name="logger">Logger.</param>
+        public static void GenerateBindings(string swiftAbiPath, string dylibPath, string tbdPath, string outputDirectory, ILogger logger)
         {
             var typeDatabase = new TypeDatabase();
             string[] moduleDatabases = { "FoundationDatabase.xml", "SwiftDatabase.xml" };
@@ -97,14 +103,13 @@ namespace BindingsGeneration
                 typeDatabase.LoadModuleDatabaseFromFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Swift", database)).Wait();
             }
 
-            if (verbose > 0)
-                Console.WriteLine($"Starting bindings generation for {swiftAbiPath}...");
+            logger.Info($"Starting bindings generation for {swiftAbiPath}...");
 
             // Parse the TBD file
-            Demangling.DemanglingResults demangledTbdFile = Demangling.DemanglingResults.FromTbd(tbdPath);
+            Demangling.DemanglingResults demangledTbdFile = Demangling.DemanglingResults.FromTbd(tbdPath, logger);
 
             // Initialize the Swift ABI parser
-            var swiftParser = new SwiftABIParser(swiftAbiPath, typeDatabase, demangledTbdFile, verbose);
+            var swiftParser = new SwiftABIParser(swiftAbiPath, typeDatabase, demangledTbdFile, logger);
             var moduleName = swiftParser.GetModuleName();
 
             // Skip if the module has already been processed
@@ -114,23 +119,21 @@ namespace BindingsGeneration
                 // Parse the Swift ABI file and generate declarations
                 var (decl, moduleTypes) = swiftParser.ParseModule();
 
-                var moduleProcessor = new ModuleProcessor(moduleName, dylibPath, moduleTypes, typeDatabase, verbose);
+                var moduleProcessor = new ModuleProcessor(moduleName, dylibPath, moduleTypes, typeDatabase, 2);
                 var moduleDatabase = moduleProcessor.FinalizeTypeProcessingAndCreateModuleDatabase().ModuleDatabase;
                 typeDatabase.AddModuleDatabase(moduleDatabase);
 
-                if (verbose > 1)
-                    Console.WriteLine("Parsed Swift ABI file successfully.");
+                logger.Debug("Parsed Swift ABI file successfully.");
 
                 // Emit the C# bindings
-                var stringEmitter = new StringEmitter(outputDirectory, typeDatabase, verbose);
+                var stringEmitter = new StringEmitter(outputDirectory, typeDatabase, 2);
                 stringEmitter.EmitModule(decl);
 
-                if (verbose > 0)
-                    Console.WriteLine($"Bindings generation completed for {swiftAbiPath}.");
+                logger.Info($"Bindings generation completed for {swiftAbiPath}.");
 
             }
-            else if (verbose > 0)
-                Console.WriteLine($"Bindings generation already completed for {swiftAbiPath}.");
+            else
+                logger.Warning($"Bindings generation already completed for {swiftAbiPath}.");
 
             // Copy the Swift library to the output directory
             CopyDirectory(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Swift"), Path.Combine(outputDirectory, "Swift"), true);

--- a/src/Swift.Bindings/src/Program.cs
+++ b/src/Swift.Bindings/src/Program.cs
@@ -126,7 +126,7 @@ namespace BindingsGeneration
                 logger.Debug("Parsed Swift ABI file successfully.");
 
                 // Emit the C# bindings
-                var stringEmitter = new StringEmitter(outputDirectory, typeDatabase, 2);
+                var stringEmitter = new StringEmitter(outputDirectory, typeDatabase, logger);
                 stringEmitter.EmitModule(decl);
 
                 logger.Info($"Bindings generation completed for {swiftAbiPath}.");

--- a/src/Swift.Bindings/src/Program.cs
+++ b/src/Swift.Bindings/src/Program.cs
@@ -21,8 +21,8 @@ namespace BindingsGeneration
             Option<string> tbdOption = new(aliases: new[] { "-t", "--tbd" }, "Path to the TBD file.") { IsRequired = true };
             Option<string> outputDirectoryOption = new(aliases: new[] { "-o", "--output" }, "Output directory for generated bindings.") { IsRequired = true };
             Option<int> verboseOption = new(
-                aliases: new[] { "-v", "--verbose" }, 
-                description: "Verbosity level. 0 = No logging, 1 = Error, 2 = Warning, 3 = Info, 4 = Debug. (default: 3)", 
+                aliases: new[] { "-v", "--verbose" },
+                description: "Verbosity level. 0 = No logging, 1 = Error, 2 = Warning, 3 = Info, 4 = Debug. (default: 3)",
                 getDefaultValue: () => 3);
             Option<bool> helpOption = new(aliases: new[] { "-h", "--help" }, "Display a help message.");
 

--- a/src/Swift.Bindings/src/Swift.Bindings.csproj
+++ b/src/Swift.Bindings/src/Swift.Bindings.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="../../Swift.Runtime/src/Swift.Runtime.csproj">
       <ReferenceSourceTarget></ReferenceSourceTarget>
     </ProjectReference>
+    <ProjectReference Include="../../Utils/src/Utils.csproj" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.0" />

--- a/src/Utils/src/Logger/ConsoleLogger.cs
+++ b/src/Utils/src/Logger/ConsoleLogger.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace TbdParsing.Logging
+namespace Utils.Logging
 {
     /// <summary>
     /// Simple console logger implementation
@@ -47,7 +47,7 @@ namespace TbdParsing.Logging
             if (MinimumLevel <= LogLevel.Error)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine($"[ERROR] {message}");
+                Console.Error.WriteLine($"[ERROR] {message}");
                 Console.ResetColor();
             }
         }
@@ -57,9 +57,9 @@ namespace TbdParsing.Logging
             if (MinimumLevel <= LogLevel.Error)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine($"[ERROR] {message}");
-                Console.WriteLine($"Exception: {ex.Message}");
-                Console.WriteLine(ex.StackTrace);
+                Console.Error.WriteLine($"[ERROR] {message}");
+                Console.Error.WriteLine($"Exception: {ex.Message}");
+                Console.Error.WriteLine(ex.StackTrace);
                 Console.ResetColor();
             }
         }

--- a/src/Utils/src/Logger/ILogger.cs
+++ b/src/Utils/src/Logger/ILogger.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace TbdParsing.Logging
+namespace Utils.Logging
 {
     /// <summary>
     /// Defines logging levels for the TBD parser

--- a/src/Utils/src/Logger/LoggerFactory.cs
+++ b/src/Utils/src/Logger/LoggerFactory.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Utils.Logging
+{
+    /// <summary>
+    /// Factory for creating logger instances with appropriate verbosity levels.
+    /// </summary>
+    public static class LoggerFactory
+    {
+        /// <summary>
+        /// Creates a logger with the specified verbosity level.
+        /// </summary>
+        /// <param name="verbosityLevel">
+        /// Numeric verbosity level where:
+        /// 0 = No logging
+        /// 1 = Errors only
+        /// 2 = Warnings and errors
+        /// 3 = Info, warnings, and errors (default)
+        /// 4 = Debug, info, warnings, and errors
+        /// </param>
+        /// <returns>A configured ILogger instance</returns>
+        public static ILogger Create(int verbosityLevel = 3)
+        {
+            if (verbosityLevel == 0)
+            {
+                return new NullLogger();
+            }
+
+            // Convert numeric level to LogLevel enum
+            LogLevel logLevel = verbosityLevel switch
+            {
+                1 => LogLevel.Error,
+                2 => LogLevel.Warning,
+                3 => LogLevel.Info,
+                _ => LogLevel.Debug // 4 or higher
+            };
+            
+            return new ConsoleLogger { MinimumLevel = logLevel };
+        }
+        
+        /// <summary>
+        /// Creates a logger with the specified minimum log level.
+        /// </summary>
+        /// <param name="level">The minimum log level to report</param>
+        /// <returns>A configured ILogger instance</returns>
+        public static ILogger Create(LogLevel level)
+        {
+            return new ConsoleLogger { MinimumLevel = level };
+        }
+        
+        /// <summary>
+        /// Creates a null logger that discards all log messages.
+        /// </summary>
+        /// <returns>A NullLogger instance</returns>
+        public static ILogger CreateNull()
+        {
+            return new NullLogger();
+        }
+    }
+}

--- a/src/Utils/src/Logger/LoggerFactory.cs
+++ b/src/Utils/src/Logger/LoggerFactory.cs
@@ -37,10 +37,10 @@ namespace Utils.Logging
                 3 => LogLevel.Info,
                 _ => LogLevel.Debug // 4 or higher
             };
-            
+
             return new ConsoleLogger { MinimumLevel = logLevel };
         }
-        
+
         /// <summary>
         /// Creates a logger with the specified minimum log level.
         /// </summary>
@@ -50,7 +50,7 @@ namespace Utils.Logging
         {
             return new ConsoleLogger { MinimumLevel = level };
         }
-        
+
         /// <summary>
         /// Creates a null logger that discards all log messages.
         /// </summary>

--- a/src/Utils/src/Logger/NullLogger.cs
+++ b/src/Utils/src/Logger/NullLogger.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace TbdParsing.Logging
+namespace Utils.Logging
 {
     /// <summary>
     /// A logger implementation that does nothing (null object pattern)

--- a/src/Utils/src/Utils.csproj
+++ b/src/Utils/src/Utils.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This PR adds initial support for Logger inside the Swift projection tooling. 

### Key Changes
- Logger implementation is moved to `Utils.Logging` namespace
- `--verbose` now translates to a Logger setting which is passed around to ensure appropriate and consistent logging. The possible options are: 
```
- 0 = No logging 
- 1 = Only errors
- 2 = Errors and warnings
- 3 = Errors, warnings, and info
- 4 = Errors, warnings, info, debug
```

### Future Work
- Onboard `Conductor` + `Handler*` codebase as this requires more extensive work rather than just replacing `int verbose` with `ILLogger logger`.



---

FYI: If you were using `--verbose 2` to get all logging (including debug prints), please switch to `--verbose 4` after this PR.

Partially contributes to https://github.com/dotnet/runtimelab/issues/2973