### PR TITLE
[NativeAOT-LLVM] Avoid unnecessary zeroing in LSSA

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2680,6 +2680,13 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
             {
                 verboseDump = true;
             }
+
+#ifdef TARGET_WASM
+            if (!verboseDump && m_llvm->EnableVerboseDump())
+            {
+                verboseDump = true;
+            }
+#endif // TARGET_WASM
         }
     }
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2682,10 +2682,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
             }
 
 #ifdef TARGET_WASM
-            if (!verboseDump && m_llvm->EnableVerboseDump())
-            {
-                verboseDump = true;
-            }
+            verboseDump |= m_llvm->EnableVerboseDump();
 #endif // TARGET_WASM
         }
     }

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -850,6 +850,7 @@ RELEASE_CONFIG_INTEGER(JitCheckLlvmIR, "JitCheckLlvmIR", 0)
 RELEASE_CONFIG_INTEGER(JitRunLssaTests, "JitRunLssaTests", 0)
 RELEASE_CONFIG_INTEGER(JitGcStress, "JitGcStress", 0)
 
+CONFIG_STRING(JitDumpSymbol, "JitDumpSymbol")
 CONFIG_STRING(JitEnableLssaRange, "JitEnableLssaRange")
 #endif // TARGET_WASM
 

--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -82,6 +82,9 @@ Llvm::Llvm(Compiler* compiler)
     , m_phiPairs(compiler->getAllocator(CMK_Codegen))
     , m_ehModel(GetExceptionHandlingModel())
     , m_debugVariablesMap(compiler->getAllocator(CMK_Codegen))
+#ifdef DEBUG
+    , m_optimizationRequirements(compiler->getAllocator(CMK_DebugOnly))
+#endif // DEBUG
 {
 }
 
@@ -106,6 +109,20 @@ Llvm::Llvm(Compiler* compiler)
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif // HOST_WINDOWS
+}
+
+bool Llvm::EnableVerboseDump()
+{
+#ifdef DEBUG
+    const char* dumpSymbolName = JitConfig.JitDumpSymbol();
+    const char* compilingSymbolName = GetMangledMethodName(m_info->compMethodHnd);
+    if ((dumpSymbolName != nullptr) && (strcmp(dumpSymbolName, compilingSymbolName) == 0))
+    {
+        return true;
+    }
+#endif // DEBUG
+
+    return false;
 }
 
 var_types Llvm::GetArgTypeForStructWasm(CORINFO_CLASS_HANDLE structHnd, structPassingKind* pPassKind)
@@ -827,6 +844,44 @@ bool Llvm::IsVirtualUnwindFrameVisible()
 void Llvm::GetJitTestInfo(CorInfoLlvmJitTestKind kind, CORINFO_LLVM_JIT_TEST_INFO* pInfo)
 {
     CallEEApi<EEAI_GetJitTestInfo, CORINFO_GENERIC_HANDLE>(m_pEECorInfo, kind, pInfo);
+}
+
+void Llvm::ImposeOptimizationRequirement(GenTree* node, NodeOptimizationRequirement requirement)
+{
+#ifdef DEBUG
+    assert(node != nullptr);
+    *m_optimizationRequirements.LookupPointerOrAdd(node, NOR_NONE) |= requirement;
+#endif // DEBUG
+}
+
+void Llvm::SatisfyOptimizationRequirement(GenTree* node, NodeOptimizationRequirement requirement)
+{
+#ifdef DEBUG
+    assert(node != nullptr);
+    NodeOptimizationRequirement* pRequired = m_optimizationRequirements.LookupPointer(node);
+    if (pRequired != nullptr)
+    {
+        *pRequired &= ~requirement;
+        if (*pRequired == NOR_NONE)
+        {
+            m_optimizationRequirements.Remove(node);
+        }
+    }
+#endif // DEBUG
+}
+
+void Llvm::VerifyAllOptimizationRequirementsSatisfied()
+{
+#ifdef DEBUG
+    if (m_optimizationRequirements.GetCount() != 0)
+    {
+        for (GenTree* node : decltype(m_optimizationRequirements)::KeyIteration(&m_optimizationRequirements))
+        {
+            _compiler->gtDispTree(node, nullptr, nullptr, true);
+        }
+        assert(!"Found nodes with unsatisfied optimization requirements");
+    }
+#endif // DEBUG
 }
 
 static SingleThreadedCompilationContext* StartSingleThreadedCompilation(

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -14,9 +14,6 @@
 #include "JitEEApi.Shared.cspp"
 #include <new>
 
-// this breaks StringMap.h
-#undef NumItems
-
 // TODO-LLVM-Upstream: figure out how to fix these warnings in LLVM headers.
 #pragma warning(push)
 #pragma warning(disable : 4146)
@@ -224,6 +221,27 @@ inline CallSiteFacts& operator |=(CallSiteFacts& a, CallSiteFacts b)
     return a = static_cast<CallSiteFacts>(static_cast<int>(a) | static_cast<int>(b));
 }
 
+enum NodeOptimizationRequirement
+{
+    NOR_NONE = 0,
+    NOR_SHADOW_TAILCALL = 1
+};
+
+inline NodeOptimizationRequirement& operator |=(NodeOptimizationRequirement& a, NodeOptimizationRequirement b)
+{
+    return a = static_cast<NodeOptimizationRequirement>(static_cast<int>(a) | static_cast<int>(b));
+}
+
+inline NodeOptimizationRequirement& operator &=(NodeOptimizationRequirement& a, NodeOptimizationRequirement b)
+{
+    return a = static_cast<NodeOptimizationRequirement>(static_cast<int>(a) & static_cast<int>(b));
+}
+
+inline NodeOptimizationRequirement operator ~(NodeOptimizationRequirement a)
+{
+    return static_cast<NodeOptimizationRequirement>(~static_cast<int>(a));
+}
+
 struct ThrowHelperKey
 {
     unsigned ThrowIndex;
@@ -238,6 +256,14 @@ struct ThrowHelperKey
     {
         return (keyOne.ThrowIndex == keyTwo.ThrowIndex) && (keyOne.HelperFunc == keyTwo.HelperFunc);
     }
+};
+
+struct ThrowHelperCode
+{
+    llvm::BasicBlock* LlvmBlock;
+#ifdef DEBUG
+    bool ShadowTailCalledThrowHelper;
+#endif // DEBUG
 };
 
 struct PhiPair
@@ -339,7 +365,7 @@ private:
     llvm::IRBuilder<> _builder;
     JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, Value*> _sdsuMap;
     JitHashTable<SSAName, SSAName, Value*> _localsMap;
-    JitHashTable<ThrowHelperKey, ThrowHelperKey, llvm::BasicBlock*> m_throwHelperBlocksMap;
+    JitHashTable<ThrowHelperKey, ThrowHelperKey, ThrowHelperCode> m_throwHelperBlocksMap;
     jitstd::vector<PhiPair> m_phiPairs;
     FunctionInfo* m_functions;
 
@@ -370,6 +396,10 @@ private:
     unsigned m_preciseVirtualUnwindFrameLclNum = BAD_VAR_NUM;
     unsigned _llvmArgCount = 0;
 
+#ifdef DEBUG
+    JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, NodeOptimizationRequirement> m_optimizationRequirements;
+#endif // DEBUG
+
     // ================================================================================================================
     // |                                                   General                                                    |
     // ================================================================================================================
@@ -378,6 +408,7 @@ public:
     Llvm(Compiler* compiler);
 
     static void ConfigureDiagnosticOutput();
+    bool EnableVerboseDump();
 
     var_types GetArgTypeForStructWasm(CORINFO_CLASS_HANDLE structHnd, structPassingKind* pPassKind);
     var_types GetReturnTypeForStructWasm(CORINFO_CLASS_HANDLE structHnd, structPassingKind* pPassKind);
@@ -435,6 +466,10 @@ private:
         unsigned* pAbsoluteValue, unsigned shadowFrameSize, CORINFO_LLVM_EH_CLAUSE* pClauses, int clauseCount);
     bool IsVirtualUnwindFrameVisible();
     void GetJitTestInfo(CorInfoLlvmJitTestKind kind, CORINFO_LLVM_JIT_TEST_INFO* pInfo);
+
+    void ImposeOptimizationRequirement(GenTree* node, NodeOptimizationRequirement requirement);
+    void SatisfyOptimizationRequirement(GenTree* node, NodeOptimizationRequirement requirement);
+    void VerifyAllOptimizationRequirementsSatisfied();
 
     // ================================================================================================================
     // |                                                 Type system                                                  |
@@ -506,9 +541,8 @@ private:
     void lowerDissolveDependentlyPromotedLocals();
     void dissolvePromotedLocal(unsigned lclNum);
 
-    void lowerCanonicalizeFirstBlock();
     bool isFirstBlockCanonical();
-    void lowerAndInsertIntoFirstBlock(LIR::Range& range, GenTree* insertAfter = nullptr);
+    GenTree* lowerAndInsertIntoFirstBlock(LIR::Range& range, GenTree* insertAfter = nullptr);
 
 public:
     PhaseStatus AddVirtualUnwindFrame();
@@ -554,7 +588,8 @@ private:
 
     unsigned getShadowFrameSize(unsigned funcIdx) const;
     unsigned getCalleeShadowStackOffset(unsigned funcIdx, bool isTailCall) const;
-    bool canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter DEBUGARG(const char** pReasonWhyNot)) const;
+    bool canEmitCallAsShadowTailCall(
+        bool callIsInTry, bool callIsInFilter DEBUGARG(const char** pReasonWhyNot = nullptr)) const;
     bool isPotentialGcSafePoint(GenTree* node) const;
     bool isShadowFrameLocal(LclVarDsc* varDsc) const;
     bool isShadowStackLocal(unsigned lclNum) const;
@@ -632,19 +667,21 @@ private:
     void buildCallFinally(BasicBlock* block);
 
     Value* consumeAddressAndEmitNullCheck(GenTreeIndir* indir);
-    void emitNullCheckForAddress(GenTree* addr, Value* addrValue);
-    void emitAlignmentCheckForAddress(GenTree* addr, Value* addrValue, unsigned alignment);
+    void emitNullCheckForAddress(GenTree* addr, Value* addrValue DEBUGARG(GenTree* indir));
+    void emitAlignmentCheckForAddress(GenTree* addr, Value* addrValue, unsigned alignment DEBUGARG(GenTree* indir));
     bool isAddressAligned(GenTree* addr, unsigned alignment);
 
     Value* consumeInitVal(GenTree* initVal);
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
 
-    void emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFunc);
-    Value* emitCheckedArithmeticOperation(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value);
+    void emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFunc DEBUGARG(GenTree* nodeThrowing));
+    Value* emitCheckedArithmeticOperation(
+        llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value DEBUGARG(GenTree* opNode));
 
     llvm::CallBase* emitGcStressCall(GenTreeCall* call, llvm::CallBase* callValue);
