### PR TITLE
[RuntimeAsync] Do not rely on signature parsing to figure if a call is Async

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -523,18 +523,6 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
         {
             call->AsCall()->gtCallMoreFlags |= GTF_CALL_M_SPECIAL_INTRINSIC;
         }
-
-        // Temporary hack since these functions have to be recognized as async
-        // calls in JIT generated state machines only.
-        if (compIsAsync() &&
-            ((ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_AwaitAwaiterFromRuntimeAsync) ||
-             (ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_UnsafeAwaitAwaiterFromRuntimeAsync) ||
-             (ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_Await)))
-        {
-            assert((call != nullptr) && call->OperIs(GT_CALL));
-            call->AsCall()->gtIsAsyncCall = true;
-            JITDUMP("Marking [%06u] as a special-case async call\n", dspTreeID(call));
-        }
     }
     assert(sig);
     assert(clsHnd || (opcode == CEE_CALLI)); // We're never verifying for CALLI, so this is not set.
@@ -3362,14 +3350,11 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
         return node;
     }
 
-    if ((ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_AwaitAwaiterFromRuntimeAsync) ||
-        (ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_UnsafeAwaitAwaiterFromRuntimeAsync) ||
-        (ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_Await))
+    if (ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_Await)
     {
-        // These are marked intrinsics simply to mark the call node as async,
-        // which the caller will do. Make sure we keep pIntrinsicName assigned
-        // (it would be overridden if we left this up to the rest of this
-        // function).
+        // These are marked intrinsics simply to match them by name in
+        // the Await pattern optimization. Make sure we keep pIntrinsicName assigned
+        // (it would be overridden if we left this up to the rest of this function).
         *pIntrinsicName = ni;
         return nullptr;
     }
@@ -11032,15 +11017,6 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                             else if (strcmp(methodName, "GetMethodTable") == 0)
                             {
                                 result = NI_System_Runtime_CompilerServices_RuntimeHelpers_GetMethodTable;
-                            }
-                            else if (strcmp(methodName, "AwaitAwaiterFromRuntimeAsync") == 0)
-                            {
-                                result = NI_System_Runtime_CompilerServices_RuntimeHelpers_AwaitAwaiterFromRuntimeAsync;
-                            }
-                            else if (strcmp(methodName, "UnsafeAwaitAwaiterFromRuntimeAsync") == 0)
-                            {
-                                result =
-                                    NI_System_Runtime_CompilerServices_RuntimeHelpers_UnsafeAwaitAwaiterFromRuntimeAsync;
                             }
                             else if (strcmp(methodName, "Await") == 0)
                             {

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -119,8 +119,6 @@ enum NamedIntrinsic : unsigned short
     NI_System_Runtime_CompilerServices_RuntimeHelpers_IsKnownConstant,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_IsReferenceOrContainsReferences,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_GetMethodTable,
-    NI_System_Runtime_CompilerServices_RuntimeHelpers_AwaitAwaiterFromRuntimeAsync,
-    NI_System_Runtime_CompilerServices_RuntimeHelpers_UnsafeAwaitAwaiterFromRuntimeAsync,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_Await,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_AsyncSuspend,
     NI_System_Runtime_CompilerServices_RuntimeHelpers_get_RuntimeAsyncViaJitGeneratedStateMachines,

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -418,8 +418,6 @@ enum ConvToJitSigFlags : int
     CONV_TO_JITSIG_FLAGS_LOCALSIG   = 0x1,
 };
 
-AsyncMethodSignatureKind ClassifyAsyncMethodSignatureCore(SigPointer sig, Module* pModule, PCCOR_SIGNATURE initialSig, ULONG* offsetOfAsyncDetails, bool *isValueTask);
-
 //---------------------------------------------------------------------------------------
 //
 //@GENERICS:
@@ -512,12 +510,6 @@ static void ConvToJitSig(
         }
         sigRet->retType = CEEInfo::asCorInfoType(type, typeHnd, &sigRet->retTypeClass);
         sigRet->retTypeSigClass = CORINFO_CLASS_HANDLE(typeHnd.AsPtr());
-
-        auto asyncMethodClassification = ClassifyAsyncMethodSignatureCore(sig, module, NULL, NULL, NULL);
-        if (IsAsyncSigAsync(asyncMethodClassification))
-        {
-            sigRet->callConv = (CorInfoCallConv)(sigRet->callConv | CORINFO_CALLCONV_ASYNCCALL);
-        }
 
         IfFailThrow(sig.SkipExactlyOne());  // must to a skip so we skip any class tokens associated with the return type
         _ASSERTE(sigRet->retType < CORINFO_TYPE_COUNT);
