### PR TITLE
[RuntimeAsync] Removed IsStructMethodOperatingOnCopy

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -721,9 +721,6 @@ enum CorInfoOptions
                                                CORINFO_GENERICS_CTXT_FROM_METHODDESC |
                                                CORINFO_GENERICS_CTXT_FROM_METHODTABLE),
     CORINFO_GENERICS_CTXT_KEEP_ALIVE        = 0x00000100, // Keep the generics context alive throughout the method even if there is no explicit use, and report its location to the CLR
-    CORINFO_OPT_COPY_STRUCT_INSTANCE        = 0x00000200, // Function is a struct instance method that operates on a copy of "this"
-
-
 };
 
 //

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3964,11 +3964,6 @@ public:
                          // However, if there is a "ldarga 0" or "starg 0" in the IL,
                          // we will redirect all "ldarg(a) 0" and "starg 0" to this temp.
 
-     // For struct instance functions with CORINFO_OPT_COPY_STRUCT_INSTANCE
-     // this is the local that has the copy of "this" to which accesses on
-     // "this" are redirected to
-    unsigned lvaThisCopyVar = BAD_VAR_NUM;
-
     unsigned lvaInlineeReturnSpillTemp = BAD_VAR_NUM; // The temp to spill the non-VOID return expression
                                         // in case there are multiple BBJ_RETURN blocks in the inlinee
                                         // or if the inlinee has GC ref locals.
@@ -6435,7 +6430,6 @@ protected:
     void fgObserveInlineConstants(OPCODE opcode, const FgStack& stack, bool isInlining);
 
     void fgAdjustForAddressExposedOrWrittenThis();
-    void fgInitializeThisCopyVar();
 
     unsigned fgStressBBProf()
     {
@@ -10891,11 +10885,6 @@ public:
     bool compIsAsync() const
     {
         return opts.jitFlags->IsSet(JitFlags::JIT_FLAG_ASYNC);
-    }
-
-    bool compIsStructMethodThatOperatesOnCopy() const
-    {
-        return (info.compMethodInfo->options & CORINFO_OPT_COPY_STRUCT_INSTANCE) != 0;
     }
 
     //------------------------------------------------------------------------

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2541,11 +2541,6 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
         fgAdjustForAddressExposedOrWrittenThis();
     }
 
-    if (compIsStructMethodThatOperatesOnCopy())
-    {
-        fgInitializeThisCopyVar();
-    }
-
     // Now that we've seen the IL, set lvSingleDef for root method
     // locals.
     //
@@ -2614,21 +2609,6 @@ void Compiler::fgAdjustForAddressExposedOrWrittenThis()
         thisVarDsc->CleanAddressExposed();
         thisVarDsc->lvHasILStoreOp = false;
     }