-    llvm::CallBase* emitHelperCall(CorInfoHelpFunc helperFunc, ArrayRef<Value*> sigArgs = {});
+    llvm::CallBase* emitHelperCall(
+        CorInfoHelpFunc helperFunc, ArrayRef<Value*> sigArgs = {} DEBUGARG(bool* pIsShadowTailCall = nullptr));
     bool canEmitHelperCallAsShadowTailCall(CorInfoHelpFunc helperFunc);
     llvm::CallBase* emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Value*> args, CallSiteFacts facts);
 

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -873,6 +873,8 @@ void Llvm::generateAuxiliaryArtifacts()
 void Llvm::verifyGeneratedCode()
 {
 #ifdef DEBUG
+    VerifyAllOptimizationRequirementsSatisfied();
+
     for (unsigned funcIdx = 0; funcIdx < _compiler->compFuncCount(); funcIdx++)
     {
         Function* llvmFunc = m_functions[funcIdx].LlvmFunction;
@@ -1349,7 +1351,7 @@ void Llvm::buildAdd(GenTreeOp* node)
         {
             llvm::Intrinsic::ID intrinsicId =
                 node->IsUnsigned() ? llvm::Intrinsic::uadd_with_overflow : llvm::Intrinsic::sadd_with_overflow;
-            addValue = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value);
+            addValue = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value DEBUGARG(node));
         }
         else
         {
@@ -1394,7 +1396,7 @@ void Llvm::buildSub(GenTreeOp* node)
         {
             llvm::Intrinsic::ID intrinsicId =
                 node->IsUnsigned() ? llvm::Intrinsic::usub_with_overflow: llvm::Intrinsic::ssub_with_overflow;
-            subValue = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value);
+            subValue = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value DEBUGARG(node));
         }
         else
         {
@@ -1433,7 +1435,7 @@ void Llvm::buildDivMod(GenTree* node)
     if ((exceptions & ExceptionSetFlags::DivideByZeroException) != ExceptionSetFlags::None)
     {
         Value* isDivisorZeroValue = _builder.CreateICmpEQ(divisorValue, llvm::ConstantInt::get(llvmType, 0));
-        emitJumpToThrowHelper(isDivisorZeroValue, CORINFO_HELP_THROWDIVZERO);
+        emitJumpToThrowHelper(isDivisorZeroValue, CORINFO_HELP_THROWDIVZERO DEBUGARG(node));
     }
     if ((exceptions & ExceptionSetFlags::ArithmeticException) != ExceptionSetFlags::None)
     {
@@ -1442,7 +1444,7 @@ void Llvm::buildDivMod(GenTree* node)
         Value* isDivisorMinusOneValue = _builder.CreateICmpEQ(divisorValue, llvm::ConstantInt::get(llvmType, -1));
         Value* isDividendMinValue = _builder.CreateICmpEQ(dividendValue, llvm::ConstantInt::get(llvmType, minDividend));
         Value* isOverflowValue = _builder.CreateAnd(isDivisorMinusOneValue, isDividendMinValue);
-        emitJumpToThrowHelper(isOverflowValue, CORINFO_HELP_OVERFLOW);
+        emitJumpToThrowHelper(isOverflowValue, CORINFO_HELP_OVERFLOW DEBUGARG(node));
     }
 
     switch (node->OperGet())
@@ -1591,7 +1593,7 @@ void Llvm::buildCast(GenTreeCast* cast)
             isOverflowValue = _builder.CreateCmp(llvm::CmpInst::ICMP_UGT, checkedValue, upperBoundValue);
         }
 
-        emitJumpToThrowHelper(isOverflowValue, CORINFO_HELP_OVERFLOW);
+        emitJumpToThrowHelper(isOverflowValue, CORINFO_HELP_OVERFLOW DEBUGARG(cast));
     }
 
     switch (castFromType)
@@ -1804,7 +1806,7 @@ void Llvm::buildIntegralConst(GenTreeIntConCommon* node)
     Type* constLlvmType = getLlvmTypeForVarType(constType);
 
     Value* constValue;
-    if (node->IsCnsIntOrI() && node->IsIconHandle()) // TODO-LLVM: change to simply "IsIconHandle" once upstream does.
+    if (node->IsIconHandle())
     {
         constValue = getOrCreateSymbol(CORINFO_GENERIC_HANDLE(node->AsIntCon()->IconValue()));
     }
@@ -1962,7 +1964,7 @@ void Llvm::buildBinaryOperation(GenTree* node)
             {
                 llvm::Intrinsic::ID intrinsicId =
                     node->IsUnsigned() ? llvm::Intrinsic::umul_with_overflow : llvm::Intrinsic::smul_with_overflow;
-                result = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value);
+                result = emitCheckedArithmeticOperation(intrinsicId, op1Value, op2Value DEBUGARG(node));
             }
             else
             {
@@ -2049,7 +2051,7 @@ void Llvm::buildAtomicOp(GenTreeIndir* atomicOpNode)
     var_types opType = atomicOpNode->TypeGet();
     Value* addrValue = consumeAddressAndEmitNullCheck(atomicOpNode);
     Value* valueValue = consumeValue(atomicOpNode->Data(), getLlvmTypeForVarType(opType));
-    emitAlignmentCheckForAddress(atomicOpNode->Addr(), addrValue, genTypeSize(opType));
+    emitAlignmentCheckForAddress(atomicOpNode->Addr(), addrValue, genTypeSize(opType) DEBUGARG(atomicOpNode));
 
     llvm::AtomicRMWInst::BinOp binOpInst;
     switch (atomicOpNode->OperGet())
@@ -2083,7 +2085,7 @@ void Llvm::buildCmpXchg(GenTreeCmpXchg* cmpXchgNode)
     Value* addrValue = consumeAddressAndEmitNullCheck(cmpXchgNode);
     Value* newValue = consumeValue(cmpXchgNode->Data(), opLlvmType);
     Value* cmpValue = consumeValue(cmpXchgNode->Comparand(), opLlvmType);
-    emitAlignmentCheckForAddress(cmpXchgNode->Addr(), addrValue, genTypeSize(opType));
+    emitAlignmentCheckForAddress(cmpXchgNode->Addr(), addrValue, genTypeSize(opType) DEBUGARG(cmpXchgNode));
 
     // CmpXchg returns a tuple of { <type> previous value, i1 success }. We only need the former.
     llvm::AtomicOrdering order = llvm::AtomicOrdering::SequentiallyConsistent;
@@ -2213,7 +2215,7 @@ void Llvm::buildBoundsCheck(GenTreeBoundsChk* boundsCheckNode)
 
     Value* indexOutOfRangeValue = _builder.CreateCmp(llvm::CmpInst::ICMP_UGE, indexValue, lengthValue);
     CorInfoHelpFunc helperFunc = static_cast<CorInfoHelpFunc>(_compiler->acdHelper(boundsCheckNode->gtThrowKind));
-    emitJumpToThrowHelper(indexOutOfRangeValue, helperFunc);
+    emitJumpToThrowHelper(indexOutOfRangeValue, helperFunc DEBUGARG(boundsCheckNode));
 }
 
 void Llvm::buildCkFinite(GenTreeUnOp* ckNode)
@@ -2225,7 +2227,7 @@ void Llvm::buildCkFinite(GenTreeUnOp* ckNode)
     // Taken from IR Clang generates for "isfinite".
     Value* absOpValue = _builder.CreateIntrinsic(llvm::Intrinsic::fabs, fpLlvmType, opValue);
     Value* isNotFiniteValue = _builder.CreateFCmpUEQ(absOpValue, llvm::ConstantFP::get(fpLlvmType, INFINITY));
-    emitJumpToThrowHelper(isNotFiniteValue, CORINFO_HELP_OVERFLOW);;
+    emitJumpToThrowHelper(isNotFiniteValue, CORINFO_HELP_OVERFLOW DEBUGARG(ckNode));;
 
     mapGenTreeToValue(ckNode, opValue);
 }
@@ -2327,14 +2329,14 @@ Value* Llvm::consumeAddressAndEmitNullCheck(GenTreeIndir* indir)
     if ((indir->gtFlags & GTF_IND_NONFAULTING) == 0)
     {
         // Note how we emit the check **before** the inbounds GEP so as to avoid the latter producing poison.
-        emitNullCheckForAddress(addr, addrValue);
+        emitNullCheckForAddress(addr, addrValue DEBUGARG(indir));
     }
 
     addrValue = gepOrAddrInBounds(addrValue, offset);
     return addrValue;
 }
 
-void Llvm::emitNullCheckForAddress(GenTree* addr, Value* addrValue)
+void Llvm::emitNullCheckForAddress(GenTree* addr, Value* addrValue DEBUGARG(GenTree* indir))
 {
     // The frontend's contract with the backend is that it will not insert null checks for accesses which
     // are inside the "[0..compMaxUncheckedOffsetForNullObject]" range. Thus, we usually need to check not
@@ -2363,10 +2365,10 @@ void Llvm::emitNullCheckForAddress(GenTree* addr, Value* addrValue)
         isNullValue = _builder.CreateICmpULT(addrValue, checkValue);
     }
 
-    emitJumpToThrowHelper(isNullValue, CORINFO_HELP_THROWNULLREF);
+    emitJumpToThrowHelper(isNullValue, CORINFO_HELP_THROWNULLREF DEBUGARG(indir));
 }
 
-void Llvm::emitAlignmentCheckForAddress(GenTree* addr, Value* addrValue, unsigned alignment)
+void Llvm::emitAlignmentCheckForAddress(GenTree* addr, Value* addrValue, unsigned alignment DEBUGARG(GenTree* indir))
 {
     if (isAddressAligned(addr, alignment))
     {
@@ -2377,7 +2379,7 @@ void Llvm::emitAlignmentCheckForAddress(GenTree* addr, Value* addrValue, unsigne
     Value* addrValueAsIntValue = _builder.CreatePtrToInt(addrValue, getIntPtrLlvmType());
     Value* addrAlignBitsValue = _builder.CreateAnd(addrValueAsIntValue, alignment - 1);
     Value* addrIsNotAlignedValue = _builder.CreateICmpNE(addrAlignBitsValue, getIntPtrConst(0));
-    emitJumpToThrowHelper(addrIsNotAlignedValue, CORINFO_HELP_THROWMISALIGN);
+    emitJumpToThrowHelper(addrIsNotAlignedValue, CORINFO_HELP_THROWMISALIGN DEBUGARG(indir));
 }
 
 bool Llvm::isAddressAligned(GenTree* addr, unsigned alignment)
@@ -2494,44 +2496,46 @@ unsigned Llvm::buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned en
     return size;
 }
 
-void Llvm::emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFunc)
+void Llvm::emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFunc DEBUGARG(GenTree* nodeThrowing))
 {
+    bool shadowTailCalledThrowHelper = false;
     if (_compiler->fgUseThrowHelperBlocks())
     {
         assert(CurrentBlock() != nullptr);
 
         // For code with throw helper blocks, create and use the shared helper block for raising the exception.
-        llvm::BasicBlock* throwLlvmBlock;
+        ThrowHelperCode throwCode;
         Compiler::AcdKeyDesignator dsg = Compiler::AcdKeyDesignator::KD_NONE;
         ThrowHelperKey throwBlockKey{_compiler->bbThrowIndex(CurrentBlock(), &dsg), helperFunc};
-        if (!m_throwHelperBlocksMap.Lookup(throwBlockKey, &throwLlvmBlock))
+        if (!m_throwHelperBlocksMap.Lookup(throwBlockKey, &throwCode))
         {
             LlvmBlockRange* currentLlvmBlocks = getCurrentLlvmBlocks();
 
-            throwLlvmBlock = llvm::BasicBlock::Create(m_context->Context, "BBTH", getCurrentLlvmFunction());
-            LlvmBlockRange throwLlvmBlocks(throwLlvmBlock);
+            throwCode.LlvmBlock = llvm::BasicBlock::Create(m_context->Context, "BBTH", getCurrentLlvmFunction());
+            LlvmBlockRange throwLlvmBlocks(throwCode.LlvmBlock);
 
             setCurrentEmitContextBlocks(&throwLlvmBlocks);
-            emitHelperCall(helperFunc);
+            emitHelperCall(helperFunc, {} DEBUGARG(&throwCode.ShadowTailCalledThrowHelper));
             _builder.CreateUnreachable();
-            m_throwHelperBlocksMap.Set(throwBlockKey, throwLlvmBlock);
+            m_throwHelperBlocksMap.Set(throwBlockKey, throwCode);
 
             setCurrentEmitContextBlocks(currentLlvmBlocks);
         }
+        INDEBUG(shadowTailCalledThrowHelper = throwCode.ShadowTailCalledThrowHelper);
 
         // Jump to the exception-throwing block on error.
         llvm::BasicBlock* nextLlvmBlock = createInlineLlvmBlock();
-        _builder.CreateCondBr(jumpCondValue, throwLlvmBlock, nextLlvmBlock);
+        _builder.CreateCondBr(jumpCondValue, throwCode.LlvmBlock, nextLlvmBlock);
         _builder.SetInsertPoint(nextLlvmBlock);
     }
     else
     {
-        // The code to throw the exception will be generated inline; we will jump around it in the non-exception case.
+        // The code to throw the exception will be generated inline; we will jump around it in the no exception case.
         llvm::BasicBlock* jumpCondLlvmBlock = _builder.GetInsertBlock();
 
         llvm::BasicBlock* throwLlvmBlock = createInlineLlvmBlock();
         _builder.SetInsertPoint(throwLlvmBlock);
-        emitHelperCall(helperFunc);
+        emitHelperCall(helperFunc, {} DEBUGARG(&shadowTailCalledThrowHelper));
         _builder.CreateUnreachable();
 
         llvm::BasicBlock* nextLlvmBlock = createInlineLlvmBlock();
@@ -2540,15 +2544,23 @@ void Llvm::emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFun
 
         _builder.SetInsertPoint(nextLlvmBlock);
     }
+
+#ifdef DEBUG
+    if (shadowTailCalledThrowHelper)
+    {
+        SatisfyOptimizationRequirement(nodeThrowing, NOR_SHADOW_TAILCALL);
+    }
+#endif // DEBUG
 }
 
