### PR TITLE
[NativeAOT-LLVM] Exclude `ExceptionHandling.cs` from the WASM build and pass `-O1` to `emcc`

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -588,8 +588,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Condition="'$(NativeDebugSymbols)' != 'true'" Include="-Wl,--strip-all" />
       <!-- TODO-LLVM: https://github.com/dotnet/runtimelab/issues/2752. -->
       <!--<CustomLinkerArg Condition="'$(NativeDebugSymbols)' != 'true'" Include="-Wl,compress-relocations" />-->
-      <!-- see https://github.com/emscripten-core/emscripten/issues/16836 for the issue that means we have to force the linker to include these symbols before LTO -->
-      <!--<CustomLinkerArg Condition="'$(Optimize)' != 'true'" Include="$(WasmOptimizationSetting) -flto" /> -->
       <CustomLinkerArg Condition="'$(IlcLlvmTarget)' != ''" Include="-target $(IlcLlvmTarget)" />
     </ItemGroup>
 
@@ -601,13 +599,15 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-s GLOBAL_BASE=$(IlcWasmGlobalBase)" />
       <CustomLinkerArg Include="-s TOTAL_STACK=$(IlcWasmStackSize)" />
       <CustomLinkerArg Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" Condition="'$(IlcTreatWarningsAsErrors)' != 'true'" />
-      <CustomLinkerArg Condition="'$(WasmEnableJSBigIntIntegration)' == 'true'" Include="-s WASM_BIGINT=1" />
-      <CustomLinkerArg Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'" Include="-s DISABLE_EXCEPTION_CATCHING=0" />
-
-      <CustomLinkerArg Include="$(EmccFlags)" />
+      <CustomLinkerArg Include="-s WASM_BIGINT=1" Condition="'$(WasmEnableJSBigIntIntegration)' == 'true'" />
+      <CustomLinkerArg Include="-s DISABLE_EXCEPTION_CATCHING=0" Condition="'$(IlcLlvmExceptionHandlingModel)' == 'cpp'" />
       <CustomLinkerArg Include="-s MAXIMUM_MEMORY=$(EmccMaximumHeapSize)" Condition="'$(EmccMaximumHeapSize)' != ''" />
       <CustomLinkerArg Include="-s INITIAL_MEMORY=$(EmccInitialHeapSize)" Condition="'$(EmccInitialHeapSize)' != ''" />
-      <CustomLinkerArg Condition="'$(EmccEnableAssertions)' == 'true'" Include="-s ASSERTIONS=1" />
+      <CustomLinkerArg Include="-s ASSERTIONS=1" Condition="'$(EmccEnableAssertions)' == 'true'" />
+
+      <!-- See https://github.com/dotnet/runtimelab/issues/2357 for why we don't run wasm-opt (it would mangle our strack trace info). -->
+      <CustomLinkerArg Condition="'$(Optimize)' == 'true'" Include="-O1" />
+      <CustomLinkerArg Include="$(EmccFlags)" />
     </ItemGroup>
 
     <!-- wasm-ld only supports listing exports on the command line -->

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -96,7 +96,7 @@ namespace System.Runtime
                     }
                     else
                     {
-                        if (ShouldTypedClauseCatchThisException(exception, clause.ClauseType, false /* tryUnwrapException, not used for NATIVEAOT */))
+                        if (ShouldTypedClauseCatchThisException(exception, clause.ClauseType))
                         {
                             goto FoundHandler;
                         }
@@ -868,5 +868,99 @@ namespace System.Runtime
 
             return (int)(pCurrent - pUnwindInfo);
         }
