### PR TITLE
[NativeAOT-LLVM] Slightly more precise null checking

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -657,6 +657,7 @@ private:
 
     Value* consumeAddressAndEmitNullCheck(GenTreeIndir* indir);
     void emitNullCheckForAddress(GenTree* addr, Value* addrValue DEBUGARG(GenTree* indir));
+    bool isAddressNullOrValid(GenTree* addr);
     void emitAlignmentCheckForAddress(GenTree* addr, Value* addrValue, unsigned alignment DEBUGARG(GenTree* indir));
     bool isAddressAligned(GenTree* addr, unsigned alignment);
 

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2340,10 +2340,10 @@ void Llvm::emitNullCheckForAddress(GenTree* addr, Value* addrValue DEBUGARG(GenT
 {
     // The frontend's contract with the backend is that it will not insert null checks for accesses which
     // are inside the "[0..compMaxUncheckedOffsetForNullObject]" range. Thus, we usually need to check not
-    // just for "null", but "null + small offset". However, for TYP_REF, we know it will either be a valid
-    // object on heap, or null, and can utilize the more direct form.
+    // just for "null", but "null + small offset". However, for certain addresses, we know it will either
+    // be a valid address, or null.
     Value* isNullValue;
-    if (addr->TypeIs(TYP_REF))
+    if (isAddressNullOrValid(addr))
     {
         // LLVM's FastISel, used for unoptimized code, is not able to generate sensible WASM unless we do
         // a comparison using an integer zero here. This workaround saves 5+% on debug code size.
@@ -2366,6 +2366,30 @@ void Llvm::emitNullCheckForAddress(GenTree* addr, Value* addrValue DEBUGARG(GenT
     }
 
     emitJumpToThrowHelper(isNullValue, CORINFO_HELP_THROWNULLREF DEBUGARG(indir));
+}
+
+bool Llvm::isAddressNullOrValid(GenTree* addr)
+{
+    if (addr->TypeIs(TYP_REF))
+    {
+        return true;
+    }
+
+    // Weed out transient byrefs that could've been created by "fgMorphField". This is not as easy as it may look
+    // as we must accomodate for the possibility of the frontend transforming these in arbitrary ways. We do this
+    // by taking advantage of the managed ABI which prohibits passing such byrefs across call boundaries.
+    if (addr->OperIs(GT_LCL_VAR) && (addr->AsLclVar()->GetSsaNum() == SsaConfig::FIRST_SSA_NUM) &&
+        _compiler->lvaGetDesc(addr->AsLclVar())->lvIsParam)
+    {
+        return true;
+    }
+
+    if (addr->IsCall())
+    {
+        return true;
+    }
+
+    return false;
 }
 
 void Llvm::emitAlignmentCheckForAddress(GenTree* addr, Value* addrValue, unsigned alignment DEBUGARG(GenTree* indir))

--- a/src/coreclr/jit/llvmlower.cpp
+++ b/src/coreclr/jit/llvmlower.cpp
@@ -977,7 +977,7 @@ void Llvm::lowerAddressToAddressMode(GenTreeIndir* indir)
             (size_t)offset);
 
     // Invariant access can be assumed to be in bounds by construction.
-    if (((indir->gtFlags & GTF_IND_INVARIANT) == 0) && !isAddressInBounds(baseAddr, fieldSeq, offset))
+    if (!indir->IsInvariantLoad() && !isAddressInBounds(baseAddr, fieldSeq, offset))
     {
         JITDUMP("no, not in bounds\n");
         return;


### PR DESCRIPTION
This change reduces the number of instances where we have to use the longer `addr < 1024` null check form by being a bit more precise about which addresses we can consider "null or valid" aka "not an almost-null compiler-created byref".

Diffs (WasmDebugging):
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 674872
Total bytes of diff: 670850
Total bytes of delta: -4022 (-0.60% % of base)
Average relative delta: -4.19%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
          16 ( 2.03% of base) : 1278.dasm - S_P_CoreLib_System_Runtime_EH__DispatchEx
           7 ( 1.61% of base) : 1354.dasm - S_P_CoreLib_System_Number_BigInteger__Add
           6 ( 1.39% of base) : 1391.dasm - S_P_CoreLib_System_Environment__GetEnvironmentVariableCore
           2 ( 0.54% of base) : 1389.dasm - S_P_CoreLib_System_SpanHelpers__ClearWithReferences

Top method improvements (percentages):
        -404 (-30.98% of base) : 1090.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetNamedTypeForMetadata
        -279 (-25.36% of base) : 1073.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_ExecutionEnvironmentImplementation__GetTypeSequence
         -81 (-21.89% of base) : 1343.dasm - S_P_CoreLib_System_Runtime_EH_PreciseVirtualUnwindFrame__GetLast
         -44 (-18.18% of base) : 1312.dasm - S_P_CoreLib_System_Runtime_EH_EHTable__GetClauseInfo
         -34 (-15.96% of base) : 1296.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_StackTraceMetadata_PerModuleMethodNameResolver_StackTraceData____GetFieldHelper
         -34 (-15.96% of base) : 1293.dasm - S_P_CoreLib_System_Runtime_CompilerServices_ClassConstructorRunner_Cctor____GetFieldHelper
         -70 (-15.87% of base) : 1342.dasm - S_P_CoreLib_System_Runtime_PreciseVirtualUnwindInfo__Parse
         -34 (-15.81% of base) : 1160.dasm - S_P_CoreLib_System_Collections_Generic_Dictionary_2_Enumerator<System___Canon__System___Canon>____GetFieldHelper
         -27 (-15.70% of base) : 1094.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifierW_2_Entry<S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo_UnificationKey__System___Canon>____GetFieldHelper
         -27 (-15.70% of base) : 1294.dasm - S_P_CoreLib_System_Threading_SyncTable_Entry____GetFieldHelper
         -27 (-15.52% of base) : 1166.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifier_2_Entry<Int32__System___Canon>____GetFieldHelper
         -27 (-15.34% of base) : 1017.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifier_2_Entry<System___Canon__System___Canon>____GetFieldHelper
         -27 (-15.34% of base) : 1159.dasm - S_P_CoreLib_System_Collections_Generic_Dictionary_2_Entry<System___Canon__System___Canon>____GetFieldHelper
         -20 (-14.39% of base) : 1447.dasm - S_P_CoreLib_System_Collections_Generic_HashSet_1_Entry<Char>____GetFieldHelper
         -20 (-14.39% of base) : 1274.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo_UnificationKey____GetFieldHelper
         -20 (-14.39% of base) : 1165.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifierWKeyed_2_Entry<S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeHasElementTypeInfo_UnificationKey__System___Canon>____GetFieldHelper
         -20 (-14.39% of base) : 1477.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifierWKeyed_2_Entry<S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeConstructedGenericTypeInfo_UnificationKey__System___Canon>____GetFieldHelper
         -20 (-14.39% of base) : 1072.dasm - S_P_CoreLib_System_Collections_Concurrent_ConcurrentUnifierWKeyed_2_Entry<S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeFunctionPointerTypeInfo_UnificationKey__System___Canon>____GetFieldHelper
         -20 (-14.39% of base) : 1164.dasm - S_P_CoreLib_System_Runtime_CompilerServices_ConditionalWeakTable_2_Entry<System___Canon__System___Canon>____GetFieldHelper
         -13 (-12.75% of base) : 1292.dasm - S_P_CoreLib_System_Runtime_CompilerServices_ClassConstructorRunner_BlockingRecord____GetFieldHelper

483 total methods with Code Size differences (479 improved, 4 regressed)
```
