### PR TITLE
[NativeAOT-LLVM] Add a codegen switch for LLVM IR verification

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -845,6 +845,7 @@ CONFIG_INTEGER(JitDispIns, "JitDispIns", 0)
 #endif // defined(TARGET_LOONGARCH64)
 
 #ifdef TARGET_WASM
+RELEASE_CONFIG_INTEGER(JitVerifyLlvmIR, "JitVerifyLlvmIR", 0)
 RELEASE_CONFIG_INTEGER(JitCheckLlvmIR, "JitCheckLlvmIR", 0)
 RELEASE_CONFIG_INTEGER(JitRunLssaTests, "JitRunLssaTests", 0)
 RELEASE_CONFIG_INTEGER(JitGcStress, "JitGcStress", 0)

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -863,6 +863,15 @@ static void FinishSingleThreadedCompilation(SingleThreadedCompilationContext* co
         module.addModuleFlag(llvm::Module::Warning, "Debug Info Version", 3);
     }
 
+    if (JitConfig.JitVerifyLlvmIR())
+    {
+        // Serialize verification so that the results are more legible.
+        static CritSecObject s_verifyLock;
+        CritSecHolder verifyLock(s_verifyLock);
+        llvm::errs() << "Verifying: '" << module.getName() << "'\n";
+        llvm::verifyModule(module, &llvm::errs());
+    }
+
     std::error_code code;
     StringRef outputFilePath = module.getName();
     if (JitConfig.JitCheckLlvmIR())


### PR DESCRIPTION
This is useful for diagnosing failures "in the field". Motivated by a recent lengthy remote debugging session on Discord where the failure mode would have been trivial and obvious with this switch, instead of the oblique "invalid record".

Some output (with induced invalid IR):
```
  LLVM compilation to IR finished in 2.95 seconds
  Verifying: C:\Users\Accretion\source\dotnet\runtimelab\artifacts\tests\coreclr/obj/wasi.wasm.debug/Managed/nativeaot\SmokeTests\HelloWasm\WasmDebugging\native\WasmDebugging.0.bc
  Verifying: C:\Users\Accretion\source\dotnet\runtimelab\artifacts\tests\coreclr/obj/wasi.wasm.debug/Managed/nativeaot\SmokeTests\HelloWasm\WasmDebugging\native\WasmDebugging.1.bc
  Verifying: C:\Users\Accretion\source\dotnet\runtimelab\artifacts\tests\coreclr/obj/wasi.wasm.debug/Managed/nativeaot\SmokeTests\HelloWasm\WasmDebugging\native\WasmDebugging.2.bc
  Verifying: C:\Users\Accretion\source\dotnet\runtimelab\artifacts\tests\coreclr/obj/wasi.wasm.debug/Managed/nativeaot\SmokeTests\HelloWasm\WasmDebugging\native\WasmDebugging.3.bc
  Verifying: C:\Users\Accretion\source\dotnet\runtimelab\artifacts\tests\coreclr/obj/wasi.wasm.debug/Managed/nativeaot\SmokeTests\HelloWasm\WasmDebugging\native\WasmDebugging.4.bc
  Verifying: C:\Users\Accretion\source\dotnet\runtimelab\artifacts\tests\coreclr/obj/wasi.wasm.debug/Managed/nativeaot\SmokeTests\HelloWasm\WasmDebugging\native\WasmDebugging.5.bc
  Verifying: C:\Users\Accretion\source\dotnet\runtimelab\artifacts\tests\coreclr/obj/wasi.wasm.debug/Managed/nativeaot\SmokeTests\HelloWasm\WasmDebugging\native\WasmDebugging.6.bc
  Call parameter type does not match function signature!
    %128 = ptrtoint ptr %126 to i32, !dbg !984
   ptr  call void @S_P_CoreLib_System_Runtime_EH__RhpThrowEx(ptr %127, i32 %128), !dbg !984
```