### PR TITLE
[NativeAOT-LLVM] Port the `ExternSymbolNode` change

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -329,7 +329,7 @@ namespace ILCompiler
                 case ReadyToRunHelperId.ObjectAllocator:
                     {
                         var type = (TypeDesc)targetOfLookup;
-                        return NodeFactory.ExternSymbol(JitHelper.GetNewObjectHelperForType(type));
+                        return NodeFactory.ExternFunctionSymbol(JitHelper.GetNewObjectHelperForType(type));
                     }
 
                 default:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternEETypeSymbolNode.cs
@@ -9,7 +9,7 @@ namespace ILCompiler.DependencyAnalysis
     /// Represents a symbol that is defined externally but modelled as a type in the
     /// DependencyAnalysis infrastructure during compilation.
     /// </summary>
-    public sealed class ExternEETypeSymbolNode : ExternSymbolNode, IEETypeNode
+    public sealed class ExternEETypeSymbolNode : ExternDataSymbolNode, IEETypeNode
     {
         private TypeDesc _type;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternMethodSymbolNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternMethodSymbolNode.cs
@@ -9,7 +9,7 @@ namespace ILCompiler.DependencyAnalysis
     /// Represents a symbol that is defined externally but modelled as a method
     /// in the DependencyAnalysis infrastructure during compilation
     /// </summary>
-    public sealed class ExternMethodSymbolNode : ExternSymbolNode, IMethodNode
+    public sealed class ExternMethodSymbolNode : ExternFunctionSymbolNode, IMethodNode
     {
         private MethodDesc _method;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternSymbolNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternSymbolNode.cs
@@ -11,13 +11,15 @@ namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
     /// Represents a symbol that is defined externally and statically linked to the output obj file.
+    /// When making a new node, do not derive from this class directly, derive from one of its subclasses
+    /// (ExternFunctionSymbolNode / ExternDataSymbolNode) instead.
     /// </summary>
-    public class ExternSymbolNode : SortableDependencyNode, ISortableSymbolNode
+    public abstract class ExternSymbolNode : SortableDependencyNode, ISortableSymbolNode
     {
         private readonly Utf8String _name;
         private readonly bool _isIndirection;
 
-        public ExternSymbolNode(Utf8String name, bool isIndirection = false)
+        protected ExternSymbolNode(Utf8String name, bool isIndirection = false)
         {
             _name = name;
             _isIndirection = isIndirection;
@@ -31,6 +33,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             sb.Append(_name);
         }
+
         public int Offset => 0;
         public virtual bool RepresentsIndirectionCell => _isIndirection;
 
@@ -44,8 +47,6 @@ namespace ILCompiler.DependencyAnalysis
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
 
 #if !SUPPORT_JIT
-        public override int ClassCode => 1092559304;
-
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             return _name.CompareTo(((ExternSymbolNode)other)._name);
@@ -58,11 +59,26 @@ namespace ILCompiler.DependencyAnalysis
         }
     }
 
-    public class AddressTakenExternSymbolNode : ExternSymbolNode
+    /// <summary>
+    /// Represents a function symbol that is defined externally and statically linked to the output obj file.
+    /// </summary>
+    public class ExternFunctionSymbolNode(Utf8String name, bool isIndirection = false) : ExternSymbolNode(name, isIndirection)
     {
-        public AddressTakenExternSymbolNode(Utf8String name)
-            : base(name) { }
+        public override int ClassCode => 1452455506;
+    }
 
+    public class AddressTakenExternFunctionSymbolNode(Utf8String name) : ExternFunctionSymbolNode(name)
+    {
         public override int ClassCode => -45645737;
+    }
+
+    /// <summary>
+    /// Represents a data symbol that is defined externally and statically linked to the output obj file.
+    /// </summary>
+    public class ExternDataSymbolNode(Utf8String name) : ExternSymbolNode(name)
+    {
+        public override int ClassCode => 1428609964;
+
+        protected override string GetName(NodeFactory factory) => $"ExternDataSymbolNode {ToString()}";
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternSymbolsImportedNodeProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternSymbolsImportedNodeProvider.cs
@@ -15,12 +15,12 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ISortableSymbolNode ImportedGCStaticNode(NodeFactory factory, MetadataType type)
         {
-            return new ExternSymbolNode(GCStaticsNode.GetMangledName(type, factory.NameMangler));
+            return new ExternDataSymbolNode(GCStaticsNode.GetMangledName(type, factory.NameMangler));
         }
 
         public override ISortableSymbolNode ImportedNonGCStaticNode(NodeFactory factory, MetadataType type)
         {
-            return new ExternSymbolNode(NonGCStaticsNode.GetMangledName(type, factory.NameMangler));
+            return new ExternDataSymbolNode(NonGCStaticsNode.GetMangledName(type, factory.NameMangler));
         }
 
         public override ISortableSymbolNode ImportedMethodDictionaryNode(NodeFactory factory, MethodDesc method)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -735,7 +735,7 @@ namespace ILCompiler.DependencyAnalysis
         public override ISymbolNode GetTarget(NodeFactory factory, GenericLookupResultContext dictionary)
         {
             TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
-            return factory.ExternSymbol(JitHelper.GetNewObjectHelperForType(instantiatedType));
+            return factory.ExternFunctionSymbol(JitHelper.GetNewObjectHelperForType(instantiatedType));
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             _target = context.Target;
 
-            InitialInterfaceDispatchStub = new AddressTakenExternSymbolNode("RhpInitialDynamicInterfaceDispatch");
+            InitialInterfaceDispatchStub = new AddressTakenExternFunctionSymbolNode("RhpInitialDynamicInterfaceDispatch");
 
             _context = context;
             _compilationModuleGroup = compilationModuleGroup;
@@ -256,13 +256,17 @@ namespace ILCompiler.DependencyAnalysis
                 return new FieldRvaDataNode(key);
             });
 
-            _externSymbols = new NodeCache<string, ExternSymbolNode>((string name) =>
+            _externFunctionSymbols = new NodeCache<string, ExternFunctionSymbolNode>((string name) =>
             {
-                return new ExternSymbolNode(name);
+                return new ExternFunctionSymbolNode(name);
             });
-            _externIndirectSymbols = new NodeCache<string, ExternSymbolNode>((string name) =>
+            _externIndirectFunctionSymbols = new NodeCache<string, ExternFunctionSymbolNode>((string name) =>
             {
-                return new ExternSymbolNode(name, isIndirection: true);
+                return new ExternFunctionSymbolNode(name, isIndirection: true);
+            });
+            _externDataSymbols = new NodeCache<string, ExternDataSymbolNode>((string name) =>
+            {
+                return new ExternDataSymbolNode(name);
             });
 
             _pInvokeModuleFixups = new NodeCache<PInvokeModuleData, PInvokeModuleFixupNode>((PInvokeModuleData moduleData) =>
@@ -762,7 +766,7 @@ namespace ILCompiler.DependencyAnalysis
             }
             else
             {
-                return ExternSymbol(NameMangler.NodeMangler.ThreadStaticsIndex(type));
+                return ExternDataSymbol(NameMangler.NodeMangler.ThreadStaticsIndex(type));
             }
         }
 
@@ -872,24 +876,31 @@ namespace ILCompiler.DependencyAnalysis
             return _genericVariances.GetOrAdd(details);
         }
 
-        private NodeCache<string, ExternSymbolNode> _externSymbols;
+        private NodeCache<string, ExternFunctionSymbolNode> _externFunctionSymbols;
 
-        public ISortableSymbolNode ExternSymbol(string name)
+        public ISortableSymbolNode ExternFunctionSymbol(string name)
         {
-            return _externSymbols.GetOrAdd(name);
+            return _externFunctionSymbols.GetOrAdd(name);
+        }
+
+        private NodeCache<string, ExternFunctionSymbolNode> _externIndirectFunctionSymbols;
+
+        public ISortableSymbolNode ExternIndirectFunctionSymbol(string name)
+        {
+            return _externIndirectFunctionSymbols.GetOrAdd(name);
+        }
+
+        private NodeCache<string, ExternDataSymbolNode> _externDataSymbols;
+
+        public ISortableSymbolNode ExternDataSymbol(string name)
+        {
+            return _externDataSymbols.GetOrAdd(name);
         }
 
         public ISortableSymbolNode ExternVariable(string name)
         {
             string mangledName = NameMangler.NodeMangler.ExternVariable(name);
-            return _externSymbols.GetOrAdd(mangledName);
-        }
-
-        private NodeCache<string, ExternSymbolNode> _externIndirectSymbols;
-
-        public ISortableSymbolNode ExternIndirectSymbol(string name)
-        {
-            return _externIndirectSymbols.GetOrAdd(name);
+            return _externDataSymbols.GetOrAdd(mangledName);
         }
 
         private NodeCache<PInvokeModuleData, PInvokeModuleFixupNode> _pInvokeModuleFixups;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/RuntimeImportMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/RuntimeImportMethodNode.cs
@@ -9,7 +9,7 @@ namespace ILCompiler.DependencyAnalysis
     /// <summary>
     /// Represents a method that is imported from the runtime library.
     /// </summary>
-    public class RuntimeImportMethodNode : ExternSymbolNode, IMethodNode, ISymbolDefinitionNode
+    public class RuntimeImportMethodNode : ExternFunctionSymbolNode, IMethodNode, ISymbolDefinitionNode
     {
         private MethodDesc _method;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs
@@ -128,7 +128,7 @@ namespace ILCompiler.DependencyAnalysis
                         if (targetMethod.OwningType.IsInterface)
                         {
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, factory.InterfaceDispatchCell(targetMethod));
-                            encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
+                            encoder.EmitJMP(factory.ExternFunctionSymbol("RhpResolveInterfaceMethod"));
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM64/ARM64ReadyToRunHelperNode.cs
@@ -147,7 +147,7 @@ namespace ILCompiler.DependencyAnalysis
                             encoder.EmitINT3();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, factory.InterfaceDispatchCell(targetMethod));
-                            encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
+                            encoder.EmitJMP(factory.ExternFunctionSymbol("RhpResolveInterfaceMethod"));
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64ReadyToRunHelperNode.cs
@@ -139,7 +139,7 @@ namespace ILCompiler.DependencyAnalysis
                             encoder.EmitBreak();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, factory.InterfaceDispatchCell(targetMethod));