@@ -4893,6 +4885,9 @@ static void getMethodSigInternal(
             sigRet->callConv = (CorInfoCallConv) (sigRet->callConv | CORINFO_CALLCONV_PARAMTYPE);
     }
 
+    if (ftn->IsAsyncMethod())
+        sigRet->callConv = (CorInfoCallConv)(sigRet->callConv | CORINFO_CALLCONV_ASYNCCALL);
+
     // We want the calling convention bit to be consistant with the method attribute bit
     _ASSERTE( (IsMdStatic(ftn->GetAttrs()) == 0) == ((sigRet->callConv & CORINFO_CALLCONV_HASTHIS) != 0) );
 }
@@ -7677,6 +7672,9 @@ static void getMethodInfoHelper(
     // take an extra argument representing their instantiation
     if (ftn->RequiresInstArg())
         methInfo->args.callConv = (CorInfoCallConv)(methInfo->args.callConv | CORINFO_CALLCONV_PARAMTYPE);
+
+    if (ftn->IsAsyncMethod())
+        methInfo->args.callConv = (CorInfoCallConv)(methInfo->args.callConv | CORINFO_CALLCONV_ASYNCCALL);
 
     _ASSERTE((IsMdStatic(ftn->GetAttrs()) == 0) == ((methInfo->args.callConv & CORINFO_CALLCONV_HASTHIS) != 0));
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -235,28 +235,17 @@ enum class AsyncVariantLookup
     AsyncOtherVariant
 };
 
-enum class AsyncMethodSignatureKind
+enum class MethodReturnKind
 {
+    NormalMethod,
     GenericTaskReturningMethod,
-    NonGenericTaskReturningMethod,
-    NonVoidAsyncMethod,
-    VoidAsyncMethod,
-    NormalMethod
+    NonGenericTaskReturningMethod
 };
 
-inline bool IsAsyncSigNormal(AsyncMethodSignatureKind input)
+inline bool IsTaskReturning(MethodReturnKind input)
 {
-    return input == AsyncMethodSignatureKind::NormalMethod;
-}
-
-inline bool IsAsyncSigAsync(AsyncMethodSignatureKind input)
-{
-    return (input == AsyncMethodSignatureKind::NonVoidAsyncMethod) || (input == AsyncMethodSignatureKind::VoidAsyncMethod);
-}
-
-inline bool IsAsyncSigTaskReturning(AsyncMethodSignatureKind input)
-{
-    return (input == AsyncMethodSignatureKind::GenericTaskReturningMethod) || (input == AsyncMethodSignatureKind::NonGenericTaskReturningMethod);
+    return (input == MethodReturnKind::GenericTaskReturningMethod) ||
+        (input == MethodReturnKind::NonGenericTaskReturningMethod);
 }
 
 // The size of this structure needs to be a multiple of MethodDesc::ALIGNMENT
@@ -3850,7 +3839,7 @@ ReadyToRunStandaloneMethodMetadata* GetReadyToRunStandaloneMethodMetadata(Method
 void InitReadyToRunStandaloneMethodMetadata();
 #endif // FEATURE_READYTORUN
 
-AsyncMethodSignatureKind ClassifyAsyncMethodSignature(SigPointer sig, Module* pModule, ULONG* offsetOfAsyncDetails, bool *pIsValueType);
+MethodReturnKind ClassifyMethodReturnKind(SigPointer sig, Module* pModule, ULONG* offsetOfAsyncDetails, bool *pIsValueType);
 
 #include "method.inl"
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -85,10 +85,15 @@ enum class AsyncMethodKind
     //   Example: "Task<int> Foo();"  ===> "modreq(Task`) int Foo();"
     //   Example: "ValueTask Bar();"  ===> "modreq(ValueTask) void Bar();"
     //
-    // It is possible to get from one variant to another unambiguously via GetAsyncOtherVariant.
-    //
-    // Async methods are called with CORINFO_CALLCONV_ASYNCCALL call convention.
+    // The reason for this encoding is that:
+    //   - it uses parts of original signature, as-is, thus does not need to look for or construct anything
+    //   - it "unwraps" the element type.
+    //   - it is reversible. In particular nonconflicting signatures will map to nonconflicting ones.
     // 
+    // Async methods are called with CORINFO_CALLCONV_ASYNCCALL call convention.
+    //
+    // It is possible to get from one variant to another via GetAsyncOtherVariant.
+    //
     // NOTE: not all Async methods are "variants" from a pair, see AsyncExplicitImpl below.
     //=============================================================
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -2749,9 +2749,7 @@ bool IsTypeDefOrRefAByRefStruct(Module* pModule, mdToken tk)
     return false;
 }
 
