### PR TITLE
[NativeAOT-LLVM] Add linux-arm64 build and testing

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -32,7 +32,8 @@
          does not scale for local development because it requires you to build the same host tools for each target configuration.
          E. g. you need to build the same Debug compiler 3 times if you want to compile code in Debug, Checked and Release. -->
     <IlcConfig Condition="'$(IlcConfig)' == ''">$(CoreCLRConfiguration)</IlcConfig>
-    <CoreCLRCrossILCompilerDir Condition="'$(CoreCLRCrossILCompilerDir)' != '' and '$(TargetsWasm)' == 'true'">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'coreclr', '$(HostOS).$(BuildArchitecture).$(IlcConfig)', 'ilc'))</CoreCLRCrossILCompilerDir>
+    <IlcHostArch Condition="'$(IlcHostArch)' == ''">$(BuildArchitecture)</IlcHostArch>
+    <CoreCLRCrossILCompilerDir Condition="'$(CoreCLRCrossILCompilerDir)' != '' and '$(TargetsWasm)' == 'true'">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'coreclr', '$(HostOS).$(IlcHostArch).$(IlcConfig)', 'ilc'))</CoreCLRCrossILCompilerDir>
 
     <Crossgen2Dir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', 'crossgen2-published'))</Crossgen2Dir>
     <Crossgen2InBuildDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)', '$(BuildArchitecture)', 'crossgen2'))</Crossgen2InBuildDir>

--- a/eng/native/gen-buildsys.sh
+++ b/eng/native/gen-buildsys.sh
@@ -97,6 +97,7 @@ fi
 cmake_extra_defines_wasm=()
 if [[ "$host_arch" == "wasm" ]]; then
     if [[ "$target_os" == "browser" ]]; then
+        export EMSDK_QUIET=1 && source $EMSDK/emsdk_env.sh
         cmake_command="emcmake $cmake_command"
     elif [[ "$target_os" == "wasi" ]]; then
         if [[ -z $WASI_SDK_PATH ]]; then

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -207,14 +207,14 @@ jobs:
       - ${{ if ne(parameters.hostedOs, 'windows') }}:
         - script: /tmp/docker exec -t -u 0 naot-llvm-ci-container sh -c "tdnf install -y sudo"
           displayName: Install sudo
-        - script: $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-build-and-test-tools.sh $(Build.SourcesDirectory)/wasm-tools
+        - script: $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-build-and-test-tools.sh
           displayName: Install NativeAOT-LLVM build and test tools
       - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-emscripten.ps1 $(Build.SourcesDirectory)/wasm-tools -CI
         displayName: Install/activate emscripten
       - ${{ if eq(parameters.hostedOs, 'windows') }}:
         - script: call $(Build.SourcesDirectory)/eng/pipelines/runtimelab/set-cmake-path.cmd
           displayName: Set CMake path
-      - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-llvm.ps1 -CloneDir $(Build.SourcesDirectory)/wasm-tools -Configs ${{ parameters.buildConfig }} -CI
+      - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-llvm.ps1 -CloneDir $(Build.SourcesDirectory)/wasm-tools -Configs $(_BuildConfig) -Arch $(hostedTargetArch) -CI
         displayName: Install/build LLVM
       - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-nodejs.ps1 $(Build.SourcesDirectory)/wasm-tools
         displayName: Install NodeJS

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -219,7 +219,7 @@ jobs:
       - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-nodejs.ps1 $(Build.SourcesDirectory)/wasm-tools
         displayName: Install NodeJS
 
-    - ${{ if and(eq(parameters.runtimeFlavor, 'coreclr'), or(eq(parameters.platform, 'wasi_wasm_win'), eq(parameters.platform, 'wasi_wasm_linux_x64_naot_llvm'))) }}:
+    - ${{ if and(eq(parameters.runtimeFlavor, 'coreclr'), eq(parameters.osGroup, 'wasi')) }}:
       # Install Wasi Wasm dependencies: wasi-sdk, wasmtime
       - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-wasi-sdk.ps1 -CI -InstallDir $(Build.SourcesDirectory)/wasm-tools
         displayName: Install wasi-sdk
