### PR TITLE
[RuntimeAsync] Possible way to optimize GetParallelMethodDesc for async (if needed)

### DIFF
--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -7810,23 +7810,25 @@ MethodDesc* MethodTable::GetParallelMethodDesc(MethodDesc* pDefMD, AsyncVariantL
     }
     else
     {
-        // Slow path for finding the Async variant (or not-Async variant, if we start from Async one)
-        // This could be optimized with some trickery around slot numbers, but doing so is ... confusing, so I'm not implementing this yet
-        mdMethodDef tkMethod = pDefMD->GetMemberDef();
-        Module* mod = pDefMD->GetModule();
-        bool isAsyncVariantMethod = pDefMD->IsAsyncVariantMethod();
+        WORD slot = pDefMD->GetSlot();
 
-        MethodTable::IntroducedMethodIterator it(this);
-        for (; it.IsValid(); it.Next())
+        // Async variants are laid out one after another
+        // - fist the task-returning entry and then async2 variant.
+        // Thus what we look for is at +1 or -1 from the definition we are given.
+        // 
+        // TODO: if we search within the same MT and the current chunk has space,
+        //       we may just increment/decrement pDefMD by the size of current desc.
+        //       (it would be even faster than through slot tables)
+        if (pDefMD->IsTaskReturningMethod())
         {
-            MethodDesc* pMD = it.GetMethodDesc();
-            if (pMD->GetMemberDef() == tkMethod
-                && pMD->GetModule() == mod
-                && pMD->IsAsyncVariantMethod() != isAsyncVariantMethod)
-            {
-                return pMD;
-            }
+            return GetMethodDescForSlot_NoThrow(slot + 1);
         }
+        else if (pDefMD->IsAsyncVariantMethod())
+        {
+            return GetMethodDescForSlot_NoThrow(slot - 1);
+        }
+
+        // the definition is not a variant from a pair. (TODO: this is likely unreachable)
         return NULL;
     }
 }

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -5631,7 +5631,8 @@ MethodTableBuilder::PlaceNonVirtualMethods()
 #endif // _DEBUG
 
         if (!fCanHaveNonVtableSlots ||
-            it->GetMethodType() == mcInstantiated)
+            it->GetMethodType() == mcInstantiated ||
+            it->GetAsyncMethodKind() != AsyncMethodKind::NotAsync)
         {
             // We use slot during remoting and to map methods between generic instantiations
             // (see MethodTable::GetParallelMethodDesc). The current implementation


### PR DESCRIPTION

This is a possible way to speed up the GetParallelMethodDesc - in most cases switching from linear to constant time.  
(where N is the number of methoddescs in a type)

It is a space-for-speed trade that we typically do only for something we need to look up at run time. At JIT time may be not enough reason. 
We should know at some point if this is necessary

I am not going to merge this. Just to show that it is possible and what a potential optimization could entail.
(per item ` (VM) Optimize MethodTable::GetParallelMethodDesc` in https://github.com/dotnet/runtime/pull/113976)https://github.com/dotnet/runtime/pull/113976

