### PR TITLE
[NativeAOT-LLVM] Do not specify the compilation directory for LLVM modules

### DIFF
--- a/src/coreclr/jit/llvmdebuginfo.cpp
+++ b/src/coreclr/jit/llvmdebuginfo.cpp
@@ -268,21 +268,18 @@ private:
     DICompileUnit* InitializeCompileUnit()
     {
         StringRef path = m_context->Module.getName();
-        StringRef dir;
         StringRef name;
         size_t dirEnd = path.find_last_of("\\/");
         if (dirEnd != StringRef::npos)
         {
-            dir = path.take_front(dirEnd);
             name = path.substr(dirEnd + 1);
         }
         else
         {
-            dir = "";
             name = path;
         }
 
-        DIFile* debugFile = m_diBuilder.createFile(name, dir);
+        DIFile* debugFile = m_diBuilder.createFile(name, "");
         return m_diBuilder.createCompileUnit(DW_LANG_C_plus_plus, debugFile, "ILC", false, "", 1, "",
             DICompileUnit::FullDebug, 0, false);
     }

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.cs
@@ -9,7 +9,7 @@
 using System;
 using System.Diagnostics;
 
-unsafe class Program
+unsafe partial class Program
 {
     public static int Main()
     {
@@ -32,6 +32,8 @@ unsafe class Program
         simpleStruct.TestStructInstanceMethod();
         simpleClass.TestClassInstanceMethod();
         TestVariables(5, simpleStruct, simpleClass);
+        TestSourceFileResolved();
+        TestMappedSourceFileResolved();
 
         // TODO-LLVM-DI: debugging and EH.
         return 100;
@@ -132,6 +134,11 @@ unsafe class Program
         Debugger.Break(); // "p2" and "structLocal" should be equal to "{ 5, 2.0 }".
         classLocal = p3;
         Debugger.Break(); // "p3" and "classLocal" should be equal to "{ 5, 2.0 }".
+    }
+
+    private static void TestSourceFileResolved()
+    {
+        Debugger.Break(); // This source code should be resolved and visible.
     }
 }
 

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.csproj
@@ -1,10 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <InvariantGlobalization>true</InvariantGlobalization>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+
+    <PathMap>$(MSBuildThisFileDirectory)WasmDebuggingMappedPath=MAPPED_PATH</PathMap>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsWasi)' == 'true'">
@@ -31,5 +33,6 @@ CLRTestExecutionArguments=("$WASM_DEBUGGING_LLDB" $(_LldbArgs) -- "$WASM_DEBUGGI
 
   <ItemGroup>
     <Compile Include="WasmDebugging.cs" />
+    <Compile Include="WasmDebuggingMappedPath/WasmDebuggingMappedFile.cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.py
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebugging.py
@@ -39,6 +39,8 @@ def run_wasm_debugging_tests(debugger):
     test_struct_instance_method(target, process, thread)
     test_class_instance_method(target, process, thread)
     test_variables(target, process, thread);
+    test_source_file_resolved(target, process, thread)
+    test_mapped_source_file_resolved(target, process, thread)
 
     if all_tests_passed:
         print('==== All WASM debugging tests passed ====')
@@ -184,6 +186,25 @@ def test_values_display(target, process, thread, pyname, expected_states, use_ge
                 fail_test(f'unexpected "{name}": "{actual_value_as_string}" (expected "{value}")')
                 return
     pass_test()
+
+def test_source_file_resolved(target, process, thread):
+    start_test('test_source_file_resolved')
+    process.Continue()
+    source_file = thread.GetSelectedFrame().line_entry.file;
+    print(f'File under test: "{source_file}"')
+    end_test(source_file.exists, f'"{source_file}" not found')
+
+def test_mapped_source_file_resolved(target, process, thread):
+    start_test('test_mapped_source_file_resolved')
+    path = os.path.abspath(os.path.dirname(__file__))
+    path = os.path.join(path, "WasmDebuggingMappedPath")
+    print(f'Mapping MAPPED_PATH to "{path}"')
+    target.GetDebugger().HandleCommand(f'settings set target.source-map MAPPED_PATH "{path}"')
+    process.Continue()
+
+    source_file = thread.GetSelectedFrame().line_entry.file;
+    print(f'File under test: "{source_file}"')
+    end_test(source_file.exists, f'"{source_file}" not found')
 
 all_tests_passed = True
 current_test_name = None

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebuggingMappedPath/WasmDebuggingMappedFile.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/WasmDebuggingMappedPath/WasmDebuggingMappedFile.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+partial class Program
+{
+    private static void TestMappedSourceFileResolved()
+    {
+        Debugger.Break(); // This source code should be resolved and visible.
+    }
+}


### PR DESCRIPTION
Fixes a bug reported on Discord.

In DWARF, the final source code path as determined by the debugger
consists of three parts, recorded in .debug_line:
1) The compilation directory (for a compile unit).
2) The "include directory".
3) The file name.

If the "include directory" is relative (i. e. does not start with 'C:'
or '/'), the final path is going to be the concatenation of all three.

We don't control the "include directory" as it comes directly from
the managed PDBs, and we can't even know if it's truly relative or
an absolute path that just looks like a relative one (e. g. a URL).

Concatenating such an absolute path with any compilation directory
we might have is going to be wrong, so this change stops emitting it.