@@ -228,7 +228,7 @@ jobs:
       - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/install-jco.ps1 $(Build.SourcesDirectory)
         displayName: Install Jco
 
-    - ${{ if or(eq(parameters.platform, 'browser_wasm_win'), and(eq(parameters.platform, 'wasi_wasm_win'), not(eq(parameters.runtimeFlavor, 'coreclr')))) }}:
+    - ${{ if and(eq(parameters.hostedOs, 'windows'), eq(parameters.archType, 'wasm')) }}:
       # Update machine certs
       - task: PowerShell@2
         displayName: Update machine certs

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -514,7 +514,7 @@ jobs:
       targetRid: browser-wasm
       platform: browser_wasm_linux_x64_naot_llvm
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_x64_sanitizer_naot_llvm
+      container: linux_x64_naot_llvm
       jobParameters:
         hostedOs: linux
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
@@ -533,9 +533,30 @@ jobs:
       targetRid: wasi-wasm
       platform: wasi_wasm_linux_x64_naot_llvm
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_x64_sanitizer_naot_llvm
+      container: linux_x64_naot_llvm
       jobParameters:
         hostedOs: linux
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        stagedBuild: ${{ parameters.stagedBuild }}
+        buildConfig: ${{ parameters.buildConfig }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
+
+- ${{ if containsValue(parameters.platforms, 'browser_wasm_linux_arm64_naot_llvm') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: browser
+      archType: wasm
+      targetRid: browser-wasm
+      platform: browser_wasm_linux_arm64_naot_llvm
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_arm64_naot_llvm
+      jobParameters:
+        hostedOs: linux
+        hostedTargetArch: arm64
+        nameSuffix: arm64
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -500,10 +500,10 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Browser WebAssembly Linux X64 for NAOT-LLVM
+# WebAssembly Linux for NAOT-LLVM
 # Use a different name to differentiate from upstream as we need the -sanitizer image to get build tools that are not present in the stock browser_wasm image.
 
-- ${{ if containsValue(parameters.platforms, 'Browser_wasm_linux_x64_naot_llvm') }}:
+- ${{ if containsValue(parameters.platforms, 'browser_wasm_linux_x64_naot_llvm') }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}
@@ -512,7 +512,7 @@ jobs:
       osGroup: browser
       archType: wasm
       targetRid: browser-wasm
-      platform: Browser_wasm_linux_x64_naot_llvm
+      platform: browser_wasm_linux_x64_naot_llvm
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       container: linux_x64_sanitizer_naot_llvm
       jobParameters:
@@ -521,9 +521,6 @@ jobs:
         stagedBuild: ${{ parameters.stagedBuild }}
         buildConfig: ${{ parameters.buildConfig }}
         ${{ insert }}: ${{ parameters.jobParameters }}
-
-# WASI WebAssembly Linux X64 for NAOT-LLVM
-# Use a different name to differentiate from upstream as we need the -sanitizer image to get build tools that are not present in the stock wasi-wasm image.
 
 - ${{ if containsValue(parameters.platforms, 'wasi_wasm_linux_x64_naot_llvm') }}:
   - template: xplat-setup.yml

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -82,11 +82,18 @@ extends:
       # We need to be able to use 'tdnf install'. We can't because of https://github.com/dotnet/dotnet-docker/issues/788.
       # This is the hackaround: https://github.com/microsoft/azure-pipelines-agent/issues/2043#issuecomment-489692810.
       # TODO-LLVM-Upstream: replace with an image that has our prerequisites (LLDB) already installed.
-      linux_x64_sanitizer_naot_llvm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64-sanitizer
+      linux_x64_naot_llvm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64-sanitizer
         options: '--name naot-llvm-ci-container -v /usr/bin/docker:/tmp/docker:ro'
         env:
           ROOTFS_DIR: /crossrootfs/x64
+
+      # For arm64, we need to install QEMU.
+      linux_arm64_naot_llvm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-arm64
+        options: '--name naot-llvm-ci-container -v /usr/bin/docker:/tmp/docker:ro'
+        env:
+          ROOTFS_DIR: /crossrootfs/arm64
 
       # We use a CentOS Stream 8 image here to test building from source on CentOS Stream 9.
       SourceBuild_centos_x64:

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -52,6 +52,12 @@ jobs:
       - name: osSubgroup
         value: ${{ parameters.osSubgroup }}
 
+      - name: hostedTargetArch
+        ${{ if ne(parameters.jobParameters.hostedTargetArch, '') }}:
+          value: ${{ parameters.jobParameters.hostedTargetArch }}
+        ${{ else }}:
+          value: x64
+
       - name: _runSmokeTestsOnlyArg
         value: '/p:RunSmokeTestsOnly=$(isRunSmokeTestsOnly)'
 

--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -38,7 +38,7 @@ extends:
           platforms:
           - browser_wasm_win
           - wasi_wasm_win
-          - Browser_wasm_linux_x64_naot_llvm
+          - browser_wasm_linux_x64_naot_llvm
           jobParameters:
             templatePath: 'templates-official'
             timeoutInMinutes: 300

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -61,7 +61,7 @@ extends:
             - windows_x64
             - browser_wasm_win
             - wasi_wasm_win
-            - Browser_wasm_linux_x64_naot_llvm
+            - browser_wasm_linux_x64_naot_llvm
             - wasi_wasm_linux_x64_naot_llvm
             jobParameters:
               timeoutInMinutes: 300
@@ -101,10 +101,10 @@ extends:
             - linux_x64
             - osx_x64
             - windows_x64
-            - Browser_wasm_win
+            - browser_wasm_win
             - wasi_wasm_win
+            - browser_wasm_linux_x64_naot_llvm
             - wasi_wasm_linux_x64_naot_llvm
-            - Browser_wasm_linux_x64_naot_llvm
             jobParameters:
               timeoutInMinutes: 300
               buildArgs: -s clr.aot+libs -c $(_BuildConfig)

--- a/eng/pipelines/runtimelab.yml
+++ b/eng/pipelines/runtimelab.yml
@@ -105,6 +105,7 @@ extends:
             - wasi_wasm_win
             - browser_wasm_linux_x64_naot_llvm
             - wasi_wasm_linux_x64_naot_llvm
+            - browser_wasm_linux_arm64_naot_llvm
             jobParameters:
               timeoutInMinutes: 300
               buildArgs: -s clr.aot+libs -c $(_BuildConfig)

--- a/eng/pipelines/runtimelab/install-build-and-test-tools.sh
+++ b/eng/pipelines/runtimelab/install-build-and-test-tools.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 set -e
-dir=$(dirname "$0")
-echo; $dir/install-python.sh
-echo; $dir/install-lldb.sh
+
+echo Setting EMSDK_PYTHON to /usr/bin/python3
+echo '##vso[task.setvariable variable=EMSDK_PYTHON]'/usr/bin/python3
+echo
+
+echo Installing LLDB, QEMU
+sudo tdnf install -y lldb python3-lldb qemu-user
+echo

--- a/eng/pipelines/runtimelab/install-lldb.sh
+++ b/eng/pipelines/runtimelab/install-lldb.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-echo Installing LLDB
-sudo tdnf install -y lldb python3-lldb
-echo Installed LLDB

--- a/eng/pipelines/runtimelab/install-llvm.ps1
+++ b/eng/pipelines/runtimelab/install-llvm.ps1
@@ -3,11 +3,11 @@ param(
     [string]$CloneDir = $null,
     [ValidateSet("Debug","Release","Checked")][string[]]$Configs = @("Debug","Release"),
     [string]$Path = "llvm-project",
+    [string]$Arch = $null,
     [switch]$CI,
     [switch]$NoClone,
     [switch]$NoBuild
 )
-
 $ErrorActionPreference="Stop"
 
 if (!(gcm git -ErrorAction SilentlyContinue))
@@ -23,6 +23,11 @@ if ($CloneDir)
 {
     New-Item -ItemType Directory -Path $CloneDir -Force
     Set-Location -Path $CloneDir
+}
+
+if (!$Arch)
+{
+    $Arch = [Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()
 }
 
 $LlvmProjectTag = "llvmorg-18.1.3"
@@ -45,22 +50,6 @@ else
 {
     $DepthOption = if ($CI) {"--depth","1"} else {}
     git clone https://github.com/llvm/llvm-project $Path --branch $LlvmProjectTag $DepthOption
-}
-
-# Set the compiler for CI on non-Windows
-if (!$IsWindows) {
-    $RepoDir = Split-path $PSScriptRoot | Split-Path | Split-Path
-
-    bash -c "build_arch=amd64 compiler=clang source $RepoDir/eng/common/native/init-compiler.sh && set | grep -e CC -e CXX -e LDFLAGS" |
-      ForEach-Object {
-        if ($CI)
-        {
-            # Split the "<name>=<value>" line into the variable's name and value.
-            $name, $value = $_ -split '=', 2
-            # Define it as a process-level environment variable in PowerShell.
-            Set-Content ENV:$name $value
-        }
-     }
 }
 
 # There is no [C/c]hecked LLVM config, so change to Debug
@@ -90,7 +79,23 @@ foreach ($Config in $Configs | % { if ($_ -eq "Checked") { "Debug" } else { $_ }
     }
     elseif ($env:ROOTFS_DIR)
     {
-        $CmakeConfigureCommandLine += "-DCMAKE_SYSROOT=$env:ROOTFS_DIR", "-DCMAKE_INSTALL_PREFIX=/usr/local/llvm-cross"
+        # This logic was copied from gen-buildsys.sh. Maybe we should just call it here directly?
+        $RepoRoot = Split-Path $PSScriptRoot | Split-Path | Split-Path
+        # We're assuming here that the sysroot is coming from our CI docker images.
+        $TargetTriple = (Get-ChildItem $env:ROOTFS_DIR/usr/lib/gcc).Name
+
+        bash -c "build_arch=$Arch compiler=clang source $RepoRoot/eng/common/native/init-compiler.sh && set | grep -e CC -e CXX -e LDFLAGS" |
+            ForEach-Object {
+                # Split the "<name>=<value>" line into the variable's name and value.
+                $name, $value = $_ -Split '=', 2
+                # Define it as a process-level environment variable in PowerShell.
+                Set-Content ENV:$name $value
+            }
+        $env:TARGET_BUILD_ARCH = $Arch # Used by toolchain.cmake
+        $CmakeConfigureCommandLine +=
+            "-DCMAKE_TOOLCHAIN_FILE=$RepoRoot/eng/common/cross/toolchain.cmake",
+            "-DLLVM_HOST_TRIPLE=$TargetTriple",
+            "-DCMAKE_ASM_COMPILER_VERSION=18.1.2" # Workaround for https://gitlab.kitware.com/cmake/cmake/-/issues/22995.
     }
 
     Write-Host "Invoking CMake configure: 'cmake $CmakeConfigureCommandLine'"

--- a/eng/pipelines/runtimelab/install-nodejs.ps1
+++ b/eng/pipelines/runtimelab/install-nodejs.ps1
@@ -1,19 +1,15 @@
 $InstallPath = $Args[0]
 $NodeJSVersion = "v20.2.0"
 
-if (!(Test-Path variable:global:IsWindows))
+$HostArch = [Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()
+if ($IsWindows)
 {
-    $IsWindows = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
-}
-
-if ($IsWIndows)
-{
-    $NodeJSInstallName = "node-$NodeJSVersion-win-x64"
+    $NodeJSInstallName = "node-$NodeJSVersion-win-$HostArch"
     $NodeJSZipName = "$NodeJSInstallName.zip"
 }
 else
 {
-    $NodeJSInstallName = "node-$NodeJSVersion-linux-x64"
+    $NodeJSInstallName = "node-$NodeJSVersion-linux-$HostArch"
     $NodeJSZipName = "$NodeJSInstallName.tar.xz"
 }
 

--- a/eng/pipelines/runtimelab/install-python.sh
+++ b/eng/pipelines/runtimelab/install-python.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-echo Setting EMSDK_PYTHON to /usr/bin/python3
-echo '##vso[task.setvariable variable=EMSDK_PYTHON]'/usr/bin/python3

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -5,7 +5,6 @@ parameters:
   osSubgroup: ''
   platform: ''
   runtimeVariant: ''
-  testFilter: tree nativeaot
   isOfficialBuild: false
   librariesConfiguration: Debug
 
@@ -26,43 +25,23 @@ steps:
 
   # Build coreclr native test output outside of official build
   - ${{ if ne(parameters.isOfficialBuild, true) }}:
-    - ${{ if eq(parameters.platform, 'browser_wasm_win') }}:
-      - script: |
-          call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+    - ${{ if eq(parameters.archType, 'wasm') }}:
+      - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.osGroup }} $(crossArg) $(_officialBuildParameter) ci tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
         displayName: Build WebAssembly tests
-    - ${{ elseif eq(parameters.platform, 'wasi_wasm_win') }}:
-      - script: |
-          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci wasi tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-        displayName: Build WebAssembly tests
-    - ${{ elseif eq(parameters.platform, 'Browser_wasm_linux_x64_naot_llvm') }}:
-      - script: |
-          source $(Build.SourcesDirectory)/wasm-tools/emsdk/emsdk_env.sh
-          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) $(crossArg) $(_officialBuildParameter) ci -browser tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-        displayName: Build WebAssembly tests
-    - ${{ elseif eq(parameters.platform, 'wasi_wasm_linux_x64_naot_llvm') }}:
-      - script: |
-          $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) $(crossArg) $(_officialBuildParameter) ci -wasi tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-        displayName: Build WebAssembly tests
-
-    - ${{ elseif eq(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci ${{ parameters.testFilter }} /p:NativeAotMultimodule=true /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-        displayName: Build tests
     - ${{ else }}:
-      - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci 'tree nativeaot' /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-        displayName: Build tests
+      - ${{ if eq(parameters.osGroup, 'windows') }}:
+        - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+          displayName: Build tests
+      - ${{ else }}:
+        - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci 'tree nativeaot' /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
+          displayName: Build tests
 
-    - ${{ if in(parameters.platform, 'browser_wasm_win', 'wasi_wasm_win') }}:
-      - script: |
-          call $(Build.SourcesDirectory)\wasm-tools\emsdk\emsdk_env
-          $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
-        displayName: Run WebAssembly tests in single file mode
-    - ${{ elseif eq(parameters.osGroup, 'windows') }}:
+    - ${{ if contains(parameters.platform, 'win') }}:
       - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
-        displayName: Run tests in single file mode
+        displayName: Run runtime tests
     - ${{ else }}:
       - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) --runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
-        displayName: Run tests in single file mode
+        displayName: Run runtime tests
 
     - ${{ if eq(parameters.archType, 'wasm') }}:
       - script: |

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -3,6 +3,7 @@ parameters:
   archType: ''
   osGroup: ''
   osSubgroup: ''
+  nameSuffix: ''
   platform: ''
   runtimeVariant: ''
   isOfficialBuild: false
@@ -12,29 +13,33 @@ steps:
   # For NativeAOT-LLVM, we have just built the Wasm-targeting native artifacts (the runtime and libraries).
   # Now we need to build the cross-targeting compilers, RyuJit and ILC. Likewise with packages.
   - ${{ if eq(parameters.archType, 'wasm') }}:
-    - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.wasmjit+clr.aot -c $(buildConfigUpper) $(_officialBuildParameter) -ci -cross
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) clr.wasmjit+clr.aot -a $(hostedTargetArch) -c $(buildConfigUpper) -cross $(_officialBuildParameter) -ci
       displayName: Build the ILC and RyuJit cross-compilers
 
     # Build target packages (note: target libs already built).
-    - script: $(Build.SourcesDirectory)/build$(scriptExt) nativeaot.packages -a wasm -os ${{ parameters.osGroup }} -c $(buildConfigUpper) $(_officialBuildParameter) -ci
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) nativeaot.packages -os ${{ parameters.osGroup }} -a wasm -c $(buildConfigUpper) $(_officialBuildParameter) -ci
       displayName: Build target packages
 
     # Build host packages.
-    - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -c $(buildConfigUpper) $(_officialBuildParameter) -ci -cross
+    - script: $(Build.SourcesDirectory)/build$(scriptExt) libs+nativeaot.packages -a $(hostedTargetArch) -c $(buildConfigUpper) -cross $(_officialBuildParameter) -ci
       displayName: Build host packages
 
   # Build coreclr native test output outside of official build
   - ${{ if ne(parameters.isOfficialBuild, true) }}:
+    - ${{ if and(eq(parameters.archType, 'wasm'), ne(parameters.nameSuffix, '')) }}:
+      - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/set-ilc-emulation-environment.ps1 -Arch $(hostedTargetArch)
+        displayName: Set up ILC emulation environment
+
     - ${{ if eq(parameters.archType, 'wasm') }}:
       - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.osGroup }} $(crossArg) $(_officialBuildParameter) ci tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-        displayName: Build WebAssembly tests