-Value* Llvm::emitCheckedArithmeticOperation(llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value)
+Value* Llvm::emitCheckedArithmeticOperation(
+    llvm::Intrinsic::ID intrinsicId, Value* op1Value, Value* op2Value DEBUGARG(GenTree* opNode))
 {
     assert(op1Value->getType()->isIntegerTy() && op2Value->getType()->isIntegerTy());
 
     Value* checkedValue = _builder.CreateIntrinsic(intrinsicId, op1Value->getType(), {op1Value, op2Value});
     Value* isOverflowValue = _builder.CreateExtractValue(checkedValue, 1);
-    emitJumpToThrowHelper(isOverflowValue, CORINFO_HELP_OVERFLOW);
+    emitJumpToThrowHelper(isOverflowValue, CORINFO_HELP_OVERFLOW DEBUGARG(opNode));
 
     return _builder.CreateExtractValue(checkedValue, 0);
 }
@@ -2595,7 +2607,8 @@ llvm::CallBase* Llvm::emitGcStressCall(GenTreeCall* call, llvm::CallBase* callVa
     return callValue;
 }
 
-llvm::CallBase* Llvm::emitHelperCall(CorInfoHelpFunc helperFunc, ArrayRef<Value*> sigArgs)
+llvm::CallBase* Llvm::emitHelperCall(
+    CorInfoHelpFunc helperFunc, ArrayRef<Value*> sigArgs DEBUGARG(bool* pIsShadowTailCall))
 {
     CORINFO_GENERIC_HANDLE handle = getSymbolHandleForHelperFunc(helperFunc);
     const char* symbolName = GetMangledSymbolName(handle);
@@ -2611,7 +2624,9 @@ llvm::CallBase* Llvm::emitHelperCall(CorInfoHelpFunc helperFunc, ArrayRef<Value*
     CallSiteFacts callSiteFacts = getCallSiteFactsForHelper(helperFunc);
     if (helperCallHasShadowStackArg(helperFunc))
     {
-        Value* shadowStackArg = getShadowStackForCallee(canEmitHelperCallAsShadowTailCall(helperFunc));
+        bool isShadowTailCall = canEmitHelperCallAsShadowTailCall(helperFunc);
+        DBEXEC(pIsShadowTailCall != nullptr, *pIsShadowTailCall = isShadowTailCall);
+        Value* shadowStackArg = getShadowStackForCallee(isShadowTailCall);
         ArrayStack<Value*> args(_compiler->getAllocator(CMK_Codegen), static_cast<int>(sigArgs.size() + 1));
         args.Push(shadowStackArg);
         for (Value* sigArg : sigArgs)
@@ -2634,10 +2649,8 @@ bool Llvm::canEmitHelperCallAsShadowTailCall(CorInfoHelpFunc helperFunc)
     assert(helperCallHasShadowStackArg(helperFunc));
 
     // Right now the check on whether the call is in a "tail" position is simply that it won't return.
-    INDEBUG(const char* reasonWhyNot);
-    if (Compiler::s_helperCallProperties.AlwaysThrow(helperFunc) &&
-        canEmitCallAsShadowTailCall(getCurrentProtectedRegionIndex() != EHblkDsc::NO_ENCLOSING_INDEX,
-                                    isCurrentContextInFilter() DEBUGARG(&reasonWhyNot)))
+    if (Compiler::s_helperCallProperties.AlwaysThrow(helperFunc) && canEmitCallAsShadowTailCall(
+            getCurrentProtectedRegionIndex() != EHblkDsc::NO_ENCLOSING_INDEX, isCurrentContextInFilter()))
     {
         return true;
     }

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -1322,11 +1322,17 @@ bool Llvm::isFirstBlockCanonical()
     return !block->hasTryIndex() && (block->bbPreds == nullptr);
 }
 
-void Llvm::lowerAndInsertIntoFirstBlock(LIR::Range& range, GenTree* insertAfter)
+GenTree* Llvm::lowerAndInsertIntoFirstBlock(LIR::Range& range, GenTree* insertAfter)
 {
     assert(isFirstBlockCanonical());
     lowerRange(_compiler->fgFirstBB, range);
-    LIR::AsRange(_compiler->fgFirstBB).InsertAfter(insertAfter, std::move(range));
+
+    GenTree* lastNode = range.LastNode();
+    if (!range.IsEmpty())
+    {
+        LIR::AsRange(_compiler->fgFirstBB).InsertAfter(insertAfter, std::move(range));
+    }
+    return lastNode;
 }
 
 //------------------------------------------------------------------------
@@ -2139,6 +2145,13 @@ bool Llvm::mayPhysicallyThrow(GenTree* node)
         {
             return false;
         }
+    }
+
+    if (node->OperIs(GT_LCLHEAP))
+    {
+        // This is supposed to throw SO, but we don't implement that currently.
+        // TODO-LLVM: come up with a way to do so...?
+        return false;
     }
 
     return node->OperMayThrow(_compiler);

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -1344,7 +1344,7 @@ private:
                 (varDsc->GetRegNum() == REG_STK_CANDIDATE_UNCONDITIONAL))
             {
                 // We model candidates like "any other [non-GC] local" that just happened to need to be stored
-                // to the shadow stock. Therefore, we don't need to "initialize" them here (it'll happen in
+                // to the shadow stack. Therefore, we don't need to "initialize" them here (it'll happen in
                 // codegen). What we do here for them is initialize the shadow stack slot itself. For locals
                 // that are unconditionally rewritten to be shadow stack references however, they need to be
                 // initialized properly (e. g. if they're parameters).

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -20,12 +20,12 @@
 // optimizing, we utilize liveness as well as SSA to only allocate those locals that have their lifetimes
 // crossed by a safe point (a call which may trigger GC). This is a three-step process:
 //
-// 1) We determine which locals are may be allocated on the shadow stack. Broadly, there are two cases:
+// 1) We determine which locals may need to be allocated on the shadow stack. Broadly, there are two cases:
 //    - "Tentative", where we know the precise lifetimes. These locals may not end up on the shadow stack at
-//      all, as we may determine that they don't cross any safe point, or only some of their defs may end up
+//      all, as we may determine that they don't cross any safe point, or only some of their defs end up
 //      there.
 //    - "Unconditional" cases, where the local will be fully commited to the shadow stack and stored on each def,
-//      and reloaded on each use. This may be because the local was address-exposed, and we don't know its exact
+//      reloaded on each use. This may be because the local was address-exposed, and we don't know its exact
 //      live range, or due to implementation constraints.
 //
 // 2) We walk over the totality of IR, in dominator pre-order, maintaining the stack of currently active SSA
@@ -44,6 +44,9 @@ class ShadowStackAllocator
 
     // TODO-LLVM-LSSA-TP: we could use a denser indexing for the candidates to save memory...
     unsigned m_largestCandidateVarIndexPlusOne = 0;
+
+    BitVecTraits m_candidateBitSetTraits = BitVecTraits(0, nullptr);
+    BitVec m_explicitInitShadowSlots = BitVecOps::UninitVal();
 
     unsigned m_prologZeroingOffset = 0;
     unsigned m_prologZeroingSize = 0;
@@ -204,6 +207,12 @@ private:
 
             if (allocLocation != REG_NA)
             {
+                if (varDsc->IsAddressExposed() || varDsc->lvPinned)
+                {
+                    assert(allocLocation == REG_STK_CANDIDATE_UNCONDITIONAL);
+                    m_llvm->m_anyAddressExposedOrPinnedShadowLocals = true;
+                }
+
                 JITDUMP("V%02u: %s (%s)\n", lclNum, getRegName(allocLocation), reason);
                 varDsc->SetRegNum(allocLocation);
             }
@@ -258,10 +267,45 @@ private:
             Active // The stack slot (if any) associated with the def contains its value.
         };
 
+        // Zero initialization of locals follows special rules in our model. As a choice, we don't want
+        // to leave "random" state on the shadow stack. This implies zero-initializing the whole shadow
+        // frame on entry, even those parts of it not "live" on entry (overwritten before any explicit
+        // use). Still, we can optimize out the cases where there are no **implicit** uses - no safe
+        // points before the shadow stack slot is initialized with a valid (GC) value, by collecting
+        // the set of candidate locals (which will later be assigned SS slots) for which their spilled
+        // definitions dominate **all** safe points.
+        enum class SafePointLocation
+        {
+            None,
+            ThisBlock,
+            Descendant
+        };
+        struct BlockShadowSlotsState
+        {
+            BitVec Defs;
+            BitVec DescendantDefs;
+            bool DefsInitialized;
+            SafePointLocation SafePoint;
+        };
+
+        static const unsigned DEF_STATUS_UNINIT = ValueNumStore::NoVN;
+
         static const unsigned GC_EXPOSED_NO = 0;
         static const unsigned GC_EXPOSED_SPILL = 1;
         static const unsigned GC_EXPOSED_YES = 2;
-        static const unsigned GC_EXPOSED_UNKNOWN = ValueNumStore::NoVN;
+        static const unsigned GC_EXPOSED_BIT_COUNT = 2;
+        static const unsigned GC_EXPOSED_MASK = (1 << GC_EXPOSED_BIT_COUNT) - 1;
+        static const unsigned GC_EXPOSED_UNKNOWN = DEF_STATUS_UNINIT & GC_EXPOSED_MASK;
+
+        static const unsigned EXPLICIT_INIT_INDEX_SHIFT = GC_EXPOSED_BIT_COUNT;
+        static const unsigned EXPLICIT_INIT_INDEX_MASK = ~0u << EXPLICIT_INIT_INDEX_SHIFT;
+        static const unsigned EXPLICIT_INIT_INDEX_INVALID = DEF_STATUS_UNINIT >> EXPLICIT_INIT_INDEX_SHIFT;
+
+        static_assert_no_msg(
+            GC_EXPOSED_NO != GC_EXPOSED_UNKNOWN &&
+            GC_EXPOSED_SPILL != GC_EXPOSED_UNKNOWN &&
+            GC_EXPOSED_YES != GC_EXPOSED_UNKNOWN);
+
         static const unsigned LAST_ACTIVE_USE_IS_LAST_USE_BIT = 1 << 31;
 
         Llvm* m_llvm;
@@ -274,6 +318,12 @@ private:
         bool m_anyCandidates;
         SsaRenameState m_activeDefs;
         VARSET_TP m_liveDefs;
+
+        // The zeroing optimization tracking data structures.
+        int m_domWalkDepth = 0;
+        ArrayStack<BlockShadowSlotsState> m_shadowSlotsStates;
+        BitVecTraits m_candidateBitSetTraits;
+        ArrayStack<BitVec> m_candidateBitSetPool;
 
 #ifdef DEBUG
         JitHashTable<LclSsaVarDsc*, JitPtrKeyFuncs<LclSsaVarDsc>, const char*> m_gcExposedStatusReasonMap;
