### PR TITLE
[NativeAOT-LLVM] Replace extern method accessors with cells

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -777,11 +777,10 @@ const char* Llvm::GetAlternativeFunctionName()
     return CallEEApi<EEAI_GetAlternativeFunctionName, const char*>(m_pEECorInfo);
 }
 
-CORINFO_GENERIC_HANDLE Llvm::GetExternalMethodAccessor(
-    CORINFO_METHOD_HANDLE methodHandle, const TargetAbiType* sig, int sigLength)
+void Llvm::GetExternalMethodAddress(
+    CORINFO_METHOD_HANDLE methodHandle, const TargetAbiType* sig, int sigLength, CORINFO_CONST_LOOKUP* pLookup)
 {
-    return CallEEApi<EEAI_GetExternalMethodAccessor, CORINFO_GENERIC_HANDLE>(
-        m_pEECorInfo, methodHandle, sig, sigLength);
+    return CallEEApi<EEAI_GetExternalMethodAddress, void>(m_pEECorInfo, methodHandle, sig, sigLength, pLookup);
 }
 
 void Llvm::GetDebugInfoForCurrentMethod(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -423,8 +423,8 @@ private:
     CorInfoType GetPrimitiveTypeForTrivialWasmStruct(CORINFO_CLASS_HANDLE structHandle);
     void GetTypeDescriptor(CORINFO_CLASS_HANDLE typeHandle, TypeDescriptor* pTypeDescriptor);
     const char* GetAlternativeFunctionName();
-    CORINFO_GENERIC_HANDLE GetExternalMethodAccessor(
-        CORINFO_METHOD_HANDLE methodHandle, const TargetAbiType* callSiteSig, int sigLength);
+    void GetExternalMethodAddress(
+        CORINFO_METHOD_HANDLE methodHandle, const TargetAbiType* callSiteSig, int sigLength, CORINFO_CONST_LOOKUP* pLookup);
     void GetDebugInfoForCurrentMethod(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo);
     SingleThreadedCompilationContext* GetSingleThreadedCompilationContext();
     CorInfoLlvmEHModel GetExceptionHandlingModel();

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2719,42 +2719,45 @@ FunctionType* Llvm::createFunctionType()
 
 llvm::FunctionCallee Llvm::consumeCallTarget(GenTreeCall* call)
 {
-    llvm::FunctionCallee callee;
+    Value* calleeValue;
     if (call->IsVirtualVtable() || call->IsDelegateInvoke() || (call->gtCallType == CT_INDIRECT))
     {
-        FunctionType* calleeFuncType = createFunctionTypeForCall(call);
         GenTree* calleeNode = (call->gtCallType == CT_INDIRECT) ? call->gtCallAddr : call->gtControlExpr;
-        Value* calleeValue = consumeValue(calleeNode, getPtrLlvmType());
-
-        callee = {calleeFuncType, calleeValue};
+        calleeValue = consumeValue(calleeNode, getPtrLlvmType());
     }
     else
     {
-        CORINFO_GENERIC_HANDLE handle = call->gtEntryPoint.handle;
-        CorInfoHelpFunc helperFunc = _compiler->eeGetHelperNum(call->gtCallMethHnd);
-        if (handle == nullptr)
+        CORINFO_CONST_LOOKUP lookup = call->gtEntryPoint;
+        CorInfoHelpFunc helperFunc = call->GetHelperNum();
+        if (lookup.handle == nullptr)
         {
-            handle = getSymbolHandleForHelperFunc(helperFunc);
-        }
-        else
-        {
-            assert(call->gtEntryPoint.accessType == IAT_VALUE);
+            lookup.accessType = IAT_VALUE;
+            lookup.handle = getSymbolHandleForHelperFunc(helperFunc);
         }
 
-        const char* symbolName = GetMangledSymbolName(handle);
-        AddCodeReloc(handle); // Replacement for _info.compCompHnd->recordRelocation.
+        StringRef symbolName = GetMangledSymbolName(lookup.handle);
+        AddCodeReloc(lookup.handle); // Replacement for _info.compCompHnd->recordRelocation.
 
-        callee = getOrCreateKnownLlvmFunction(symbolName, [this, call]() -> FunctionType* {
-            return createFunctionTypeForCall(call);
-        }, [this, helperFunc](Function* llvmFunc) {
-            if (helperFunc != CORINFO_HELP_UNDEF)
-            {
-                annotateHelperFunction(helperFunc, llvmFunc);
-            }
-        });
+        if (lookup.accessType == IAT_VALUE)
+        {
+            Function* llvmFunc = getOrCreateKnownLlvmFunction(symbolName, [this, call]() -> FunctionType* {
+                return createFunctionTypeForCall(call);
+            }, [this, helperFunc](Function* llvmFunc) {
+                if (helperFunc != CORINFO_HELP_UNDEF)
+                {
+                    annotateHelperFunction(helperFunc, llvmFunc);
+                }
+            });
+            return llvmFunc;
+        }
+
+        assert(lookup.accessType == IAT_PVALUE);
+        calleeValue = getOrCreateSymbol(lookup.handle);
+        calleeValue = _builder.CreateLoad(getPtrLlvmType(), calleeValue);
     }
 
-    return callee;
+    FunctionType* calleeFuncType = createFunctionTypeForCall(call);
+    return {calleeFuncType, calleeValue};
 }
 
 FunctionType* Llvm::createFunctionTypeForSignature(CORINFO_SIG_INFO* pSig)

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -850,18 +850,10 @@ void Llvm::lowerUnmanagedCall(GenTreeCall* callNode)
         // given module, we can only have one function declaration, thus, one callee type. And we cannot know whether
         // this type will be the right one until, in general, runtime (this is the case for WASM imports provided by
         // the host environment). Thus, to achieve the experience of runtime erros on signature mismatches, we "hide"
-        // the target behind an external function from another module, turning this call into an indirect one.
-        GenTreeCall* getTargetCall =
-            _compiler->gtNewHelperCallNode(CORINFO_HELP_LLVM_GET_EXTERNAL_CALL_TARGET, TYP_I_IMPL);
-        getTargetCall->gtEntryPoint.handle =
-            GetExternalMethodAccessor(callNode->gtCallMethHnd, &sig.BottomRef(), sig.Height());
-        getTargetCall->gtEntryPoint.accessType = IAT_VALUE;
-
-        callNode->gtCallType = CT_INDIRECT;
-        callNode->gtCallAddr = getTargetCall;
-        callNode->gtCallCookie = nullptr;
-        CurrentRange().InsertBefore(callNode, getTargetCall);
-        lowerNode(getTargetCall);
+        // the target behind an indirection, turning this call into an indirect one.
+        // TODO-LLVM-Cleanup: switch to using the standard "getAddressOfPInvokeTarget" Jit-EE call, we no longer need
+        // the signature on the EE side.
+        GetExternalMethodAddress(callNode->gtCallMethHnd, &sig.BottomRef(), sig.Height(), &callNode->gtEntryPoint);
     }
 }
 

