### PR TITLE
[NativeAOT-LLVM] Stop passing the signatures around for external methods

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -179,7 +179,7 @@
 
   <ItemGroup>
     <!-- NativeAOT-LLVM subsets. -->
-    <SubsetName Include="NativeAot.Packages" Description="The CoreCLR native AOT compiler." />
+    <SubsetName Include="NativeAot.Packages" Description="The CoreCLR native AOT packages." />
     <SubsetName Include="NativeAot.Build" Description="The CoreCLR native AOT build integration." />
     <SubsetName Include="Clr.Ilc" Description="The CoreCLR native AOT compiler (ILC)." />
 

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -178,9 +178,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- CoreClr Native AOT -->
+    <!-- NativeAOT-LLVM subsets. -->
     <SubsetName Include="NativeAot.Packages" Description="The CoreCLR native AOT compiler." />
     <SubsetName Include="NativeAot.Build" Description="The CoreCLR native AOT build integration." />
+    <SubsetName Include="Clr.Ilc" Description="The CoreCLR native AOT compiler (ILC)." />
 
     <!-- CoreClr -->
     <SubsetName Include="Clr" Description="The full CoreCLR runtime. Equivalent to: $(DefaultCoreClrSubsets)" />
@@ -509,6 +510,10 @@
   <ItemGroup Condition="$(_subset.Contains('+nativeaot.build+'))">
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.Build.Tasks\ILCompiler.Build.Tasks.csproj" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)nativeaot\BuildIntegration\BuildIntegration.proj" Category="clr" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+clr.ilc+'))">
+    <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler.csproj" Category="clr" />
   </ItemGroup>
 
   <!-- Mono sets -->

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -687,28 +687,6 @@ CorInfoType Llvm::getLlvmReturnType(CorInfoType sigRetType, CORINFO_CLASS_HANDLE
     return toCorInfoType(arg->AbiInfo.ArgType);
 }
 
-TargetAbiType Llvm::getAbiTypeForType(var_types type)
-{
-    switch (genActualType(type))
-    {
-        case TYP_VOID:
-            return TargetAbiType::Void;
-        case TYP_INT:
-            return TargetAbiType::Int32;
-        case TYP_LONG:
-            return TargetAbiType::Int64;
-        case TYP_REF:
-        case TYP_BYREF:
-            return (TARGET_POINTER_SIZE == 4) ? TargetAbiType::Int32 : TargetAbiType::Int64;
-        case TYP_FLOAT:
-            return TargetAbiType::Float;
-        case TYP_DOUBLE:
-            return TargetAbiType::Double;
-        default:
-            unreached();
-    }
-}
-
 CORINFO_GENERIC_HANDLE Llvm::getSymbolHandleForHelperFunc(CorInfoHelpFunc helperFunc)
 {
     void* pIndirection = nullptr;
@@ -777,10 +755,9 @@ const char* Llvm::GetAlternativeFunctionName()
     return CallEEApi<EEAI_GetAlternativeFunctionName, const char*>(m_pEECorInfo);
 }
 
-void Llvm::GetExternalMethodAddress(
-    CORINFO_METHOD_HANDLE methodHandle, const TargetAbiType* sig, int sigLength, CORINFO_CONST_LOOKUP* pLookup)
+void Llvm::GetExternalMethodAddress(CORINFO_METHOD_HANDLE methodHandle, CORINFO_CONST_LOOKUP* pLookup)
 {
-    return CallEEApi<EEAI_GetExternalMethodAddress, void>(m_pEECorInfo, methodHandle, sig, sigLength, pLookup);
+    return CallEEApi<EEAI_GetExternalMethodAddress, void>(m_pEECorInfo, methodHandle, pLookup);
 }
 
 void Llvm::GetDebugInfoForCurrentMethod(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo)

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -54,15 +54,6 @@ const int TARGET_POINTER_BITS = TARGET_POINTER_SIZE * BITS_PER_BYTE;
 
 // Part of the Jit/EE interface, must be kept in sync with the managed versions in "CorInfoImpl.Llvm.cs".
 //
