### PR TITLE
[RuntimeAsync] Fix handling of implicit byref liveness

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -148,7 +148,8 @@ bool AsyncLiveness::IsLive(unsigned lclNum)
 
     LclVarDsc* dsc = m_comp->lvaGetDesc(lclNum);
 
-    if ((dsc->TypeGet() == TYP_BYREF) || ((dsc->TypeGet() == TYP_STRUCT) && dsc->GetLayout()->HasGCByRef()))
+    if (((dsc->TypeGet() == TYP_BYREF) && !dsc->IsImplicitByRef()) ||
+        ((dsc->TypeGet() == TYP_STRUCT) && dsc->GetLayout()->HasGCByRef()))
     {
         // Even if these are address exposed we expect them to be dead at
         // suspension points. TODO: It would be good to somehow verify these
@@ -1019,7 +1020,10 @@ void Async2Transformation::FillInGCPointersOnSuspension(const jitstd::vector<Liv
                 }
             }
 
-            m_comp->lvaSetVarDoNotEnregister(inf.LclNum DEBUGARG(DoNotEnregisterReason::LocalField));
+            if (!dsc->IsImplicitByRef())
+            {
+                m_comp->lvaSetVarDoNotEnregister(inf.LclNum DEBUGARG(DoNotEnregisterReason::LocalField));
+            }
         }
     }
 }

--- a/src/tests/async/shared-generic.cs
+++ b/src/tests/async/shared-generic.cs
@@ -27,14 +27,12 @@ public class Async2SharedGeneric
 
         // struct with an obj and its nullable
         Async1EntryPoint<S0>(typeof(S0), new S0(42)).Wait();
-        // TODO: uncomment to repro https://github.com/dotnet/runtimelab/issues/3043
-        // Async1EntryPoint<S0?>(typeof(S0?), new S0(42)).Wait();
+        Async1EntryPoint<S0?>(typeof(S0?), new S0(42)).Wait();
         Async1EntryPoint<S0?>(typeof(S0?), null).Wait();
 
         // generic struct with an obj and its nullable
         Async1EntryPoint<S1<string>>(typeof(S1<string>), new S1<string> { t = "ghj" }).Wait();
-        // TODO: uncomment to repro https://github.com/dotnet/runtimelab/issues/3043
-        // Async1EntryPoint<S1<string>?>(typeof(S1<string>?), new S1<string> { t = "qwe" }).Wait();
+        Async1EntryPoint<S1<string>?>(typeof(S1<string>?), new S1<string> { t = "qwe" }).Wait();
         Async1EntryPoint<S1<string>?>(typeof(S1<string>?), null).Wait();
 
         // simple cases


### PR DESCRIPTION
This scenario was handled in the first version of the prototype, so the rest of the support is already there to handle these properly.
It looks like I broke the liveness part of the support in 34897d7c9401e412857a2c98c4de2cb7c0fa7a19 when I introduced the byref check.

Fix #3043