### PR TITLE
[NativeAOT-LLVM] Separate out trivial includes and types from llvm.h

### DIFF
--- a/src/coreclr/jit/llvm.cpp
+++ b/src/coreclr/jit/llvm.cpp
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include "jitpch.h"
 #include "llvm.h"
 
 // TODO-LLVM-Upstream: figure out how to fix these warnings in LLVM headers.
@@ -12,6 +11,7 @@
 #pragma warning (disable : 4267)
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Support/Signals.h"
+#include "llvm/IR/Verifier.h"
 #pragma warning(pop)
 
 void* g_callbacks[EEAI_Count];

--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -23,11 +23,14 @@
 #pragma warning(disable : 4459)
 #pragma warning(disable : 4702)
 #include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/Verifier.h"
-#include "llvm/IR/IntrinsicsWebAssembly.h"
 #pragma warning(pop)
+
+// Forward-declare some LLVM types to avoid including the corresponding header into each compilation unit.
+namespace llvm
+{
+    class DIBuilder;
+};
 
 using llvm::LLVMContext;
 using llvm::Module;
@@ -51,24 +54,12 @@ const int TARGET_POINTER_BITS = TARGET_POINTER_SIZE * BITS_PER_BYTE;
 
 // Part of the Jit/EE interface, must be kept in sync with the managed versions in "CorInfoImpl.Llvm.cs".
 //
-enum class CorInfoLlvmEHModel
-{
-    Cpp, // Landingpad-based LLVM IR; compatible with Itanium ABI.
-    Wasm, // WinEH-based LLVM IR; custom WASM EH-based ABI.
-    Emulated, // Invoke-free LLVM IR; "unwinding" performed via explicit checks and returns
-};
-
 struct CORINFO_LLVM_EH_CLAUSE
 {
     CORINFO_EH_CLAUSE_FLAGS Flags;
     unsigned EnclosingIndex;
     mdToken ClauseTypeToken;
     unsigned FilterIndex;
-};
-
-enum CorInfoLlvmJitTestKind
-{
-    CORINFO_JIT_TEST_LSSA = 1
 };
 
 struct CORINFO_LLVM_JIT_TEST_INFO
@@ -117,7 +108,7 @@ template <typename T>
 struct JitStdMallocAllocator
 {
     MallocAllocator m_alloc;
-    JitStdMallocAllocator(MallocAllocator alloc) : m_alloc(alloc) { }
+    JitStdMallocAllocator(MallocAllocator alloc) : m_alloc(alloc) {}
 
     T* allocate(size_t count)
     {
@@ -263,35 +254,9 @@ struct PhiPair
     llvm::PHINode* LlvmPhiNode;
 };
 
-struct LlvmBlockRange
-{
-    llvm::BasicBlock* FirstBlock;
-    llvm::BasicBlock* LastBlock;
-    INDEBUG(unsigned Count = 1);
-
-    LlvmBlockRange(llvm::BasicBlock* llvmBlock) : FirstBlock(llvmBlock), LastBlock(llvmBlock)
-    {
-    }
-};
-
-typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, llvm::AllocaInst*> AllocaMap;
-
-struct FunctionInfo
-{
-    Function* LlvmFunction;
-    union {
-        llvm::AllocaInst** Allocas; // Dense "lclNum -> Alloca*" mapping used for the main function.
-        AllocaMap* AllocaMap; // Sparse "lclNum -> Alloca*" mapping used for funclets.
-    };
-    llvm::BasicBlock* ResumeLlvmBlock;
-    llvm::BasicBlock* ExceptionThrownReturnLlvmBlock;
-};
-
-struct EHRegionInfo
-{
-    llvm::BasicBlock* UnwindBlock;
-    Value* CatchArgValue;
-};
+struct LlvmBlockRange;
+struct EHRegionInfo;
+struct FunctionInfo;
 
 class TypeDebugInfoModule;
 class SingleThreadedCompilationContext
@@ -684,8 +649,8 @@ private:
     CallSiteFacts getCallSiteFactsForHelper(CorInfoHelpFunc helperFunc);
     void annotateHelperFunction(CorInfoHelpFunc helperFunc, Function* llvmFunc);
     Function* getOrCreateKnownLlvmFunction(StringRef name,
-                                           std::function<FunctionType*()> createFunctionType,
-                                           std::function<void(Function*)> annotateFunction = [](Function*) { });
+        std::function<FunctionType* ()> createFunctionType,
+        std::function<void(Function*)> annotateFunction = [](Function*) {});
 
     EHRegionInfo& getEHRegionInfo(unsigned ehIndex);
     llvm::BasicBlock* getUnwindLlvmBlockForCurrentInvoke();