-enum class TargetAbiType : uint8_t
-{
-    Void,
-    Int32,
-    Int64,
-    Float,
-    Double
-};
-
 enum class CorInfoLlvmEHModel
 {
     Cpp, // Landingpad-based LLVM IR; compatible with Itanium ABI.
@@ -408,7 +399,6 @@ private:
 
     static CorInfoType toCorInfoType(var_types varType);
     static CorInfoType getLlvmArgTypeForCallArg(CallArg* arg);
-    TargetAbiType getAbiTypeForType(var_types type);
 
     CORINFO_GENERIC_HANDLE getSymbolHandleForHelperFunc(CorInfoHelpFunc helperFunc);
     CORINFO_GENERIC_HANDLE getSymbolHandleForClassToken(mdToken token);
@@ -423,8 +413,7 @@ private:
     CorInfoType GetPrimitiveTypeForTrivialWasmStruct(CORINFO_CLASS_HANDLE structHandle);
     void GetTypeDescriptor(CORINFO_CLASS_HANDLE typeHandle, TypeDescriptor* pTypeDescriptor);
     const char* GetAlternativeFunctionName();
-    void GetExternalMethodAddress(
-        CORINFO_METHOD_HANDLE methodHandle, const TargetAbiType* callSiteSig, int sigLength, CORINFO_CONST_LOOKUP* pLookup);
+    void GetExternalMethodAddress(CORINFO_METHOD_HANDLE methodHandle, CORINFO_CONST_LOOKUP* pLookup);
     void GetDebugInfoForCurrentMethod(CORINFO_LLVM_METHOD_DEBUG_INFO* pInfo);
     SingleThreadedCompilationContext* GetSingleThreadedCompilationContext();
     CorInfoLlvmEHModel GetExceptionHandlingModel();

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -837,23 +837,7 @@ void Llvm::lowerUnmanagedCall(GenTreeCall* callNode)
     {
         // We cannot easily handle varargs as we do not know which args are the fixed ones.
         assert((callNode->gtCallType == CT_USER_FUNC) && !callNode->IsVarargs());
-
-        ArrayStack<TargetAbiType> sig(_compiler->getAllocator(CMK_Codegen));
-        sig.Push(getAbiTypeForType(JITtype2varType(callNode->gtCorInfoType)));
-        for (CallArg& arg : callNode->gtArgs.Args())
-        {
-            sig.Push(getAbiTypeForType(JITtype2varType(getLlvmArgTypeForCallArg(&arg))));
-        }
-
-        // WASM requires the callee and caller signature to match. At the LLVM level, "callee type" is the function
-        // type attached of the called operand and "caller" - that of its callsite. The problem, then, is that for a
-        // given module, we can only have one function declaration, thus, one callee type. And we cannot know whether
-        // this type will be the right one until, in general, runtime (this is the case for WASM imports provided by
-        // the host environment). Thus, to achieve the experience of runtime erros on signature mismatches, we "hide"
-        // the target behind an indirection, turning this call into an indirect one.
-        // TODO-LLVM-Cleanup: switch to using the standard "getAddressOfPInvokeTarget" Jit-EE call, we no longer need
-        // the signature on the EE side.
-        GetExternalMethodAddress(callNode->gtCallMethHnd, &sig.BottomRef(), sig.Height(), &callNode->gtEntryPoint);
+        GetExternalMethodAddress(callNode->gtCallMethHnd, &callNode->gtEntryPoint);
     }
 }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmAbi.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmAbi.cs
@@ -12,59 +12,18 @@ namespace ILCompiler.DependencyAnalysis.Wasm
         public static WasmValueType GetNaturalIntType(TargetDetails target) =>
             target.PointerSize == 4 ? WasmValueType.I32 : WasmValueType.I64;
 
