### PR TITLE
[NativeAOT-LLVM] Fix saturating FP casts to small types

### DIFF
--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1652,13 +1652,19 @@ void Llvm::buildCast(GenTreeCast* cast)
 
                 case TYP_BYTE:
                 case TYP_SHORT:
+                case TYP_UBYTE:
+                case TYP_USHORT:
+                    // Casts to small types must go through TYP_INT (see "fgMorphCast").
+                    castValue = _builder.CreateIntrinsic(
+                        Type::getInt32Ty(m_context->Context), llvm::Intrinsic::fptosi_sat, castFromValue);
+                    castValue = _builder.CreateTrunc(castValue, castToLlvmType);
+                    break;
+
                 case TYP_INT:
                 case TYP_LONG:
                     castValue = _builder.CreateIntrinsic(castToLlvmType, llvm::Intrinsic::fptosi_sat, castFromValue);
                     break;
 
-                case TYP_UBYTE:
-                case TYP_USHORT:
                 case TYP_UINT:
                 case TYP_ULONG:
                     castValue = _builder.CreateIntrinsic(castToLlvmType, llvm::Intrinsic::fptoui_sat, castFromValue);

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -29,9 +29,6 @@
       <!-- Only automated on WASI with LLDB, which we don't have on Windows CI machines. -->
       <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\HelloWasm\WasmDebugging.csproj" Condition="'$(TargetOS)' == 'browser' or '$(OS)' == 'Windows_NT' or '$(Configuration)' != 'Debug'" />
       <DisabledProjects Include="$(TestRoot)readytorun\**\*.csproj" Condition="'$(TestBuildMode)' == 'nativeaot'" />
-
-      <!-- Fails, see https://github.com/dotnet/runtimelab/issues/3074 -->
-      <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\Preinitialization\Preinitialization.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Match upstream behavior (we differ because there is an ifdef in morph around the code that inserts the intermediate cast).

Fixes https://github.com/dotnet/runtimelab/issues/3074.