### PR TITLE
[RuntimeAsync] Use approved value for MethodImplAttributes.Async

### DIFF
--- a/buildroslynnugets.cmd
+++ b/buildroslynnugets.cmd
@@ -1,7 +1,7 @@
 setlocal ENABLEEXTENSIONS
 pushd %~dp0
-set ASYNC_ROSLYN_COMMIT=d2174cf2f5a1d13c1fc393b44246b9dce851c555
-set ASYNC_SUFFIX=async-14
+set ASYNC_ROSLYN_COMMIT=792910b18a652dbf46bf292ee66dec974e39da9b
+set ASYNC_SUFFIX=async-15
 set ASYNC_ROSLYN_BRANCH=demos/async2-experiment1
 
 cd ..

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,9 +44,9 @@
       Any tools that contribute to the design-time experience should use the MicrosoftCodeAnalysisVersion_LatestVS property above to ensure
       they do not break the local dev experience.
     -->
-    <MicrosoftCodeAnalysisCSharpVersion>4.14.0-async-14</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftCodeAnalysisVersion>4.14.0-async-14</MicrosoftCodeAnalysisVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.14.0-async-14</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftCodeAnalysisCSharpVersion>4.14.0-async-15</MicrosoftCodeAnalysisCSharpVersion>
+    <MicrosoftCodeAnalysisVersion>4.14.0-async-15</MicrosoftCodeAnalysisVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.14.0-async-15</MicrosoftNetCompilersToolsetVersion>
   </PropertyGroup>
   <!--
     For source generator support we need to target multiple versions of Roslyn in order to be able to run on older versions of Roslyn.

--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -640,7 +640,7 @@ typedef enum CorMethodImpl
     miNoOptimization     =   0x0040,   // Method may not be optimized.
     miAggressiveOptimization = 0x0200, // Method may contain hot code and should be aggressively optimized.
 
-    miAsync              =   0x0400,   // Method requires async state machine rewrite.
+    miAsync              =   0x2000,   // Method requires async state machine rewrite.
 
     // These are the flags that are allowed in MethodImplAttribute's Value
     // property. This should include everything above except the code impl

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodImplAttributes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodImplAttributes.cs
@@ -31,6 +31,7 @@ namespace System.Reflection
         AggressiveInlining = 0x0100,   // Method should be inlined if possible.
         NoOptimization = 0x0040,   // Method may not be optimized.
         AggressiveOptimization = 0x0200, // Method may contain hot code and should be aggressively optimized.
+        Async = 0x2000,
 
         MaxMethodImplVal = 0xffff,
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/MethodImplOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/MethodImplOptions.cs
@@ -16,7 +16,7 @@ namespace System.Runtime.CompilerServices
         PreserveSig = 0x0080,
         AggressiveInlining = 0x0100,
         AggressiveOptimization = 0x0200,
-        Async = 0x0400,
+        Async = 0x2000,
         InternalCall = 0x1000
     }
 }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12369,6 +12369,7 @@ namespace System.Reflection
         AggressiveInlining = 256,
         AggressiveOptimization = 512,
         InternalCall = 4096,
+        Async = 8192,
         MaxMethodImplVal = 65535,
     }
     public abstract partial class MethodInfo : System.Reflection.MethodBase
@@ -13669,7 +13670,7 @@ namespace System.Runtime.CompilerServices
         PreserveSig = 128,
         AggressiveInlining = 256,
         AggressiveOptimization = 512,
-        Async = 1024,
+        Async = 8192,
         InternalCall = 4096,
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Method, Inherited=false)]


### PR DESCRIPTION
I missed this change in the PR that adjusted the feature to use the approved API. 

`MethodImplAttributes.Async` now has a different value, to make sure there is no unnecessary confusion with formerly used values.

This requires updating Roslyn ref.
Otherwise it is just a cherrypick of corresponding change in [the "Moving to main" PR.](https://github.com/dotnet/runtime/pull/114675)