+    }
+
+    // TODO-LLVM-Upstream: create ExceptionHandling.Common.cs and put the things below there.
+    internal static unsafe partial class EH
+    {
+        private enum RhEHFrameType
+        {
+            RH_EH_FIRST_FRAME = 1,
+            RH_EH_FIRST_RETHROW_FRAME = 2,
+        }
+
+        private enum RhEHClauseKind
+        {
+            RH_EH_CLAUSE_TYPED = 0,
+            RH_EH_CLAUSE_FAULT = 1,
+            RH_EH_CLAUSE_FILTER = 2,
+            RH_EH_CLAUSE_UNUSED = 3,
+        }
+
+        internal struct MethodRegionInfo
+        {
+        }
+
+        internal struct ExInfo
+        {
+        }
+
+        internal struct PAL_LIMITED_CONTEXT
+        {
+        }
+
+        [StackTraceHidden]
+        [RuntimeExport("RhExceptionHandling_FailedAllocation")]
+        public static void FailedAllocation(MethodTable* pEEType, bool fIsOverflow)
+        {
+            ExceptionIDs exID = fIsOverflow ? ExceptionIDs.Overflow : ExceptionIDs.OutOfMemory;
+
+            // Throw the out of memory exception defined by the classlib, using the input MethodTable*
+            // to find the correct classlib.
+
+            throw pEEType->GetClasslibException(exID);
+        }
+
+        private static bool ShouldTypedClauseCatchThisException(object exception, MethodTable* pClauseType)
+        {
+            return TypeCast.IsInstanceOfException(pClauseType, exception);
+        }
+
+        private static void OnFirstChanceExceptionViaClassLib(object exception)
+        {
+            IntPtr pOnFirstChanceFunction =
+                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(exception.GetMethodTable(), ClassLibFunctionId.OnFirstChance);
+
+            if (pOnFirstChanceFunction == IntPtr.Zero)
+            {
+                return;
+            }
+
+            try
+            {
+                ((delegate*<object, void>)pOnFirstChanceFunction)(exception);
+            }
+            catch when (true)
+            {
+                // disallow all exceptions leaking out of callbacks
+            }
+        }
+
+        private static void OnUnhandledExceptionViaClassLib(object exception)
+        {
+            IntPtr pOnUnhandledExceptionFunction =
+                (IntPtr)InternalCalls.RhpGetClasslibFunctionFromEEType(exception.GetMethodTable(), ClassLibFunctionId.OnUnhandledException);
+
+            if (pOnUnhandledExceptionFunction == IntPtr.Zero)
+            {
+                return;
+            }
+
+            try
+            {
+                ((delegate*<object, void>)pOnUnhandledExceptionFunction)(exception);
+            }
+            catch when (true)
+            {
+                // disallow all exceptions leaking out of callbacks
+            }
+        }
+
+#pragma warning disable IDE0060
+        internal static void FallbackFailFast(RhFailFastReason reason, object? unhandledException)
+        {
+            InternalCalls.RhpFallbackFailFast();
+        }
+#pragma warning restore IDE0060
     }
 }

--- a/src/coreclr/nativeaot/Runtime/wasm/ExceptionHandling/ExceptionHandling.cpp
+++ b/src/coreclr/nativeaot/Runtime/wasm/ExceptionHandling/ExceptionHandling.cpp
@@ -48,8 +48,3 @@ FCIMPL0(void*, RhpGetLastPreciseVirtualUnwindFrame)
     return static_cast<uint8_t*>(pShadowStack) - sizeof(void*);
 }
 FCIMPLEND
-
-// We do not use these helpers. TODO-LLVM: exclude them from the WASM build.
-FCIMPL4(void*, RhpCallCatchFunclet, void*, void*, void*, void*) { abort(); } FCIMPLEND
-FCIMPL3(bool, RhpCallFilterFunclet, void*, void*, void*) { abort(); } FCIMPLEND
-FCIMPL2(void, RhpCallFinallyFunclet, void*, void*) { abort(); } FCIMPLEND

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -588,8 +588,11 @@
     <Compile Include="$(RuntimeBasePath)System\Runtime\MethodTable.Runtime.cs">
       <Link>Runtime.Base\src\System\Runtime\MethodTable.Runtime.cs</Link>
     </Compile>
-    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.cs">
+    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.cs" Condition="'$(WasmAbi)' != 'true'">
       <Link>Runtime.Base\src\System\Runtime\ExceptionHandling.cs</Link>
+    </Compile>
+    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.wasm.cs" Condition="'$(WasmAbi)' == 'true'">
+      <Link>Runtime.Base\src\System\Runtime\ExceptionHandling.wasm.cs</Link>
     </Compile>
     <Compile Include="$(RuntimeBasePath)System\Runtime\InternalCalls.cs">
       <Link>Runtime.Base\src\System\Runtime\InternalCalls.cs</Link>
@@ -611,9 +614,6 @@
     </Compile>
     <Compile Include="$(AotCommonPath)\Internal\Runtime\TransitionBlock.cs">
       <Link>Common\TransitionBlock.cs</Link>