-                            encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
+                            encoder.EmitJMP(factory.ExternFunctionSymbol("RhpResolveInterfaceMethod"));
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_RiscV64/RiscV64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_RiscV64/RiscV64ReadyToRunHelperNode.cs
@@ -137,7 +137,7 @@ namespace ILCompiler.DependencyAnalysis
                             encoder.EmitBreak();
 
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, factory.InterfaceDispatchCell(targetMethod));
-                            encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
+                            encoder.EmitJMP(factory.ExternFunctionSymbol("RhpResolveInterfaceMethod"));
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/MetadataManager.Wasm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/MetadataManager.Wasm.cs
@@ -86,6 +86,6 @@ namespace ILCompiler
     public partial class ObjectDataInterner
     {
         public static ObjectDataInterner NullWithTracking { get; } =
-            new ObjectDataInterner() { _symbolRemapping = new() { [new ExternSymbolNode("")] = null } };
+            new ObjectDataInterner() { _symbolRemapping = new() { [new ExternFunctionSymbolNode("")] = null } };
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmFunctionType.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_Wasm/WasmFunctionType.cs
@@ -27,7 +27,8 @@ namespace ILCompiler.DependencyAnalysis.Wasm
             return hash.ToHashCode();
         }
 
-        public static bool IsFunction(ISymbolNode symbol) => symbol is ExternSymbolNode or IWasmFunctionNode or IMethodNode { Offset: 0 };
+        public static bool IsFunction(ISymbolNode symbol) =>
+            symbol is ExternFunctionSymbolNode or IWasmFunctionNode or IMethodNode { Offset: 0 };
 
         public static bool Equals(WasmFunctionType type, WasmValueType result, ReadOnlySpan<WasmValueType> parameters) =>
             type._result == result && type.Parameters.SequenceEqual(parameters);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X64/X64ReadyToRunHelperNode.cs