+        displayName: Build runtime tests
     - ${{ else }}:
       - ${{ if eq(parameters.osGroup, 'windows') }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci tree nativeaot /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-          displayName: Build tests
+          displayName: Build runtime tests
       - ${{ else }}:
         - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) nativeaot $(buildConfigUpper) ${{ parameters.archType }} $(crossArg) $(_officialBuildParameter) ci 'tree nativeaot' /p:LibrariesConfiguration=${{ parameters.librariesConfiguration }}
-          displayName: Build tests
+          displayName: Build runtime tests
 
     - ${{ if contains(parameters.platform, 'win') }}:
       - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
@@ -43,9 +48,9 @@ steps:
       - script: $(Build.SourcesDirectory)/src/tests/run$(scriptExt) --runnativeaottests $(buildConfigUpper) ${{ parameters.archType }} ${{ parameters.osGroup }}
         displayName: Run runtime tests
 
-    - ${{ if eq(parameters.archType, 'wasm') }}:
-      - script: |
-            $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -test -a ${{ parameters.archType }} -os ${{ parameters.osGroup }} -lc ${{ parameters.librariesConfiguration }} -rc $(buildConfigUpper) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true
+    # Don't compile/run the libraries tests with emulated ILC to save CI time/resources.
+    - ${{ if and(eq(parameters.archType, 'wasm'), eq(parameters.nameSuffix, '')) }}:
+      - script: $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -test -a ${{ parameters.archType }} -os ${{ parameters.osGroup }} -lc ${{ parameters.librariesConfiguration }} -rc $(buildConfigUpper) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true
         displayName: Build and run WebAssembly libraries tests
 
   - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/remove-duplicate-packages.ps1 -Config $(_BuildConfig) -TargetOS ${{ parameters.osGroup }} -TargetArch ${{ parameters.archType }}