--- a/src/coreclr/tools/Common/JitInterface/JitEEApi.Shared.cspp
+++ b/src/coreclr/tools/Common/JitInterface/JitEEApi.Shared.cspp
@@ -30,7 +30,7 @@ enum EEApiId
     EEAI_GetPrimitiveTypeForTrivialWasmStruct,
     EEAI_GetTypeDescriptor,
     EEAI_GetAlternativeFunctionName,
-    EEAI_GetExternalMethodAccessor,
+    EEAI_GetExternalMethodAddress,
     EEAI_GetDebugInfoForCurrentMethod,
     EEAI_GetSingleThreadedCompilationContext,
     EEAI_GetExceptionHandlingModel,

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/WasmObjectWriter.EmitObject.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/WasmObjectWriter.EmitObject.cs
@@ -56,9 +56,9 @@ namespace ILCompiler.ObjectWriter
                 }
 
                 WasmObjectWriter writer;
-                if (node is ExternMethodAccessorNode accessor)
+                if (node is ExternMethodCellNode methodCell)
                 {
-                    accessor.EmitWarnings(compilation);
+                    methodCell.EmitWarnings(compilation);
                     writer = externalObjectWriter;
                 }
                 else

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/ExternMethodCellNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/ExternMethodCellNode.cs
@@ -20,7 +20,7 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    internal sealed class ExternMethodAccessorNode(string externMethodName) : AssemblyStubNode, IWasmFunctionNode
+    internal sealed class ExternMethodCellNode(string externMethodName) : ObjectNode, ISymbolDefinitionNode
     {
         private readonly Utf8String _externMethodName = externMethodName;
         private TargetAbiType[] _signature;
@@ -29,7 +29,10 @@ namespace ILCompiler.DependencyAnalysis
         public Utf8String ExternMethodName => _externMethodName;
         public ref TargetAbiType[] Signature => ref _signature;
 
-        public override int ClassCode => 935251149;
+        public int Offset => 0;
+        public override bool RepresentsIndirectionCell => true;
+        public override bool IsShareable => false;
+        public override bool StaticDependenciesAreComputed => true;
 
         public void AddMethod(MethodDesc method)
         {
@@ -87,20 +90,6 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
-        {
-            sb.Append("get.");
-            sb.Append(ExternMethodName);
-        }
-
-        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
-        {
-            return ExternMethodName.CompareTo(((ExternMethodAccessorNode)other).ExternMethodName);
-        }
-
-        public WasmFunctionType GetWasmFunctionType(NodeFactory factory) =>
-            new WasmFunctionType(WasmAbi.GetNaturalIntType(factory.Target), []);
-
         public void EmitWarnings(Compilation compilation)
         {
             if (HasSignatureMismatch(compilation.NodeFactory))
@@ -117,32 +106,40 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        protected override void EmitCode(NodeFactory factory, ref WasmEmitter encoder, bool relocsOnly)
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
-            encoder.DefineLocals();
-            encoder.EmitNaturalConst(((LLVMCodegenNodeFactory)factory).ExternWasmMethod(this));
-            encoder.EmitEnd();
+            ObjectDataBuilder builder = new(factory, relocsOnly);
+            builder.AddSymbol(this);
+            builder.EmitPointerReloc(((LLVMCodegenNodeFactory)factory).ExternWasmMethod(this));
+
+            return builder.ToObjectData();
         }
 
-        protected override void EmitCode(NodeFactory factory, ref X64Emitter instructionEncoder, bool relocsOnly) => throw new NotImplementedException();
-        protected override void EmitCode(NodeFactory factory, ref X86Emitter instructionEncoder, bool relocsOnly) => throw new NotImplementedException();
-        protected override void EmitCode(NodeFactory factory, ref ARMEmitter instructionEncoder, bool relocsOnly) => throw new NotImplementedException();
-        protected override void EmitCode(NodeFactory factory, ref ARM64Emitter instructionEncoder, bool relocsOnly) => throw new NotImplementedException();
-        protected override void EmitCode(NodeFactory factory, ref LoongArch64Emitter instructionEncoder, bool relocsOnly) => throw new NotImplementedException();
-        protected override void EmitCode(NodeFactory factory, ref RiscV64Emitter instructionEncoder, bool relocsOnly) => throw new NotImplementedException();
+        public override ObjectNodeSection GetSection(NodeFactory factory) => ObjectNodeSection.ReadOnlyDataSection;
 
-        protected override string GetName(NodeFactory context) => $"ExternMethodAccessor {ExternMethodName}";
+        public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append("cell.");
+            sb.Append(ExternMethodName);
+        }
+
+        public override int ClassCode => 935251149;
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            return ExternMethodName.CompareTo(((ExternMethodCellNode)other).ExternMethodName);
+        }
+
+        protected override string GetName(NodeFactory context) => $"{nameof(ExternMethodCellNode)} {ExternMethodName}";
     }
 