-    </Compile>
-    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.wasm.cs" Condition="'$(WasmAbi)' == 'true'">
-      <Link>Runtime.Base\src\System\Runtime\ExceptionHandling.wasm.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(InPlaceRuntime)' == 'true'">

--- a/src/tests/nativeaot/Directory.Build.props
+++ b/src/tests/nativeaot/Directory.Build.props
@@ -15,4 +15,10 @@
     <DefineConstants Condition="'$(TargetsWasm)' == 'true'">$(DefineConstants);CODEGEN_WASM</DefineConstants>
     <DefineConstants Condition="$(TargetOS) == 'wasi'">$(DefineConstants);CODEGEN_WASI</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Our stack trace implementation is not compatible with post-link optimizations/changes. -->
+    <!-- Exempt $(EmccExtraArgs) so that quick experimentation from the command line is still possible. -->
+    <LinkerArg Include="-sERROR_ON_WASM_CHANGES_AFTER_LINK=1" Condition="'$(TargetsBrowser)' == 'true' and '$(EmccExtraArgs)' == ''" />
+  </ItemGroup>
 </Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
@@ -496,10 +496,6 @@ if ($Analyze -or $Summary)
 
         $RegressionCount = 0
         $ImprovementCount = 0
-        $HaveRegressionDiffs = $false
-        $HaveImprovementDiffs = $false
-        $HaveBaseOnlyMethods = $false
-        $HaveDiffOnlyMethods = $false
         $AverageRelativeCodeSizeDelta = 0.0
         foreach ($Diff in $Diffs)
         {
@@ -517,22 +513,11 @@ if ($Analyze -or $Summary)
             # Just skip them for now.
             if ($Diff.Base.Size -eq 0)
             {
-                $HaveDiffOnlyMethods = $true
                 continue
             }
             if ($Diff.Diff.Size -eq 0)
             {
-                $HaveBaseOnlyMethods = $true
                 continue
-            }
-
-            if ($IsRegression)
-            {
-                $HaveRegressionDiffs = $true
-            }
-            else
-            {
-                $HaveImprovementDiffs = $true
             }
 
             $AverageRelativeCodeSizeDelta += $Diff.CodeSizeDelta / $Diff.Base.Size
@@ -558,8 +543,13 @@ if ($Analyze -or $Summary)
         Write-Host "    average relative diff is $($AverageRelativeCodeSizeDelta -lt 0 ? 'an improvement' : 'a regression')"
         Write-Host ""
 
-        function ShowRelativeDiffs($DiffsToShow, $Message, $ShowBaseOnlyMethods = $false, $ShowDiffOnlyMethods = $false)
+        function ShowRelativeDiffs($DiffsToShow, $Message)
         {
+            if ($DiffsToShow.Length -eq 0)
+            {
+                return
+            }
+
             Write-Host $Message
 
             $DiffsShown = 0
@@ -570,42 +560,33 @@ if ($Analyze -or $Summary)
                     break
                 }
 
-                $IsBaseOnlyMethod = $Diff.Diff.Size -eq 0
-                $IsDiffOnlyMethod = $Diff.Base.Size -eq 0
-                if (($ShowBaseOnlyMethods -eq $IsBaseOnlyMethod) -and ($ShowDiffOnlyMethods -eq $IsDiffOnlyMethod))
-                {
-                    Write-Host ("    {0,8} ({1,6:P} of base) : {2} - {3}" -f
-                        $Diff.CodeSizeDelta, ($Diff.CodeSizeDelta / $Diff.Base.Size), $Diff.DiffFileName, $Diff.Name)
-                    $DiffsShown++
-                }
+                Write-Host("    {0,8} ({1,6:P} of base) : {2} - {3}" -f
+                    $Diff.CodeSizeDelta, ($Diff.CodeSizeDelta / $Diff.Base.Size), $Diff.DiffFileName, $Diff.Name)
+                $DiffsShown++
             }
             Write-Host ""
         }
 
         if ($RegressionCount -ne 0)
         {
-            $RegressionDiffs = $Diffs | sort { $_.CodeSizeDelta / $_.Base.Size } -Descending | where CodeSizeDelta -gt 0
-            if ($HaveRegressionDiffs)
-            {
-                ShowRelativeDiffs $RegressionDiffs "Top method regressions (percentages):"
-            }
-            if ($HaveDiffOnlyMethods)
-            {
-                ShowRelativeDiffs $RegressionDiffs "Top methods only present in diff:" -ShowDiffOnlyMethods $true
-            }
+            $RegressionDiffs = $Diffs | where CodeSizeDelta -gt 0
+
+            $ActualRegressionDiffs = $RegressionDiffs | where { $_.Base.Size -ne 0 } | sort { $_.CodeSizeDelta / $_.Base.Size } -Descending
+            ShowRelativeDiffs $ActualRegressionDiffs "Top method regressions (percentages):"
+
+            $DiffOnlyDiffs = $RegressionDiffs | where { $_.Base.Size -eq 0 } | sort CodeSizeDelta -Descending
+            ShowRelativeDiffs $DiffOnlyDiffs "Top methods only present in diff:"
         }
 
         if ($ImprovementCount -ne 0)
         {
-            $ImprovementDiffs = $Diffs | sort { $_.CodeSizeDelta / $_.Base.Size } | where CodeSizeDelta -lt 0
-            if ($HaveImprovementDiffs)
-            {
-                ShowRelativeDiffs $ImprovementDiffs "Top method improvements (percentages):"
-            }
-            if ($HaveBaseOnlyMethods)
-            {
-                ShowRelativeDiffs $ImprovementDiffs "Top methods only present in base:" -ShowBaseOnlyMethods $true
-            }
+            $ImprovementDiffs = $Diffs | where CodeSizeDelta -lt 0
+
+            $ActualImprovementDiffs = $ImprovementDiffs | where { $_.Diff.Size -ne 0 } | sort { $_.CodeSizeDelta / $_.Base.Size }
+            ShowRelativeDiffs $ActualImprovementDiffs "Top method improvements (percentages):"
+
+            $BaseOnlyDiffs = $ImprovementDiffs | where { $_.Diff.Size -eq 0 } | sort CodeSizeDelta
+            ShowRelativeDiffs $BaseOnlyDiffs "Top methods only present in base:"
         }
 
         Write-Host "$($Diffs.Count) total methods with Code Size differences ($ImprovementCount improved, $RegressionCount regressed)"


