### PR TITLE
[RuntimeAsync] Use explicit store types

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -828,14 +828,14 @@ BasicBlock* Async2Transformation::CreateSuspension(BasicBlock*               blo
     GenTree* newContinuation = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
     unsigned resumeOffset    = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationResumeFldHnd);
     GenTree* resumeStubAddr  = CreateResumptionStubAddrTree();
-    GenTree* storeResume     = StoreAtOffset(newContinuation, resumeOffset, resumeStubAddr);
+    GenTree* storeResume     = StoreAtOffset(newContinuation, resumeOffset, resumeStubAddr, TYP_I_IMPL);
     LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeResume));
 
     // Fill in 'state'
     newContinuation       = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
     unsigned stateOffset  = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationStateFldHnd);
     GenTree* stateNumNode = m_comp->gtNewIconNode((ssize_t)stateNum, TYP_INT);
-    GenTree* storeState   = StoreAtOffset(newContinuation, stateOffset, stateNumNode);
+    GenTree* storeState   = StoreAtOffset(newContinuation, stateOffset, stateNumNode, TYP_INT);
     LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeState));
 
     // Fill in 'flags'
@@ -850,7 +850,7 @@ BasicBlock* Async2Transformation::CreateSuspension(BasicBlock*               blo
     newContinuation      = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
     unsigned flagsOffset = m_comp->info.compCompHnd->getFieldOffset(m_async2Info.continuationFlagsFldHnd);
     GenTree* flagsNode   = m_comp->gtNewIconNode((ssize_t)continuationFlags, TYP_INT);
-    GenTree* storeFlags  = StoreAtOffset(newContinuation, flagsOffset, flagsNode);
+    GenTree* storeFlags  = StoreAtOffset(newContinuation, flagsOffset, flagsNode, TYP_INT);
     LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeFlags));
 
     if (layout.GCRefsCount > 0)
@@ -962,8 +962,8 @@ void Async2Transformation::FillInGCPointersOnSuspension(const jitstd::vector<Liv
             GenTree* value     = m_comp->gtNewLclvNode(inf.LclNum, TYP_REF);
             GenTree* objectArr = m_comp->gtNewLclvNode(objectArrLclNum, TYP_REF);
             GenTree* store =
-                StoreAtOffset(objectArr, OFFSETOF__CORINFO_Array__data + (inf.GCDataIndex * TARGET_POINTER_SIZE),
-                              value);
+                StoreAtOffset(objectArr, OFFSETOF__CORINFO_Array__data + (inf.GCDataIndex * TARGET_POINTER_SIZE), value,
+                              TYP_REF);
             LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
         }
         else