-}
-
-//------------------------------------------------------------------------
-// fgInitializeThisCopyVar:
-//   Initialize the local used to copy the "this" instance to for struct
-//   methods with CORINFO_OPT_COPY_STRUCT_INSTANCE set.
-//
-void Compiler::fgInitializeThisCopyVar()
-{
-    assert(lvaThisCopyVar == BAD_VAR_NUM);
-    lvaThisCopyVar = lvaGrabTemp(false DEBUGARG("Copy of 'this'"));
-    lvaSetStruct(lvaThisCopyVar, info.compClassHnd, false);
-
-    LclVarDsc* lclDsc     = lvaGetDesc(lvaThisCopyVar);
-    lclDsc->lvHasLdAddrOp = 1;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -2041,24 +2041,6 @@ void Compiler::fgInsertInlineeArgument(InlineInfo*       inlineInfo,
             argSingleUseNode->ReplaceWith(argNode, this);
             return;
         }
-        else if (argInfo.argIsByRefToCopy)
-        {
-            ClassLayout* layout        = typGetObjLayout(inlineInfo->inlineCandidateInfo->clsHandle);
-            unsigned     copyOfThisLcl = lvaGrabTemp(false DEBUGARG("Copy of inlinee struct instance"));
-            lvaSetStruct(copyOfThisLcl, layout, false);
-            GenTree* copyBlock = gtNewStoreLclVarNode(copyOfThisLcl, gtNewBlkIndir(layout, argNode));
-            *newStmt           = gtNewStmt(copyBlock, callDI);
-            fgInsertStmtAfter(block, *afterStmt, *newStmt);
-            DISPSTMT(*newStmt);
-            *afterStmt = *newStmt;
-
-            GenTree* storeTmp =
-                gtNewTempStore(argInfo.argTmpNum, gtNewLclVarAddrNode(copyOfThisLcl, argNode->TypeGet()));
-            *newStmt = gtNewStmt(storeTmp, callDI);
-            fgInsertStmtAfter(block, *afterStmt, *newStmt);
-            DISPSTMT(*newStmt);
-            *afterStmt = *newStmt;
-        }
         else
         {
             // We're going to assign the argument value to the temp we use for it in the inline body.
@@ -2081,7 +2063,6 @@ void Compiler::fgInsertInlineeArgument(InlineInfo*       inlineInfo,
         noway_assert(!argInfo.argIsUsed || argInfo.argIsInvariant || argInfo.argIsLclVar);
         noway_assert((argInfo.argIsLclVar == 0) ==
                      (argNode->gtOper != GT_LCL_VAR || (argNode->gtFlags & GTF_GLOB_REF)));
-        noway_assert(!argInfo.argIsByRefToCopy);
 
         // If the argument has side effects, append it
         if (argInfo.argHasSideEff)

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2394,19 +2394,6 @@ PhaseStatus Compiler::fgAddInternal()
 
             madeChanges = true;
         }
-
-        if (lvaThisCopyVar != BAD_VAR_NUM)
-        {
-            ClassLayout* layout = lvaGetDesc(lvaThisCopyVar)->GetLayout();
-            GenTree*     addr   = gtNewLclVarNode(info.compThisArg);
-            GenTree*     store  = gtNewStoreLclVarNode(lvaThisCopyVar, gtNewBlkIndir(layout, addr));
-            Statement*   stmt   = fgNewStmtAtBeg(fgFirstBB, store);
-
-            JITDUMP("\nCopy \"this\" to V%02u for struct instance method operating on copy\n", lvaThisCopyVar);
-            DISPSTMT(stmt);
-
-            madeChanges = true;
-        }
     }
 
     // Merge return points if required or beneficial

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -6770,11 +6770,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
                 if (compIsForInlining())
                 {
-                    if ((lclNum == 0) && compIsStructMethodThatOperatesOnCopy())
-                    {
-                        BADCODE("Illegal starg 0 in function");
-                    }
-
                     op1 = impInlineFetchArg(impInlineInfo->inlArgInfo[lclNum], impInlineInfo->lclVarInfo[lclNum]);
                     noway_assert(op1->gtOper == GT_LCL_VAR);
                     lclNum = op1->AsLclVar()->GetLclNum();
@@ -6788,11 +6783,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 if (lclNum == info.compThisArg)
                 {
                     lclNum = lvaArg0Var;
-
-                    if (compIsStructMethodThatOperatesOnCopy())
-                    {
-                        BADCODE("Illegal starg 0 in function");
-                    }
                 }
 
                 // We should have seen this arg write in the prescan
@@ -7012,11 +7002,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         return;
                     }
 
-                    if ((lclNum == 0) && compIsStructMethodThatOperatesOnCopy())
-                    {
-                        BADCODE("Illegal ldarga 0 in function");
-                    }
-
                     op1->ChangeType(TYP_BYREF);
                     op1->SetOper(GT_LCL_ADDR);
                     op1->AsLclFld()->SetLclOffs(0);
@@ -7029,11 +7014,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 if (lclNum == info.compThisArg)
                 {
                     lclNum = lvaArg0Var;
-
-                    if (compIsStructMethodThatOperatesOnCopy())
-                    {
-                        BADCODE("Illegal ldarga 0 in function");
-                    }
                 }
 
                 goto ADRVAR;
@@ -11077,14 +11057,6 @@ void Compiler::impLoadArg(unsigned ilArgNum, IL_OFFSET offset)
         if (lclNum == info.compThisArg)
         {
             lclNum = lvaArg0Var;
-
-            // Redirect to copy in some struct instance methods
-            if (lvaThisCopyVar != BAD_VAR_NUM)
-            {
-                GenTree* lclAddr = gtNewLclVarAddrNode(lvaThisCopyVar, TYP_BYREF);
-                impPushOnStack(lclAddr, makeTypeInfoForLocal(lclNum));
-                return;
-            }
         }
 
         impLoadVar(lclNum, offset);
@@ -13433,17 +13405,6 @@ void Compiler::impInlineInitVars(InlineInfo* pInlineInfo)
         if (inlineResult->IsFailure())
         {
             return;
-        }
-
-        if ((arg.GetWellKnownArg() == WellKnownArg::ThisPointer) &&
-            ((methInfo->options & CORINFO_OPT_COPY_STRUCT_INSTANCE) != 0))
-        {
-            // Method call to a struct instance method that operates on a copy.
-            // We will load the instance as part of copying, so set up flags to
-            // indicate that there is a side effect.
-            argInfo->argIsByRefToCopy = true;
-            argInfo->argHasGlobRef    = true;
-            argInfo->argHasSideEff    = true;
         }
     }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -13792,7 +13792,7 @@ GenTree* Compiler::impInlineFetchArg(InlArgInfo& argInfo, const InlLclVarInfo& l
 {
     // Cache the relevant arg and lcl info for this argument.
     // We will modify argInfo but not lclVarInfo.
-    const bool      argCanBeModified = argInfo.argHasLdargaOp || argInfo.argHasStargOp || argInfo.argIsByRefToCopy;
+    const bool      argCanBeModified = argInfo.argHasLdargaOp || argInfo.argHasStargOp;
     const var_types lclTyp           = lclInfo.lclTypeInfo;
     GenTree*        op1              = nullptr;
 
@@ -13869,7 +13869,7 @@ GenTree* Compiler::impInlineFetchArg(InlArgInfo& argInfo, const InlLclVarInfo& l
             }
         }
     }