@@ -149,7 +149,7 @@ namespace ILCompiler.DependencyAnalysis
                         if (targetMethod.OwningType.IsInterface)
                         {
                             encoder.EmitLEAQ(encoder.TargetRegister.Arg1, factory.InterfaceDispatchCell(targetMethod));
-                            encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
+                            encoder.EmitJMP(factory.ExternFunctionSymbol("RhpResolveInterfaceMethod"));
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunHelperNode.cs
@@ -159,7 +159,7 @@ namespace ILCompiler.DependencyAnalysis
                         if (targetMethod.OwningType.IsInterface)
                         {
                             encoder.EmitMOV(encoder.TargetRegister.Arg1, factory.InterfaceDispatchCell(targetMethod));
-                            encoder.EmitJMP(factory.ExternSymbol("RhpResolveInterfaceMethod"));
+                            encoder.EmitJMP(factory.ExternFunctionSymbol("RhpResolveInterfaceMethod"));
                         }
                         else
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ILScanner.cs
@@ -198,7 +198,7 @@ namespace ILCompiler
 
                 ISymbolNode entryPoint;
                 if (mangledName != null)
-                    entryPoint = _compilation.NodeFactory.ExternSymbol(mangledName);
+                    entryPoint = _compilation.NodeFactory.ExternFunctionSymbol(mangledName);
                 else
                     entryPoint = _compilation.NodeFactory.MethodEntrypoint(methodDesc);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
@@ -476,7 +476,7 @@ namespace ILCompiler.ObjectWriter
                         relocTarget.Offset);
 
                     if (_options.HasFlag(ObjectWritingOptions.ControlFlowGuard) &&
-                        relocTarget is IMethodNode or AssemblyStubNode or AddressTakenExternSymbolNode)
+                        relocTarget is IMethodNode or AssemblyStubNode or AddressTakenExternFunctionSymbolNode)
                     {
                         // For now consider all method symbols address taken.
                         // We could restrict this in the future to those that are referenced from

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/WasmObjectWriter.EmitObject.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/WasmObjectWriter.EmitObject.cs
@@ -90,7 +90,7 @@ namespace ILCompiler.ObjectWriter
             public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
             {
                 byte[] data = new byte[4];
-                ExternSymbolNode canary = new ExternSymbolNode("RhpGetStackTraceIpCanary");
+                ExternFunctionSymbolNode canary = new ExternFunctionSymbolNode("RhpGetStackTraceIpCanary");
                 Relocation reloc = new Relocation(RelocType.R_WASM_FUNCTION_INDEX_I32, 0, canary);
                 return new ObjectData(data, [reloc], data.Length, [this]);
             }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/WasmObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/WasmObjectWriter.cs
@@ -819,13 +819,12 @@ namespace ILCompiler.ObjectWriter
                     case IMethodNode methodNode:
                         return WasmAbi.GetWasmFunctionType(methodNode.Method);
                     default:
-                        // We assume extenal symbol nodes are functions. This is rather fragile, but handling this precisely
-                        // would require modifying producers of these nodes to provide more information (namely, the signature
-                        // for function symbols).
+                        // The below is rather fragile, but handling this precisely would require modifying producers of
+                        // these nodes to provide more information (namely, the signature for function symbols).
                         // TODO-LLVM-Bug: depending on the order symbols are encountered, this hack could lead to problems.
                         // E. g. a "naked" RhpNewFast, then a "properly typed" RhpNewFast runtime import. However, the linker
                         // can tolerate mismatches, so as long as the problematic functions aren't called directly...
-                        Debug.Assert(Symbol is ExternSymbolNode);
+                        Debug.Assert(Symbol is ExternFunctionSymbolNode);
                         return new WasmFunctionType(WasmValueType.Invalid, []);
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/ExternMethodCellNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/ExternMethodCellNode.cs
@@ -143,7 +143,7 @@ namespace ILCompiler.DependencyAnalysis
         protected override string GetName(NodeFactory context) => $"{nameof(ExternMethodCellNode)} {ExternMethodName}";
     }
 