@@ -291,6 +341,9 @@ private:
             , m_anyCandidates(lssa->m_largestCandidateVarIndexPlusOne != 0)
             , m_activeDefs(m_compiler->getAllocator(CMK_LSRA), lssa->m_largestCandidateVarIndexPlusOne)
             , m_liveDefs(VarSetOps::MakeEmpty(m_compiler))
+            , m_shadowSlotsStates(m_compiler->getAllocator(CMK_LSRA))
+            , m_candidateBitSetTraits(lssa->m_largestCandidateVarIndexPlusOne, m_compiler)
+            , m_candidateBitSetPool(m_compiler->getAllocator(CMK_LSRA))
 #ifdef DEBUG
             , m_gcExposedStatusReasonMap(m_compiler->getAllocator(CMK_DebugOnly))
 #endif // DEBUG
@@ -299,11 +352,13 @@ private:
 
         void PreOrderVisit(BasicBlock* block)
         {
+            PushShadowSlotsStateForBlock();
             ProcessBlock(block);
         }
 
         void PostOrderVisit(BasicBlock* block)
         {
+            PopShadowSlotsStateForBlock(block);
             m_activeDefs.PopBlockStacks(block);
         }
 
@@ -311,6 +366,8 @@ private:
         {
             if (m_anyCandidates)
             {
+                JITDUMPEXEC(PrintDomTree());
+
                 // Push the live-in definitions on the stack.
                 unsigned lclVarIndex;
                 BasicBlock* initBlock = m_compiler->fgFirstBB;
@@ -325,10 +382,13 @@ private:
                     }
                 }
 
+                InitializeShadowSlotsStates();
+
                 // When optimizing, we need to keep track of the most recent SSA defininions for locals,
                 // and so process blocks in dominator pre-order.
                 WalkTree(m_compiler->m_domTree);
 
+                FinalizeShadowSlotsStates();
                 INDEBUG(VerifyActiveUseCounts());
             }
             else
@@ -343,8 +403,9 @@ private:
     private:
         void ProcessBlock(BasicBlock* block)
         {
+            JITDUMP("\n ==== ");
+            JITDUMPEXEC(block->dspBlockHeader(m_compiler, /* showKind */ true, /* showFlags */ true));
             assert(m_liveSdsuGcDefs.Count() == 0);
-            LIR::Range& blockRange = LIR::AsRange(block);
 
             if (m_anyCandidates)
             {
@@ -352,11 +413,12 @@ private:
                 JITDUMPEXEC(PrintCurrentLiveCandidates());
             }
 
+            LIR::Range& blockRange = LIR::AsRange(block);
             for (GenTree* node = blockRange.FirstNode(); node != nullptr; node = node->gtNext)
             {
                 if (node->isContained())
                 {
-                    assert(!m_llvm->isPotentialGcSafePoint(node));
+                    assert(!m_llvm->isPotentialGcSafePoint(node) && !m_llvm->mayPhysicallyThrow(node));
                     continue;
                 }
 
@@ -385,7 +447,8 @@ private:
                     user = m_containedOperands.Pop();
                 }
 
-                // Find out if we need to spill anything.
+                UpdateShadowSlotsStateForSafepoint(block, node);
+
                 if (m_llvm->isPotentialGcSafePoint(node))
                 {
                     ProcessSafePoint(block, node);
@@ -570,25 +633,11 @@ private:
         {
             LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
             LclSsaVarDsc* ssaDsc = varDsc->GetPerSsaData(ssaNum);
-            GenTreeLclVarCommon* defNode = ssaDsc->GetDefNode();
 
             INDEBUG(const char* reason);
             if (!IsGcExposedLocalValue(varDsc, ssaNum, DefStatus::Active DEBUGARG(&reason)))
             {
                 JITDUMP("V%02u/%d %s, but did not insert a spill: %s\n", lclNum, ssaNum, spillReason, reason);
-                return;
-            }
-
-            if (defNode == nullptr)
-            {
-                // The implicit definitions is always "spilled", see "AllocateAndInitializeLocals". We could be more
-                // precise by:
-                // 1. Only spilling the implicit definition when it is explicitly live (same as for other definitions).
-                // 2. At each safe point, mark all candidates that do not have a dominating spill as "implicitly live",
-                //    so that they are zero-initialized in the prolog.
-                // TODO-LLVM-LSSA-CQ: implement the above optimization.
-                JITDUMP("V%02u/%d (implicit def) %s, anticipating initialization in prolog\n", lclNum, ssaNum);
-                MarkLocalSpilled(varDsc, ssaDsc);
                 return;
             }
 
@@ -599,8 +648,16 @@ private:
             value->SetRegNum(REG_LLVM);
             GenTree* store = m_compiler->gtNewStoreLclVarNode(lclNum, value);
 
-            LIR::Range& defBlockRange = LIR::AsRange(ssaDsc->GetBlock());
-            if (defNode->IsPhiDefn())
+            BasicBlock* block = GetDefBlock(ssaDsc);
+            LIR::Range& defBlockRange = LIR::AsRange(block);
+            GenTreeLclVarCommon* defNode = ssaDsc->GetDefNode();
+            if (defNode == nullptr)
+            {
+                VarSetOps::AddElemD(m_compiler, block->bbLiveIn, varDsc->lvVarIndex);
+                defBlockRange.InsertAfter(m_lssa->m_lastPrologNode, value, store);
+                m_lssa->m_lastPrologNode = store;
+            }
+            else if (defNode->IsPhiDefn())
             {
                 defBlockRange.InsertBefore(
                     defBlockRange.FirstNonPhiOrCatchArgNode(), value, store);
@@ -610,9 +667,12 @@ private:
                 defBlockRange.InsertAfter(defNode, value, store);
             }
 
-            JITDUMP("V%02u/%d %s, inserted a spill:\n", lclNum, ssaNum, spillReason);
+            JITDUMP("V%02u/%d %s, inserted a spill in " FMT_BB ":\n", lclNum, ssaNum, spillReason, block->bbNum);
             DISPTREERANGE(defBlockRange, store);
-            MarkLocalSpilled(varDsc, ssaDsc);
+
+            varDsc->SetRegNum(REG_STK_CANDIDATE_COMMITED);
+            SetGcExposedStatus(ssaDsc, GC_EXPOSED_SPILL DEBUGARG("already spilled"));
+            UpdateShadowSlotsStateForSpilledDef(varDsc, ssaDsc);
         }
 
         bool IsGcExposedValue(GenTree* node, DefStatus defStatus)
@@ -678,20 +738,30 @@ private:
             unsigned status = GetGcExposedStatus(ssaDsc DEBUGARG(pReason));
             if (status == GC_EXPOSED_UNKNOWN)
             {
+                bool isExposed = true;
                 INDEBUG(const char* reason = nullptr);
                 GenTreeLclVarCommon* defNode = ssaDsc->GetDefNode();
-                if ((defNode != nullptr) && defNode->OperIs(GT_STORE_LCL_VAR) &&
-                    !IsGcExposedValue(defNode->Data(), DefStatus::Unknown))
+                if (defNode == nullptr)
+                {
+                    assert(ssaNum == SsaConfig::FIRST_SSA_NUM);
+
+                    // For a non-parameter, all GC pointers of the implicit on-entry def must be zeroed.
+                    ValueInitKind initKind = m_llvm->getInitKindForLocal(m_compiler->lvaGetLclNum(varDsc));
+                    assert(initKind != ValueInitKind::None);
+                    if (initKind != ValueInitKind::Param)
+                    {
+                        INDEBUG(reason = "value is zero at implicit def");
+                        isExposed = false;
+                    }
+                }
+                else if (defNode->OperIs(GT_STORE_LCL_VAR) && !IsGcExposedValue(defNode->Data(), DefStatus::Unknown))
                 {
                     INDEBUG(reason = "value not exposed");
-                    status = GC_EXPOSED_NO;
-                }
-                else
-                {
-                    status = GC_EXPOSED_YES;
+                    isExposed = false;
                 }
 
                 // This caching is designed to prevent quadratic behavior.
+                status = isExposed ? GC_EXPOSED_YES : GC_EXPOSED_NO;
                 SetGcExposedStatus(ssaDsc, status DEBUGARG(reason));
                 DBEXEC(pReason != nullptr, *pReason = reason);
             }
@@ -711,41 +781,13 @@ private:
             // shadow stack slots to distinct SSA definitions of the same local.
             //
             else if ((status == GC_EXPOSED_SPILL) && (defStatus == DefStatus::Unknown) &&
-                     (m_activeDefs.Top(varDsc->lvVarIndex) != ssaNum))
+                (m_activeDefs.Top(varDsc->lvVarIndex) != ssaNum))
             {
                 status = GC_EXPOSED_YES;
             }
 
             assert(status != GC_EXPOSED_UNKNOWN);
             return status == GC_EXPOSED_YES;
-        }
-
-        void SetGcExposedStatus(LclSsaVarDsc* ssaDsc, unsigned status DEBUGARG(const char* reason))
-        {
-            unsigned* pStatus = GetRawGcExposedStatusRef(ssaDsc);
-            assert((*pStatus == GC_EXPOSED_UNKNOWN) || ((*pStatus == GC_EXPOSED_YES) && (status == GC_EXPOSED_SPILL)));
-            assert(status != GC_EXPOSED_UNKNOWN);
-
-            DBEXEC(reason != nullptr, m_gcExposedStatusReasonMap.Set(ssaDsc, reason));
-            *pStatus = status;
-        }
-
-        unsigned GetGcExposedStatus(LclSsaVarDsc* ssaDsc DEBUGARG(const char** pReason))
-        {
-            INDEBUG(m_gcExposedStatusReasonMap.Lookup(ssaDsc, pReason));
-            return *GetRawGcExposedStatusRef(ssaDsc);
-        }
-
-        unsigned* GetRawGcExposedStatusRef(LclSsaVarDsc* ssaDsc)
-        {
-            // We do a little hack here to avoid modifying "LclSsaVarDsc". VNs are not used at this point.
-            return ssaDsc->m_vnPair.GetLiberalAddr();
-        }
-
-        void MarkLocalSpilled(LclVarDsc* varDsc, LclSsaVarDsc* ssaDsc)
-        {
-            varDsc->SetRegNum(REG_STK_CANDIDATE_COMMITED);
-            SetGcExposedStatus(ssaDsc, GC_EXPOSED_SPILL DEBUGARG("already spilled"));
         }
 
         void ProcessDef(BasicBlock* block, GenTree* node)
@@ -759,6 +801,9 @@ private:
             LclVarDsc* varDsc;
             if (IsCandidateLocalNode(node, &varDsc))
             {
+                JITDUMP(" -- Processing a candidate:\n");
+                DISPNODE(node);
+
                 // We depend here on the conservativeness of GC in not reloading after a safepoint.
                 assert(m_lssa->IsGcConservative());
                 node->SetRegNum(REG_LLVM);
@@ -769,6 +814,7 @@ private:
                 {
                     PushActiveLocalDef(block, varDsc, ssaNum);
                     UpdateLiveLocalDefs(varDsc, node->AsLclVarCommon()->HasLastUse(), /* isBorn */ true);
+                    UpdateShadowSlotsStateForDef(node->AsLclVarCommon());
                 }
                 // Increment the "active" use count used for accurate last use detection. Note that skipping
                 // unused locals here means that we could technically extend their live ranges unnecessarily
@@ -780,7 +826,7 @@ private:
                 }
             }
             else if (node->IsValue() && !node->IsUnusedValue() && IsGcExposedType(node) &&
-                     IsGcExposedSdsuValue(node, DefStatus::Active))
+                IsGcExposedSdsuValue(node, DefStatus::Active))
             {
                 node->gtLIRFlags |= LIR::Flags::Mark;
                 m_liveSdsuGcDefs.AddOrUpdate(node, BAD_VAR_NUM);
@@ -832,6 +878,274 @@ private:
             JITDUMPEXEC(PrintCurrentLiveCandidates());
         }
 
