### PR TITLE
[NativeAOT-LLVM] Add a PNSE ThunkPool to the WASM build and prune out precise virtual unwind code

### DIFF
--- a/src/coreclr/nativeaot/Directory.Build.props
+++ b/src/coreclr/nativeaot/Directory.Build.props
@@ -75,14 +75,8 @@
 
   <!-- Platform specific properties -->
   <PropertyGroup Condition="'$(Platform)' == 'wasm'">
-    <!-- "WASM ABI" here refers to the use of shadow stacks, native-based EH, conservative GC, etc. -->
-    <!-- It does not, in principle, imply TARGET_WASM, or vice-versa, though currently this is the case. -->
-    <!-- In the future we may want to create a Windows/Unix build targeting this ABI, for testing. -->
-    <WasmAbi>true</WasmAbi>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DefineConstants>TARGET_32BIT;TARGET_WASM;$(DefineConstants)</DefineConstants>
-    <DefineConstants Condition="'$(TargetsBrowser)' == 'true'">TARGET_BROWSER;$(DefineConstants)</DefineConstants>
-    <DefineConstants Condition="'$(TargetsWasi)' == 'true'">TARGET_WASI;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <DefineConstants>TARGET_64BIT;TARGET_AMD64;$(DefineConstants)</DefineConstants>
@@ -107,6 +101,8 @@
     <DefineConstants Condition="'$(TargetsWindows)'=='true'">TARGET_WINDOWS;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(TargetsUnix)'=='true'">TARGET_UNIX;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(TargetsBrowser)'=='true' or '$(TargetsWasi)'=='true'">TARGET_UNIX;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition="'$(TargetsBrowser)'=='true'">TARGET_BROWSER;$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition="'$(TargetsWasi)'=='true'">TARGET_WASI;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Configuration specific properties -->

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/ExceptionHandling.wasm.cs
@@ -377,7 +377,11 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.NoInlining)] // Ensures that the RhGetCurrentThreadStackTrace frame is always present
         private static unsafe int RhGetCurrentThreadStackTrace(IntPtr[] outputBuffer)
         {
-            Debug.Assert(RuntimeAugments.PreciseVirtualUnwind);
+            if (!RuntimeAugments.PreciseVirtualUnwind) // This helps to trim out the code below from !PreciseVirtualUnwind builds.
+            {
+                Debug.Fail("RhGetCurrentThreadStackTrace called with !PreciseVirtualUnwind");
+                return 0;
+            }
 
             int count = 0;
             void* pFrameLimit = PreciseVirtualUnwindFrame.GetLimit();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -44,7 +44,7 @@
     <FeatureSharedLowLevelLock>true</FeatureSharedLowLevelLock>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(WasmAbi)' == 'true'">
+  <PropertyGroup Condition="'$(TargetsWasm)' == 'true'">
     <FeaturePortableGetUnboxingStubTarget>true</FeaturePortableGetUnboxingStubTarget>
   </PropertyGroup>
 
@@ -212,7 +212,8 @@
     <Compile Include="System\Runtime\ExceptionIDs.cs" />
     <Compile Include="System\Runtime\GCSettings.NativeAot.cs" />
     <Compile Include="System\Runtime\TypeLoaderExports.cs" />
-    <Compile Include="System\Runtime\ThunkPool.cs" />
+    <Compile Include="System\Runtime\ThunkPool.cs" Condition="'$(TargetsWasm)' != 'true'" />
+    <Compile Include="System\Runtime\ThunkPool.NotSupported.cs" Condition="'$(TargetsWasm)' == 'true'" />
     <Compile Include="System\Runtime\InitializeFinalizerThread.cs" />
     <Compile Include="System\Runtime\InteropServices\ComEventsHelper.NativeAot.cs" Condition="'$(FeatureCominterop)' == 'true'" />
     <Compile Include="System\Runtime\InteropServices\ComWrappers.NativeAot.cs" Condition="'$(FeatureComWrappers)' == 'true'" />
@@ -239,7 +240,7 @@
     <Compile Include="System\RuntimeExceptionHelpers.cs" />
     <Compile Include="System\EETypePtr.cs" />
     <Compile Include="System\Runtime\RuntimeImports.cs" />
-    <Compile Include="System\Runtime\RuntimeImports.Wasm.cs" Condition="'$(WasmAbi)' == 'true'" />
+    <Compile Include="System\Runtime\RuntimeImports.Wasm.cs" Condition="'$(TargetsWasm)' == 'true'" />
     <Compile Include="System\ModuleHandle.cs" />
     <Compile Include="System\RuntimeFieldHandle.cs" />
     <Compile Include="System\Text\StringBuilder.NativeAot.cs" />
@@ -593,16 +594,16 @@
     <Compile Include="$(RuntimeBasePath)System\Runtime\MethodTable.Runtime.cs">
       <Link>Runtime.Base\src\System\Runtime\MethodTable.Runtime.cs</Link>
     </Compile>
-    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.cs" Condition="'$(WasmAbi)' != 'true'">
+    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.cs" Condition="'$(TargetsWasm)' != 'true'">
       <Link>Runtime.Base\src\System\Runtime\ExceptionHandling.cs</Link>
     </Compile>
-    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.wasm.cs" Condition="'$(WasmAbi)' == 'true'">
+    <Compile Include="$(RuntimeBasePath)System\Runtime\ExceptionHandling.wasm.cs" Condition="'$(TargetsWasm)' == 'true'">
       <Link>Runtime.Base\src\System\Runtime\ExceptionHandling.wasm.cs</Link>
     </Compile>
     <Compile Include="$(RuntimeBasePath)System\Runtime\InternalCalls.cs">
       <Link>Runtime.Base\src\System\Runtime\InternalCalls.cs</Link>
     </Compile>
-    <Compile Include="$(RuntimeBasePath)System\Runtime\InternalCalls.Wasm.cs" Condition="'$(WasmAbi)' == 'true'">
+    <Compile Include="$(RuntimeBasePath)System\Runtime\InternalCalls.Wasm.cs" Condition="'$(TargetsWasm)' == 'true'">
       <Link>Runtime.Base\src\System\Runtime\InternalCalls.Wasm.cs</Link>
     </Compile>
     <Compile Include="$(RuntimeBasePath)System\Runtime\RuntimeExports.cs">
@@ -622,8 +623,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(InPlaceRuntime)' == 'true'">
-    <Compile Include="$(IntermediatesDir)\nativeaot\Runtime\Full\AsmOffsets.cs" Condition="'$(WasmAbi)' != 'true'" />
-    <Compile Include="$(IntermediatesDir.Replace('\ide', ''))\nativeaot\Runtime\Portable\AsmOffsetsPortable.cs" Condition="'$(WasmAbi)' == 'true'" /> <!-- its never in \ide\ -->
+    <Compile Include="$(IntermediatesDir)\nativeaot\Runtime\Full\AsmOffsets.cs" Condition="'$(TargetsWasm)' != 'true'" />
+    <Compile Include="$(IntermediatesDir.Replace('\ide', ''))\nativeaot\Runtime\Portable\AsmOffsetsPortable.cs" Condition="'$(TargetsWasm)' == 'true'" /> <!-- its never in \ide\ -->
   </ItemGroup>
 
   <Import Project="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System.Private.CoreLib.Shared.projitems" Label="Shared" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ThunkPool.NotSupported.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/ThunkPool.NotSupported.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// WASM in general does not have support for dynamic code generation without access to the host.
+// Browser as a platform **does**, but we have so far decided to not support the APIs requiring
+// thunks there anyway, hence this stub implementaiton of the thunk pool.
+//
+#pragma warning disable CA1822 // Mark members as static
+
+using Internal.Runtime.CompilerHelpers;
+
+namespace System.Runtime
+{
+    internal class ThunksHeap
+    {
+        public static unsafe ThunksHeap? CreateThunksHeap(IntPtr commonStubAddress)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public unsafe IntPtr AllocateThunk()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public unsafe void FreeThunk(IntPtr thunkAddress)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public unsafe bool TryGetThunkData(IntPtr thunkAddress, out IntPtr context, out IntPtr target)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public unsafe void SetThunkData(IntPtr thunkAddress, IntPtr context, IntPtr target)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/Test.CoreLib.csproj
@@ -56,7 +56,7 @@
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\InternalCalls.cs">
       <Link>Runtime.Base\src\System\Runtime\InternalCalls.cs</Link>
     </Compile>
-    <Compile Include="..\..\Runtime.Base\src\System\Runtime\InternalCalls.Wasm.cs" Condition="'$(WasmAbi)' == 'true'">
+    <Compile Include="..\..\Runtime.Base\src\System\Runtime\InternalCalls.Wasm.cs" Condition="'$(TargetsWasm)' == 'true'">
       <Link>Runtime.Base\src\System\Runtime\InternalCalls.Wasm.cs</Link>
     </Compile>
     <Compile Include="..\..\Runtime.Base\src\System\Runtime\RuntimeExports.cs">
@@ -79,8 +79,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(InPlaceRuntime)' == 'true'">
-    <Compile Include="$(IntermediatesDir)\nativeaot\Runtime\Full\AsmOffsets.cs" Condition="'$(WasmAbi)' != 'true'"/>
-    <Compile Include="$(IntermediatesDir.Replace('\ide', ''))\nativeaot\Runtime\Portable\AsmOffsetsPortable.cs" Condition="'$(WasmAbi)' == 'true'"/> <!-- its never in \ide\ -->
+    <Compile Include="$(IntermediatesDir)\nativeaot\Runtime\Full\AsmOffsets.cs" Condition="'$(TargetsWasm)' != 'true'"/>
+    <Compile Include="$(IntermediatesDir.Replace('\ide', ''))\nativeaot\Runtime\Portable\AsmOffsetsPortable.cs" Condition="'$(TargetsWasm)' == 'true'"/> <!-- its never in \ide\ -->
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CompilerCommonPath)\Internal\NativeFormat\NativeFormatReader.Primitives.cs">

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
@@ -7,13 +7,14 @@
 Param(
     [Parameter(Position=0)]$TestProject = "HelloWasm.csproj",
     [ValidateSet("browser","wasi")][string]$OS = "browser",
-    [switch]$Build,
+    [switch][Alias("b")]$Build,
     [switch]$Rebuild,
     [switch]$Analyze,
     [switch]$Summary,
     [switch]$Llvm,
     [ValidateSet("Debug","Checked","Release")][string]$Config = "Release",
     [ValidateSet("Debug","Checked","Release")][string]$IlcConfig = "Release",
+    [string][Alias("bt")]$BaseTag = "",
     [Nullable[bool]]$DebugSymbols = $null,
     [uint]$NumberOfDiffsToShow = 20,
     [string]$PassThrough = ""
@@ -40,6 +41,7 @@ if ($ShowHelp)
     Write-Host "  -Llvm                : Analyze LLVM bitcode output instead of WASM"
     Write-Host "  -Config              : Test configuration (Debug/Release). Default is Release"
     Write-Host "  -IlcConfig           : ILC configuration (Debug/Checked/Release). Default is Release"
+    Write-Host "  -BaseTag             : Suffix to use for the 'base' directory. Default is none"
     Write-Host "  -DebugSymbols        : Whether to build with debug symbols. Default is yes"
     Write-Host "  -NumberOfDiffsToShow : Number of diffs to show. Default is 20"
     Write-Host "  -PassThrough         : Additional command line to pass directly to 'dotnet'"
@@ -82,10 +84,11 @@ $TestProjectDirectory = [IO.Path]::GetDirectoryName($TestProjectPath)
 $RuntimeTestsDirectory = "$RuntimelabDirectory/src/tests"
 $TestProjectDirectoryRelativePath = [System.IO.Path]::GetRelativePath($RuntimeTestsDirectory, $TestProjectDirectory)
 
+$FullBaseTag = $BaseTag ? "base.$BaseTag" : "base"
 $TestProjectNativeObjDirectory = "$RuntimelabDirectory/artifacts/tests/coreclr/obj/$OS.$Arch.$Config/Managed/$TestProjectDirectoryRelativePath/$TestProjectName/native"
-$TestProjectBaseNativeObjDirectory = "$TestProjectNativeObjDirectory.base"
+$TestProjectBaseNativeObjDirectory = "$TestProjectNativeObjDirectory.$FullBaseTag"
 $TestProjectNativeOutputDirectory = "$RuntimelabDirectory/artifacts/tests/coreclr/$OS.$Arch.$Config/$TestProjectDirectoryRelativePath/$TestProjectName/native"
-$TestProjectBaseNativeOutputDirectory = "$TestProjectNativeOutputDirectory.base"
+$TestProjectBaseNativeOutputDirectory = "$TestProjectNativeOutputDirectory.$FullBaseTag"
 $TestProjectWasmOutput = "$TestProjectNativeOutputDirectory/$TestProjectName.wasm"
 $TestProjectBaseWasmOutput = "$TestProjectBaseNativeOutputDirectory/$TestProjectName.wasm"
 


### PR DESCRIPTION
The last bits and pieces from https://github.com/dotnet/runtimelab/issues/3132 that are downstream-specific. There is also an upstream change now pending review that we will ingest naturally in the next merge.

Diffs (WasmDebugging, browser):
```
Analysing base..........
Analysing diff..........

Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 655907
Total bytes of diff: 647755
Total bytes of delta: -8152 (-1.24% % of base)
Average relative delta: 14.92%
    diff is an improvement
    average relative diff is a regression

Top method regressions (percentages):
         202 (673.33% of base) : 1088.dasm - S_P_CoreLib_System_Collections_Generic_NonRandomizedStringEqualityComparer_OrdinalComparer__GetHashCode
         179 (596.67% of base) : 1026.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeNamedTypeInfo__get_ContainsGenericParameters
          62 (442.86% of base) : 1039.dasm - S_P_CoreLib_System_Collections_Generic_NonRandomizedStringEqualityComparer__Equals
          86 (226.32% of base) : 1122.dasm - <Boxed>S_P_CoreLib_System_Collections_Generic_KeyValuePair_2<System___Canon__S_P_Reflection_Execution_Internal_Reflection_Execution_ExecutionEnvironmentImplementation_FunctionPointersToOffsets>__<unbox>S_P_CoreLib_System_Collections_Generic_KeyValuePair_2__ToString
         118 (222.64% of base) : 1054.dasm - S_P_CoreLib_System_Threading_LowLevelLock__Finalize
          67 (203.03% of base) : 1115.dasm - Int32__ToString
          38 (190.00% of base) : 1057.dasm - S_P_CoreLib_System_Collections_Generic_GenericComparer_1<S_P_StackTraceMetadata_Internal_StackTraceMetadata_StackTraceMetadata_PerModuleMethodNameResolver_StackTraceData>__GetHashCode
         191 (180.19% of base) : 1060.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_TypeInstantiationSignature___ctor
         116 (123.40% of base) : 1052.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtable_2<IntPtr__System___Canon>__VolatileReadNonSentinelFromHashtable
         473 (115.65% of base) : 1090.dasm - S_P_CoreLib_System_Collections_Generic_ArraySortHelper_1<S_P_CoreLib_Internal_Runtime_CompilerServices_UnboxingStubTargetsMap_UnboxingStubTargetMapping>__IntroSort
         231 (112.68% of base) : 1116.dasm - S_P_CoreLib_System_Text_UTF8Encoding__GetByteCount_2
          94 (78.99% of base) : 1055.dasm - S_P_CoreLib_System_Globalization_CompareInfo__GetHashCode
         239 (65.48% of base) : 1103.dasm - S_P_CoreLib_System_Globalization_NumberFormatInfo___ctor_0
         122 (61.93% of base) : 1123.dasm - S_P_CoreLib_System_Runtime_TypeCast__AreTypesAssignable
          85 (57.05% of base) : 1058.dasm - S_P_CoreLib_Internal_Metadata_NativeFormat_ArraySignature___ctor
         270 (56.60% of base) : 1087.dasm - S_P_CoreLib_System_CrashInfo__WriteHeader
         536 (46.65% of base) : 1125.dasm - S_P_CoreLib_System_Number___FormatInt32_g__FormatInt32Slow_20_0
         414 (42.59% of base) : 1015.dasm - S_P_CoreLib_System_Text_Encoding__GetCharsWithFallback_1
         233 (40.73% of base) : 1016.dasm - S_P_CoreLib_System_Text_Unicode_Utf8__ToUtf16
         121 (35.91% of base) : 1061.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_MethodNameFormatter__EmitNamespaceReferenceName

Top methods only present in diff:
          42 (     ∞ of base) : 1130.dasm - S_P_CoreLib_System_PlatformNotSupportedException___ctor

Top method improvements (percentages):
        -689 (-99.42% of base) : 1030.dasm - S_P_CoreLib_System_Runtime_EH__RhGetCurrentThreadStackTrace
        -459 (-97.66% of base) : 1074.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__TryGetValue
        -390 (-97.26% of base) : 1070.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__AllocateThunk
        -201 (-94.81% of base) : 1073.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__AddOrGetExistingInner
        -172 (-94.51% of base) : 1042.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__FreeThunk
        -182 (-90.10% of base) : 1031.dasm - S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport___cctor
         -50 (-83.33% of base) : 1032.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__SetThunkData
         -95 (-82.61% of base) : 1094.dasm - S_P_CoreLib_System_Collections_Generic_GenericEqualityComparer_1<Char>__GetHashCode_0
         -98 (-72.06% of base) : 1107.dasm - String__StartsWith
        -313 (-67.17% of base) : 1100.dasm - S_P_CoreLib_System_CrashInfo__WriteIntValue
         -82 (-58.57% of base) : 1075.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__CreateThunksHeap
        -925 (-57.06% of base) : 1114.dasm - S_P_CoreLib_System_Exception__ToString
        -164 (-54.67% of base) : 1028.dasm - S_P_CoreLib_System_Collections_Generic_LowLevelList_1<System___Canon>__Add
         -49 (-53.26% of base) : 1112.dasm - Double__ToString
        -339 (-46.95% of base) : 1128.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeConstructedGenericTypeInfo__ToString
        -157 (-42.20% of base) : 1082.dasm - S_P_CoreLib_System_Reflection_Runtime_General_Helpers__EscapeTypeNameIdentifier
         -23 (-41.07% of base) : 1108.dasm - Int64__System_IConvertible_ToInt16
        -142 (-39.89% of base) : 1080.dasm - S_P_CoreLib_System_Number__TryInt64ToHexStr<Char>
        -196 (-39.28% of base) : 1053.dasm - S_P_CoreLib_System_Threading_WaitSubsystem__SetEvent_0
        -327 (-37.76% of base) : 1129.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeConstructedGenericTypeInfo__get_FullName

Top methods only present in base:
        -864 (-100.00% of base) : 1045.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__TryAddOrGetExisting
        -845 (-100.00% of base) : 1046.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__Expand
        -638 (-100.00% of base) : 1067.dasm - S_P_CoreLib_System_Runtime_ThunkBlocks__GetNewThunksBlock
        -371 (-100.00% of base) : 1097.dasm - S_P_CoreLib_System_Runtime_PreciseVirtualUnwindInfo__Parse
        -343 (-100.00% of base) : 1047.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__ExpandHeap
        -327 (-100.00% of base) : 1033.dasm - S_P_CoreLib_System_Runtime_ThunksHeap___ctor
        -303 (-100.00% of base) : 1063.dasm - S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkHashtable__CompareValueToValue
        -289 (-100.00% of base) : 1098.dasm - S_P_CoreLib_System_Runtime_EH_PreciseVirtualUnwindFrame__GetLast
        -265 (-100.00% of base) : 1036.dasm - S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkHashtable__CompareKeyToValue
        -233 (-100.00% of base) : 1049.dasm - S_P_CoreLib_System_Runtime_Constants___cctor
        -163 (-100.00% of base) : 1021.dasm - S_P_CoreLib_System_Runtime_ThunkBlocks___cctor
        -151 (-100.00% of base) : 1012.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__WaitForSentinelInHashtableToDisappear
        -143 (-100.00% of base) : 1062.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__TryGetThunkDataAddress
        -139 (-100.00% of base) : 1066.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__IsThunkInHeap
        -137 (-100.00% of base) : 1034.dasm - S_P_CoreLib_System_Runtime_ThunksHeap__TryGetThunkData
        -132 (-100.00% of base) : 1037.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__HashInt1
        -123 (-100.00% of base) : 1043.dasm - S_P_CoreLib_System_HashCode__Combine_0<IntPtr__IntPtr>
         -92 (-100.00% of base) : 1065.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__TryWriteSentinelToLocation
         -86 (-100.00% of base) : 1072.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>___ctor
         -84 (-100.00% of base) : 1064.dasm - S_P_CoreLib_Internal_TypeSystem_LockFreeReaderHashtableOfPointers_2<S_P_CoreLib_Internal_Runtime_IDynamicCastableSupport_InstantiatingThunkKey__IntPtr>__VolatileReadNonSentinelFromHashtable

131 total methods with Code Size differences (85 improved, 46 regressed)
```
(The regressions are - as usual - LLVM inlining noise)