-    internal sealed class ExternWasmMethodNode(ExternMethodCellNode methodCell) : ExternSymbolNode(methodCell.ExternMethodName), IWasmFunctionNode
+    internal sealed class ExternWasmMethodNode(ExternMethodCellNode methodCell) : ExternFunctionSymbolNode(methodCell.ExternMethodName), IWasmFunctionNode
     {
         private readonly ExternMethodCellNode _methodCell = methodCell;
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -112,7 +112,7 @@ namespace Internal.JitInterface
 
             // TODO-LLVM: below is a hack. A proper solution would involve upstream work to allow ExternSymbolNode
             // to specify whether it represents a function or data symbol (and what its signature is if the former).
-            if (node is ExternSymbolNode externSymbolNode)
+            if (node is ExternFunctionSymbolNode externSymbolNode)
             {
                 ReadOnlySpan<byte> name = externSymbolNode.Utf8Name.AsSpan();
                 if (name.StartsWith("RhpNew"u8))
@@ -187,7 +187,7 @@ namespace Internal.JitInterface
         private static IntPtr getExceptionThrownVariable(IntPtr thisHandle)
         {
             CorInfoImpl _this = GetThis(thisHandle);
-            ISymbolNode node = _this._compilation.NodeFactory.ExternSymbol("RhpExceptionThrown");
+            ISymbolNode node = _this._compilation.NodeFactory.ExternDataSymbol("RhpExceptionThrown");
             return _this.ObjectToHandle(node);
         }
 
@@ -277,7 +277,7 @@ namespace Internal.JitInterface
                 if ((pClause->Flags & CORINFO_EH_CLAUSE_FLAGS.CORINFO_EH_CLAUSE_FILTER) != 0)
                 {
                     GetMangledFilterFuncletName(sb, pClause->FilterIndex);
-                    symbol = factory.ExternSymbol(sb.ToString());
+                    symbol = factory.ExternFunctionSymbol(sb.ToString());
                 }
                 else
                 {

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -606,28 +606,28 @@ namespace Internal.JitInterface
                     id = ReadyToRunHelper.NewObject;
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST:
-                    return _compilation.NodeFactory.ExternSymbol("RhpNewFast");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpNewFast");
                 case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_FINALIZE:
-                    return _compilation.NodeFactory.ExternSymbol("RhpNewFinalizable");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpNewFinalizable");
                 case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8:
-                    return _compilation.NodeFactory.ExternSymbol("RhpNewFastAlign8");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpNewFastAlign8");
                 case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8_FINALIZE:
-                    return _compilation.NodeFactory.ExternSymbol("RhpNewFinalizableAlign8");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpNewFinalizableAlign8");
                 case CorInfoHelpFunc.CORINFO_HELP_NEWSFAST_ALIGN8_VC:
-                    return _compilation.NodeFactory.ExternSymbol("RhpNewFastMisalign");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpNewFastMisalign");
                 case CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_DIRECT:
                     id = ReadyToRunHelper.NewArray;
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_ALIGN8:
-                    return _compilation.NodeFactory.ExternSymbol("RhpNewArrayAlign8");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpNewArrayAlign8");
                 case CorInfoHelpFunc.CORINFO_HELP_NEWARR_1_VC:
-                    return _compilation.NodeFactory.ExternSymbol("RhpNewArray");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpNewArray");
 
                 case CorInfoHelpFunc.CORINFO_HELP_STACK_PROBE:
-                    return _compilation.NodeFactory.ExternSymbol("RhpStackProbe");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpStackProbe");
 
                 case CorInfoHelpFunc.CORINFO_HELP_POLL_GC:
-                    return _compilation.NodeFactory.ExternSymbol("RhpGcPoll");
+                    return _compilation.NodeFactory.ExternFunctionSymbol("RhpGcPoll");
 
                 case CorInfoHelpFunc.CORINFO_HELP_LMUL:
                     id = ReadyToRunHelper.LMul;
@@ -785,9 +785,9 @@ namespace Internal.JitInterface
                     break;
 
                 case CorInfoHelpFunc.CORINFO_HELP_VALIDATE_INDIRECT_CALL:
-                    return _compilation.NodeFactory.ExternIndirectSymbol("__guard_check_icall_fptr");
+                    return _compilation.NodeFactory.ExternIndirectFunctionSymbol("__guard_check_icall_fptr");
                 case CorInfoHelpFunc.CORINFO_HELP_DISPATCH_INDIRECT_CALL:
-                    return _compilation.NodeFactory.ExternIndirectSymbol("__guard_dispatch_icall_fptr");
+                    return _compilation.NodeFactory.ExternIndirectFunctionSymbol("__guard_dispatch_icall_fptr");
 
                 case CorInfoHelpFunc.CORINFO_HELP_LLVM_GET_OR_INIT_SHADOW_STACK_TOP:
                     mangledName = "RhpGetOrInitShadowStackTop";
@@ -828,13 +828,9 @@ namespace Internal.JitInterface
 
             ISymbolNode entryPoint;
             if (mangledName != null)
-            {
-                entryPoint = _compilation.NodeFactory.ExternSymbol(mangledName);
-            }
+                entryPoint = _compilation.NodeFactory.ExternFunctionSymbol(mangledName);
             else
-            {
                 entryPoint = _compilation.NodeFactory.MethodEntrypoint(methodDesc);
-            }
 
             return entryPoint;
         }
@@ -1674,7 +1670,7 @@ namespace Internal.JitInterface
                     // If this is LDVIRTFTN of an interface method that is part of a verifiable delegate creation sequence,
                     // RyuJIT is not going to use this value.
                     pResult->exactContextNeedsRuntimeLookup = false;
-                    pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternSymbol("NYI_LDVIRTFTN"));
+                    pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternFunctionSymbol("NYI_LDVIRTFTN"));
                 }
                 else
                 {
@@ -1946,7 +1942,7 @@ namespace Internal.JitInterface
             string externName = _compilation.PInvokeILProvider.GetDirectCallExternName(md);
             externName = _compilation.NodeFactory.NameMangler.NodeMangler.ExternMethod(externName, md);
 
-            pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternSymbol(externName));
+            pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternFunctionSymbol(externName));
         }
 
         private void getGSCookie(IntPtr* pCookieVal, IntPtr** ppCookieVal)