+        void InitializeShadowSlotsStates()
+        {
+            // Add a virtual "first block" to simplify the logic below.
+            m_domWalkDepth++;
+            m_shadowSlotsStates.Push({});
+        }
+
+        void FinalizeShadowSlotsStates()
+        {
+            assert(m_domWalkDepth == 1);
+            assert(m_shadowSlotsStates.Height() == 1);
+
+            BitVec initDefs;
+            BlockShadowSlotsState* state = &m_shadowSlotsStates.TopRef();
+            if (state->SafePoint == SafePointLocation::None)
+            {
+                initDefs = BitVecOps::MakeFull(&m_candidateBitSetTraits);
+                JITDUMP("\nExplicit init shadow slots: { all; no safepoints }\n");
+            }
+            else
+            {
+                assert(state->SafePoint == SafePointLocation::Descendant);
+                initDefs = state->DescendantDefs;
+                JITDUMP("\nExplicit init shadow slots: ");
+                JITDUMPEXEC(PrintCandidateBitSet(initDefs));
+                JITDUMP("\n");
+            }
+
+            m_lssa->m_candidateBitSetTraits = m_candidateBitSetTraits;
+            m_lssa->m_explicitInitShadowSlots = initDefs;
+        }
+
+        void PushShadowSlotsStateForBlock()
+        {
+            m_domWalkDepth++;
+
+            // If we already know there is a dominating safe point, the set of "stack slot stores dominating all safe
+            // points" will by definition be empty for this block and its successors. We do not (need to) track it.
+            if (m_shadowSlotsStates.TopRef().SafePoint != SafePointLocation::ThisBlock)
+            {
+                m_shadowSlotsStates.Push({});
+            }
+        }
+
+        void UpdateShadowSlotsStateForSafepoint(BasicBlock* block, GenTree* node)
+        {
+            if (!m_anyCandidates)
+            {
+                return;
+            }
+
+            BlockShadowSlotsState* state = &m_shadowSlotsStates.TopRef();
+            if (state->SafePoint != SafePointLocation::ThisBlock)
+            {
+                assert(m_domWalkDepth == m_shadowSlotsStates.Height());
+                assert(state->SafePoint == SafePointLocation::None);
+
+                // We need to include may-throw nodes here in addition to regular safepoints since
+                // at the point of the throw, the shadow frame of this function will still be live,
+                // and throwing by itself will of course call managed code.
+                bool canShadowTailCall = false;
+                if (m_llvm->isPotentialGcSafePoint(node))
+                {
+                    canShadowTailCall = node->IsCall() && m_lssa->CanShadowTailCall(block, node->AsCall());
+                }
+                else if (m_llvm->mayPhysicallyThrow(node))
+                {
+                    canShadowTailCall = m_lssa->CanShadowTailCallInBlock(block);
+                }
+                else
+                {
+                    return;
+                }
+                if (canShadowTailCall)
+                {
+                    m_llvm->ImposeOptimizationRequirement(node, NOR_SHADOW_TAILCALL);
+                    return;
+                }
+
+                JITDUMP("BlockShadowSlotsState[" FMT_BB "]::SafePoint: None -> ThisBlock due to [%06u]\n",
+                    block->bbNum, Compiler::dspTreeID(node));
+                state->SafePoint = SafePointLocation::ThisBlock;
+            }
+        }
+
+        void UpdateShadowSlotsStateForDef(GenTreeLclVarCommon* lclNode)
+        {
+            assert(lclNode->OperIsLocalStore() && IsCandidateLocalNode(lclNode));
+            BlockShadowSlotsState* state = &m_shadowSlotsStates.TopRef();
+            if (state->SafePoint == SafePointLocation::None) // Only dominating defs are tracked.
+            {
+                assert(m_domWalkDepth == m_shadowSlotsStates.Height());
+                if (lclNode->IsPartialLclFld(m_compiler))
+                {
+                    return; // We don't do partial initialization tracking, though in theory we could.
+                }
+
+                LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNode);
+                LclSsaVarDsc* ssaDsc = varDsc->GetPerSsaData(lclNode->GetSsaNum());
+                unsigned blockIndex = m_shadowSlotsStates.Height() - 1;
+                SetShadowSlotExplicitInitBlockIndex(ssaDsc, blockIndex);
+            }
+            else
+            {
+                assert(state->SafePoint == SafePointLocation::ThisBlock);
+            }
+        }
+
+        void UpdateShadowSlotsStateForSpilledDef(LclVarDsc* varDsc, LclSsaVarDsc* ssaDsc)
+        {
+            unsigned blockIndex = GetShadowSlotExplicitInitBlockIndex(ssaDsc);
+            if (blockIndex == EXPLICIT_INIT_INDEX_INVALID)
+            {
+                return; // This def does not dominate the safepoints of its block.
+            }
+            BlockShadowSlotsState* state = &m_shadowSlotsStates.BottomRef(blockIndex);
+            if (!state->DefsInitialized)
+            {
+                state->Defs = AcquireCandidateBitSet();
+                state->DefsInitialized = true;
+            }
+
+            JITDUMP("BlockShadowSlotsState[" FMT_BB "]::Defs: adding V%02u\n", GetDefBlock(ssaDsc)->bbNum,
+                m_compiler->lvaGetLclNum(varDsc));
+            BitVecOps::AddElemD(&m_candidateBitSetTraits, state->Defs, varDsc->lvVarIndex);
+        }
+
+        void PopShadowSlotsStateForBlock(BasicBlock* block)
+        {
+            JITDUMP(" PopShadowSlotsStateForBlock[" FMT_BB "] => ", block->bbNum);
+
+            int domWalkDepth = m_domWalkDepth--;
+            if (domWalkDepth > m_shadowSlotsStates.Height())
+            {
+                JITDUMP("skipped\n");
+                return; // Skipping this part of the graph.
+            }
+
+            assert(domWalkDepth == m_shadowSlotsStates.Height());
+            BlockShadowSlotsState current = m_shadowSlotsStates.Pop();
+            BlockShadowSlotsState* parent = &m_shadowSlotsStates.TopRef();
+            JITDUMP("[" FMT_BB "]::", block->bbIDom != nullptr ? block->bbIDom->bbNum : 0);
+            JITDUMPEXEC(PrintCandidateBitSet(parent->DescendantDefs, parent->SafePoint == SafePointLocation::None));
+            JITDUMP(" &= ");
+
+            if (current.SafePoint != SafePointLocation::None)
+            {
+                // Compute the current block's def set.
+                BitVec defsSet;
+                bool isEmptySet = false;
+                if (current.SafePoint == SafePointLocation::ThisBlock)
+                {
+                    defsSet = current.Defs;
+                    isEmptySet = !current.DefsInitialized;
+                }
+                else
+                {
+                    assert(current.SafePoint == SafePointLocation::Descendant);
+                    defsSet = current.DescendantDefs;
+                    if (current.DefsInitialized)
+                    {
+                        BitVecOps::UnionD(&m_candidateBitSetTraits, defsSet, current.Defs);
+                        ReleaseCandidateBitSet(current.Defs);
+                    }
+                }
+
+                JITDUMPEXEC(PrintCandidateBitSet(defsSet, /* isFull */ false, isEmptySet));
+
+                // Now intersect the current set with the parent's descendant set.
+                assert(parent->SafePoint != SafePointLocation::ThisBlock);
+                if (parent->SafePoint == SafePointLocation::None)
+                {
+                    parent->SafePoint = SafePointLocation::Descendant;
+                    parent->DescendantDefs = isEmptySet ? AcquireCandidateBitSet() : defsSet;
+                }
+                else if (isEmptySet)
+                {
+                    BitVecOps::ClearD(&m_candidateBitSetTraits, parent->DescendantDefs);
+                }
+                else
+                {
+                    BitVecOps::IntersectionD(&m_candidateBitSetTraits, parent->DescendantDefs, defsSet);
+                    ReleaseCandidateBitSet(defsSet);
+                }
+            }
+            else
+            {
+                // No safe points - equivalent to a full set of defs.
+                assert(current.SafePoint == SafePointLocation::None);
+                if (current.DefsInitialized)
+                {
+                    ReleaseCandidateBitSet(current.Defs);
+                }
+
+                JITDUMP("{ all; no safepoints }");
+            }
+
+            JITDUMP(" => ");
+            JITDUMPEXEC(PrintCandidateBitSet(parent->DescendantDefs, parent->SafePoint == SafePointLocation::None));
+            JITDUMP("\n");
+        }
+
+        BitVec AcquireCandidateBitSet()
+        {
+            BitVec set;
+            if (!m_candidateBitSetPool.Empty())
+            {
+                set = m_candidateBitSetPool.Pop();
+                BitVecOps::ClearD(&m_candidateBitSetTraits, set);
+            }
+            else
+            {
+                set = BitVecOps::MakeEmpty(&m_candidateBitSetTraits);
+            }
+            return set;
+        }
+
+        void ReleaseCandidateBitSet(BitVec bitSet)
+        {
+            m_candidateBitSetPool.Push(bitSet);
+        }
+
+        void SetGcExposedStatus(LclSsaVarDsc* ssaDsc, unsigned status DEBUGARG(const char* reason))
+        {
+            unsigned oldStatus = GetGcExposedStatus(ssaDsc);
+            assert((oldStatus == GC_EXPOSED_UNKNOWN) || ((oldStatus == GC_EXPOSED_YES) && (status == GC_EXPOSED_SPILL)));
+            assert(status != GC_EXPOSED_UNKNOWN);
+
+            unsigned* pStatus = GetRawDefStatusRef(ssaDsc);
+            DBEXEC(reason != nullptr, m_gcExposedStatusReasonMap.Set(ssaDsc, reason));
+            *pStatus = (*pStatus & ~GC_EXPOSED_MASK) | status;
+        }
+
+        unsigned GetGcExposedStatus(LclSsaVarDsc* ssaDsc DEBUGARG(const char** pReason = nullptr))
+        {
+            INDEBUG(m_gcExposedStatusReasonMap.Lookup(ssaDsc, pReason));
+            return *GetRawDefStatusRef(ssaDsc) & GC_EXPOSED_MASK;
+        }
+
+        void SetShadowSlotExplicitInitBlockIndex(LclSsaVarDsc* ssaDsc, unsigned index)
+        {
+            unsigned indexEncoded = index << EXPLICIT_INIT_INDEX_SHIFT;
+            if ((index == EXPLICIT_INIT_INDEX_INVALID) || ((indexEncoded >> EXPLICIT_INIT_INDEX_SHIFT) != index))
+            {
+                IMPL_LIMITATION("Too many blocks");
+            }
+
+            assert(GetShadowSlotExplicitInitBlockIndex(ssaDsc) != index);
+            unsigned* pDefStatus = GetRawDefStatusRef(ssaDsc);
+            *pDefStatus = (*pDefStatus & ~EXPLICIT_INIT_INDEX_MASK) | indexEncoded;
+        }
+
+        unsigned GetShadowSlotExplicitInitBlockIndex(LclSsaVarDsc* ssaDsc)
+        {
+            if (ssaDsc->GetDefNode() == nullptr)
+            {
+                // The implicit def by definition dominates all safepoints.
+                return 1;
+            }
+            return *GetRawDefStatusRef(ssaDsc) >> EXPLICIT_INIT_INDEX_SHIFT;
+        }
+
+        unsigned* GetRawDefStatusRef(LclSsaVarDsc* ssaDsc)
+        {
+            // We do a little hack here to avoid modifying "LclSsaVarDsc". VNs are not used at this point.
+            return ssaDsc->m_vnPair.GetLiberalAddr();
+        }
+
         void SetLastActiveUseIsLastUse(LclSsaVarDsc* ssaDsc)
         {
             assert(!IsLastActiveUseLastUse(ssaDsc));
@@ -876,7 +1190,7 @@ private:
         bool IsCandidateLocal(LclVarDsc* varDsc)
         {
             return (varDsc->GetRegNum() == REG_STK_CANDIDATE_TENTATIVE) ||
-                   (varDsc->GetRegNum() == REG_STK_CANDIDATE_COMMITED);
+                (varDsc->GetRegNum() == REG_STK_CANDIDATE_COMMITED);
         }
 
         bool IsCandidateLocalNode(GenTree* node, LclVarDsc** pVarDsc = nullptr)
@@ -895,6 +1209,17 @@ private:
             }
 
             return false;