-        public static WasmFunctionType GetWasmFunctionType(MethodDesc method) =>
-            GetWasmFunctionType(method.Signature, method.RequiresInstArg());
-
-        public static WasmFunctionType GetWasmFunctionType(MethodSignature signature, bool hasHiddenParam)
+        public static bool HasWasmFunctionType(MethodDesc method, WasmFunctionType type, WasmFunctionAbiOptions options = 0)
         {
-            WasmValueType wasmPointerType = GetNaturalIntType(signature.Context.Target);
+            WasmFunctionType? expectedType = type;
+            GetWasmFunctionTypeImpl(ref expectedType, method, options);
+            return expectedType != null;
+        }
 
-            WasmValueType GetWasmArgTypeForArg(TypeDesc argSigType)
-            {
-                bool isPassedByRef = false;
-                TypeDesc argType = argSigType;
-                if (IsStruct(argSigType))
-                {
-                    argType = GetPrimitiveTypeForTrivialWasmStruct(argSigType);
-                    if (argType == null)
-                    {
-                        isPassedByRef = true;
-                    }
-                }
-
-                return isPassedByRef ? wasmPointerType : GetWasmTypeForTypeDesc(argType);
-            }
-
-            WasmValueType wasmReturnType = GetWasmReturnType(signature.ReturnType, out bool isReturnByRef);
-
-            int maxWasmSigLength = signature.Length + 4;
-            Span<WasmValueType> signatureTypes =
-                maxWasmSigLength > 100 ? new WasmValueType[maxWasmSigLength] : stackalloc WasmValueType[maxWasmSigLength];
-
-            int index = 0;
-            signatureTypes[index++] = wasmPointerType; // Shadow stack.
-
-            if (!signature.IsStatic) // TODO-LLVM-Bug: doesn't handle explicit 'this'.
-            {
-                signatureTypes[index++] = wasmPointerType;
-            }
-
-            if (isReturnByRef)
-            {
-                signatureTypes[index++] = wasmPointerType;
-            }
-
-            if (hasHiddenParam)
-            {
-                signatureTypes[index++] = wasmPointerType;
-            }
-
-            foreach (TypeDesc type in signature)
-            {
-                signatureTypes[index++] = GetWasmArgTypeForArg(type);
-            }
-
-            return new WasmFunctionType(wasmReturnType, signatureTypes.Slice(0, index).ToArray());
+        public static WasmFunctionType GetWasmFunctionType(MethodDesc method, WasmFunctionAbiOptions options = 0)
+        {
+            WasmFunctionType? type = null;
+            GetWasmFunctionTypeImpl(ref type, method, options);
+            return type.Value;
         }
 
         public static WasmValueType GetWasmReturnType(MethodDesc method, out bool isPassedByRef) =>
@@ -112,6 +71,71 @@ namespace ILCompiler.DependencyAnalysis.Wasm
             }
 
             return null;