-AsyncMethodSignatureKind ClassifyAsyncMethodSignatureCore(SigPointer sig, Module* pModule, PCCOR_SIGNATURE initialSig, ULONG* offsetOfAsyncDetails, bool *isValueTask);
-
-AsyncMethodSignatureKind ClassifyAsyncMethodSignature(SigPointer sig, Module* pModule, ULONG* offsetOfAsyncDetails, bool *isValueTask)
+MethodReturnKind ClassifyMethodReturnKind(SigPointer sig, Module* pModule, ULONG* offsetOfAsyncDetails, bool *isValueTask)
 {
     PCCOR_SIGNATURE initialSig = sig.GetPtr();
     uint32_t data;
@@ -2762,151 +2760,56 @@ AsyncMethodSignatureKind ClassifyAsyncMethodSignature(SigPointer sig, Module* pM
         IfFailThrow(sig.GetData(&data));
     }
 
-    // Return argument count
+    // skip argument count
     IfFailThrow(sig.GetData(&data));
-    return ClassifyAsyncMethodSignatureCore(sig, pModule, initialSig, offsetOfAsyncDetails, isValueTask);
-}
 
-AsyncMethodSignatureKind ClassifyAsyncMethodSignatureCore(SigPointer sig, Module* pModule, PCCOR_SIGNATURE initialSig, ULONG* offsetOfAsyncDetails, bool *pIsValueTask)
-{
-    uint32_t data;
-    bool dummy = false;
-    if (pIsValueTask == NULL)
-    {
-        pIsValueTask = &dummy;
-    }
-
-    *pIsValueTask = false;
-
-    // Now we should be parsing the return type
-
-    // TODO: (async) this is always runtime-provided now. Perhaps we can avoid parsing modreq'd variant?
-    // If the first custom modifier is a MOD_REQ to Task/Task`1/ValueTask/ValueTask`1
-    // Then this is a Async signature
+    // now look at return type
+    // NOTE: this will skip modifiers
     CorElementType elemType;
-    if (offsetOfAsyncDetails != NULL)
-        *offsetOfAsyncDetails = (ULONG)(sig.GetPtr() - initialSig);
-    BYTE elemTypeByte;
-    IfFailThrow(sig.GetByte(&elemTypeByte)); // Don't use GetElemType as it skips custom modifiers
-    elemType = (CorElementType)elemTypeByte;
+    IfFailThrow(sig.GetElemType(&elemType));
 
+    // can't reason about ELEMENT_TYPE_INTERNAL, but should not see it in metadata
+    if (elemType == ELEMENT_TYPE_INTERNAL)
+        ThrowHR(COR_E_BADIMAGEFORMAT);
+
+    *offsetOfAsyncDetails = (ULONG)(sig.GetPtr() - initialSig) - 1;
     LPCSTR name, _namespace;
     mdToken tk;
-    while ((elemType == ELEMENT_TYPE_CMOD_OPT) || (elemType == ELEMENT_TYPE_CMOD_REQD))
-    {
-        CorElementType elemTypeCmod = elemType;
-
-        IfFailThrow(sig.GetToken(&tk));
-        GetNameOfTypeDefOrRef(pModule, tk, &name, &_namespace);
-        IfFailThrow(sig.GetByte(&elemTypeByte)); // Don't use GetElemType as it skips custom modifiers
-        elemType = (CorElementType)elemTypeByte;
-        if (strcmp(_namespace, "System.Threading.Tasks") == 0 && IsTypeDefOrRefImplementedInSystemModule(pModule, tk) && (elemTypeCmod == ELEMENT_TYPE_CMOD_REQD))
-        {
-            if ((strcmp(name, "Task`1") == 0) || (strcmp(name, "ValueTask`1") == 0))
-            {
-                *pIsValueTask = name[0] == 'V';
-                // This must have been the last CMOD before the element type, and the element type MUST be one which can be expressed structurally as a generic parameter
-                switch (elemType)
-                {
-                    case ELEMENT_TYPE_CLASS:
-                    case ELEMENT_TYPE_VALUETYPE:
-                    case ELEMENT_TYPE_STRING:
-                    case ELEMENT_TYPE_OBJECT:
-                    case ELEMENT_TYPE_I:
-                    case ELEMENT_TYPE_U:
-                    case ELEMENT_TYPE_I1:
-                    case ELEMENT_TYPE_U1:
-                    case ELEMENT_TYPE_I2:
-                    case ELEMENT_TYPE_U2:
-                    case ELEMENT_TYPE_I4:
-                    case ELEMENT_TYPE_U4:
-                    case ELEMENT_TYPE_I8:
-                    case ELEMENT_TYPE_U8:
-                    case ELEMENT_TYPE_R4:
-                    case ELEMENT_TYPE_R8:
-                    case ELEMENT_TYPE_BOOLEAN:
-                    case ELEMENT_TYPE_CHAR:
-                    case ELEMENT_TYPE_ARRAY:
-                    case ELEMENT_TYPE_SZARRAY:
-                    case ELEMENT_TYPE_VAR:
-                    case ELEMENT_TYPE_MVAR:
-                        return AsyncMethodSignatureKind::NonVoidAsyncMethod;
-                    case ELEMENT_TYPE_TYPEDBYREF:
-                        ThrowHR(COR_E_BADIMAGEFORMAT);
-                    case ELEMENT_TYPE_GENERICINST:
-                        IfFailThrow(sig.GetElemType(&elemType));
-                        if (elemType == ELEMENT_TYPE_CLASS)
-                        {
-                            return AsyncMethodSignatureKind::NonVoidAsyncMethod;
-                        }
-                        else
-                        {
-                            IfFailThrow(sig.GetToken(&tk));
-                            if (IsTypeDefOrRefAByRefStruct(pModule, tk))
-                            {
-                                ThrowHR(COR_E_BADIMAGEFORMAT);
-                            }
-                            else
-                            {
-                                return AsyncMethodSignatureKind::NonVoidAsyncMethod;
-                            }
-                        }
-                    default:
-                        ThrowHR(COR_E_BADIMAGEFORMAT);
-                }
-            }
-            else if ((strcmp(name, "Task") == 0) || (strcmp(name, "ValueTask") == 0))
-            {
-                *pIsValueTask = name[0] == 'V';
-                if (elemType == ELEMENT_TYPE_VOID)
-                {
-                    return AsyncMethodSignatureKind::VoidAsyncMethod;
-                }
-                else
-                {
-                    ThrowHR(COR_E_BADIMAGEFORMAT);
-                }
-            }
-        }
-
-        if (offsetOfAsyncDetails != NULL)
-            *offsetOfAsyncDetails = (ULONG)(sig.GetPtr() - initialSig) - 1;
-    }
-
     if (elemType == ELEMENT_TYPE_GENERICINST)
     {
         IfFailThrow(sig.GetElemType(&elemType));
+        // can't reason about ELEMENT_TYPE_INTERNAL, but should not see it in metadata
         if (elemType == ELEMENT_TYPE_INTERNAL)
-            return AsyncMethodSignatureKind::NormalMethod;
+            ThrowHR(COR_E_BADIMAGEFORMAT);
 
-        *pIsValueTask = (elemType == ELEMENT_TYPE_VALUETYPE);
+        *isValueTask = (elemType == ELEMENT_TYPE_VALUETYPE);
         IfFailThrow(sig.GetToken(&tk));
         IfFailThrow(sig.GetData(&data));
         if (data == 1)
         {
             // This might be System.Threading.Tasks.Task`1
             GetNameOfTypeDefOrRef(pModule, tk, &name, &_namespace);
-            if ((strcmp(name, *pIsValueTask ? "ValueTask`1" : "Task`1") == 0) && strcmp(_namespace, "System.Threading.Tasks") == 0)
+            if ((strcmp(name, *isValueTask ? "ValueTask`1" : "Task`1") == 0) && strcmp(_namespace, "System.Threading.Tasks") == 0)
             {
                 if (IsTypeDefOrRefImplementedInSystemModule(pModule, tk))
-                    return AsyncMethodSignatureKind::GenericTaskReturningMethod;
+                    return MethodReturnKind::GenericTaskReturningMethod;
             }
         }
     }
     else if ((elemType == ELEMENT_TYPE_CLASS) || (elemType == ELEMENT_TYPE_VALUETYPE))
     {
         IfFailThrow(sig.GetToken(&tk));
-        *pIsValueTask = (elemType == ELEMENT_TYPE_VALUETYPE);
+        *isValueTask = (elemType == ELEMENT_TYPE_VALUETYPE);
         // This might be System.Threading.Tasks.Task or ValueTask
         GetNameOfTypeDefOrRef(pModule, tk, &name, &_namespace);
-        if ((strcmp(name, *pIsValueTask ? "ValueTask" : "Task") == 0) && strcmp(_namespace, "System.Threading.Tasks") == 0)
+        if ((strcmp(name, *isValueTask ? "ValueTask" : "Task") == 0) && strcmp(_namespace, "System.Threading.Tasks") == 0)
         {
             if (IsTypeDefOrRefImplementedInSystemModule(pModule, tk))
-                return AsyncMethodSignatureKind::NonGenericTaskReturningMethod;
+                return MethodReturnKind::NonGenericTaskReturningMethod;
         }
     }
 
-    return AsyncMethodSignatureKind::NormalMethod;
+    return MethodReturnKind::NormalMethod;
 }
 
 //---------------------------------------------------------------------------------------