+        }
+
+        BasicBlock* GetDefBlock(LclSsaVarDsc* ssaDsc)
+        {
+            BasicBlock* block = ssaDsc->GetBlock();
+            if (block == nullptr)
+            {
+                assert(ssaDsc->GetDefNode() == nullptr);
+                block = m_compiler->fgFirstBB;
+            }
+            return block;
         }
 
 #ifdef DEBUG
@@ -920,6 +1245,60 @@ private:
             }
         }
 
+        void PrintDomTree()
+        {
+            static const int STEP = 2;
+
+            class DomTreePrinter final : public DomTreeVisitor<DomTreePrinter>
+            {
+            public:
+                int Depth = 0;
+
+                DomTreePrinter(Compiler* compiler) : DomTreeVisitor<DomTreePrinter>(compiler)
+                {
+                }
+
+                void PreOrderVisit(BasicBlock* block)
+                {
+                    for (size_t i = 0; i < Depth; i++)
+                    {
+                        printf(" ");
+                    }
+                    printf(FMT_BB "\n", block->bbNum);
+                    Depth += STEP;
+                }
+
+                void PostOrderVisit(BasicBlock* block)
+                {
+                    Depth -= STEP;
+                }
+            };
+
+            printf("Doms:\n");
+            DomTreePrinter visitor(m_compiler);
+            visitor.Depth = 1;
+            visitor.WalkTree(m_compiler->m_domTree);
+        }
+
+        void PrintCandidateBitSet(BitVec bitSet, bool isFull = false, bool isEmpty = false)
+        {
+            printf("{ ");
+            if (isFull)
+            {
+                printf("all ");
+            }
+            else if (!isEmpty)
+            {
+                unsigned lclVarIndex;
+                BitVecOps::Iter iter(&m_candidateBitSetTraits, bitSet);
+                while (iter.NextElem(&lclVarIndex))
+                {
+                    printf("V%02u ", m_compiler->lvaTrackedIndexToLclNum(lclVarIndex));
+                }
+            }
+            printf("}");
+        }
+
         void PrintCurrentLiveCandidates()
         {
             if (!m_anyCandidates)
@@ -927,7 +1306,7 @@ private:
                 return;
             }
 
-            printf("Liveness: { ");
+            // printf("Liveness: { ");
             unsigned lclVarIndex;
             VarSetOps::Iter iter(m_compiler, m_liveDefs);
             while (iter.NextElem(&lclVarIndex))
@@ -937,10 +1316,10 @@ private:
                 if (IsCandidateLocal(varDsc))
                 {
                     // TOOD-LLVM Reinstate when https://github.com/dotnet/runtimelab/issues/3053 is addressed.
-//                    printf("V%02u/%d ", lclNum, m_activeDefs.Top(lclVarIndex));
+                    // printf("V%02u/%d ", lclNum, m_activeDefs.Top(lclVarIndex));
                 }
             }
-            printf("}\n");
+            // printf("}\n");
         }
 #endif // DEBUG
     };
@@ -964,17 +1343,27 @@ private:
             if ((varDsc->GetRegNum() == REG_STK_CANDIDATE_COMMITED) ||
                 (varDsc->GetRegNum() == REG_STK_CANDIDATE_UNCONDITIONAL))
             {
-                ValueInitKind initValueKind = m_llvm->getInitKindForLocal(lclNum, ValueInitOpts::IncludeImplicitGcUse);
+                // We model candidates like "any other [non-GC] local" that just happened to need to be stored
+                // to the shadow stock. Therefore, we don't need to "initialize" them here (it'll happen in
+                // codegen). What we do here for them is initialize the shadow stack slot itself. For locals
+                // that are unconditionally rewritten to be shadow stack references however, they need to be
+                // initialized properly (e. g. if they're parameters).
+                ValueInitKind initValueKind;
+                if (varDsc->GetRegNum() == REG_STK_CANDIDATE_COMMITED)
+                {
+                    initValueKind =
+                        BitVecOps::IsMember(&m_candidateBitSetTraits, m_explicitInitShadowSlots, varDsc->lvVarIndex)
+                        ? ValueInitKind::None
+                        : ValueInitKind::Zero;
+                }
+                else
+                {
+                    initValueKind = m_llvm->getInitKindForLocal(lclNum, ValueInitOpts::IncludeImplicitGcUse);
+                }
                 if (initValueKind == ValueInitKind::Param)
                 {
-                    GenTreeLclVar* initValue = m_compiler->gtNewLclvNode(lclNum, varDsc->TypeGet());
+                    GenTreeLclVar* initValue = m_compiler->gtNewLclVarNode(lclNum);
                     initValue->SetRegNum(REG_LLVM);
-                    if (m_compiler->lvaInSsa(lclNum))
-                    {
-                        // Fortunately for the implicit GC def logic, SSA always adds an implicit def for parameters.
-                        assert(varDsc->GetPerSsaData(SsaConfig::FIRST_SSA_NUM)->GetDefNode() == nullptr);
-                        initValue->SetSsaNum(SsaConfig::FIRST_SSA_NUM);
-                    }
                     if (varDsc->lvTracked)
                     {
                         VarSetOps::AddElemD(m_compiler, m_compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex);
@@ -1007,8 +1396,6 @@ private:
         // defs will increment the count back if there are any non-shadow references.
         varDsc->lvImplicitlyReferenced = 0;
         varDsc->setLvRefCnt(0);
-
-        m_llvm->m_anyAddressExposedOrPinnedShadowLocals |= (varDsc->IsAddressExposed() || varDsc->lvPinned);
     }
 
     void AssignShadowFrameOffsets(jitstd::vector<unsigned>& shadowFrameLocals)
@@ -1016,12 +1403,12 @@ private:
         if (m_compiler->opts.OptimizationEnabled())
         {
             jitstd::sort(shadowFrameLocals.begin(), shadowFrameLocals.end(),
-                         [compiler = m_compiler](unsigned lhsLclNum, unsigned rhsLclNum)
-            {
-                LclVarDsc* lhsVarDsc = compiler->lvaGetDesc(lhsLclNum);
-                LclVarDsc* rhsVarDsc = compiler->lvaGetDesc(rhsLclNum);
-                return lhsVarDsc->lvRefCntWtd() > rhsVarDsc->lvRefCntWtd();
-            });
+                [compiler = m_compiler](unsigned lhsLclNum, unsigned rhsLclNum)
+                {
+                    LclVarDsc* lhsVarDsc = compiler->lvaGetDesc(lhsLclNum);
+                    LclVarDsc* rhsVarDsc = compiler->lvaGetDesc(rhsLclNum);
+                    return lhsVarDsc->lvRefCntWtd() > rhsVarDsc->lvRefCntWtd();
+                });
         }
 
         unsigned offset = 0;
@@ -1039,7 +1426,7 @@ private:
             varDsc->SetStackOffset(offset);
             offset += m_compiler->lvaLclSize(m_compiler->lvaGetLclNum(varDsc));
             varDsc->SetRegNum(REG_STK);
-        };
+            };
 
         unsigned preciseVirtualUnwindFrameLclNum = m_llvm->m_preciseVirtualUnwindFrameLclNum;
         if (preciseVirtualUnwindFrameLclNum != BAD_VAR_NUM)
@@ -1108,8 +1495,8 @@ private:
 
     void FinalizeProlog()
     {
-        LIR::Range range;
-        m_llvm->m_currentRange = &range;
+        LIR::Range initRange;
+        m_llvm->m_currentRange = &initRange;
         m_llvm->initializePreciseVirtualUnwindFrame();
 
         unsigned zeroingSize = m_prologZeroingSize;
@@ -1120,20 +1507,24 @@ private:
             GenTree* zero = m_compiler->gtNewIconNode(0);
             ClassLayout* layout = m_compiler->typGetBlkLayout(zeroingSize);
             GenTree* store = m_compiler->gtNewStoreBlkNode(layout, addr, zero, GTF_IND_NONFAULTING);
-            range.InsertAfter(addr, zero, store);
+            initRange.InsertAfter(addr, zero, store);
 
             JITDUMP("Added zero-initialization for shadow locals at: [%i, %i]:\n", offset, offset + zeroingSize);
-            DISPTREERANGE(range, store);
+            DISPTREERANGE(initRange, store);
             RecordAllocationActionZeroInit(m_compiler->fgFirstBB, offset, zeroingSize);
+        }
+
+        GenTree* lastInitNode = m_llvm->lowerAndInsertIntoFirstBlock(initRange); // Insert at the start.
+        if (m_lastPrologNode == nullptr)
+        {
+            m_lastPrologNode = lastInitNode;
         }
 
         // Insert a zero-offset ILOffset to notify codegen this is the start of user code.
         DebugInfo zeroILOffsetDi =
             DebugInfo(m_compiler->compInlineContext, ILLocation(0, /* isStackEmpty */ true, /* isCall */ false));
         GenTree* zeroILOffsetNode = new (m_compiler, GT_IL_OFFSET) GenTreeILOffset(zeroILOffsetDi);
-        range.InsertAtEnd(zeroILOffsetNode);
-
-        m_llvm->lowerAndInsertIntoFirstBlock(range, m_lastPrologNode);
+        LIR::AsRange(m_compiler->fgFirstBB).InsertAfter(m_lastPrologNode, zeroILOffsetNode);
     }
 
     GenTreeLclVar* InitializeLocalInProlog(unsigned lclNum, GenTree* value)
@@ -1146,12 +1537,9 @@ private:
         LIR::Range range;
         range.InsertAtEnd(value);
         range.InsertAtEnd(store);
-        m_llvm->lowerRange(m_compiler->fgFirstBB, range);
-        DISPTREERANGE(range, store);
+        m_lastPrologNode = m_llvm->lowerAndInsertIntoFirstBlock(range, m_lastPrologNode);
 
-        LIR::AsRange(m_compiler->fgFirstBB).InsertAfter(m_lastPrologNode, std::move(range));
-        m_lastPrologNode = store;
-
+        DISPTREERANGE(LIR::AsRange(m_compiler->fgFirstBB), store);
         return store;
     }
 
@@ -1285,9 +1673,11 @@ private:
         if (m_llvm->callHasManagedCallingConvention(call))
         {
             INDEBUG(const char* reasonWhyNot = nullptr);
-            bool isTailCall = CanShadowTailCall(call DEBUGARG(&reasonWhyNot));
+            BasicBlock* block = m_llvm->CurrentBlock();
+            bool isTailCall = CanShadowTailCall(block, call DEBUGARG(&reasonWhyNot));
             if (isTailCall)
             {
+                m_llvm->SatisfyOptimizationRequirement(call, NOR_SHADOW_TAILCALL);
                 JITDUMP("Shadow tail-calling [%06u]\n", Compiler::dspTreeID(call));
             }
             else
@@ -1295,7 +1685,7 @@ private:
                 JITDUMP("Not shadow tail-calling [%06u]: %s\n", Compiler::dspTreeID(call), reasonWhyNot);
             }
 
-            unsigned funcIdx = m_llvm->getLlvmFunctionIndexForBlock(m_llvm->CurrentBlock());
+            unsigned funcIdx = m_llvm->getLlvmFunctionIndexForBlock(block);
             unsigned calleeShadowStackOffset = m_llvm->getCalleeShadowStackOffset(funcIdx, isTailCall);
             GenTree* calleeShadowStack =
                 m_llvm->insertShadowStackAddr(call, calleeShadowStackOffset, m_llvm->_shadowStackLclNum);
@@ -1313,11 +1703,9 @@ private:
         }
     }
 