--- a/eng/pipelines/runtimelab/set-ilc-emulation-environment.ps1
+++ b/eng/pipelines/runtimelab/set-ilc-emulation-environment.ps1
@@ -1,0 +1,19 @@
+[CmdletBinding(PositionalBinding=$false)]
+param(
+    [string]$Arch
+)
+$ErrorActionPreference="Stop"
+
+if ($IsWindows)
+{
+    Write-Error "Windows ILC emulation not implemented"
+}
+else
+{
+    $QemuArch = $Arch -eq "arm64" ? "aarch64" : $Arch
+    $IlcLauncher = "qemu-$QemuArch -L $env:ROOTFS_DIR"
+    Write-Host "Setting `$(IlcLauncher) to '$IlcLauncher'"
+    Write-Host "Setting `$(IlcHostArch) to '$Arch'"
+    Write-Host "##vso[task.setvariable variable=IlcLauncher]$IlcLauncher"
+    Write-Host "##vso[task.setvariable variable=IlcHostArch]$Arch"
+}

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -370,7 +370,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_IlcEnvironmentVariables Condition="'$(IlcUseServerGc)' == 'false'">DOTNET_gcServer=0;$(_IlcEnvironmentVariables)</_IlcEnvironmentVariables>
     </PropertyGroup>
 