@@ -995,7 +995,7 @@ void Async2Transformation::FillInGCPointersOnSuspension(const jitstd::vector<Liv
                 GenTree* objectArr = m_comp->gtNewLclvNode(objectArrLclNum, TYP_REF);
                 unsigned offset =
                     OFFSETOF__CORINFO_Array__data + ((inf.GCDataIndex + gcRefIndex) * TARGET_POINTER_SIZE);
-                GenTree* store = StoreAtOffset(objectArr, offset, value);
+                GenTree* store = StoreAtOffset(objectArr, offset, value, TYP_REF);
                 LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
 
                 gcRefIndex++;
@@ -1008,7 +1008,7 @@ void Async2Transformation::FillInGCPointersOnSuspension(const jitstd::vector<Liv
                     if (dsc->IsImplicitByRef())
                     {
                         GenTree* baseAddr = m_comp->gtNewLclvNode(inf.LclNum, dsc->TypeGet());
-                        store             = StoreAtOffset(baseAddr, i * TARGET_POINTER_SIZE, null);
+                        store             = StoreAtOffset(baseAddr, i * TARGET_POINTER_SIZE, null, TYP_REF);
                     }
                     else
                     {
@@ -1053,7 +1053,7 @@ void Async2Transformation::FillInDataOnSuspension(const jitstd::vector<LiveLocal
 
         GenTree* byteArr               = m_comp->gtNewLclvNode(byteArrLclNum, TYP_REF);
         unsigned offset                = OFFSETOF__CORINFO_Array__data;
-        GenTree* storePatchpointOffset = StoreAtOffset(byteArr, offset, ilOffsetToStore);
+        GenTree* storePatchpointOffset = StoreAtOffset(byteArr, offset, ilOffsetToStore, TYP_INT);
         LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storePatchpointOffset));
     }
 
@@ -1078,7 +1078,7 @@ void Async2Transformation::FillInDataOnSuspension(const jitstd::vector<LiveLocal
         }
         else
         {
-            value = m_comp->gtNewLclvNode(inf.LclNum, genActualType(dsc->TypeGet()));
+            value = m_comp->gtNewLclVarNode(inf.LclNum);
         }
 
         GenTree* store;
@@ -1093,7 +1093,7 @@ void Async2Transformation::FillInDataOnSuspension(const jitstd::vector<LiveLocal
         }
         else
         {
-            store = StoreAtOffset(byteArr, offset, value);
+            store = StoreAtOffset(byteArr, offset, value, dsc->TypeGet());
         }
 
         LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
@@ -1338,7 +1338,7 @@ void Async2Transformation::RestoreFromGCPointersOnResumption(unsigned           
                 if (dsc->IsImplicitByRef())
                 {
                     GenTree* baseAddr = m_comp->gtNewLclvNode(inf.LclNum, dsc->TypeGet());
-                    store             = StoreAtOffset(baseAddr, i * TARGET_POINTER_SIZE, value);
+                    store             = StoreAtOffset(baseAddr, i * TARGET_POINTER_SIZE, value, TYP_REF);
                     // Implicit byref args are never on heap
                     store->gtFlags |= GTF_IND_TGT_NOT_HEAP;
                 }
@@ -1595,17 +1595,21 @@ GenTreeIndir* Async2Transformation::LoadFromOffset(GenTree*     base,
 //   base       - Base address of the store
 //   offset     - Offset to add on top of the base address
 //   value      - Value to store
+//   storeType  - Type of store
 //
 // Returns:
 //   IR node of the store.
 //
-GenTreeStoreInd* Async2Transformation::StoreAtOffset(GenTree* base, unsigned offset, GenTree* value)
+GenTreeStoreInd* Async2Transformation::StoreAtOffset(GenTree*  base,
+                                                     unsigned  offset,
+                                                     GenTree*  value,
+                                                     var_types storeType)
 {
     assert(base->TypeIs(TYP_REF, TYP_BYREF, TYP_I_IMPL));
     GenTree*         cns      = m_comp->gtNewIconNode((ssize_t)offset, TYP_I_IMPL);
     var_types        addrType = base->TypeIs(TYP_I_IMPL) ? TYP_I_IMPL : TYP_BYREF;
     GenTree*         addr     = m_comp->gtNewOperNode(GT_ADD, addrType, base, cns);
-    GenTreeStoreInd* store    = m_comp->gtNewStoreIndNode(value->TypeGet(), addr, value, GTF_IND_NONFAULTING);
+    GenTreeStoreInd* store    = m_comp->gtNewStoreIndNode(storeType, addr, value, GTF_IND_NONFAULTING);
     return store;
 }
 

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -128,7 +128,7 @@ class Async2Transformation
                                     unsigned     offset,
                                     var_types    type,
                                     GenTreeFlags indirFlags = GTF_IND_NONFAULTING);
-    GenTreeStoreInd* StoreAtOffset(GenTree* base, unsigned offset, GenTree* value);
+    GenTreeStoreInd* StoreAtOffset(GenTree* base, unsigned offset, GenTree* value, var_types storeType);
 
     unsigned GetDataArrayVar();
     unsigned GetGCDataArrayVar();

--- a/src/tests/async/small.cs
+++ b/src/tests/async/small.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Small
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        SmallType(123).Wait();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async2 Task SmallType(byte arg)
+    {
+        await Task.Yield();
+        Assert.Equal(123, arg);
+    }
+}

--- a/src/tests/async/small.csproj
+++ b/src/tests/async/small.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The type should not be determined from the incoming node: for small types this does not make sense.

Diff of the suspension code from the test:
```diff
@@ -1,19 +1,19 @@
 G_M5761_IG05:  ;; offset=0x00DB
        xor      edx, edx
        mov      r8d, 1
        call     [CORINFO_HELP_ALLOC_CONTINUATION]
        mov      rcx, 0x7FFAA7E20720      ; code for (dynamicClass):IL_STUB_AsyncResume_SmallType_Optimized(System.Object):System.Object
        mov      qword ptr [rax+0x20], rcx
        xor      ecx, ecx
        mov      qword ptr [rax+0x28], rcx
        mov      rcx, gword ptr [rax+0x10]
-       mov      dword ptr [rcx+0x10], ebx
+       mov      byte  ptr [rcx+0x10], bl
        mov      rcx, rax
```
The base technically writes beyond the end of the memory that was allocated, though in practice for coreclr that doesn't cause any buffer overflow.