-    bool CanShadowTailCall(GenTreeCall* call DEBUGARG(const char** pReasonWhyNot))
+    bool CanShadowTailCall(BasicBlock* block, GenTreeCall* call DEBUGARG(const char** pReasonWhyNot = nullptr))
     {
-        BasicBlock* block = m_llvm->CurrentBlock();
-        if (!m_llvm->canEmitCallAsShadowTailCall(
-            block->hasTryIndex(), m_llvm->isBlockInFilter(block) DEBUGARG(pReasonWhyNot)))
+        if (!CanShadowTailCallInBlock(block DEBUGARG(pReasonWhyNot)))
         {
             return false;
         }
@@ -1338,8 +1726,14 @@ private:
             return true;
         }
 
-        INDEBUG(*pReasonWhyNot = "not in a tail position");
+        DBEXEC(pReasonWhyNot != nullptr, *pReasonWhyNot = "not in a tail position");
         return false;
+    }
+
+    bool CanShadowTailCallInBlock(BasicBlock* block DEBUGARG(const char** pReasonWhyNot = nullptr))
+    {
+        return m_llvm->canEmitCallAsShadowTailCall(
+            block->hasTryIndex(), m_llvm->isBlockInFilter(block) DEBUGARG(pReasonWhyNot));
     }
 
     bool IsGcConservative() const
@@ -1696,7 +2090,7 @@ private:
                 case AllocationActionKind::ZeroInit:
                     PrintFormatted(pBuffer, format);
                     for (unsigned offset = action.ZeroInitOffset; offset < action.ZeroInitOffsetEnd;
-                         offset += TARGET_POINTER_SIZE)
+                        offset += TARGET_POINTER_SIZE)
                     {
                         unsigned slot;
                         if (m_slotMap.Lookup(offset, &slot))
@@ -1791,11 +2185,11 @@ private:
         }
     };
 #else // !FEATURE_LSSA_ALLOCATION_RESULT
-    void InitializeAllocationResult() { }
-    void ReportAllocationResult() { }
+    void InitializeAllocationResult() {}
+    void ReportAllocationResult() {}
     bool RecordAllocationResult() const { return false; }
-    void RecordAllocationActionZeroInit(BasicBlock* initialBlock, unsigned offset, unsigned size) { }
-    void RecordAllocationActionLoadStore(BasicBlock* block, unsigned offset, GenTreeLclVarCommon* lclNode) { }
+    void RecordAllocationActionZeroInit(BasicBlock* initialBlock, unsigned offset, unsigned size) {}
+    void RecordAllocationActionLoadStore(BasicBlock* block, unsigned offset, GenTreeLclVarCommon* lclNode) {}
 #endif // !FEATURE_LSSA_ALLOCATION_RESULT
 };
 
@@ -1956,7 +2350,7 @@ bool Llvm::canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter DEB
     // calls down the stack may modify (corrupt) shadow variables from their callers.
     if (_compiler->opts.compDbgCode)
     {
-        INDEBUG(*pReasonWhyNot = "debug code");
+        DBEXEC(pReasonWhyNot != nullptr, *pReasonWhyNot = "debug code");
         return false;
     }
 
@@ -1964,7 +2358,7 @@ bool Llvm::canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter DEB
     // Likewise with pinning.
     if (m_anyAddressExposedOrPinnedShadowLocals)
     {
-        INDEBUG(*pReasonWhyNot = "pinned or address-exposed shadow locals present");
+        DBEXEC(pReasonWhyNot != nullptr, *pReasonWhyNot = "pinned or address-exposed shadow locals present");
         return false;
     }
 