-    internal sealed class ExternWasmMethodNode(ExternMethodAccessorNode accessor) : ExternSymbolNode(accessor.ExternMethodName), IWasmFunctionNode
+    internal sealed class ExternWasmMethodNode(ExternMethodCellNode methodCell) : ExternSymbolNode(methodCell.ExternMethodName), IWasmFunctionNode
     {
-        private readonly ExternMethodAccessorNode _accessor = accessor;
-
-        public override int ClassCode => 1890343813;
+        private readonly ExternMethodCellNode _methodCell = methodCell;
 
         public WasmFunctionType GetWasmFunctionType(NodeFactory factory)
         {
-            if (_accessor.HasSignatureMismatch(factory))
+            if (_methodCell.HasSignatureMismatch(factory))
             {
                 return new WasmFunctionType(WasmValueType.Invalid, []);
             }
@@ -162,7 +159,7 @@ namespace ILCompiler.DependencyAnalysis
                 _ => throw new NotImplementedException()
             };
 
-            ReadOnlySpan<TargetAbiType> jitSig = _accessor.Signature;
+            ReadOnlySpan<TargetAbiType> jitSig = _methodCell.Signature;
             WasmValueType wasmReturnType = ToWasmType(jitSig[0]);
             WasmValueType[] wasmParamTypes = new WasmValueType[jitSig.Length - 1];
             for (int i = 0; i < wasmParamTypes.Length; i++)
@@ -176,15 +173,17 @@ namespace ILCompiler.DependencyAnalysis
         public bool GetImportModuleAndName(Compilation compilation, out string module, out string name)
         {
             NodeFactory factory = compilation.NodeFactory;
-            if (_accessor.HasSignatureMismatch(factory))
+            if (_methodCell.HasSignatureMismatch(factory))
             {
                 (module, name) = (null, null);
                 return false;
             }
 
-            MethodDesc method = _accessor.GetSingleMethod(factory);
+            MethodDesc method = _methodCell.GetSingleMethod(factory);
             return compilation.PInvokeILProvider.GetWasmImportCallInfo(method, out name, out module);
         }
+
+        public override int ClassCode => 1890343813;
 
         protected override string GetName(NodeFactory context) => $"WasmImportFunctionNode {Utf8Name}";
     }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