+        }
+
+        private static void GetWasmFunctionTypeImpl(
+            ref WasmFunctionType? expectedType, MethodDesc method, WasmFunctionAbiOptions options = 0)
+        {
+            MethodSignature signature = method.Signature;
+            WasmValueType wasmPointerType = GetNaturalIntType(signature.Context.Target);
+
+            WasmValueType GetWasmArgTypeForArg(TypeDesc argSigType)
+            {
+                bool isPassedByRef = false;
+                TypeDesc argType = argSigType;
+                if (IsStruct(argSigType))
+                {
+                    argType = GetPrimitiveTypeForTrivialWasmStruct(argSigType);
+                    if (argType == null)
+                    {
+                        isPassedByRef = true;
+                    }
+                }
+
+                return isPassedByRef ? wasmPointerType : GetWasmTypeForTypeDesc(argType);
+            }
+
+            WasmValueType wasmReturnType = GetWasmReturnType(signature.ReturnType, out bool isReturnByRef);
+
+            int maxWasmSigLength = signature.Length + 4;
+            Span<WasmValueType> wasmParamTypes =
+                maxWasmSigLength > 100 ? new WasmValueType[maxWasmSigLength] : stackalloc WasmValueType[maxWasmSigLength];
+
+            int index = 0;
+            if ((options & WasmFunctionAbiOptions.IsNative) == 0)
+            {
+                wasmParamTypes[index++] = wasmPointerType; // Shadow stack.
+            }
+
+            if (!signature.IsStatic) // TODO-LLVM-Bug: doesn't handle explicit 'this'.
+            {
+                wasmParamTypes[index++] = wasmPointerType;
+            }
+
+            if (isReturnByRef)
+            {
+                wasmParamTypes[index++] = wasmPointerType;
+            }
+
+            if (method.RequiresInstArg())
+            {
+                wasmParamTypes[index++] = wasmPointerType;
+            }
+
+            foreach (TypeDesc type in signature)
+            {
+                wasmParamTypes[index++] = GetWasmArgTypeForArg(type);
+            }
+
+            wasmParamTypes = wasmParamTypes.Slice(0, index);
+            if (expectedType is null)
+            {
+                expectedType = new WasmFunctionType(wasmReturnType, wasmParamTypes.ToArray());
+            }
+            else if (!WasmFunctionType.Equals(expectedType.Value, wasmReturnType, wasmParamTypes))
+            {
+                expectedType = null;
+            }
         }
 
         private static WasmValueType GetWasmReturnType(TypeDesc sigReturnType, out bool isPassedByRef)
@@ -173,5 +197,11 @@ namespace ILCompiler.DependencyAnalysis.Wasm
         }
 
         private static bool IsStruct(TypeDesc type) => type.Category is TypeFlags.ValueType or TypeFlags.Nullable;
+    }
+
+    [Flags]
+    public enum WasmFunctionAbiOptions
+    {
+        IsNative = 0x1,
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmFunctionType.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmFunctionType.cs
@@ -17,11 +17,7 @@ namespace ILCompiler.DependencyAnalysis.Wasm
         public ReadOnlySpan<WasmValueType> Parameters => _parameters;
 
         public override bool Equals(object obj) => obj is WasmFunctionType type && Equals(type);
-
-        public bool Equals(WasmFunctionType other)
-        {
-            return Results.SequenceEqual(other.Results) && Parameters.SequenceEqual(other.Parameters);
-        }
+        public bool Equals(WasmFunctionType other) => Equals(this, other._result, other._parameters);
 
         public override int GetHashCode()
         {
@@ -32,6 +28,9 @@ namespace ILCompiler.DependencyAnalysis.Wasm
         }
 
         public static bool IsFunction(ISymbolNode symbol) => symbol is ExternSymbolNode or IWasmFunctionNode or IMethodNode { Offset: 0 };
+
+        public static bool Equals(WasmFunctionType type, WasmValueType result, ReadOnlySpan<WasmValueType> parameters) =>
+            type._result == result && type.Parameters.SequenceEqual(parameters);
 
         public static bool operator ==(WasmFunctionType left, WasmFunctionType right) => left.Equals(right);
         public static bool operator !=(WasmFunctionType left, WasmFunctionType right) => !(left == right);

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/ExternMethodCellNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/ExternMethodCellNode.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 
 using ILCompiler.DependencyAnalysis.ARM;
 using ILCompiler.DependencyAnalysis.ARM64;
@@ -20,14 +21,21 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
+    //
+    // WASM requires the callee and caller signature to match. At the LLVM level, "callee type" is the function
+    // type attached of the called operand and "caller" - that of its callsite. The problem, then, is that for a
+    // given module, we can only have one function declaration, thus, one callee type. And we cannot know whether
+    // this type will be the right one until, in general, runtime (this is the case for WASM imports provided by
+    // the host environment). Thus, to achieve the experience of runtime erros on signature mismatches, we "hide"
+    // the target behind an indirection.
+    //
     internal sealed class ExternMethodCellNode(string externMethodName) : ObjectNode, ISymbolDefinitionNode
     {
-        private readonly Utf8String _externMethodName = externMethodName;
-        private TargetAbiType[] _signature;
+        private WasmFunctionType? _signature;
         private object _methods;
 
-        public Utf8String ExternMethodName => _externMethodName;
-        public ref TargetAbiType[] Signature => ref _signature;
+        public string ExternMethodName { get; } = externMethodName;
+        public WasmFunctionType Signature => _signature.Value;
 
         public int Offset => 0;
         public override bool RepresentsIndirectionCell => true;
@@ -42,16 +50,24 @@ namespace ILCompiler.DependencyAnalysis
             {
                 case null:
                     _methods = method;
-                    break;
+                    _signature = WasmAbi.GetWasmFunctionType(method, WasmFunctionAbiOptions.IsNative);
+                    return;
+
                 case MethodDesc oneMethod:
                     if (oneMethod != method)
                     {
                         _methods = new HashSet<MethodDesc>() { oneMethod, method };
                     }
                     break;
+
                 default:
                     ((HashSet<MethodDesc>)_methods).Add(method);
                     break;
+            }
+
+            if (_signature != null && !WasmAbi.HasWasmFunctionType(method, Signature, WasmFunctionAbiOptions.IsNative))
+            {
+                _signature = null; // Mismatch!
             }
         }
 
@@ -59,19 +75,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             Debug.Assert(factory.MarkingComplete); // This question can only be answered after we've encountered all PIs.
             return _signature == null;
-        }
-
-        public IEnumerable<MethodDesc> EnumerateMethods()
-        {
-            switch (_methods)
-            {
-                case null:
-                    return Array.Empty<MethodDesc>();
-                case MethodDesc oneMethod:
-                    return new MethodDesc[] { oneMethod };
-                default:
-                    return (HashSet<MethodDesc>)_methods;
-            }
         }
 
         public MethodDesc GetSingleMethod(NodeFactory factory)