@@ -1977,7 +2371,7 @@ bool Llvm::canEmitCallAsShadowTailCall(bool callIsInTry, bool callIsInFilter DEB
     // Both protected regions and filters induce exceptional flow that may return back to this method.
     if (callIsInTry || callIsInFilter)
     {
-        INDEBUG(*pReasonWhyNot = "call is in a protected region or filter handler");
+        DBEXEC(pReasonWhyNot != nullptr, *pReasonWhyNot = "call is in a protected region or filter handler");
         return false;
     }
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/LSSATests.IL.il
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/LSSATests.IL.il
@@ -119,14 +119,14 @@
   .method private static void Optimized_ExposedLocal_Untracked(object* pObj) noinlining
   {
     .custom instance void System.Runtime.JitTesting.LSSATestAttribute::.ctor(string) =
-      {string('BB01:\n  STORE SS00 USR01 SDSU\n  LOAD SS00 USR01\n  STORE SS01 USR02 USR02/1\n  STORE SS00 USR01 SDSU')}
+      {string('BB01:\n  ZEROINIT SS01\n  STORE SS00 USR01 SDSU\n  LOAD SS00 USR01\n  STORE SS01 USR02 USR02/1\n  STORE SS00 USR01 SDSU')}
     .locals (object pinned pinnedObj, object objCopy)
 
     // Pinned locals will always be untracked, so they're convenient to use for
     // this kind of test.
     ldarg pObj
-    ldind.ref
-    stloc pinnedObj
+    ldind.ref       // Note how we need to zero-init SS01 since this might throw and we can't
+    stloc pinnedObj // tail-call the throw helper due to the presence of a pinned local.
     ldloc pinnedObj
     stloc objCopy
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/LSSATests.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/LSSATests.cs
@@ -11,6 +11,7 @@ public unsafe class LSSATests
     public static void Run()
     {
         int value = 10;
+        bool flag = true;
         object obj = NewObject();
 
 #if DEBUG
@@ -21,17 +22,27 @@ public unsafe class LSSATests
         Optimized_ParameterExposed(NewObject());
         Optimized_AddressExposedValuesAndEH();
         Optimized_LastUses_DisjointValuesNotExposed();
-        Optimized_LastUses_ForkedFlowNotExposed(flag: true);
-        Optimized_LastUses_ForkedFlowExposed(flag: true, NewObject());
+        Optimized_LastUses_ForkedFlowNotExposed(flag);
+        Optimized_LastUses_ForkedFlowExposed(flag, NewObject());
         Optimized_LastUses_UseLocation(NewObject());
         Optimized_LastUses_OutOfOrder(NewObject());
-        Optimized_LastUses_OutOfOrderMultiple(flag: true, NewObject());
+        Optimized_LastUses_OutOfOrderMultiple(flag, NewObject());
         Optimized_ExplicitInit_NotExposed(ref value, &obj);
+        Optimized_ExplicitInit_NotExposed_SingleDefSimpleFlow(flag, &obj, &obj);
+        Optimized_ExplicitInit_NotExposed_SingleDefComplexFlow(value, &obj, &obj);
+        Optimized_ExplicitInit_NotExposed_MultipleDefsSimpleFlow(flag, &obj, &obj);
+        Optimized_ExplicitInit_NotExposed_MultipleDefsComplexFlow(value, &obj, &obj, &obj);
+        Optimized_ExplicitInit_NotExposed_DefSafePointDef(flag, &obj, &obj);
+        Optimized_ExplicitInit_NotExposed_ShadowTailCall(flag, &obj);
         Optimized_ExplicitInit_Exposed();
-        Optimized_NonGcValues_SingleDef(flag: true);
+        Optimized_ExplicitInit_Exposed_DeadSlotBefore(flag, &obj);
+        Optimized_ExplicitInit_Exposed_DeadSlotAfter(value, &obj);
+        Optimized_ExplicitInit_Exposed_DefSafePointDef(1);
+        Optimized_ExplicitInit_Exposed_EHFlow(flag, &obj);
+        Optimized_NonGcValues_SingleDef(flag);
         Optimized_AlreadySpilled(NewObject());
         Optimized_AlreadySpilled_AddressExposed(NewObject());
-        Optimized_AlreadySpilled_DerivedAddress(flag: true, new ClassWithField(), new int[1]);
+        Optimized_AlreadySpilled_DerivedAddress(flag, new ClassWithField(), new int[1]);
 
         LSSATestsIL.Optimized_Run();
 #endif
@@ -203,6 +214,154 @@ public unsafe class LSSATests
         SafePoint(x, x);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("BB01: STORE SS00 USR03 USR03/4")]
+    private static unsafe object Optimized_ExplicitInit_NotExposed_SingleDefSimpleFlow(bool flag, object* pObjOne, object* pObjTwo)
+    {
+        // Test that this object does not get zero-init-ed. There are no safe points between its spill and the prolog.
+        object x;
+        ForceILLocal(&x);
+        if (flag)
+        {
+            x = *pObjOne;
+        }
+        else
+        {
+            x = *pObjTwo;
+        }
+        SafePoint(); // The spill occurs at the beginning of this block.
+        return x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("BB01: STORE SS00 USR03 USR03/4")]
+    private static unsafe object Optimized_ExplicitInit_NotExposed_SingleDefComplexFlow(int value, object* pObjOne, object* pObjTwo)
+    {
+        // Test that this object does not get zero-init-ed. There are no safe points between its spill and the prolog.
+        object x;
+        ForceILLocal(&x);
+        for (int i = 0; i < 10; i++)
+        {
+            if (value < 100)
+            {
+                value -= 10;
+            }
+            value *= 20;
+            if (value % 12 == 0)
+            {
+                goto EXIT;
+            }
+        }
+        if (value < 0)
+        {
+            x = *pObjOne;
+        }
+        else
+        {
+            x = *pObjTwo;
+        }
+    EXIT:
+        SafePoint(); // The spill occurs at the beginning of this block.
+        return x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("""
+     BB01:
+       STORE SS00 USR03 USR03/3
+     BB02:
+       STORE SS00 USR03 USR03/2
+     """)]
+    private static unsafe object Optimized_ExplicitInit_NotExposed_MultipleDefsSimpleFlow(bool flag, object* pObjOne, object* pObjTwo)
+    {
+        // Test that this object does not get zero-init-ed. There are no safe points between its spills and the prolog.
+        object x;
+        ForceILLocal(&x);
+        if (flag)
+        {
+            x = *pObjOne; // Spill one
+            SafePoint();
+        }
+        else
+        {
+            x = *pObjTwo; // Spill two
+            AnotherSafePoint();
+        }
+        return x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("""
+     BB01:
+       STORE SS00 USR04 USR04/4
+     BB02:
+       STORE SS00 USR04 USR04/3
+     BB03:
+       STORE SS00 USR04 USR04/2
+     """)]
+    private static unsafe object Optimized_ExplicitInit_NotExposed_MultipleDefsComplexFlow(int value, object* pObjOne, object* pObjTwo, object* pObjThree)
+    {
+        // Test that this object does not get zero-init-ed. There are no safe points between its spill and the prolog.
+        object x;
+        ForceILLocal(&x);
+        for (int i = 0; i < 10; i++)
+        {
+            if (value < 100)
+            {
+                value -= 10;
+            }
+            value *= 20;
+            if (value % 12 == 0)
+            {
+                x = *pObjThree; // Spill one
+                YetAnotherSafePoint();
+                goto EXIT;
+            }
+        }
+        if (value < 0)
+        {
+            x = *pObjOne; // Spill two
+            SafePoint();
+        }
+        else
+        {
+            x = *pObjTwo; // Spill three
+            AnotherSafePoint();
+        }
+    EXIT:
+        return x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("""
+     BB01:
+       STORE SS00 USR03 USR03/3
+       STORE SS00 USR03 USR03/4
+     """)]
+    private static unsafe object Optimized_ExplicitInit_NotExposed_DefSafePointDef(bool flag, object* pObjOne, object* pObjTwo)
+    {
+        object x = null;
+        if (flag)
+        {
+            // Test that our logic can correct see that the spilled definition is **before** a safepoint in this block.
+            x = *pObjOne; // Spill one
+            SafePoint();
+            SafePoint(x, x);
+            x = *pObjTwo; // Spill two
+            SafePoint();
+        }
+        return x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("BB01: STORE SS00 USR02 USR02/2")]
+    private static unsafe void Optimized_ExplicitInit_NotExposed_ShadowTailCall(bool flag, object* pObj)
+    {
+        if (flag)
+        {
+            object x = *pObj; // This will be spilled.
+            ForceILLocal(&x);
+            SafePoint();
+            SafePoint(x, x);
+        }
+
+        SafePoint(); // No need for a zero-init of 'x' since this should be tail-called.
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining), LSSATest("""
      BB01:
        ZEROINIT SS00
@@ -218,6 +377,89 @@ public unsafe class LSSATests
         ForceILLocal(&x);
         SafePoint(null);
         SafePoint(x, x);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("""
+     BB01:
+       ZEROINIT SS00
+     BB02:
+       STORE SS00 USR02 USR02/2
+     """)]
+    private static unsafe void Optimized_ExplicitInit_Exposed_DeadSlotBefore(bool flag, object* pObj)
+    {
+        // Test that we zero-init the shadow slot for 'x'.
+        if (flag)
+        {
+            SafePoint(); // 'x' not live at this point.
+            return;
+        }
+
+        object x = *pObj; // This will be spilled.
+        ForceILLocal(&x);
+        SafePoint();
+        SafePoint(x, x);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("""
+     BB01:
+       ZEROINIT SS00
+     BB02:
+       STORE SS00 USR02 USR02/2
+     """)]
+    private static unsafe void Optimized_ExplicitInit_Exposed_DeadSlotAfter(int value, object* pObj)
+    {
+        // Test that we zero-init the shodow slot for 'x'.
+        if (value != 0)
+        {
+            object x = *pObj; // This will be spilled.
+            ForceILLocal(&x);
+            SafePoint();
+            SafePoint(x, x);
+        }
+
+        if (value != 1)
+        {
+            SafePoint(); // 'x' not live at this point.
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("""
+     BB01:
+       ZEROINIT SS00
+     BB02:
+       STORE SS00 USR02 USR02/4
+     """)]
+    private static ref int Optimized_ExplicitInit_Exposed_DefSafePointDef(int one)
+    {
+        int local = 0;
+        ref int x = ref *(int*)null;
+        if (one != 0)
+        {
+            // Test that our logic can correctly see that the spilled definition is **after** a safepoint in this block.
+            x = ref *(int*)((byte*)&local + one); // Not spilled.
+            SafePoint();
+            SafePoint(ref x, ref x);
+            x = ref NewObject().Field; // Spilled.
+            SafePoint();
+        }
+        return ref x;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining), LSSATest("""
+     BB01:
+       ZEROINIT SS00 SS01
+       STORE SS00 USR02 USR02/2
+       STORE SS01 USR03 SDSU
+     """)]
+    private static object Optimized_ExplicitInit_Exposed_EHFlow(bool flag, object* pObj)
+    {
+        // We cannot optimize out the zeroing of 'x' here because "*pObj" might throw
+        // and invoke managed code with this method's shadow frame active on the stack.
+        object x = *pObj; // Potential exception & spill.
+        ForceILLocal(&x);
+        object y = NewObject();
+        SafePoint(ref y); // An address-exposed local to block shadow tail calling.
+        return x;
     }
 
     // TODO-LLVM: add this test, but in such a way that we don't need to encode the virtual unwind
@@ -354,6 +596,9 @@ public unsafe class LSSATests
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SafePoint() { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void SafePoint(object x) { }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -369,7 +614,16 @@ public unsafe class LSSATests
     private static void SafePoint(ref int x) { }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SafePoint(ref int x, ref int y) { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void AnotherSafePoint() { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void AnotherSafePoint(object x) { }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void YetAnotherSafePoint() { }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static ClassWithField NewObject() => new();


### PR DESCRIPTION
Up until now, we've assumed in LSSA that all shadow stack slots will need to be zero-initialized, i. e. that all of them have an "implicit GC use" (a safepoint which may see their contents undefined, which we want to avoid).

This change refines this model by explicitly tracking which slots are initialized before any safepoint and excluding them from the must-zero-init set, by collecting the set of shadow slot definitions that dominate all safepoints of a given dominator tree part, as follows:
1) Let `Defs` be the set of shadow slots defined in this block, before any safepoint. Let `DominatingDefs` be the result set.
2) If the block has a safepoint, `DominatingDefs` is equal to `Defs` and we return, since no downstream def may dominate this safepoint.
3) Otherwise, for each dominated child block, collect its `DominatingDefs`. Intersect all of these sets, starting from a full set.
4) Union in the resulting set with `Defs` - this is the result, i. e. `DominatingDefs` for this block.

In the end, `DominatingDefs` of the first block (it's 'virtual' in the implementation) is the set of defs that dominate all safepoints. Since we walk the tree in a non-recursing fashion, we track the necessary state via an explicit stack, and perform step `3` (intersection) incrementally as we're finishing visiting the child blocks.

The diffs for this change are a bit mixed because it corrects the former logic which could be too liberal in eliding the zero-init with `lvExplitiInit` locals, where we didn't check that this explicit init actually did end up being spilled:
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 3047824
Total bytes of diff: 3047250
Total bytes of delta: -574 (-0.02% % of base)
Average relative delta: 0.30%
    diff is an improvement
    average relative diff is a regression

Top method regressions (percentages):
         203 (390.38% of base) : 1197.dasm - S_P_CoreLib_System_IO_TextReader__Dispose
          62 (19.56% of base) : 1118.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_RuntimeNamedMethodInfo_1<S_P_CoreLib_System_Reflection_Runtime_MethodInfos_NativeFormat_NativeFormatMethodCommon>__Equals
           7 (10.00% of base) : 1192.dasm - HelloWasm_IL_System_Runtime_JitTesting_LSSATestsIL__Optimized_ExposedLocal_Untracked
          10 ( 6.06% of base) : 1044.dasm - S_P_CoreLib_System_Buffers_SpanAction_2<Char__IntPtr>__InvokeMulticastThunk
          10 ( 5.56% of base) : 1043.dasm - S_P_CoreLib_System_Buffers_SpanFunc_5<Char__System___Canon__S_P_CoreLib_System_Globalization_CalendarId__S_P_CoreLib_System_Globalization_CalendarDataType__S_P_CoreLib_Interop_Globalization_ResultCode>__InvokeMulticastThunk
           7 ( 5.51% of base) : 1055.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_GenericDictionaryCell_ThreadStaticIndexCell__Create
          15 ( 5.23% of base) : 1208.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetDynamicGenericMethodDictionary
           7 ( 5.22% of base) : 1238.dasm - S_P_TypeLoader_Internal_TypeSystem_TypeDesc__GetOrCreateTypeBuilderState
          16 ( 4.40% of base) : 1059.dasm - S_P_CoreLib_System_Globalization_TimeSpanParse_TimeSpanRawInfo__ProcessToken
          17 ( 4.28% of base) : 1099.dasm - S_P_CoreLib_System_Threading_WaitSubsystem_WaitableObject__Wait
           7 ( 4.09% of base) : 1075.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_GenericDictionaryCell_FieldLdTokenCell__Create
          28 ( 3.99% of base) : 1091.dasm - S_P_CoreLib_System_Reflection_Runtime_General_MetadataReaderExtensions__CreateRuntimeAssemblyNameFromMetadata
           7 ( 3.89% of base) : 1058.dasm - S_P_CoreLib_System_Reflection_Runtime_PropertyInfos_RuntimePropertyInfo__get_Getter
           7 ( 3.89% of base) : 1110.dasm - S_P_CoreLib_System_Reflection_Runtime_PropertyInfos_RuntimePropertyInfo__get_Setter
           7 ( 3.29% of base) : 1109.dasm - S_P_CoreLib_System_Reflection_Runtime_BindingFlagSupport_PropertyPolicies__GetAccessorMethod
          11 ( 3.17% of base) : 1120.dasm - S_P_CoreLib_System_Runtime_CompilerServices_ConditionalWeakTable_2_Enumerator<System___Canon__System___Canon>__MoveNext
          10 ( 2.81% of base) : 1106.dasm - S_P_CoreLib_System_Globalization_CultureData__UnescapeNlsString
          10 ( 2.77% of base) : 1100.dasm - S_P_CoreLib_System_Exception__RestoreDispatchState
          10 ( 2.77% of base) : 1012.dasm - S_P_CoreLib_System_Runtime_RuntimeExports__RhBox
          10 ( 2.64% of base) : 1033.dasm - S_P_CoreLib_System_Threading_Tasks_Task__AddException_0

Top method improvements (percentages):
        -125 (-20.66% of base) : 1073.dasm - S_P_CoreLib_System_Reflection_Runtime_Assemblies_NativeFormat_NativeFormatRuntimeAssembly__GetTypeCoreCaseInsensitive
          -7 (-9.46% of base) : 1227.dasm - S_P_CoreLib_System_Collections_ObjectModel_ReadOnlyCollection_1<System___Canon>__System_Collections_IEnumerable_GetEnumerator
          -7 (-9.46% of base) : 1247.dasm - S_P_CoreLib_System_Collections_ObjectModel_ReadOnlyCollection_1<S_P_CoreLib_System_Reflection_CustomAttributeNamedArgument>__System_Collections_IEnumerable_GetEnumerator
          -7 (-9.46% of base) : 1248.dasm - S_P_CoreLib_System_Collections_ObjectModel_ReadOnlyCollection_1<S_P_CoreLib_System_Reflection_CustomAttributeTypedArgument>__System_Collections_IEnumerable_GetEnumerator
         -22 (-8.84% of base) : 1161.dasm - S_P_CoreLib_System_Number__TryFormatFloat<Single__Char>
         -22 (-8.84% of base) : 1162.dasm - S_P_CoreLib_System_Number__TryFormatFloat<Double__Char>
          -7 (-7.61% of base) : 1215.dasm - S_P_CoreLib_System_Collections_ObjectModel_ReadOnlyCollection_1<System___Canon>__get_Count
          -7 (-7.53% of base) : 1202.dasm - S_P_CoreLib_System_IO_Strategies_OSFileStreamStrategy__Dispose
          -7 (-6.80% of base) : 1214.dasm - S_P_CoreLib_System_Collections_ObjectModel_ReadOnlyCollection_1<System___Canon>__CopyTo
          -7 (-6.54% of base) : 1088.dasm - System_Console_System_WasmConsoleStream__Dispose
          -7 (-6.48% of base) : 1111.dasm - S_P_CoreLib_System_Reflection_Runtime_CustomAttributes_RuntimePseudoCustomAttributeData___ctor
          -7 (-6.19% of base) : 1179.dasm - S_P_CoreLib_System_Threading_CancellationTokenSource__TimerCallback
          -7 (-5.98% of base) : 1193.dasm - S_P_CoreLib_System_TimeZoneInfo__Equals_0
         -15 (-5.93% of base) : 1226.dasm - S_P_CoreLib_System_Globalization_DateTimeFormatInfoScanner__ArrayElementsHaveSpace
          -7 (-5.83% of base) : 1018.dasm - S_P_CoreLib_System_Threading_Tasks_Task___c___AssignCancellationToken_b__36_1
          -7 (-5.51% of base) : 1159.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeNamedTypeInfo__get_CustomAttributes_d__4__System_IDisposable_Dispose
          -7 (-5.51% of base) : 1041.dasm - S_P_CoreLib_System_Reflection_Runtime_MethodInfos_RuntimeNamedMethodInfo_1__get_CustomAttributes_d__7<S_P_CoreLib_System_Reflection_Runtime_MethodInfos_NativeFormat_NativeFormatMethodCommon>__System_IDisposable_Dispose
          -7 (-5.51% of base) : 1170.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__CoreGetDeclaredSyntheticConstructors_d__185__System_IDisposable_Dispose
          -7 (-5.51% of base) : 1134.dasm - S_P_CoreLib_System_Reflection_Runtime_FieldInfos_RuntimeFieldInfo__get_CustomAttributes_d__2__System_IDisposable_Dispose
          -7 (-5.51% of base) : 1257.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo__CoreGetDeclaredSyntheticMethods_d__187__System_IDisposable_Dispose

262 total methods with Code Size differences (197 improved, 65 regressed)
```