@@ -2507,10 +2503,10 @@ namespace Internal.JitInterface
         private void getThreadLocalStaticInfo_NativeAOT(CORINFO_THREAD_STATIC_INFO_NATIVEAOT* pInfo)
         {
             pInfo->offsetOfThreadLocalStoragePointer = (uint)(11 * PointerSize); // Offset of ThreadLocalStoragePointer in the TEB
-            pInfo->tlsIndexObject = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternSymbol("_tls_index"));
+            pInfo->tlsIndexObject = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternDataSymbol("_tls_index"));
             pInfo->tlsRootObject = CreateConstLookupToSymbol(_compilation.NodeFactory.TlsRoot);
             pInfo->threadStaticBaseSlow = CreateConstLookupToSymbol(_compilation.NodeFactory.HelperEntrypoint(HelperEntrypoint.GetInlinedThreadStaticBaseSlow));
-            pInfo->tlsGetAddrFtnPtr = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternSymbol("__tls_get_addr"));
+            pInfo->tlsGetAddrFtnPtr = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternFunctionSymbol("__tls_get_addr"));
         }
 
 #pragma warning disable CA1822 // Mark members as static


### PR DESCRIPTION
The key change is in the second commit:
```diff
-        public static bool IsFunction(ISymbolNode symbol) => symbol is ExternSymbolNode or IWasmFunctionNode or IMethodNode { Offset: 0 };
+        public static bool IsFunction(ISymbolNode symbol) =>
+            symbol is ExternFunctionSymbolNode or IWasmFunctionNode or IMethodNode { Offset: 0 };
```