@@ -94,15 +97,22 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (HasSignatureMismatch(compilation.NodeFactory))
             {
-                string text = $"Signature mismatch detected: '{ExternMethodName}' will not be imported from the host environment";
-
-                foreach (MethodDesc method in EnumerateMethods())
+                IEnumerable<MethodDesc> methods = _methods switch
                 {
-                    text += $"\n Defined as: {method.Signature.ReturnType} {method}";
+                    null => [],
+                    MethodDesc oneMethod => [oneMethod],
+                    _ => (HashSet<MethodDesc>)_methods,
+                };
+
+                StringBuilder text = new();
+                text.Append($"Signature mismatch detected: '{ExternMethodName}' will not be imported from the host environment");
+                foreach (MethodDesc method in methods)
+                {
+                    text.Append($"\n Defined as: {method.Signature.ReturnType} {method}");
                 }
 
                 // Error code is just below the "AOT analysis" namespace.
-                compilation.Logger.LogWarning(text, 3049, (string)null);
+                compilation.Logger.LogWarning(text.ToString(), 3049, (string)null);
             }
         }
 
@@ -137,38 +147,8 @@ namespace ILCompiler.DependencyAnalysis
     {
         private readonly ExternMethodCellNode _methodCell = methodCell;
 
-        public WasmFunctionType GetWasmFunctionType(NodeFactory factory)
-        {
-            if (_methodCell.HasSignatureMismatch(factory))
-            {
-                return new WasmFunctionType(WasmValueType.Invalid, []);
-            }
-
-            // TODO-LLVM: the initial design of ExternMethodAccessorNode assumed that, eventually, ILC would not
-            // need to concern itself with ABI (i. e. that only the Jit would need to know the ABI details). That
-            // is why Signature is provided by Jit. However, at this point, it has become clear that we will not
-            // be able to avoid WASM signature building in ILC, and so the Jit-based mechanism is redundant (ILC
-            // can compute the details by itself). Remove it.
-            static WasmValueType ToWasmType(TargetAbiType type) => type switch
-            {
-                TargetAbiType.Void => WasmValueType.Invalid,
-                TargetAbiType.Int32 => WasmValueType.I32,
-                TargetAbiType.Int64 => WasmValueType.I64,
-                TargetAbiType.Float => WasmValueType.F32,
-                TargetAbiType.Double => WasmValueType.F64,
-                _ => throw new NotImplementedException()
-            };
-
-            ReadOnlySpan<TargetAbiType> jitSig = _methodCell.Signature;
-            WasmValueType wasmReturnType = ToWasmType(jitSig[0]);
-            WasmValueType[] wasmParamTypes = new WasmValueType[jitSig.Length - 1];
-            for (int i = 0; i < wasmParamTypes.Length; i++)
-            {
-                wasmParamTypes[i] = ToWasmType(jitSig[i + 1]);
-            }
-
-            return new WasmFunctionType(wasmReturnType, wasmParamTypes);
-        }
+        public WasmFunctionType GetWasmFunctionType(NodeFactory factory) =>
+            _methodCell.HasSignatureMismatch(factory) ? new(WasmValueType.Invalid, []) : _methodCell.Signature;
 
         public bool GetImportModuleAndName(Compilation compilation, out string module, out string name)
         {

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.DependencyAnalysis
     {
         private readonly CorInfoLlvmEHModel _ehModel;
 
-        private readonly Dictionary<string, ExternMethodCellNode> _externMethodAccessors = new();
+        private readonly Dictionary<string, ExternMethodCellNode> _externMethodCells = new();
         private readonly NodeCache<ExternMethodCellNode, ExternWasmMethodNode> _externWasmMethods =
             new(methodCell => new ExternWasmMethodNode(methodCell));
 
@@ -52,33 +52,25 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool TargetsEmulatedEH() => _ehModel is CorInfoLlvmEHModel.Emulated;
 
-        internal ExternMethodCellNode ExternMethodCell(string name, MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
+        internal ExternMethodCellNode ExternMethodCell(string name, MethodDesc method)
         {
-            Dictionary<string, ExternMethodCellNode> map = _externMethodAccessors;
+            Dictionary<string, ExternMethodCellNode> map = _externMethodCells;
 
             // Not lockless since we mutate the node. Contention on this path is not expected.
             //
             lock (map)
             {
                 ref ExternMethodCellNode node = ref CollectionsMarshal.GetValueRefOrAddDefault(map, name, out bool exists);
-
                 if (!exists)
                 {
                     node = new ExternMethodCellNode(name);
-                    node.Signature = sig.ToArray();
                 }
-                else if (!node.Signature.AsSpan().SequenceEqual(sig))
-                {
-                    // We have already seen this name with a different signature. Currently, we don't try to disambiguate.
-                    node.Signature = null;
-                }
-
                 node.AddMethod(method);
                 return node;
             }
         }
 
-        internal ExternWasmMethodNode ExternWasmMethod(ExternMethodCellNode accessor) => _externWasmMethods.GetOrAdd(accessor);
+        internal ExternWasmMethodNode ExternWasmMethod(ExternMethodCellNode methodCell) => _externWasmMethods.GetOrAdd(methodCell);
 
         protected override IMethodNode CreateMethodEntrypointNode(MethodDesc method)
         {

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilation.cs
@@ -247,12 +247,10 @@ namespace ILCompiler
             return corInfo;
         }
 
-        public override ISymbolNode GetExternalMethodCell(MethodDesc method, ReadOnlySpan<TargetAbiType> sig)
+        public override ISymbolNode GetExternalMethodCell(MethodDesc method)
         {
-            Debug.Assert(!sig.IsEmpty);
             string name = PInvokeILProvider.GetDirectCallExternName(method);
-
-            return NodeFactory.ExternMethodCell(name, method, sig);
+            return NodeFactory.ExternMethodCell(name, method);
         }
 
         public override CorInfoLlvmEHModel GetLlvmExceptionHandlingModel() => Options.ExceptionHandlingModel;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -222,7 +222,7 @@ namespace ILCompiler
         }
 
         public virtual int PadOffset(TypeDesc type, int atOffset) => throw new NotImplementedException();
-        public virtual ISymbolNode GetExternalMethodCell(MethodDesc method, ReadOnlySpan<TargetAbiType> signature) => throw new NotImplementedException();
+        public virtual ISymbolNode GetExternalMethodCell(MethodDesc method) => throw new NotImplementedException();
         public virtual CorInfoLlvmEHModel GetLlvmExceptionHandlingModel() => throw new NotImplementedException();
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -163,11 +163,11 @@ namespace Internal.JitInterface
 
         [UnmanagedCallersOnly]
         public static void getExternalMethodAddress(
-            IntPtr thisHandle, CORINFO_METHOD_STRUCT_* methodHandle, TargetAbiType* sig, int sigLength, CORINFO_CONST_LOOKUP* pLookup)
+            IntPtr thisHandle, CORINFO_METHOD_STRUCT_* methodHandle, CORINFO_CONST_LOOKUP* pLookup)
         {
             CorInfoImpl _this = GetThis(thisHandle);
             MethodDesc method = _this.HandleToObject(methodHandle);
-            ISymbolNode cellNode = _this._compilation.GetExternalMethodCell(method, new ReadOnlySpan<TargetAbiType>(sig, sigLength));
+            ISymbolNode cellNode = _this._compilation.GetExternalMethodCell(method);
             *pLookup = _this.CreateConstLookupToSymbol(cellNode);
         }
 
@@ -436,7 +436,7 @@ namespace Internal.JitInterface
             jitImports[(int)EEApiId.EEAI_GetPrimitiveTypeForTrivialWasmStruct] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, CorInfoType>)&getPrimitiveTypeForTrivialWasmStruct;
             jitImports[(int)EEApiId.EEAI_GetTypeDescriptor] = (delegate* unmanaged<IntPtr, CORINFO_CLASS_STRUCT_*, TypeDescriptor*, void>)&getTypeDescriptor;
             jitImports[(int)EEApiId.EEAI_GetAlternativeFunctionName] = (delegate* unmanaged<IntPtr, byte*>)&getAlternativeFunctionName;
-            jitImports[(int)EEApiId.EEAI_GetExternalMethodAddress] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, TargetAbiType*, int, CORINFO_CONST_LOOKUP*, void>)&getExternalMethodAddress;
+            jitImports[(int)EEApiId.EEAI_GetExternalMethodAddress] = (delegate* unmanaged<IntPtr, CORINFO_METHOD_STRUCT_*, CORINFO_CONST_LOOKUP*, void>)&getExternalMethodAddress;
             jitImports[(int)EEApiId.EEAI_GetDebugInfoForCurrentMethod] = (delegate* unmanaged<IntPtr, CORINFO_LLVM_METHOD_DEBUG_INFO*, void>)&getDebugInfoForCurrentMethod;
             jitImports[(int)EEApiId.EEAI_GetSingleThreadedCompilationContext] = (delegate* unmanaged<IntPtr, void*>)&getSingleThreadedCompilationContext;
             jitImports[(int)EEApiId.EEAI_GetExceptionHandlingModel] = (delegate* unmanaged<IntPtr, CorInfoLlvmEHModel>)&getExceptionHandlingModel;
@@ -494,15 +494,6 @@ namespace Internal.JitInterface
         }
 
         private static void* GetJitExport(CorJitApiId id) => s_jitExports[(int)id];
-    }
-
-    public enum TargetAbiType : byte
-    {
-        Void,
-        Int32,
-        Int64,
-        Float,
-        Double
     }
 
     public enum CorInfoLlvmEHModel


### PR DESCRIPTION
No longer needed now that we have settled on having ABI handling in ILC anyway. This is a no-diff change.

I've also added a convenience `clr.ilc` subset that only builds ILC, but does not publish it, intended for inner loop development (e. g. `./build clr.wasmjit+clr.ilc`).

Depends on #3120.