### PR TITLE
[NativeAOT-LLVM] Enhance unresolved symbol handling

### DIFF
--- a/eng/pipelines/runtimelab/install-emscripten.ps1
+++ b/eng/pipelines/runtimelab/install-emscripten.ps1
@@ -18,10 +18,16 @@ git checkout ca7b40ae222a2d8763b6ac845388744b0e57cfb7
 ./emsdk install 3.1.56
 ./emsdk activate 3.1.56
 
-
 if ($CI)
 {
     Write-Host "Setting EMSDK to '$InstallDir/emsdk'"
     Write-Output "##vso[task.setvariable variable=EMSDK]$InstallDir/emsdk"
+
+    if ($env:EMSDK_PYTHON)
+    {
+        # Workaround for https://github.com/dotnet/runtime/issues/116746
+        Write-Host "Setting EMSDK_PYTHON to '$env:EMSDK_PYTHON'"
+        Write-Output "##vso[task.setvariable variable=EMSDK_PYTHON]$env:EMSDK_PYTHON"
+    }
 }
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -598,9 +598,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Condition="'$(WasmHtmlTemplate)' != ''" Include="--shell-file &quot;$(WasmHtmlTemplate)&quot;" />
       <CustomLinkerArg Condition="'$(ExportsFile)' != '' and '$([System.IO.File]::ReadAllText($(ExportsFile)))' != ''" Include="-s EXPORTED_FUNCTIONS=@&quot;$(ExportsFile)&quot;" />
       <CustomLinkerArg Include="-s ALLOW_MEMORY_GROWTH=1" />
-      <CustomLinkerArg Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" />
       <CustomLinkerArg Include="-s GLOBAL_BASE=$(IlcWasmGlobalBase)" />
       <CustomLinkerArg Include="-s TOTAL_STACK=$(IlcWasmStackSize)" />
+      <CustomLinkerArg Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" Condition="'$(IlcTreatWarningsAsErrors)' != 'true'" />
       <CustomLinkerArg Condition="'$(WasmEnableJSBigIntIntegration)' == 'true'" Include="-s WASM_BIGINT=1" />
       <CustomLinkerArg Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'" Include="-s DISABLE_EXCEPTION_CATCHING=0" />
 
@@ -618,12 +618,12 @@ The .NET Foundation licenses this file to you under the MIT license.
     <ItemGroup Condition="'$(_targetOS)' == 'wasi'" >
       <CustomLinkerArg Include="--sysroot=&quot;$(WASI_SDK_PATH.Replace(&quot;\&quot;, &quot;/&quot;))/share/wasi-sysroot&quot;" />
       <CustomLinkerArg Include="@(CustomLinkerArgExport->'-Wl,--export=%(Identity)')" />
-      <!-- TODO-LLVM: change to 'warn-unresolved-symbols' once we have a WASI SDK with https://github.com/llvm/llvm-project/pull/78643. -->
-      <CustomLinkerArg Include="-Wl,--unresolved-symbols=ignore-all" />
-      <CustomLinkerArg Include="-lstdc++ -lwasi-emulated-process-clocks -lwasi-emulated-signal -lwasi-emulated-getpid" />
+      <CustomLinkerArg Include="-lstdc++;-lwasi-emulated-process-clocks;-lwasi-emulated-signal;-lwasi-emulated-getpid" />
       <CustomLinkerArg Include="-Wl,--max-memory=2147483648" />
       <CustomLinkerArg Include="-Wl,--global-base=$(IlcWasmGlobalBase)" />
       <CustomLinkerArg Include="-Wl,-z,stack-size=$(IlcWasmStackSize)" />
+      <CustomLinkerArg Include="-Wl,--warn-unresolved-symbols" />
+      <CustomLinkerArg Include="-Wl,--fatal-warnings" Condition="'$(IlcTreatWarningsAsErrors)' == 'true'" />
       <CustomLinkerArg Include="-mexec-model=reactor" Condition="'$(NativeLib)' == 'Shared'" />
     </ItemGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -616,7 +616,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ReadLinesFromFile>
 
     <ItemGroup Condition="'$(_targetOS)' == 'wasi'" >
-      <CustomLinkerArg Include="--sysroot=&quot;$(WASI_SDK_PATH.Replace(&quot;\&quot;, &quot;/&quot;))/share/wasi-sysroot&quot;" />
       <CustomLinkerArg Include="@(CustomLinkerArgExport->'-Wl,--export=%(Identity)')" />
       <CustomLinkerArg Include="-lstdc++;-lwasi-emulated-process-clocks;-lwasi-emulated-signal;-lwasi-emulated-getpid" />
       <CustomLinkerArg Include="-Wl,--max-memory=2147483648" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -612,12 +612,12 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <!-- wasm-ld only supports listing exports on the command line -->
     <ReadLinesFromFile File="$(ExportsFile)" Condition="'$(_targetOS)' == 'wasi' and '$(ExportsFile)' != ''">
-      <Output TaskParameter="Lines" ItemName="CustomLinkerArgExport" />
+      <Output TaskParameter="Lines" ItemName="_CustomLinkerArgExport" />
     </ReadLinesFromFile>
 
     <ItemGroup Condition="'$(_targetOS)' == 'wasi'" >
-      <CustomLinkerArg Include="@(CustomLinkerArgExport->'-Wl,--export=%(Identity)')" />
-      <CustomLinkerArg Include="-lstdc++;-lwasi-emulated-process-clocks;-lwasi-emulated-signal;-lwasi-emulated-getpid" />
+      <CustomLinkerArg Include="@(_CustomLinkerArgExport->'-Wl,--export=%(Identity)')" />
+      <CustomLinkerArg Include="-lstdc++;-lwasi-emulated-process-clocks;-lwasi-emulated-signal;-lwasi-emulated-mman;-lwasi-emulated-getpid" />
       <CustomLinkerArg Include="-Wl,--max-memory=2147483648" />
       <CustomLinkerArg Include="-Wl,--global-base=$(IlcWasmGlobalBase)" />
       <CustomLinkerArg Include="-Wl,-z,stack-size=$(IlcWasmStackSize)" />


### PR DESCRIPTION
Stop silently ignoring all unresolved symbols on WASI, warn instead, consistent with Emscripten. Also, respect `TreatWarningsAsErrors`.