### PR TITLE
[NativeAOT-LLVM] Add live package testing

### DIFF
--- a/eng/pipelines/runtimelab/remove-duplicate-packages.ps1
+++ b/eng/pipelines/runtimelab/remove-duplicate-packages.ps1
@@ -1,0 +1,52 @@
+# When publishing packages in CI, the full closure has duplicates. For example,
+# both win-x64/wasi and win-x64/browser produce the "runtime.win-x64.*" package,
+# Similarly with win-x64/wasi and linux-x64/wasi producing "runtime.wasi-wasm.*".
+# The publishing system does not tolerate duplicates, so we remove them before
+# the upload step. This allows us to still have all the packages available for
+# testing on all CI platforms.
+[CmdletBinding(PositionalBinding=$false)]
+param(
+    [string]$Config,
+    [string]$TargetOS,
+    [string]$TargetArch
+)
+$ErrorActionPreference="Stop"
+
+$RepoRoot = [IO.Path]::GetFullPath("../../..", $PSScriptRoot)
+if (!(Test-Path $RepoRoot/LICENSE.TXT))
+{
+    Write-Error "Unexpected repository root: '$RepoRoot'"
+}
+
+# Must be kept in sync with "upload-intermediate-artifacts-step.yml".
+$PackagesPath = Join-Path $RepoRoot "artifacts" "packages" $Config "Shipping"
+
+if (!(Test-Path $PackagesPath))
+{
+    Write-Host "'$PackagesPath' does not exist, exiting"
+    exit
+}
+
+$HostRid = [Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
+$PublishTargetPackages = $HostRid -eq "win-x64"
+if (!$PublishTargetPackages)
+{
+    $TargetRid = "$TargetOS-$TargetArch"
+    $TargetPackagePattern = "runtime.$TargetRid.Microsoft.DotNet.ILCompiler.LLVM.*.nupkg"
+    Write-Host "Removing ${TargetPackagePattern}:"
+    Get-ChildItem $PackagesPath/$TargetPackagePattern | Write-Host
+    Remove-Item -Force $PackagesPath/$TargetPackagePattern
+}
+
+$PublishHostPackages = $TargetOS -eq "browser"
+if (!$PublishHostPackages)
+{
+    $HostPackagePattern = "runtime.$HostRid.Microsoft.DotNet.ILCompiler.LLVM.*.nupkg"
+    Write-Host "Removing ${HostPackagePattern}:"
+    Get-ChildItem $PackagesPath/$HostPackagePattern | Write-Host
+    Remove-Item -Force $PackagesPath/$HostPackagePattern
+}
+
+Write-Host "Final package set:"
+Get-ChildItem $PackagesPath/* | Write-Host
+

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -16,15 +16,13 @@ steps:
     - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.wasmjit+clr.aot -c $(buildConfigUpper) $(_officialBuildParameter) -ci -cross
       displayName: Build the ILC and RyuJit cross-compilers
 
-    # Build target packages when the host OS is Windows (note: target libs already built).
-    - ${{ if contains(parameters.platform, 'win') }}:
-      - script: $(Build.SourcesDirectory)/build$(scriptExt) nativeaot.packages -a wasm -os ${{ parameters.osGroup }} -c $(buildConfigUpper) $(_officialBuildParameter) -ci
-        displayName: Build target packages
+    # Build target packages (note: target libs already built).
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) nativeaot.packages -a wasm -os ${{ parameters.osGroup }} -c $(buildConfigUpper) $(_officialBuildParameter) -ci
+      displayName: Build target packages
 
-    # Build host packages when the target OS is Browser.
-    - ${{ if eq(parameters.osGroup, 'browser') }}:
-      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) $(_officialBuildParameter) -ci -cross
-        displayName: Build host packages
+    # Build host packages.
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) $(_officialBuildParameter) -ci -cross
+      displayName: Build host packages
 
   # Build coreclr native test output outside of official build
   - ${{ if ne(parameters.isOfficialBuild, true) }}:
@@ -70,6 +68,9 @@ steps:
       - script: |
             $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -test -a ${{ parameters.archType }} -os ${{ parameters.osGroup }} -lc ${{ parameters.librariesConfiguration }} -rc $(buildConfigUpper) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true
         displayName: Build and run WebAssembly libraries tests
+
+  - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/remove-duplicate-packages.ps1 -Config $(_BuildConfig) -TargetOS ${{ parameters.osGroup }} -TargetArch ${{ parameters.archType }}
+    displayName: Remove duplicate packages before publishing
 
   # Upload unsigned artifacts
   - ${{ if eq(parameters.uploadIntermediateArtifacts, true) }}:

--- a/src/tests/Common/dirs.proj
+++ b/src/tests/Common/dirs.proj
@@ -32,6 +32,11 @@
     </ItemGroup>
 
     <ItemGroup>
+      <!-- These projects are built separately in an isolated way. -->
+      <DisabledProjects Include="$(TestRoot)nativeaot\SmokeTests\HelloWasm\PackagingTests\*.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
       <BuildTestProjects Include="$(__BuildTestProject.Split(';'))" />
       <BuildTestDirs Include="$(__BuildTestDir.Split(';'))" />
       <BuildTestTrees Include="$(__BuildTestTree.Split(';'))" />

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
@@ -1,0 +1,65 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <!-- This is the part of the package testing exposed to the runtime test infrastructure.
+         The projects themselves are intentionally isolated from the rest of the tree. -->
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWasm)' != 'true'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+
+  <Target Name="PublishPackagingTestProject" BeforeTargets="BeforeBuild">
+    <ItemGroup>
+      <PackagingTestProject Include="PackagingTests/PackagingTestProject.csproj" />
+
+      <PackagingTestProject>
+        <TestOutputPath>$(OutputPath)%(FileName)</TestOutputPath>
+      </PackagingTestProject>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <Test_Configuration>$(Configuration)</Test_Configuration>
+      <Test_TargetFramework>$(NetCoreAppCurrent)</Test_TargetFramework>
+      <Test_RuntimeIdentifier>$(TargetOS)-$(TargetArchitecture)</Test_RuntimeIdentifier>
+      <Test_RestoreSource>$(ArtifactsShippingPackagesDir)</Test_RestoreSource>
+      <Test_RestorePackagesPath>$([MSBuild]::NormalizeDirectory('$(PackageOutputPath)', 'packages', '$(Configuration)'))</Test_RestorePackagesPath>
+    </PropertyGroup>
+
+    <Error Condition="!Exists($(Test_RestoreSource))"
+           Text="The 'nativeaot.packages' subset must be built before building this project" />
+
+    <Message Text="Packed packages: '$(Test_RestoreSource)'" Importance="High" />
+    <Message Text="Unpacked packages: '$(Test_RestorePackagesPath)'" Importance="High" />
+
+    <!-- Always start with a clean unpacked state so that there is no need to
+         manually delete the old packages for the new ones to be picked up. 
+         WARNING: one still needs to manually delete the **source** packages
+         before "./build nativeaot.packages" because the pkgproj targets do
+         not declare their inputs properly. -->
+    <RemoveDir Directories="$(Test_RestorePackagesPath)" />
+    <RemoveDir Directories="@(PackagingTestProject->'%(TestOutputPath)')" />
+
+    <PropertyGroup>
+      <PackagingTestProjectProperties>
+        Test_Configuration=$(Test_Configuration);
+        Test_TargetFramework=$(Test_TargetFramework);
+        Test_RuntimeIdentifier=$(Test_RuntimeIdentifier);
+        Test_PackageVersion=$(NetCoreAppCurrentVersion).0-*;
+        Test_RestoreSource=$(Test_RestoreSource);
+        Test_RestorePackagesPath=$(Test_RestorePackagesPath);
+      </PackagingTestProjectProperties>
+    </PropertyGroup>
+
+    <MSBuild Projects="@(PackagingTestProject)"
+             Targets="Restore"
+             Properties="$(PackagingTestProjectProperties);
+                         Test_TestOutputPath=%(TestOutputPath);
+                         MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
+
+    <MSBuild Projects="@(PackagingTestProject)"
+             Targets="Publish"
+             Properties="$(PackagingTestProjectProperties);
+                         Test_TestOutputPath=%(TestOutputPath)" />
+
+    <Error Condition="!Exists('%(TestOutputPath)/bin/$(Test_Configuration)/$(Test_TargetFramework)/$(Test_RuntimeIdentifier)/publish/%(FileName).wasm')"
+           Text="%(PackagingTestProject.FullPath) did not produce the expected native artifacts" />
+  </Target>
+</Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/Directory.Build.props
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <!-- Ignore repo build setting; use properties passed by the parent project to reroute the output. -->
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(Test_TestOutputPath)', 'obj'))</BaseIntermediateOutputPath>
+    <BaseOutputPath>$([MSBuild]::NormalizeDirectory('$(Test_TestOutputPath)', 'bin'))</BaseOutputPath>
+  </PropertyGroup>
+</Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/Directory.Build.targets
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Ignore repo build setting. -->
+</Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Configuration>$(Test_Config)</Configuration>
+    <TargetFramework>$(Test_TargetFramework)</TargetFramework>
+    <RuntimeIdentifier>$(Test_RuntimeIdentifier)</RuntimeIdentifier>
+
+    <PublishTrimmed>true</PublishTrimmed>
+    <SelfContained>true</SelfContained>
+    <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
+    <UseAppHost>false</UseAppHost>
+
+    <RestorePackagesPath>$(Test_RestorePackagesPath)</RestorePackagesPath>
+    <RestoreAdditionalProjectSources>$(Test_RestoreSource)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
+    <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/Program.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/Program.cs
@@ -1,0 +1,1 @@
+﻿System.Console.WriteLine("Hello World!");

--- a/src/tests/nativeaot/nativeaot.csproj
+++ b/src/tests/nativeaot/nativeaot.csproj
@@ -2,7 +2,7 @@
 
     <ItemGroup Condition="'$(TargetsWasm)' != 'true'">
       <DisabledProjects Include="*/**/Library.csproj" />
-      <DisabledProjects Include="*/**/HelloWasm/*.??proj" />
+      <DisabledProjects Include="*/**/HelloWasm/**/*.??proj" />
     </ItemGroup>
 
     <!-- Wasm disabled projects are still in dirs.proj because Wasm is not using this merged test wrapper -->


### PR DESCRIPTION
Add a test project that builds a daughter project which references live-built packages.

Sample testing (i. e. testing published packages) not included for now.

Contributes to #https://github.com/dotnet/runtimelab/issues/2783.