### PR DESCRIPTION
The non-WASM EH code roots almost 0.8% of HelloWorld code.

Diffs (WasmDebugging):
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 674872
Total bytes of diff: 669465
Total bytes of delta: -5407 (-0.80% % of base)
Average relative delta: 2.13%
    diff is an improvement
    average relative diff is a regression

Top method regressions (percentages):
         933 (134.05% of base) : 1049.dasm - S_P_CoreLib_System_Exception__ToString
         128 (54.94% of base) : 1031.dasm - S_P_CoreLib_System_Runtime_InteropServices_GCHandle___ctor
         140 (45.16% of base) : 1007.dasm - S_P_CoreLib_System_Runtime_RuntimeExports__RhUnboxAny
         119 (16.39% of base) : 1029.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__Expand
         119 (15.78% of base) : 1028.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__TryAddOrGetExisting
          15 ( 2.38% of base) : 1050.dasm - S_P_CoreLib_System_Runtime_TypeCast__AreTypesAssignableInternalUncached

Top method improvements (percentages):
        -185 (-81.14% of base) : 1030.dasm - S_P_CoreLib_System_Runtime_CachedInterfaceDispatch__RhpCidResolve
        -122 (-37.54% of base) : 1048.dasm - S_P_CoreLib_System_Runtime_TypeCast__AreTypesAssignable
        -198 (-21.45% of base) : 1038.dasm - S_P_CoreLib_System_Runtime_EH__DispatchException
        -119 (-17.73% of base) : 1047.dasm - S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport__IDynamicCastableGetInterfaceImplementation
          -2 (-1.22% of base) : 1046.dasm - S_P_CoreLib_System_Runtime_DispatchResolve__FindImplSlotForCurrentType
          -5 (-0.95% of base) : 1008.dasm - S_P_CoreLib_Internal_Runtime_CompilerHelpers_StartupCodeHelpers__CreateTypeManagers