@@ -3041,16 +2944,12 @@ MethodTableBuilder::EnumerateClassMethods()
 
         SigParser sig(pMemberSignature, cMemberSignature);
         ULONG offsetOfAsyncDetails = 0;
-        bool isAsyncValueType = false;
-        AsyncMethodSignatureKind asyncMethodType;
+        bool returnsValueTask = false;
+        MethodReturnKind returnKind;
         
-        asyncMethodType = IsDelegate() ? AsyncMethodSignatureKind::NormalMethod : ClassifyAsyncMethodSignature(sig, GetModule(), &offsetOfAsyncDetails, &isAsyncValueType);
-
-        if (IsAsyncSigAsync(asyncMethodType))
-        {
-            // not expected in actual metadata methods
-            BuildMethodTableThrowException(IDS_CLASSLOAD_BADFORMAT);
-        }
+        returnKind = IsDelegate() ?
+            MethodReturnKind::NormalMethod :
+            ClassifyMethodReturnKind(sig, GetModule(), &offsetOfAsyncDetails, &returnsValueTask);
 
         bool hasGenericMethodArgsComputed = false;
         bool hasGenericMethodArgs = this->GetModule()->m_pMethodIsGenericMap->IsGeneric(tok, &hasGenericMethodArgsComputed);
@@ -3602,7 +3501,7 @@ MethodTableBuilder::EnumerateClassMethods()
                     type,
                     implType);
 
