### PR TITLE
[NativeAOT-LLVM] Fix debug info for implicit byrefs

### DIFF
--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -293,7 +293,7 @@ void Llvm::declareDebugVariables()
         }
 
         Value* addressValue;
-        DIExpression* debugExpression;
+        ArrayStack<uint64_t> diExpression(_compiler->getAllocator(CMK_DebugInfo));
         if (isShadowFrameLocal(varDsc))
         {
             // The obvious way to implement this (by just passing the shadow stack to dbg.declare) does not
@@ -307,20 +307,25 @@ void Llvm::declareDebugVariables()
             }
 
             addressValue = spilledShadowStackAddr;
-            unsigned offset = static_cast<unsigned>(varDsc->GetStackOffset());
-            debugExpression = m_diBuilder->createExpression({DW_OP_deref, DW_OP_plus_uconst, offset});
+            diExpression.Push(DW_OP_deref);
+            diExpression.Push(DW_OP_plus_uconst);
+            diExpression.Push(varDsc->GetStackOffset());
         }
         else if (varDsc->lvRefCnt() != 0)
         {
             addressValue = getLocalAddr(lclNum);
-            debugExpression = m_diBuilder->createExpression();
         }
         else
         {
             continue;
         }
+        if (_compiler->lvaIsImplicitByRefLocal(lclNum))
+        {
+            diExpression.Push(DW_OP_deref);
+        }
 
         llvm::DILocalVariable* debugVariable = lcl->GetValue();
+        DIExpression* debugExpression = m_diBuilder->createExpression(AsRef(diExpression));
         Instruction* debugInst =
             m_diBuilder->insertDeclare(addressValue, debugVariable, debugExpression, debugLocation, insertInst);
         JITDUMP("Declaring V%02u:\n", lclNum);
@@ -335,17 +340,21 @@ void Llvm::assignDebugVariable(unsigned lclNum, Value* value)
     llvm::DILocalVariable* debugVariable;
     if (m_debugVariablesMap.Lookup(lclNum, &debugVariable))
     {
+        DIExpression* diExpression = _compiler->lvaIsImplicitByRefLocal(lclNum)
+            ? m_diBuilder->createExpression({DW_OP_deref})
+            : m_diBuilder->createExpression();
+
         DILocation* debugLocation = getCurrentOrArtificialDebugLocation();
         Instruction* debugInst;
         if (_builder.GetInsertPoint() == _builder.GetInsertBlock()->end())
         {
-            debugInst = m_diBuilder->insertDbgValueIntrinsic(value, debugVariable, m_diBuilder->createExpression(),
-                                                             debugLocation, _builder.GetInsertBlock());
+            debugInst = m_diBuilder->insertDbgValueIntrinsic(
+                value, debugVariable, diExpression, debugLocation, _builder.GetInsertBlock());
         }
         else
         {
-            debugInst = m_diBuilder->insertDbgValueIntrinsic(value, debugVariable, m_diBuilder->createExpression(),
-                                                             debugLocation, &*_builder.GetInsertPoint());
+            debugInst = m_diBuilder->insertDbgValueIntrinsic(
+                value, debugVariable, diExpression, debugLocation, &*_builder.GetInsertPoint());
         }
         DBEXEC(CurrentBlock() == nullptr, JITDUMPEXEC(displayValue(debugInst)));
     }

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.cs
@@ -126,12 +126,12 @@ unsafe class Program
 
         p2.IntField = p1;
         p3.IntField = p1;
-        Debugger.Break(); // "p2.IntField" and "p3.IntField" should be equal to "p1".
+        Debugger.Break(); // "p1", "p2.IntField" and "p3.IntField" should be equal to 5.
 
         structLocal = p2;
-        Debugger.Break(); // "structLocal" should be equal to "p2".
+        Debugger.Break(); // "p2" and "structLocal" should be equal to "{ 5, 2.0 }".
         classLocal = p3;