@@ -757,6 +722,8 @@ private:
 
     void declareDebugVariables();
     void assignDebugVariable(unsigned lclNum, Value* value);
+
+    void finalizeDebugInfo();
 
     unsigned getLineNumberForILOffset(unsigned ilOffset);
     llvm::DILocation* getDebugLocation(unsigned lineNo);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -7,7 +7,45 @@
 
 #include "llvm.h"
 
+// TODO-LLVM-Upstream: figure out how to fix these warnings in LLVM headers.
+#pragma warning(push)
+#pragma warning(disable : 4242)
+#pragma warning(disable : 4244)
+#include "llvm/IR/Verifier.h"
+#include "llvm/IR/IntrinsicsWebAssembly.h"
+#pragma warning(pop)
+
 #define BBNAME(prefix, index) Twine(prefix) + ((index < 10) ? "0" : "") + Twine(index)
+
+using AllocaMap = JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, llvm::AllocaInst*>;
+
+struct LlvmBlockRange
+{
+    llvm::BasicBlock* FirstBlock;
+    llvm::BasicBlock* LastBlock;
+    INDEBUG(unsigned Count = 1);
+
+    LlvmBlockRange(llvm::BasicBlock* llvmBlock) : FirstBlock(llvmBlock), LastBlock(llvmBlock)
+    {
+    }
+};
+
+struct EHRegionInfo
+{
+    llvm::BasicBlock* UnwindBlock;
+    Value* CatchArgValue;
+};
+
+struct FunctionInfo
+{
+    Function* LlvmFunction;
+    union {
+        llvm::AllocaInst** Allocas; // Dense "lclNum -> Alloca*" mapping used for the main function.
+        AllocaMap* AllocaMap; // Sparse "lclNum -> Alloca*" mapping used for funclets.
+    };
+    llvm::BasicBlock* ResumeLlvmBlock;
+    llvm::BasicBlock* ExceptionThrownReturnLlvmBlock;
+};
 
 //------------------------------------------------------------------------
 // Compile: Compile IR to LLVM, adding to the LLVM Module
@@ -25,12 +63,7 @@ void Llvm::Compile()
     generateUnwindBlocks();
     generateBlocks();
     fillPhis();
-
-    if (m_diFunction != nullptr)
-    {
-        m_diBuilder->finalizeSubprogram(m_diFunction);
-    }
-
+    finalizeDebugInfo();
     generateAuxiliaryArtifacts();
 
     displayGeneratedCode();
@@ -398,7 +431,7 @@ void Llvm::generateUnwindBlocks()
     llvm::Constant* nullValue = llvm::Constant::getNullValue(ptrLlvmType);
     Function* personalityLlvmFunc = getOrCreatePersonalityLlvmFunction(m_ehModel);
     Function* cppBeginCatchFunc = nullptr;