@@ -16,9 +16,9 @@ namespace ILCompiler.DependencyAnalysis
     {
         private readonly CorInfoLlvmEHModel _ehModel;
 
-        private readonly Dictionary<string, ExternMethodAccessorNode> _externMethodAccessors = new();
-        private readonly NodeCache<ExternMethodAccessorNode, ExternWasmMethodNode> _externWasmMethods =
-            new(accessor => new ExternWasmMethodNode(accessor));
+        private readonly Dictionary<string, ExternMethodCellNode> _externMethodAccessors = new();
+        private readonly NodeCache<ExternMethodCellNode, ExternWasmMethodNode> _externWasmMethods =
+            new(methodCell => new ExternWasmMethodNode(methodCell));
 
         public LLVMCodegenNodeFactory(
             LLVMCodegenConfigProvider options,
@@ -52,19 +52,19 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool TargetsEmulatedEH() => _ehModel is CorInfoLlvmEHModel.Emulated;
 
-        internal ExternMethodAccessorNode ExternMethodAccessor(string name, MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
+        internal ExternMethodCellNode ExternMethodCell(string name, MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
         {
-            Dictionary<string, ExternMethodAccessorNode> map = _externMethodAccessors;
+            Dictionary<string, ExternMethodCellNode> map = _externMethodAccessors;
 
             // Not lockless since we mutate the node. Contention on this path is not expected.
             //
             lock (map)
             {
-                ref ExternMethodAccessorNode node = ref CollectionsMarshal.GetValueRefOrAddDefault(map, name, out bool exists);
+                ref ExternMethodCellNode node = ref CollectionsMarshal.GetValueRefOrAddDefault(map, name, out bool exists);
 
                 if (!exists)
                 {
-                    node = new ExternMethodAccessorNode(name);
+                    node = new ExternMethodCellNode(name);
                     node.Signature = sig.ToArray();
                 }
                 else if (!node.Signature.AsSpan().SequenceEqual(sig))
@@ -78,7 +78,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        internal ExternWasmMethodNode ExternWasmMethod(ExternMethodAccessorNode accessor) => _externWasmMethods.GetOrAdd(accessor);
+        internal ExternWasmMethodNode ExternWasmMethod(ExternMethodCellNode accessor) => _externWasmMethods.GetOrAdd(accessor);
 
         protected override IMethodNode CreateMethodEntrypointNode(MethodDesc method)
         {

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -247,12 +247,12 @@ namespace ILCompiler
             return corInfo;
         }
 
-        public override ISymbolNode GetExternalMethodAccessor(MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
+        public override ISymbolNode GetExternalMethodCell(MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
         {
             Debug.Assert(!sig.IsEmpty);
             string name = PInvokeILProvider.GetDirectCallExternName(method);
 
-            return NodeFactory.ExternMethodAccessor(name, method, sig);
+            return NodeFactory.ExternMethodCell(name, method, sig);
         }
 
         public override CorInfoLlvmEHModel GetLlvmExceptionHandlingModel() => Options.ExceptionHandlingModel;

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/ILCompiler.LLVM.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/ILCompiler.LLVM.csproj
@@ -24,7 +24,7 @@
     <Compile Include="CodeGen\WasmObjectWriter.cs" />
     <Compile Include="CodeGen\WasmObjectWriter.EmitObject.cs" />
     <Compile Include="CodeGen\WasmNative.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\ExternMethodAccessorNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ExternMethodCellNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\LLVMCodegenNodeFactory.cs" />
     <Compile Include="Compiler\DependencyAnalysis\LLVMMethodCodeNode.cs" />
     <Compile Include="Compiler\LLVMCompilationResults.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -222,7 +222,7 @@ namespace ILCompiler
         }
 
         public virtual int PadOffset(TypeDesc type, int atOffset) => throw new NotImplementedException();
-        public virtual ISymbolNode GetExternalMethodAccessor(MethodDesc method, ReadOnlySpan<TargetAbiType> signature) => throw new NotImplementedException();
+        public virtual ISymbolNode GetExternalMethodCell(MethodDesc method, ReadOnlySpan<TargetAbiType> signature) => throw new NotImplementedException();
         public virtual CorInfoLlvmEHModel GetLlvmExceptionHandlingModel() => throw new NotImplementedException();
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -162,13 +162,13 @@ namespace Internal.JitInterface
         }
 
         [UnmanagedCallersOnly]
-        public static IntPtr getExternalMethodAccessor(IntPtr thisHandle, CORINFO_METHOD_STRUCT_* methodHandle, TargetAbiType* sig, int sigLength)
+        public static void getExternalMethodAddress(
+            IntPtr thisHandle, CORINFO_METHOD_STRUCT_* methodHandle, TargetAbiType* sig, int sigLength, CORINFO_CONST_LOOKUP* pLookup)
         {
             CorInfoImpl _this = GetThis(thisHandle);
             MethodDesc method = _this.HandleToObject(methodHandle);
-            ISymbolNode accessorNode = _this._compilation.GetExternalMethodAccessor(method, new ReadOnlySpan<TargetAbiType>(sig, sigLength));
-
-            return _this.ObjectToHandle(accessorNode);
+            ISymbolNode cellNode = _this._compilation.GetExternalMethodCell(method, new ReadOnlySpan<TargetAbiType>(sig, sigLength));
+            *pLookup = _this.CreateConstLookupToSymbol(cellNode);
         }
 
         [UnmanagedCallersOnly]
@@ -436,7 +436,7 @@ namespace Internal.JitInterface
             jitImports[(int)EEApiId.EEAI_GetPrimitiveTypeForTrivialWasmStruct] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType>)&getPrimitiveTypeForTrivialWasmStruct;
             jitImports[(int)EEApiId.EEAI_GetTypeDescriptor] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor*, void>)&getTypeDescriptor;
             jitImports[(int)EEApiId.EEAI_GetAlternativeFunctionName] = (delegate* unmanaged<IntPtr, byte*>)&getAlternativeFunctionName;
-            jitImports[(int)EEApiId.EEAI_GetExternalMethodAccessor] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, TargetAbiType*, int, IntPtr>)&getExternalMethodAccessor;
+            jitImports[(int)EEApiId.EEAI_GetExternalMethodAddress] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, TargetAbiType*, int, CORINFO_CONST_LOOKUP*, void>)&getExternalMethodAddress;
             jitImports[(int)EEApiId.EEAI_GetDebugInfoForCurrentMethod] = (delegate* unmanaged<IntPtr, CORINFO_LLVM_METHOD_DEBUG_INFO*, void>)&getDebugInfoForCurrentMethod;
             jitImports[(int)EEApiId.EEAI_GetSingleThreadedCompilationContext] = (delegate* unmanaged<IntPtr, void*>)&getSingleThreadedCompilationContext;
             jitImports[(int)EEApiId.EEAI_GetExceptionHandlingModel] = (delegate* unmanaged<IntPtr, CorInfoLlvmEHModel>)&getExceptionHandlingModel;


### PR DESCRIPTION
Before:
```
  <push args>
  call get.method
  call_indirect
```

After:
```
  <push args>
  i32.const 0
  i32.load 2 <cell.method>
  call_indirect
```

This is a marginally larger sequence for a marginally smaller payload of the cell itself (4 bytes vs 8 for an accessor). It has worse "best-case" characteristics (WASM compilers won't be able to understand the indirect call target and potentially inline the call), but better "average case" ones (e. g. wasmtime currently does not do any WASM inlining at all).

However, the main motivation for this change is better compatibility with the -fPIC case, where the static table index relocation makes it impossible to use the ILC-produced code as-is. While we don't support -fPIC, we do have some users who use ILC directly and then do their own bitcode compilation and such.