Top methods only present in base:
        -789 (-100.00% of base) : 1036.dasm - S_P_CoreLib_System_Runtime_EH__DispatchEx
        -715 (-100.00% of base) : 1012.dasm - StackFrameIterator::NextInternal()
        -657 (-100.00% of base) : 1042.dasm - S_P_CoreLib_System_Runtime_EH__FindFirstPassHandler
        -501 (-100.00% of base) : 1039.dasm - S_P_CoreLib_System_Runtime_EH__InvokeSecondPass_0
        -415 (-100.00% of base) : 1040.dasm - S_P_CoreLib_System_Runtime_EH__UnhandledExceptionFailFastViaClasslib
        -392 (-100.00% of base) : 1010.dasm - StackFrameIterator::InternalInitForStackTrace()
        -370 (-100.00% of base) : 1025.dasm - S_P_CoreLib_System_Runtime_EH__RhThrowHwEx
        -336 (-100.00% of base) : 1034.dasm - S_P_CoreLib_System_Runtime_EH__FailFastViaClasslib
        -333 (-100.00% of base) : 1044.dasm - S_P_CoreLib_System_Runtime_EH__AppendExceptionStackFrameViaClasslib
        -280 (-100.00% of base) : 1033.dasm - S_P_CoreLib_System_Runtime_EH__GetClasslibException
        -258 (-100.00% of base) : 1009.dasm - StackFrameIterator::CalculateCurrentMethodState()
        -211 (-100.00% of base) : 1015.dasm - RhpSfiNext
        -155 (-100.00% of base) : 1014.dasm - RhpSfiInit
        -134 (-100.00% of base) : 1024.dasm - S_P_CoreLib_System_Runtime_EH__RhThrowEx
        -115 (-100.00% of base) : 1021.dasm - S_P_CoreLib_System_Runtime_EH__RhpFailFastForPInvokeExceptionPreemp
        -110 (-100.00% of base) : 1023.dasm - S_P_CoreLib_System_Runtime_EH__RhRethrow
         -78 (-100.00% of base) : 1032.dasm - S_P_CoreLib_System_Runtime_EH_ExInfo__Init
         -65 (-100.00% of base) : 1016.dasm - RhpEHEnumInitFromStackFrameIterator
         -60 (-100.00% of base) : 1000.dasm - RuntimeInstance::GetClasslibFunctionFromCodeAddress(void*, ClasslibFunctionId)
         -44 (-100.00% of base) : 1019.dasm - RhpSetThreadDoNotTriggerGC

51 total methods with Code Size differences (45 improved, 6 regressed)
```
The `-O1` change excises yet more code by making Emscripten link-in the "release" version of its standard libraries.
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 669465
Total bytes of diff: 659909
Total bytes of delta: -9556 (-1.43% % of base)
Average relative delta: -2.81%
    diff is an improvement
    average relative diff is an improvement

Top method improvements (percentages):
         -78 (-89.66% of base) : 1030.dasm - abort_message
          -3 (-11.54% of base) : 1000.dasm - __wasm_call_ctors

Top methods only present in base:
       -3376 (-100.00% of base) : 1020.dasm - fmt_fp
       -2548 (-100.00% of base) : 1011.dasm - printf_core
        -570 (-100.00% of base) : 1014.dasm - pop_arg
        -504 (-100.00% of base) : 1009.dasm - __trunctfdf2
        -403 (-100.00% of base) : 1010.dasm - __vfprintf_internal
        -300 (-100.00% of base) : 1004.dasm - wcrtomb
        -229 (-100.00% of base) : 1002.dasm - memchr
        -164 (-100.00% of base) : 1023.dasm - __overflow
        -146 (-100.00% of base) : 1006.dasm - frexp
        -136 (-100.00% of base) : 1017.dasm - fmt_u
        -132 (-100.00% of base) : 1026.dasm - locking_putc
        -132 (-100.00% of base) : 1018.dasm - pad
        -123 (-100.00% of base) : 1025.dasm - do_putc
        -123 (-100.00% of base) : 1013.dasm - getint
         -83 (-100.00% of base) : 1007.dasm - __ashlti3
         -83 (-100.00% of base) : 1008.dasm - __lshrti3
         -64 (-100.00% of base) : 1015.dasm - fmt_x
         -54 (-100.00% of base) : 1016.dasm - fmt_o
         -49 (-100.00% of base) : 1021.dasm - pop_arg_long_double
         -32 (-100.00% of base) : 1031.dasm - emscripten_stack_init

36 total methods with Code Size differences (36 improved, 0 regressed)
```

Contributes to https://github.com/dotnet/runtimelab/issues/3132.
Contributes to https://github.com/dotnet/runtimelab/issues/2169.