### PR TITLE
[NativeAOT-LLVM] Add sample testing

### DIFF
--- a/samples/HelloWorld/HelloWorld.csproj
+++ b/samples/HelloWorld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <PublishTrimmed>true</PublishTrimmed>
     <SelfContained>true</SelfContained>

--- a/samples/NativeLibrary/NativeLibrary.csproj
+++ b/samples/NativeLibrary/NativeLibrary.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <PublishTrimmed>true</PublishTrimmed>
@@ -15,7 +15,7 @@
     <PackageReference Include="runtime.$(NETCoreSdkPortableRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="10.0.0-*" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'browser-wasm'">
     <LinkerArg Include="-sEXPORTED_RUNTIME_METHODS=stringToNewUTF8" />
   </ItemGroup>
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
@@ -7,21 +7,43 @@
   </PropertyGroup>
 
   <Target Name="PublishPackagingTestProject" BeforeTargets="BeforeBuild">
-    <ItemGroup>
-      <PackagingTestProject Include="PackagingTests/PackagingTestProject.csproj" />
-
-      <PackagingTestProject>
-        <TestOutputPath>$(OutputPath)%(FileName)</TestOutputPath>
-      </PackagingTestProject>
-    </ItemGroup>
-
     <PropertyGroup>
       <Test_Configuration>$(Configuration)</Test_Configuration>
       <Test_TargetFramework>$(NetCoreAppCurrent)</Test_TargetFramework>
       <Test_RuntimeIdentifier>$(TargetOS)-$(TargetArchitecture)</Test_RuntimeIdentifier>
       <Test_RestoreSource>$(ArtifactsShippingPackagesDir)</Test_RestoreSource>
       <Test_RestorePackagesPath>$([MSBuild]::NormalizeDirectory('$(PackageOutputPath)', 'packages', '$(Configuration)'))</Test_RestorePackagesPath>
+      <Test_HostPackageRuntimeIdentifier>$(NETCoreSdkPortableRuntimeIdentifier.Replace('-$(BuildArchitecture)', '-$(IlcHostArch)'))</Test_HostPackageRuntimeIdentifier>
     </PropertyGroup>
+
+    <ItemGroup>
+      <PackagingTestProject Include="PackagingTests/PackagingTestProject.csproj">
+        <BuildProperties>
+          Test_Configuration=$(Test_Configuration);
+          Test_TargetFramework=$(Test_TargetFramework);
+          Test_RuntimeIdentifier=$(Test_RuntimeIdentifier);
+          Test_PackageVersion=$(NetCoreAppCurrentVersion).0-*;
+          Test_RestoreSource=$(Test_RestoreSource);
+          Test_RestorePackagesPath=$(Test_RestorePackagesPath);
+          Test_HostPackageRuntimeIdentifier=$(Test_HostPackageRuntimeIdentifier);
+          _hostArchitecture=$(IlcHostArch); <!-- Override host package resolution in ILC targets. -->
+        </BuildProperties>
+      </PackagingTestProject>
+      <PackagingTestProject OutputPathRoot="$(OutputPath)%(FileName)/" />
+      <PackagingTestProject BuildProperties="Test_TestOutputPath=%(OutputPathRoot);%(BuildProperties)" />
+
+      <SampleProject Include="$(RepoRoot)samples/HelloWorld/HelloWorld.csproj;
+                              $(RepoRoot)samples/NativeLibrary/NativeLibrary.csproj">
+        <BuildProperties>
+          Configuration=$(Test_Configuration);
+          RuntimeIdentifier=$(Test_RuntimeIdentifier);
+        </BuildProperties>
+      </SampleProject>
+      <SampleProject OutputPathRoot="%(RootDir)%(Directory)" />
+
+      <PackagingTestProject Include="@(SampleProject)"
+                            Condition="'$(Test_HostPackageRuntimeIdentifier)' == '$(NETCoreSdkPortableRuntimeIdentifier)'" />
+    </ItemGroup>
 
     <Error Condition="!Exists($(Test_RestoreSource))"
            Text="The 'nativeaot.packages' subset must be built before building this project" />
@@ -35,33 +57,19 @@
          before "./build nativeaot.packages" because the pkgproj targets do
          not declare their inputs properly. -->
     <RemoveDir Directories="$(Test_RestorePackagesPath)" />
-    <RemoveDir Directories="@(PackagingTestProject->'%(TestOutputPath)')" />
-
-    <PropertyGroup>
-      <PackagingTestProjectProperties>
-        Test_Configuration=$(Test_Configuration);
-        Test_TargetFramework=$(Test_TargetFramework);
-        Test_RuntimeIdentifier=$(Test_RuntimeIdentifier);
-        Test_PackageVersion=$(NetCoreAppCurrentVersion).0-*;
-        Test_RestoreSource=$(Test_RestoreSource);
-        Test_RestorePackagesPath=$(Test_RestorePackagesPath);
-        Test_HostPackageRuntimeIdentifier=$(NETCoreSdkPortableRuntimeIdentifier.Replace('-$(BuildArchitecture)', '-$(IlcHostArch)'));
-        _hostArchitecture=$(IlcHostArch); <!-- Override host package resolution in ILC targets. -->
-      </PackagingTestProjectProperties>
-    </PropertyGroup>
+    <RemoveDir Directories="%(PackagingTestProject.OutputPathRoot)bin;
+                            %(PackagingTestProject.OutputPathRoot)obj" />
 
     <MSBuild Projects="@(PackagingTestProject)"
              Targets="Restore"
-             Properties="$(PackagingTestProjectProperties);
-                         Test_TestOutputPath=%(TestOutputPath);
+             Properties="%(BuildProperties);
                          MSBuildRestoreSessionId=$([System.Guid]::NewGuid())" />
 
     <MSBuild Projects="@(PackagingTestProject)"
              Targets="Publish"
-             Properties="$(PackagingTestProjectProperties);
-                         Test_TestOutputPath=%(TestOutputPath)" />
+             Properties="%(BuildProperties)" />
 
-    <Error Condition="!Exists('%(TestOutputPath)/bin/$(Test_Configuration)/$(Test_TargetFramework)/$(Test_RuntimeIdentifier)/publish/%(FileName).wasm')"
+    <Error Condition="!Exists('%(OutputPathRoot)/bin/$(Test_Configuration)/$(Test_TargetFramework)/$(Test_RuntimeIdentifier)/publish/%(FileName).wasm')"
            Text="%(PackagingTestProject.FullPath) did not produce the expected native artifacts" />
   </Target>
 </Project>


### PR DESCRIPTION
Finishes the package testing story by adding the building of samples to the packaging test project. This will exercise the "last published" package.

Fixes #2783.