### PR TITLE
[NativeAOT-LLVM] Add linux-arm64 to official build

### DIFF
--- a/eng/pipelines/runtimelab-official.yml
+++ b/eng/pipelines/runtimelab-official.yml
@@ -39,6 +39,7 @@ extends:
           - browser_wasm_win
           - wasi_wasm_win
           - browser_wasm_linux_x64_naot_llvm
+          - browser_wasm_linux_arm64_naot_llvm
           jobParameters:
             templatePath: 'templates-official'
             timeoutInMinutes: 300

--- a/eng/pipelines/runtimelab/remove-duplicate-packages.ps1
+++ b/eng/pipelines/runtimelab/remove-duplicate-packages.ps1
@@ -7,6 +7,7 @@
 [CmdletBinding(PositionalBinding=$false)]
 param(
     [string]$Config,
+    [string]$HostArch,
     [string]$TargetOS,
     [string]$TargetArch
 )
@@ -27,7 +28,8 @@ if (!(Test-Path $PackagesPath))
     exit
 }
 
-$HostRid = [Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
+$BuildHostRid = [Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier
+$HostRid = $BuildHostRid.Substring(0, $BuildHostRid.LastIndexOf("-")) + "-" + $HostArch
 $PublishTargetPackages = $HostRid -eq "win-x64"
 if (!$PublishTargetPackages)
 {

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -53,7 +53,7 @@ steps:
       - script: $(Build.SourcesDirectory)/build$(scriptExt) libs.tests -test -a ${{ parameters.archType }} -os ${{ parameters.osGroup }} -lc ${{ parameters.librariesConfiguration }} -rc $(buildConfigUpper) /p:TestNativeAot=true /p:RunSmokeTestsOnly=true
         displayName: Build and run WebAssembly libraries tests
 
-  - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/remove-duplicate-packages.ps1 -Config $(_BuildConfig) -TargetOS ${{ parameters.osGroup }} -TargetArch ${{ parameters.archType }}
+  - script: pwsh $(Build.SourcesDirectory)/eng/pipelines/runtimelab/remove-duplicate-packages.ps1 -Config $(_BuildConfig) -HostArch $(hostedTargetArch) -TargetOS ${{ parameters.osGroup }} -TargetArch ${{ parameters.archType }}
     displayName: Remove duplicate packages before publishing
 
   # Upload unsigned artifacts


### PR DESCRIPTION
Plus a small fix for an issue I've happened to notice with the package dedup script.