-        Debugger.Break(); // "classLocal" should be equal to "p3".        
+        Debugger.Break(); // "p3" and "classLocal" should be equal to "{ 5, 2.0 }".
     }
 }
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.py
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.py
@@ -32,14 +32,14 @@ def run_wasm_debugging_tests(debugger):
     test_basic_array_display(target, process, thread)
     test_complex_array_display(target, process, thread)
     test_basic_multi_dimensional_array_display(target, process, thread)
-    # TODO-LLVM-DI: https://github.com/dotnet/runtimelab/issues/2884.
-    process.Continue() # test_simple_struct_display(target, process, thread)
+    test_simple_struct_display(target, process, thread)
     test_simple_class_display(target, process, thread)
     test_derived_class_display(target, process, thread)
     test_recursive_class_display(target, process, thread)
     # TODO-LLVM-DI: need to fix wasmtime issues with "this".
     process.Continue() # test_struct_instance_method(target, process, thread)
     process.Continue() # test_class_instance_method(target, process, thread)
+    test_variables(target, process, thread);
 
     if all_tests_passed:
         print('==== All WASM debugging tests passed ====')
@@ -74,7 +74,7 @@ def setup_wasm_debugging_tests(debugger, target, thread):
     return True
 
 def test_basic_types_display(target, process, thread):
