### PR TITLE
[NativeAOT-LLVM] Clean up physical memory computation for WASM

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -184,6 +184,8 @@ static uint8_t* g_helperPage = 0;
 // Mutex to make the FlushProcessWriteBuffersMutex thread safe
 static pthread_mutex_t g_flushProcessWriteBuffersMutex;
 
+uint64_t GetTotalPhysicalMemory_Wasm();
+
 size_t GetRestrictedPhysicalMemoryLimit();
 bool GetPhysicalMemoryUsed(size_t* val);
 
@@ -329,7 +331,9 @@ bool GCToOSInterface::Initialize()
 #endif
 
     // Get the physical memory size
-#if HAVE_SYSCONF && HAVE__SC_PHYS_PAGES
+#ifdef TARGET_WASM
+    g_totalPhysicalMemSize = GetTotalPhysicalMemory_Wasm();
+#elif HAVE_SYSCONF && HAVE__SC_PHYS_PAGES
     long pages = sysconf(_SC_PHYS_PAGES);
     if (pages == -1)
     {
@@ -1264,7 +1268,9 @@ uint64_t GetAvailablePhysicalMemory()
     uint64_t available = 0;
 
     // Get the physical memory available.
-#if defined(__APPLE__)
+#if defined(TARGET_WASM)
+    abort(); // Unreachable.
+#elif defined(__APPLE__)
     uint32_t mem_free = 0;
     size_t mem_free_length = sizeof(uint32_t);
     assert(g_kern_memorystatus_level_mib != NULL);
@@ -1286,8 +1292,6 @@ uint64_t GetAvailablePhysicalMemory()
     sysctlbyname("vm.stats.vm.v_free_count", &free_count, &sz, NULL, 0);
 
     available = (inactive_count + laundry_count + free_count) * sysconf(_SC_PAGESIZE);
-#elif defined(TARGET_WASM)
-    available = sysconf(SYSCONF_PAGES) * sysconf(_SC_PAGE_SIZE);
 #elif defined(__HAIKU__)
     system_info info;
     if (get_system_info(&info) == B_OK)

--- a/src/coreclr/gc/wasm/gcenv.wasm.cpp
+++ b/src/coreclr/gc/wasm/gcenv.wasm.cpp
@@ -4,6 +4,10 @@
 #include "common.h"
 #include "gcenv.h"
 
+#ifdef TARGET_BROWSER
+#include <emscripten/heap.h>
+#endif
+
 // Flush write buffers of processors that are executing threads of the current process - a NOP for Wasm
 void GCToOSInterface::FlushProcessWriteBuffers()
 {
@@ -119,7 +123,7 @@ bool GCToOSInterface::VirtualReset(void* address, size_t size, bool unlock)
 }
 
 //
-// CPU and memory limits - not avaliable on WASM (yet).
+// CPU and memory limits.
 //
 void InitializeCGroup()
 {
@@ -129,12 +133,31 @@ void CleanupCGroup()
 {
 }
 
+uint64_t GetTotalPhysicalMemory_Wasm()
+{
+#ifdef TARGET_BROWSER
+    // Note that Emscripten takes care not to return a value larger than max<size_t> here.
+    return emscripten_get_heap_max();
+#else // TARGET_WASI
+    // WASI doesn't have any API that could return the maximum memory size.
+    // The best we can do here is use the value we set as default --maximum-memory.
+    return 2 * 1024 * 1024 * 1024ULL; // 2GB.
+#endif // TARGET_WASI
+}
+
 size_t GetRestrictedPhysicalMemoryLimit()
 {
-    return 0; // 'Unlimited'.
+    // We must return a valid value here since you can't "overcommit" memory in WASM.
+    return GetTotalPhysicalMemory_Wasm();
 }
 
 bool GetPhysicalMemoryUsed(size_t* val)
 {
-    return false; // 'Unknown'.
+    *val = __builtin_wasm_memory_size(0) * OS_PAGE_SIZE;
+    if (*val == 0)
+    {
+        // This overflow can happen when all 4GB of memory are in use.
+        *val = GetTotalPhysicalMemory_Wasm();
+    }
+    return true;
 }


### PR DESCRIPTION
This doesn't actually fix much (the GC mostly ignores these values currently), but it does make the code more correct, in particular on WASI where `sysconf(SYSCONF_PAGES)` isn't implemented.