-    if (model == CorInfoLlvmEHModel::Cpp)
+    if (model == CORINFO_LLVM_EH_CPP)
     {
         cppBeginCatchFunc = getOrCreateKnownLlvmFunction("__cxa_begin_catch", [ptrLlvmType]() {
             return FunctionType::get(ptrLlvmType, {ptrLlvmType}, /* isVarArg */ false);
@@ -465,7 +498,7 @@ void Llvm::generateUnwindBlocks()
 
         // The code we will generate uses native unwinding to call second-pass handlers.
         //
-        // For CorInfoLlvmEHModel::Cpp:
+        // For CORINFO_LLVM_EH_CPP:
         //
         // UNWIND_INNER:
         //   __cxa_begin_catch(landingPadInst.ExceptionData);
@@ -482,7 +515,7 @@ void Llvm::generateUnwindBlocks()
         // RESUME:
         //   resume(cppExcTuple); // Rethrow the exception and unwind to caller.
         //
-        // CorInfoLlvmEHModel::Wasm has the same structure but uses Windows EH instructions and rethrows:
+        // CORINFO_LLVM_EH_WASM has the same structure but uses Windows EH instructions and rethrows:
         //
         // UNWIND_INNER:
         //   catchswitch unwind to UNWIND_OUTER
@@ -494,7 +527,7 @@ void Llvm::generateUnwindBlocks()
         //   }
         //   <Catch handler code...>
         //
-        // CorInfoLlvmEHModel::Emulated uses fully "manual" unwinding based on early returns:
+        // CORINFO_LLVM_EH_EMULATED uses fully "manual" unwinding based on early returns:
         //
         // UNWIND_INNER:
         //   RhpExceptionThrown = 0; // Stop the unwinding before calling managed code.
@@ -517,7 +550,7 @@ void Llvm::generateUnwindBlocks()
         // Create the C++ exception data alloca, to store the active landing pad value.
         FunctionInfo& funcInfo = getLlvmFunctionInfoForIndex(funcIdx);
         llvm::AllocaInst* cppExcTupleAlloca = funcData.CppExcTupleAlloca;
-        if ((model == CorInfoLlvmEHModel::Cpp) && (cppExcTupleAlloca == nullptr))
+        if ((model == CORINFO_LLVM_EH_CPP) && (cppExcTupleAlloca == nullptr))
         {
             llvm::BasicBlock* prologLlvmBlock = getOrCreatePrologLlvmBlockForFunction(funcIdx);
 
@@ -529,7 +562,7 @@ void Llvm::generateUnwindBlocks()
 
         // Generate the resume block needed in the C++ and emulated models.
         if ((funcInfo.ResumeLlvmBlock == nullptr) &&
-            ((model == CorInfoLlvmEHModel::Cpp) || (model == CorInfoLlvmEHModel::Emulated)))
+            ((model == CORINFO_LLVM_EH_CPP) || (model == CORINFO_LLVM_EH_EMULATED)))
         {
             llvm::BasicBlock* resumeLlvmBlock =
                 llvm::BasicBlock::Create(m_context->Context, "BBRE", llvmFunc, funcData.InsertBeforeLlvmBlock);
@@ -537,7 +570,7 @@ void Llvm::generateUnwindBlocks()
             setCurrentEmitContext(
                 funcIdx, EHblkDsc::NO_ENCLOSING_INDEX, EHblkDsc::NO_ENCLOSING_INDEX, &resumeLlvmBlocks);
 
-            if (model == CorInfoLlvmEHModel::Cpp)
+            if (model == CORINFO_LLVM_EH_CPP)
             {
                 Value* resumeOperandValue = _builder.CreateLoad(cppExcTupleLlvmType, cppExcTupleAlloca);
                 _builder.CreateResume(resumeOperandValue);
@@ -561,9 +594,9 @@ void Llvm::generateUnwindBlocks()
         _builder.SetCurrentDebugLocation(unwindBlocksDebugLoc);
 
         // Set up entry to the native "catch".
-        if ((model == CorInfoLlvmEHModel::Cpp) || (model == CorInfoLlvmEHModel::Emulated))
+        if ((model == CORINFO_LLVM_EH_CPP) || (model == CORINFO_LLVM_EH_EMULATED))
         {
-            if (model == CorInfoLlvmEHModel::Cpp)
+            if (model == CORINFO_LLVM_EH_CPP)
             {
                 llvm::LandingPadInst* landingPadInst = _builder.CreateLandingPad(cppExcTupleLlvmType, 1);
                 landingPadInst->addClause(nullValue); // Catch all C++ exceptions.
@@ -2275,11 +2308,11 @@ void Llvm::buildCatchRet(BasicBlock* block)
     llvm::BasicBlock* destLlvmBlock = getFirstLlvmBlockForBlock(block->GetTarget());
     switch (m_ehModel)
     {
-        case CorInfoLlvmEHModel::Cpp:
-        case CorInfoLlvmEHModel::Emulated:
+        case CORINFO_LLVM_EH_CPP:
+        case CORINFO_LLVM_EH_EMULATED:
             _builder.CreateBr(destLlvmBlock);
             break;
-        case CorInfoLlvmEHModel::Wasm:
+        case CORINFO_LLVM_EH_WASM:
             _builder.CreateCatchRet(getCatchPadForHandler(block->getHndIndex()), destLlvmBlock);
             break;
         default:
@@ -2688,7 +2721,7 @@ llvm::CallBase* Llvm::emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Val
     llvm::BasicBlock* catchLlvmBlock = getUnwindLlvmBlockForCurrentInvoke();
 
     llvm::SmallVector<llvm::OperandBundleDef, 1> bundles{};
-    if (m_ehModel == CorInfoLlvmEHModel::Wasm)
+    if (m_ehModel == CORINFO_LLVM_EH_WASM)
     {
         llvm::CatchPadInst* catchPadInst = getCatchPadForHandler(getCurrentHandlerIndex());
         if ((catchPadInst != nullptr) && (catchPadInst->getFunction() == getCurrentLlvmFunction()))
@@ -2699,7 +2732,7 @@ llvm::CallBase* Llvm::emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Val
 
     llvm::CallBase* callInst;
     bool isThrowingCall = (callSiteFacts & CSF_NO_THROW) == 0;
-    if (isThrowingCall && (catchLlvmBlock != nullptr) && (m_ehModel != CorInfoLlvmEHModel::Emulated))
+    if (isThrowingCall && (catchLlvmBlock != nullptr) && (m_ehModel != CORINFO_LLVM_EH_EMULATED))
     {
         llvm::BasicBlock* nextLlvmBlock = createInlineLlvmBlock();
         callInst = _builder.CreateInvoke(callee, nextLlvmBlock, catchLlvmBlock, args, bundles);
@@ -2715,7 +2748,7 @@ llvm::CallBase* Llvm::emitCallOrInvoke(llvm::FunctionCallee callee, ArrayRef<Val
         }
     }
 
-    if (isThrowingCall && (m_ehModel == CorInfoLlvmEHModel::Emulated))
+    if (isThrowingCall && (m_ehModel == CORINFO_LLVM_EH_EMULATED))
     {
         // In the emulated EH model, top-level calls also need to return early if they throw.
         if (catchLlvmBlock == nullptr)
@@ -2932,7 +2965,7 @@ void Llvm::annotateHelperFunction(CorInfoHelpFunc helperFunc, Function* llvmFunc
     }
 
     HelperCallProperties& properties = Compiler::s_helperCallProperties;
-    const bool isEmulatedEH = m_ehModel == CorInfoLlvmEHModel::Emulated;
+    const bool isEmulatedEH = m_ehModel == CORINFO_LLVM_EH_EMULATED;
     const bool mayThrow = helperCallMayPhysicallyThrow(helperFunc);
 
     if (!mayThrow)
@@ -3026,7 +3059,7 @@ llvm::BasicBlock* Llvm::getUnwindLlvmBlockForCurrentInvoke()
 
 void Llvm::emitUnwindToOuterHandler()
 {
-    if (m_ehModel == CorInfoLlvmEHModel::Wasm)
+    if (m_ehModel == CORINFO_LLVM_EH_WASM)
     {
         Function* wasmRethrowLlvmFunc =
             llvm::Intrinsic::getDeclaration(&m_context->Module, llvm::Intrinsic::wasm_rethrow);
@@ -3078,7 +3111,7 @@ Function* Llvm::getOrCreatePersonalityLlvmFunction(CorInfoLlvmEHModel ehModel)
 {
     switch (ehModel)
     {
-        case CorInfoLlvmEHModel::Cpp:
+        case CORINFO_LLVM_EH_CPP:
             return getOrCreateKnownLlvmFunction("__gxx_personality_v0", [this]() {
                 Type* ptrLlvmType = getPtrLlvmType();
                 Type* int32LlvmType = Type::getInt32Ty(m_context->Context);
@@ -3086,11 +3119,11 @@ Function* Llvm::getOrCreatePersonalityLlvmFunction(CorInfoLlvmEHModel ehModel)
                 return FunctionType::get(cppExcTupleLlvmType, {int32LlvmType, ptrLlvmType, ptrLlvmType}, /* isVarArg */ true);
             });
             break;
-        case CorInfoLlvmEHModel::Wasm:
+        case CORINFO_LLVM_EH_WASM:
             return getOrCreateKnownLlvmFunction("__gxx_wasm_personality_v0", [this]() {
                 return FunctionType::get(Type::getInt32Ty(m_context->Context), /* isVarArg */ true);
             });
-        case CorInfoLlvmEHModel::Emulated:
+        case CORINFO_LLVM_EH_EMULATED:
             return nullptr;
         default:
             unreached();
@@ -3099,7 +3132,7 @@ Function* Llvm::getOrCreatePersonalityLlvmFunction(CorInfoLlvmEHModel ehModel)
 
 llvm::CatchPadInst* Llvm::getCatchPadForHandler(unsigned hndIndex)
 {
-    assert(m_ehModel == CorInfoLlvmEHModel::Wasm);
+    assert(m_ehModel == CORINFO_LLVM_EH_WASM);
     if (hndIndex == EHblkDsc::NO_ENCLOSING_INDEX)
     {
         return nullptr;
@@ -3120,7 +3153,7 @@ llvm::CatchPadInst* Llvm::getCatchPadForHandler(unsigned hndIndex)
 
 llvm::BasicBlock* Llvm::getOrCreateExceptionThrownReturnBlock()
 {
-    assert(m_ehModel == CorInfoLlvmEHModel::Emulated);
+    assert(m_ehModel == CORINFO_LLVM_EH_EMULATED);
 
     FunctionInfo& funcInfo = getLlvmFunctionInfoForIndex(getCurrentLlvmFunctionIndex());
     if (funcInfo.ExceptionThrownReturnLlvmBlock == nullptr)
@@ -3144,7 +3177,7 @@ llvm::BasicBlock* Llvm::getOrCreateExceptionThrownReturnBlock()
 
 Value* Llvm::getOrCreateExceptionThrownAddressValue()
 {
-    assert(m_ehModel == CorInfoLlvmEHModel::Emulated);
+    assert(m_ehModel == CORINFO_LLVM_EH_EMULATED);
     if (m_exceptionThrownAddressValue == nullptr)
     {
         m_exceptionThrownAddressValue = getOrCreateSymbol(GetExceptionThrownVariable(), /* isThreadLocal */ true);

--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -7,6 +7,14 @@
 
 #include "llvm.h"
 
+// TODO-LLVM-Upstream: figure out how to fix these warnings in LLVM headers.
+#pragma warning(push)
+#pragma warning(disable : 4242)
+#pragma warning(disable : 4244)
+#pragma warning(disable : 4267)
+#include "llvm/IR/DIBuilder.h"
+#pragma warning(pop)
+
 using namespace llvm::dwarf;
 
 using llvm::DIBuilder;
@@ -690,6 +698,14 @@ void Llvm::assignDebugVariable(unsigned lclNum, Value* value)
                 value, debugVariable, diExpression, debugLocation, &*_builder.GetInsertPoint());
         }
         DBEXEC(CurrentBlock() == nullptr, JITDUMPEXEC(displayValue(debugInst)));
+    }
+}
+
+void Llvm::finalizeDebugInfo()
+{
+    if (m_diFunction != nullptr)
+    {
+        m_diBuilder->finalizeSubprogram(m_diFunction);
     }
 }
 

--- a/src/coreclr/jit/llvmlssa.cpp
+++ b/src/coreclr/jit/llvmlssa.cpp
@@ -1748,7 +1748,7 @@ private:
         if (JitConfig.JitRunLssaTests())
         {
             CORINFO_LLVM_JIT_TEST_INFO info;
-            m_llvm->GetJitTestInfo(CORINFO_JIT_TEST_LSSA, &info);
+            m_llvm->GetJitTestInfo(CORINFO_LLVM_JIT_TEST_LSSA, &info);
             expectedAllocation = info.ExpectedLssaAllocation;
         }
 

--- a/src/coreclr/tools/Common/JitInterface/JitEEApi.Shared.cspp
+++ b/src/coreclr/tools/Common/JitInterface/JitEEApi.Shared.cspp
@@ -1,10 +1,24 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if !__cplusplus
+#if __cplusplus
+#define public
+#else
 #pragma warning disable SA1400 // Element '<type>' should declare an access modifier
 namespace Internal.JitInterface;
 #endif
+
+public enum CorInfoLlvmEHModel
+{
+    CORINFO_LLVM_EH_CPP, // Landingpad-based LLVM IR; compatible with Itanium ABI.
+    CORINFO_LLVM_EH_WASM, // WinEH-based LLVM IR; custom WASM EH-based ABI.
+    CORINFO_LLVM_EH_EMULATED, // Invoke-free LLVM IR; "unwinding" performed via explicit checks and returns
+};
+
+enum CorInfoLlvmJitTestKind
+{
+    CORINFO_LLVM_JIT_TEST_LSSA = 1
+};
 
 enum CorInfoLlvmSingleThreadedCompilationContextFlags
 {
@@ -67,3 +81,7 @@ enum CorInfoLlvmDebugTypeForwardKind
     CORINFO_LLVM_DEBUG_TYPE_FORWARD_STRUCT,
     CORINFO_LLVM_DEBUG_TYPE_FORWARD_ENUM
 };
+
+#if __cplusplus
+#undef public
+#endif

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/DependencyAnalysis/LLVMCodegenNodeFactory.cs
@@ -50,7 +50,7 @@ namespace ILCompiler.DependencyAnalysis
             _ehModel = options.ExceptionHandlingModel;
         }
 
-        public override bool TargetsEmulatedEH() => _ehModel is CorInfoLlvmEHModel.Emulated;
+        public override bool TargetsEmulatedEH() => _ehModel is CorInfoLlvmEHModel.CORINFO_LLVM_EH_EMULATED;
 
         internal ExternMethodCellNode ExternMethodCell(string name, MethodDesc method)
         {

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/Compiler/LLVMCodegenCompilationBuilder.cs
@@ -57,9 +57,9 @@ namespace ILCompiler
                     case "LlvmExceptionHandlingModel":
                         ExceptionHandlingModel = value switch
                         {
-                            "cpp" => CorInfoLlvmEHModel.Cpp,
-                            "wasm" => CorInfoLlvmEHModel.Wasm,
-                            "emulated" => CorInfoLlvmEHModel.Emulated,
+                            "cpp" => CorInfoLlvmEHModel.CORINFO_LLVM_EH_CPP,
+                            "wasm" => CorInfoLlvmEHModel.CORINFO_LLVM_EH_WASM,
+                            "emulated" => CorInfoLlvmEHModel.CORINFO_LLVM_EH_EMULATED,
                             _ => throw new ArgumentException("Invalid LlvmExceptionHandlingModel value")
                         };
                         break;
@@ -85,7 +85,7 @@ namespace ILCompiler
         // S128 natural alignment of stack
         public string DataLayout { get; private set; } = "e-m:e-p:32:32-i64:64-n32:64-S128";
         public string Target { get; private set; } = "wasm32-unknown-emscripten";
-        public CorInfoLlvmEHModel ExceptionHandlingModel { get; private set; } = CorInfoLlvmEHModel.Wasm;
+        public CorInfoLlvmEHModel ExceptionHandlingModel { get; private set; } = CorInfoLlvmEHModel.CORINFO_LLVM_EH_WASM;
 
         // Below options are debug-only and not supported.
         public int MaxLlvmModuleCount { get; private set; } = 16;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.Llvm.cs
@@ -335,11 +335,6 @@ namespace Internal.JitInterface
             return isVisible ? 1 : 0;
         }
 
-        public enum CorInfoLlvmJitTestKind
-        {
-            CORINFO_JIT_TEST_LSSA = 1
-        }
-
         public struct CORINFO_LLVM_JIT_TEST_INFO
         {
             public byte* ExpectedLssaAllocation;
@@ -357,7 +352,7 @@ namespace Internal.JitInterface
                 return;
             }
 
-            if ((kind & CorInfoLlvmJitTestKind.CORINFO_JIT_TEST_LSSA) != 0)
+            if ((kind & CorInfoLlvmJitTestKind.CORINFO_LLVM_JIT_TEST_LSSA) != 0)
             {
                 string expectedAllocation = null;
                 if (_this._methodCodeNode.Method is EcmaMethod ecmaMethod &&
@@ -495,11 +490,4 @@ namespace Internal.JitInterface
 
         private static void* GetJitExport(CorJitApiId id) => s_jitExports[(int)id];
     }
-
-    public enum CorInfoLlvmEHModel
-    {
-        Cpp,
-        Wasm,
-        Emulated
-    };
 }


### PR DESCRIPTION
These can be moved out to places where they're actually used without many/any other changes.

This helps compile times and makes this more local.

Also move some old Jit/EE enums to the shared file.

Ultimately I want to make it so that `llvm.h` doesn't include _any_ LLVM headers, but that requires factoring out codegen into its own class (or compromising by hiding `_builder` behind an indirection). Perhaps that would be a good change on its own...