### PR TITLE
[RuntimeAsync] Replace async marker with a flag

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -228,6 +228,19 @@ void AsyncLiveness::GetLiveLocals(jitstd::vector<LiveLocalInfo>& liveLocals, uns
 // Returns:
 //   Suitable phase status.
 //
+// Remarks:
+//   This transformation creates the state machine structure of the async
+//   function. After each async call a check for whether that async call
+//   suspended is inserted. If the check passes a continuation is allocated
+//   into which the live state is stored. The continuation is returned back to
+//   the caller to indicate that now this function also suspended.
+//
+//   Associated with each suspension point is also resumption IR. The
+//   resumption IR restores all live state from the continuation object. IR is
+//   inserted at the beginning of the function to dispatch on the continuation
+//   (if one is present), which each suspension point having an associated
+//   state number that can be switched over.
+//
 PhaseStatus Compiler::TransformAsync()
 {
     assert(compIsAsync());
@@ -727,9 +740,9 @@ ContinuationLayout AsyncTransformation::LayOutContinuation(BasicBlock*          
 //   STORE_LCL_VAR/STORE_LCL_FLD that follows the call node.
 //
 // Parameters:
-//   block        - The block containing the async call
-//   call         - The async call
-//   life         - Liveness information about live locals
+//   block - The block containing the async call
+//   call  - The async call
+//   life  - Liveness information about live locals
 //
 // Returns:
 //   Information about the definition after canonicalization.

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1072,7 +1072,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result, 
         return;
     }
 
-    if (call->gtIsAsyncCall && info.compUsesAsyncContinuation)
+    if (call->IsAsync() && info.compUsesAsyncContinuation)
     {
         // Currently not supported. Could provide a nice perf benefit for
         // Task -> runtime async thunks if we supported it.

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2282,7 +2282,7 @@ bool GenTreeCall::HasSideEffects(Compiler* compiler, bool ignoreExceptions, bool
 //
 bool GenTreeCall::IsAsync() const
 {
-    return gtIsAsyncCall;
+    return (gtCallMoreFlags & GTF_CALL_M_ASYNC) != 0;
 }
 
 //-------------------------------------------------------------------------
@@ -8324,7 +8324,6 @@ GenTreeCall* Compiler::gtNewCallNode(gtCallTypes           callType,
     node->gtRetClsHnd     = nullptr;
     node->gtControlExpr   = nullptr;
     node->gtCallMoreFlags = GTF_CALL_M_EMPTY;
-    node->gtIsAsyncCall   = false;
     INDEBUG(node->gtCallDebugFlags = GTF_CALL_MD_EMPTY);
     node->gtInlineInfoCount = 0;
 
@@ -9938,9 +9937,8 @@ GenTreeCall* Compiler::gtCloneExprCallHelper(GenTreeCall* tree)
 
     copy->gtLateDevirtualizationInfo = tree->gtLateDevirtualizationInfo;
 
-    copy->gtIsAsyncCall = tree->gtIsAsyncCall;
-    copy->gtCallType    = tree->gtCallType;
-    copy->gtReturnType  = tree->gtReturnType;
+    copy->gtCallType   = tree->gtCallType;
+    copy->gtReturnType = tree->gtReturnType;
 
 #if FEATURE_MULTIREG_RET
     copy->gtReturnTypeDesc = tree->gtReturnTypeDesc;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4238,6 +4238,7 @@ enum GenTreeCallFlags : unsigned int
     GTF_CALL_M_GUARDED_DEVIRT_CHAIN    = 0x00080000, // this call is a candidate for chained guarded devirtualization
     GTF_CALL_M_ALLOC_SIDE_EFFECTS      = 0x00100000, // this is a call to an allocator with side effects
     GTF_CALL_M_SUPPRESS_GC_TRANSITION  = 0x00200000, // suppress the GC transition (i.e. during a pinvoke) but a separate GC safe point is required.
+    GTF_CALL_M_ASYNC                   = 0x00400000, // this call is a runtime async method call and thus a suspension point
     GTF_CALL_M_EXPANDED_EARLY          = 0x00800000, // the Virtual Call target address is expanded and placed in gtControlExpr in Morph rather than in Lower
     GTF_CALL_M_LDVIRTFTN_INTERFACE     = 0x01000000, // ldvirtftn on an interface type
     GTF_CALL_M_CAST_CAN_BE_EXPANDED    = 0x02000000, // this cast (helper call) can be expanded if it's profitable. To be removed.
@@ -5023,6 +5024,11 @@ struct GenTreeCall final : public GenTree
 #endif
     }
 
+    void SetIsAsync()
+    {
+        gtCallMoreFlags |= GTF_CALL_M_ASYNC;
+    }
+
     bool IsAsync() const;
 
     //---------------------------------------------------------------------------
@@ -5594,7 +5600,6 @@ struct GenTreeCall final : public GenTree
     var_types        gtReturnType : 5; // exact return type
 
     uint8_t gtInlineInfoCount; // number of inline candidates for the given call
-    bool    gtIsAsyncCall;
 
     CORINFO_CLASS_HANDLE gtRetClsHnd; // The return type handle of the call if it is a struct; always available
     union

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -714,7 +714,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
     if (sig->isAsyncCall())
     {
-        call->AsCall()->gtIsAsyncCall = true;
+        call->AsCall()->SetIsAsync();
     }
 
     // Now create the argument list.

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5450,7 +5450,7 @@ GenTree* Lowering::LowerAsyncContinuation(GenTree* asyncCont)
             {
                 JITDUMP("Marking the call [%06u] before async continuation [%06u] as an async call\n",
                         Compiler::dspTreeID(node), Compiler::dspTreeID(asyncCont));
-                node->AsCall()->gtIsAsyncCall = true;
+                node->AsCall()->SetIsAsync();
             }
 
             BlockRange().Remove(asyncCont);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -189,7 +189,6 @@ GenTree* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, bool morphAr
     call->gtCallMoreFlags = GTF_CALL_M_EMPTY;
     INDEBUG(call->gtCallDebugFlags = GTF_CALL_MD_EMPTY);
     call->gtControlExpr = nullptr;
-    call->gtIsAsyncCall = false;
     call->ClearInlineInfo();
 #ifdef UNIX_X86_ABI
     call->gtFlags |= GTF_CALL_POP_ARGS;


### PR DESCRIPTION
This was a standalone bool because I got tired of conflicts. Now that we are about to merge in it should be changed back.

Also add a high level description of the transformation that happens in async.cpp.