-    <Exec Command="&quot;$(IlcToolsPath)\ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;"
+    <Exec Command="$(IlcLauncher) &quot;$(IlcToolsPath)/ilc&quot; @&quot;$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).ilc.rsp&quot;"
           EnvironmentVariables="$(_IlcEnvironmentVariables)" />
 
     <!-- Trick ILLinker into not actually running -->

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -189,13 +189,8 @@ if defined __TestArgParsing (
 
 echo %__MsgPrefix%Commencing CoreCLR test build
 
-if "%__BuildArch%" == "wasm" (
-    if "%__TargetOS%" == "windows" (
-        set __TargetOS=browser
-    )
-
-    set __DistroRid=%__TargetOS%-%__BuildArch%
-)
+if "%__TargetOS%" == "browser" (set __BuildArch=wasm)
+if "%__TargetOS%" == "wasi" (set __BuildArch=wasm)
 
 set "__OSPlatformConfig=%__TargetOS%.%__BuildArch%.%__BuildType%"
 set "__BinDir=%__RootBinDir%\bin\coreclr\%__OSPlatformConfig%"

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
@@ -45,6 +45,8 @@
         Test_PackageVersion=$(NetCoreAppCurrentVersion).0-*;
         Test_RestoreSource=$(Test_RestoreSource);
         Test_RestorePackagesPath=$(Test_RestorePackagesPath);
+        Test_HostPackageRuntimeIdentifier=$(NETCoreSdkPortableRuntimeIdentifier.Replace('-$(BuildArchitecture)', '-$(IlcHostArch)'));
+        _hostArchitecture=$(IlcHostArch); <!-- Override host package resolution in ILC targets. -->
       </PackagingTestProjectProperties>
     </PropertyGroup>
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
-    <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
+    <PackageReference Include="runtime.$(Test_HostPackageRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We do not have linux-arm64-hosted build machines, only linux-x64 crosscompiling to arm64, so while the build process is fairly straightforward (tunneling the "host target arch" though the `.yml`s), testing is a bit tricky.

The solution I've settled on is to just use qemu user mode emulation, the ILC targets only needed a very minimal change to enable this. So while we do produce real arm64 packages and all, the only part that's "arm64" in this new build is this emulated ILC. Fortunately, it is also the only part that "needs" to be arm64.

It is an imperfect approach, since e. g. it doesn't catch arm64-specific issues in downstream components like EMSDK/WASI-SDK, but it is better than the current state of no arm64 at all. Even the "proper" alternative of using Helix would require us to move the whole build there to exercise native arm64 EMSDK/WASI-SDK.

Another downside to this is the Linux-only nature of qemu, so, unfortunately, Windows ARM64 is not opened up by this change.

Important: I am not adding anything to the official build yet. It will be a separate change, so that we can revert it by itself if needed.