### PR TITLE
[NativeAOT-LLVM] Add a property to build Wasm core modules for library project types

### DIFF
--- a/docs/using-nativeaot/compiling.md
+++ b/docs/using-nativeaot/compiling.md
@@ -115,6 +115,16 @@ Note that assemblies other than the one being published (e. g. those from refere
 
 See also the [NativeLibrary sample](../../samples/NativeLibrary).
 
+### WebAssembly Core Modules for WASI
+
+NativeAOT-LLVM by default will produce Wasi component modules using the `wasm32-unknown-wasip2` triple.  If you need to produce WebAssemblyCore modules from a library project, add
+```xml
+<PropertyGroup>
+  <WasmCoreModule>true</WasmCoreModule>
+</PropertyGroup>
+```
+to your project file.  This can be useful for uses that do not support WebAssembly components, e.g. extism.
+
 ## WebAssembly module imports
 
 Functions in other WebAssembly modules can be imported and invoked using `DllImport` and `WasmImportLinkage` e.g.

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -125,8 +125,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(OptimizationPreference) == 'Size'">-Oz</WasmOptimizationSetting>
 
     <IlcLlvmTarget Condition="'$(_targetOS)' == 'browser'">wasm32-unknown-emscripten</IlcLlvmTarget>
-    <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi' amd '$(WasmCoreModule)' != 'true'">wasm32-unknown-wasip2</IlcLlvmTarget>
-    <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi' amd '$(WasmCoreModule)' == 'true'">wasm32-unknown-wasi</IlcLlvmTarget>
+    <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi' and '$(WasmCoreModule)' != 'true'">wasm32-unknown-wasip2</IlcLlvmTarget>
+    <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi' and '$(WasmCoreModule)' == 'true'">wasm32-unknown-wasi</IlcLlvmTarget>
     <IlcWasmStackSize>1048576</IlcWasmStackSize> <!-- 1MB -->
     <IlcWasmStackSize Condition="'$(EmccStackSize)' != ''">$(EmccStackSize)</IlcWasmStackSize>
     <IlcWasmGlobalBase>1024</IlcWasmGlobalBase>
@@ -583,7 +583,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="@(NativeObjects->'&quot;%(Identity)&quot;'->Replace(&quot;\&quot;, &quot;/&quot;))" />
       <!-- The canary function should be last in the linked output. But adding it to Native[Library|Object] runs into https://github.com/dotnet/msbuild/issues/5937. -->
       <CustomLinkerArg Include="&quot;$(IlcSdkPath.Replace('\', '/'))libStackTraceIpCanary.o&quot;" Condition="'$(_targetOS)' == 'browser'" />
-      <CustomLinkerArg Include="@(WasmComponentTypeWit->'%(FullPath)'->Replace('\', '/')->'-Wl,--component-type,&quot;%(Identity)&quot;')" Condition="'$(WasmCoreModule' != 'true"/>
+      <CustomLinkerArg Include="@(WasmComponentTypeWit->'%(FullPath)'->Replace('\', '/')->'-Wl,--component-type,&quot;%(Identity)&quot;')" Condition="'$(WasmCoreModule)' != 'true'"/>
       <CustomLinkerArg Include="-o &quot;$(NativeBinary.Replace(&quot;\&quot;, &quot;/&quot;))&quot;" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' == 'true'" Include="-g3" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' != 'true'" Include="-Wl,--strip-all" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -125,7 +125,8 @@ The .NET Foundation licenses this file to you under the MIT license.
     <WasmOptimizationSetting Condition="$(Optimize) == 'true' and $(OptimizationPreference) == 'Size'">-Oz</WasmOptimizationSetting>
 
     <IlcLlvmTarget Condition="'$(_targetOS)' == 'browser'">wasm32-unknown-emscripten</IlcLlvmTarget>
-    <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi'">wasm32-unknown-wasip2</IlcLlvmTarget>
+    <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi' amd '$(WasmCoreModule)' != 'true'">wasm32-unknown-wasip2</IlcLlvmTarget>
+    <IlcLlvmTarget Condition="'$(_targetOS)' == 'wasi' amd '$(WasmCoreModule)' == 'true'">wasm32-unknown-wasi</IlcLlvmTarget>
     <IlcWasmStackSize>1048576</IlcWasmStackSize> <!-- 1MB -->
     <IlcWasmStackSize Condition="'$(EmccStackSize)' != ''">$(EmccStackSize)</IlcWasmStackSize>
     <IlcWasmGlobalBase>1024</IlcWasmGlobalBase>
@@ -582,7 +583,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="@(NativeObjects->'&quot;%(Identity)&quot;'->Replace(&quot;\&quot;, &quot;/&quot;))" />
       <!-- The canary function should be last in the linked output. But adding it to Native[Library|Object] runs into https://github.com/dotnet/msbuild/issues/5937. -->
       <CustomLinkerArg Include="&quot;$(IlcSdkPath.Replace('\', '/'))libStackTraceIpCanary.o&quot;" Condition="'$(_targetOS)' == 'browser'" />
-      <CustomLinkerArg Include="@(WasmComponentTypeWit->'%(FullPath)'->Replace('\', '/')->'-Wl,--component-type,&quot;%(Identity)&quot;')" />
+      <CustomLinkerArg Include="@(WasmComponentTypeWit->'%(FullPath)'->Replace('\', '/')->'-Wl,--component-type,&quot;%(Identity)&quot;')" Condition="'$(WasmCoreModule' != 'true"/>
       <CustomLinkerArg Include="-o &quot;$(NativeBinary.Replace(&quot;\&quot;, &quot;/&quot;))&quot;" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' == 'true'" Include="-g3" />
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' != 'true'" Include="-Wl,--strip-all" />


### PR DESCRIPTION
This PR adds a property `WasmCoreModule` that builds a Wasm core module as opposed to a component module.  This is useful when targeting hosts that do not support components, e.g. extism.  While this works for the simple cases, I suspect there is more to it.  Extism has their own API for modules and doesn't seem like there is much appetite to change to the component module.