-    test_values_display_impl(
+    test_values_display_single(
         target, process, thread, 'test_basic_types_display',
         [('boolTrue', 'true'), ('boolFalse', 'false'),
          ('charA', 'U+0061'),
@@ -87,37 +87,37 @@ def test_basic_types_display(target, process, thread):
         use_get_variable_path=True)
 
 def test_enum_display(target, process, thread):
-    test_values_display_impl(
+    test_values_display_single(
         target, process, thread, 'test_enum_display',
         [('dayOfWeek', 'Monday')],
         use_get_variable_path=True)
 
 def test_by_ref_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_byref_display',
+    test_values_display_single(target, process, thread, 'test_byref_display',
         [('(*p1).IntField', '1'), ('(*p1).FloatField', '2'),
          ('(*p2)->IntField', '1'), ('(*p2)->FloatField', '2')])
 
 def test_pointer_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_pointer_display',
+    test_values_display_single(target, process, thread, 'test_pointer_display',
         [('p->IntField', '1'), ('p->FloatField', '2')])
 
 def test_string_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_string_display',
+    test_values_display_single(target, process, thread, 'test_string_display',
         [('&s->_firstChar', 'u"Basic string"')], # TODO-LLVM-DI: improve string display.
         use_get_summary=True)
 
 def test_basic_array_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_basic_array_display',
+    test_values_display_single(target, process, thread, 'test_basic_array_display',
         [('p1->Data[0]', '1'), ('p1->Data[1]', '2'), ('p1->Data[2]', '3'), ('p1->Length', '3'), # TODO-LLVM-DI: improve array indexing.
          ('p2->Data[0]', '1'), ('p2->Data[1]', '2'), ('p2->Data[2]', '3'), ('p2->Length', '3')]) # TODO-LLVM-DI: improve array display.
 
 def test_complex_array_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_complex_array_display',
+    test_values_display_single(target, process, thread, 'test_complex_array_display',
         [('p1->Data[0]->IntField', '1'), ('p1->Data[0]->FloatField', '2'),
          ('p2->Data[0].IntField', '1'), ('p2->Data[0].FloatField', '2')])
 
 def test_basic_multi_dimensional_array_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_basic_multi_dimensional_array_display',
+    test_values_display_single(target, process, thread, 'test_basic_multi_dimensional_array_display',
         [('s->Length', '6'),
          ('sizeof(s->LowerBounds) / sizeof(*s->LowerBounds)', '2'), ('s->LowerBounds[0]', '0'), ('s->LowerBounds[1]', '0'),
          ('sizeof(s->Lengths) / sizeof(*s->Lengths)', '2'), ('s->Lengths[0]', '2'), ('s->Lengths[1]', '3'),
@@ -125,48 +125,58 @@ def test_basic_multi_dimensional_array_display(target, process, thread):
          ('s->Data[3]', '4'), ('s->Data[4]', '5'), ('s->Data[5]', '6')])
 
 def test_simple_struct_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_simple_struct_display',
+    test_values_display_single(target, process, thread, 'test_simple_struct_display',
         [('s.IntField', '1'), ('s.FloatField', '2')],
         use_get_variable_path=True)
 
 def test_simple_class_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_simple_class_display',
+    test_values_display_single(target, process, thread, 'test_simple_class_display',
         [('s->IntField', '1'), ('s->FloatField', '2')])
 
 def test_derived_class_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_derived_class_display',
+    test_values_display_single(target, process, thread, 'test_derived_class_display',
         [('s->IntField', '1'), ('s->FloatField', '2'), ('s->LongField', '3')])
 
 def test_recursive_class_display(target, process, thread):
-    test_values_display_impl(target, process, thread, 'test_recursive_class_display',
+    test_values_display_single(target, process, thread, 'test_recursive_class_display',
         [('s->Value', '1'), ('s->Next->Value', '2')])
 
-def test_values_display_impl(target, process, thread, pyname, expected_values, use_get_variable_path=False, use_get_summary=False):
-    start_test(pyname)
-    process.Continue()
-    frame = thread.GetSelectedFrame()
-    print(f'Inspecting: {frame}')
-    for (name, value) in expected_values:
-        if use_get_variable_path:
-            actual_sb_value = frame.GetValueForVariablePath(name)
-        else:
-            actual_sb_value = frame.EvaluateExpression(name)
-        if use_get_summary:
-            actual_value_as_string = actual_sb_value.GetSummary()
-        else:
-            actual_value_as_string = actual_sb_value.GetValue()
-        if actual_value_as_string != value:
-            fail_test(f'unexpected "{name}": "{actual_value_as_string}" (expected "{value}")')
-            return
-    pass_test()
+def test_variables(target, process, thread):
+    test_values_display(target, process, thread, "test_variables",
+        [[('unusedBasicLocal', '1')],
+         [('unusedClassLocal->IntField', '1'), ('unusedClassLocal->FloatField', '2')],
+         [('index', '0')],
+         [('index', '10')],
+         [('classLocal->IntField', '1')],
+         [('classLocal->IntField', '2')],
+         [('structLocal.IntField', '1')],
+         [('structLocal.IntField', '2')],
+         [('p1', '5'), ('p2.IntField', '5'), ('p3->IntField', '5')],
+         [('p2.IntField', '5'), ('p2.FloatField', '2'), ('structLocal.IntField', '5'), ('structLocal.FloatField', '2')],
+         [('p3->IntField', '5'), ('p3->FloatField', '2'), ('classLocal->IntField', '5'), ('classLocal->FloatField', '2')]])
 
-def bind_test_breakpoint_and_continue(target, process, name):
-    bp = target.BreakpointCreateByName(name)
-    if bp.num_locations == 0:
-        fail_test(f'Could not bind the breakpoint for ({bp})')
-        return False
-    process.Continue()
-    return True
+def test_values_display_single(target, process, thread, pyname, expected_values, use_get_variable_path=False, use_get_summary=False):
+    test_values_display(target, process, thread, pyname, [expected_values], use_get_variable_path, use_get_summary)
+
+def test_values_display(target, process, thread, pyname, expected_states, use_get_variable_path=False, use_get_summary=False):
+    start_test(pyname)
+    for expected_values in expected_states:
+        process.Continue()
+        frame = thread.GetSelectedFrame()
+        print(f'Inspecting: {frame}')
+        for (name, value) in expected_values:
+            if use_get_variable_path:
+                actual_sb_value = frame.GetValueForVariablePath(name)
+            else:
+                actual_sb_value = frame.EvaluateExpression(name)
+            if use_get_summary:
+                actual_value_as_string = actual_sb_value.GetSummary()
+            else:
+                actual_value_as_string = actual_sb_value.GetValue()
+            if actual_value_as_string != value:
+                fail_test(f'unexpected "{name}": "{actual_value_as_string}" (expected "{value}")')
+                return
+    pass_test()
 
 all_tests_passed = True
 current_test_name = None


### PR DESCRIPTION
Implicit byrefs introduce an indirection that must be recorded in the debug info.

Also add the python implementation for `TestVariables`.

Fixes #2884.