-    else if (argInfo.argIsByRefToStructLocal && !argInfo.argHasStargOp && !argInfo.argIsByRefToCopy)
+    else if (argInfo.argIsByRefToStructLocal && !argInfo.argHasStargOp)
     {
         /* Argument is a by-ref address to a struct, a normed struct, or its field.
            In these cases, don't spill the byref to a local, simply clone the tree and use it.

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -657,8 +657,6 @@ struct InlArgInfo
     unsigned argIsByRefToStructLocal : 1; // Is this arg an address of a struct local or a normed struct local or a
                                           // field in them?
     unsigned argIsExact       : 1;        // Is this arg of an exact class?
-    unsigned argIsByRefToCopy : 1;        // Arg is a reference to a local that will be copied (used when inlining async
-                                          // struct instance methods)
 };
 
 // InlLclVarInfo describes inline candidate argument and local variable properties.

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -7617,8 +7617,7 @@ static void getMethodInfoHelper(
     methInfo->options = (CorInfoOptions)(((UINT32)methInfo->options) |
                             ((ftn->AcquiresInstMethodTableFromThis() ? CORINFO_GENERICS_CTXT_FROM_THIS : 0) |
                              (ftn->RequiresInstMethodTableArg() ? CORINFO_GENERICS_CTXT_FROM_METHODTABLE : 0) |
-                             (ftn->RequiresInstMethodDescArg() ? CORINFO_GENERICS_CTXT_FROM_METHODDESC : 0) |
-                             (ftn->IsStructMethodOperatingOnCopy() ? CORINFO_OPT_COPY_STRUCT_INSTANCE : 0)));
+                             (ftn->RequiresInstMethodDescArg() ? CORINFO_GENERICS_CTXT_FROM_METHODDESC : 0)));
 
     if (methInfo->options & CORINFO_GENERICS_CTXT_MASK)
     {

--- a/src/tests/async/struct.cs
+++ b/src/tests/async/struct.cs
@@ -45,22 +45,28 @@ public class Async2Struct
 
         public async2 Task Test()
         {
-            AssertEqual(100, Value);
-            Value++;
-            await InstanceCall();
-            AssertEqual(101, Value);
+            // TODO: C# compiler is expected to do this, but not in the prototype.
+            S @this = this;
 
-            await TaskButNotAsync();
-            AssertEqual(102, Value);
+            AssertEqual(100, @this.Value);
+            @this.Value++;
+            await @this.InstanceCall();
+            AssertEqual(101, @this.Value);
+
+            await @this.TaskButNotAsync();
+            AssertEqual(102, @this.Value);
         }
 
         private async2 Task InstanceCall()
         {
-            AssertEqual(101, Value);
-            Value++;
-            AssertEqual(102, Value);
+            // TODO: C# compiler is expected to do this, but not in the prototype.
+            S @this = this;
+
+            AssertEqual(101, @this.Value);
+            @this.Value++;
+            AssertEqual(102, @this.Value);
             await Task.Yield();
-            AssertEqual(102, Value);
+            AssertEqual(102, @this.Value);
         }
 
         private Task TaskButNotAsync()


### PR DESCRIPTION
Removed `IsStructMethodOperatingOnCopy` VM API and dependencies in the JIT.