-                if (IsAsyncSigTaskReturning(asyncMethodType))
+                if (IsTaskReturning(returnKind))
                 {
                     // ordinary Task-returning method:
                     //    declare a TaskReturning method and add a helper thunk with Async signature
@@ -3614,8 +3513,6 @@ MethodTableBuilder::EnumerateClassMethods()
                 }
                 else
                 {
-                    _ASSERTE(IsAsyncSigNormal(asyncMethodType));
-
                     if (IsMiAsync(dwImplFlags))
                     {
                         // Explicitly-async methods have special semantics that is useful in the implementation of runtime async itself.
@@ -3646,7 +3543,7 @@ MethodTableBuilder::EnumerateClassMethods()
                 ULONG newSuffixSize;
                 ULONG newPrefixSize;
 
-                if (asyncMethodType == AsyncMethodSignatureKind::NonGenericTaskReturningMethod)
+                if (returnKind == MethodReturnKind::NonGenericTaskReturningMethod)
                 {
                     cAsyncThunkMemberSignature += 1;
                     originalTokenOffsetFromAsyncDetailsOffset = 1;
@@ -3657,7 +3554,7 @@ MethodTableBuilder::EnumerateClassMethods()
                     originalSuffixSize = 0;
                     newSuffixSize = 1;
                 }
-                else if (asyncMethodType == AsyncMethodSignatureKind::GenericTaskReturningMethod)
+                else if (returnKind == MethodReturnKind::GenericTaskReturningMethod)
                 {
                     cAsyncThunkMemberSignature -= 2;
                     originalTokenOffsetFromAsyncDetailsOffset = 2;
@@ -3687,9 +3584,9 @@ MethodTableBuilder::EnumerateClassMethods()
                 _ASSERTE((cMemberSignature - originalRemainingSigOffset) == (cAsyncThunkMemberSignature - newRemainingSigOffset));
                 memcpy(pNewMemberSignature + newRemainingSigOffset, pMemberSignature + originalRemainingSigOffset, cMemberSignature - originalRemainingSigOffset);
 
-                BYTE elemTypeClassOrValuetype = isAsyncValueType ? (BYTE)ELEMENT_TYPE_VALUETYPE : (BYTE)ELEMENT_TYPE_CLASS;
+                BYTE elemTypeClassOrValuetype = returnsValueTask ? (BYTE)ELEMENT_TYPE_VALUETYPE : (BYTE)ELEMENT_TYPE_CLASS;
 
-                if (asyncMethodType == AsyncMethodSignatureKind::NonGenericTaskReturningMethod)
+                if (returnKind == MethodReturnKind::NonGenericTaskReturningMethod)
                 {
                     // Incoming sig will look like ... E_T_CLASS/E_T_VALUETYPE <TokenOfTask>
                     // and needs to be translated to ELEMENT_TYPE_CMOD_REQD <TokenOfTask> E_T_VOID
@@ -3700,7 +3597,7 @@ MethodTableBuilder::EnumerateClassMethods()
                 }
                 else
                 {
-                    _ASSERTE(asyncMethodType == AsyncMethodSignatureKind::GenericTaskReturningMethod);
+                    _ASSERTE(returnKind == MethodReturnKind::GenericTaskReturningMethod);
                     // Incoming sig will look something like ... E_T_GENERICINST E_T_CLASS/E_T_VALUETYPE <TokenOfTask> 1 E_T_I4 ....
                     // And needs to be translated to ELEMENT_TYPE_CMOD_REQD <TokenOfTask> E_T_I4
 
@@ -3739,7 +3636,7 @@ MethodTableBuilder::EnumerateClassMethods()
             }
 
             // Normal methods only insert a single method
-            if (IsAsyncSigNormal(asyncMethodType))
+            if (!IsTaskReturning(returnKind))
             {
                 break;
             }

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -3585,7 +3585,7 @@ MethodTableBuilder::EnumerateClassMethods()
 
                 BYTE elemTypeClassOrValuetype = returnsValueTask ? (BYTE)ELEMENT_TYPE_VALUETYPE : (BYTE)ELEMENT_TYPE_CLASS;
 
-                // for more info about constructing the signature of an async varint see comments in AsyncMethodKind
+                // for more info about constructing the signature of an async variant see comments in AsyncMethodKind
                 if (returnKind == MethodReturnKind::NonGenericTaskReturningMethod)
                 {
                     // Incoming sig will look like ... E_T_CLASS/E_T_VALUETYPE <TokenOfTask>

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -2943,11 +2943,10 @@ MethodTableBuilder::EnumerateClassMethods()
         }
 
         SigParser sig(pMemberSignature, cMemberSignature);
+
         ULONG offsetOfAsyncDetails = 0;
         bool returnsValueTask = false;
-        MethodReturnKind returnKind;
-        
-        returnKind = IsDelegate() ?
+        MethodReturnKind returnKind = IsDelegate() ?
             MethodReturnKind::NormalMethod :
             ClassifyMethodReturnKind(sig, GetModule(), &offsetOfAsyncDetails, &returnsValueTask);
 
@@ -3586,6 +3585,7 @@ MethodTableBuilder::EnumerateClassMethods()
 
                 BYTE elemTypeClassOrValuetype = returnsValueTask ? (BYTE)ELEMENT_TYPE_VALUETYPE : (BYTE)ELEMENT_TYPE_CLASS;
 
+                // for more info about constructing the signature of an async varint see comments in AsyncMethodKind
                 if (returnKind == MethodReturnKind::NonGenericTaskReturningMethod)
                 {
                     // Incoming sig will look like ... E_T_CLASS/E_T_VALUETYPE <TokenOfTask>

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -3503,11 +3503,11 @@ MethodTableBuilder::EnumerateClassMethods()
                 if (IsTaskReturning(returnKind))
                 {
                     // ordinary Task-returning method:
-                    //    declare a TaskReturning method and add a helper thunk with Async signature
+                    //    Declare a TaskReturning method and add an Async variant that is a thunk to the TaskReturing one.
                     // 
                     // IsMiAsync Task-returning method:
-                    //    declare a RuntimeAsync method and add a helper method with the actual implementation
-                    //    the RuntimeAsync method becomes a thunk to the implementation helper.
+                    //    Declare a RuntimeAsync method and add an Async variant with the actual implementation.
+                    //    The RuntimeAsync method becomes a thunk to the implementation helper.
                     pNewMethod->SetAsyncMethodKind(IsMiAsync(dwImplFlags) ? AsyncMethodKind::RuntimeAsync : AsyncMethodKind::TaskReturning);
                 }
                 else
@@ -3515,7 +3515,7 @@ MethodTableBuilder::EnumerateClassMethods()
                     if (IsMiAsync(dwImplFlags))
                     {
                         // Explicitly-async methods have special semantics that is useful in the implementation of runtime async itself.
-                        // It should not be valid to declare such methods outside of runtime infrastructure methods.
+                        // It should not be valid to declare such methods outside of runtime infrastructure.
                         if (!IsTypeDefOrRefImplementedInSystemModule(GetModule(), this->GetCl()))
                         {
                             BuildMethodTableThrowException(IDS_CLASSLOAD_BADFORMAT);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -177,7 +177,6 @@ namespace System.Runtime.CompilerServices
         public static bool IsReferenceOrContainsReferences<T>() where T: allows ref struct => IsReferenceOrContainsReferences<T>();
 
 #if !NATIVEAOT
-        [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         public static void AwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion
@@ -191,9 +190,7 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
-        // Marked intrinsic since for JIT state machines this needs to be
-        // recognized as an async call.
-        [Intrinsic]
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         public static void UnsafeAwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion
@@ -207,8 +204,7 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
-        // Marked intrinsic since this needs to be
-        // recognized as an async call.
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -223,8 +219,7 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
-        // Marked intrinsic since this needs to be
-        // recognized as an async call.
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -239,8 +234,7 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
-        // Marked intrinsic since this needs to be
-        // recognized as an async call.
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -255,8 +249,7 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
-        // Marked intrinsic since this needs to be
-        // recognized as an async call.
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -271,8 +264,7 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
-        // Marked intrinsic since this needs to be
-        // recognized as an async call.
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -287,8 +279,7 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
-        // Marked intrinsic since this needs to be
-        // recognized as an async call.
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -303,8 +294,7 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
-        // Marked intrinsic since this needs to be
-        // recognized as an async call.
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -319,8 +309,7 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
-        // Marked intrinsic since this needs to be
-        // recognized as an async call.
+        // Marked intrinsic since we recognise it by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -190,7 +190,6 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         public static void UnsafeAwaitAwaiterFromRuntimeAsync<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion
@@ -204,7 +203,7 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
+        // Marked intrinsic since JIT recognises the helper by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -219,7 +218,7 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
+        // Marked intrinsic since JIT recognises the helper by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -234,7 +233,7 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
+        // Marked intrinsic since JIT recognises the helper by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -249,7 +248,7 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
+        // Marked intrinsic since JIT recognises the helper by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -264,7 +263,7 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
+        // Marked intrinsic since JIT recognises the helper by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -279,7 +278,7 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
+        // Marked intrinsic since JIT recognises the helper by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -294,7 +293,7 @@ namespace System.Runtime.CompilerServices
             awaiter.GetResult();
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
+        // Marked intrinsic since JIT recognises the helper by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]
@@ -309,7 +308,7 @@ namespace System.Runtime.CompilerServices
             return awaiter.GetResult();
         }
 
-        // Marked intrinsic since we recognise it by name when doing optimizations.
+        // Marked intrinsic since JIT recognises the helper by name when doing optimizations.
         [Intrinsic]
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.Async)]


### PR DESCRIPTION
I think parsing the signature to figure Async-ness is now mostly a vestige from times where we could have such signatures in metadata. And that was a requirement for the non-JIT based prototype. None of that is relevant anymore.

Parsing the signature is also less reliable than `IsAsyncMethod()` as we now have Async helpers that do not have the signature that parses as Async, so we need to work around that by matching helpers by name to force the right call convention. But since they are `MethodImpl.Async`, we already classify these helpers as async. Let’s use `IsAsyncMethod()` for helpers and everything else.

With this change only await helpers that participate in pattern-matching optimizations need to be `[Intrinsic]`. Methods like `..AwaitAwaiter...` do not need to be intrinsics.

Calling `IsAsyncMethod()` should also be faster than signature parsing, although not sure if it would matter.

The signature parsing routine got a bit simpler too.
