### PR TITLE
[NativeAOT-LLVM] Add some version checking to build integration

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Wasm.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Wasm.targets
@@ -21,4 +21,30 @@ The .NET Foundation licenses this file to you under the MIT license.
     <DirectPInvoke Include="libSystem.Globalization.Native" />
     <DirectPInvoke Include="libSystem.Native" />
   </ItemGroup>
+
+  <Target Name="ValidateEmsdk"
+          Condition="'$(_targetOS)' == 'browser'">
+    <!-- $(EMSDK) is typically set by the user and points to a standard emscripten layout. -->
+    <!-- $(EmscriptenSdkToolsPath) comes from upstream mono workload and points to the dotnet/emsdk-style SDK layout. -->
+    <!-- See https://github.com/dotnet/runtime/blob/main/src/mono/browser/build/EmSdkRepo.Defaults.props. -->
+    <Error Text="Emscripten not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Emscripten and ensure the EMSDK environment variable points to the directory containing emsdk.bat"
+           Condition="'$(EMSDK)' == '' and '$(EmscriptenSdkToolsPath)' == ''" />
+  </Target>
+
+  <Target Name="ValidateWasiSdk"
+          Condition="'$(_targetOS)' == 'wasi'">
+    <Error Text="Wasi SDK not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Wasi SDK and ensure the WASI_SDK_PATH environment variable points to the directory containing share/wasi-sysroot"
+           Condition="'$(WASI_SDK_PATH)' == ''" />
+
+    <!-- Verify the SDK version. We only issue a warning since it's **possible** a newer SDK might work. -->
+    <PropertyGroup>
+      <_ExpectedWasiSdkVersion>25.0</_ExpectedWasiSdkVersion>
+      <_ActualWasiSdkVersion>?</_ActualWasiSdkVersion>
+      <_ActualWasiSdkVersion Condition="Exists('$(WASI_SDK_PATH)/VERSION')">$([System.IO.File]::ReadAllText('$(WASI_SDK_PATH)/VERSION').Split()[0])</_ActualWasiSdkVersion>
+    </PropertyGroup>
+
+    <Warning Text="Wasi SDK version $(_ActualWasiSdkVersion) is being used. This differs from the expected $(_ExpectedWasiSdkVersion) and might result in build or runtime failures."
+             Condition="'$(_ExpectedWasiSdkVersion)' != '$(_ActualWasiSdkVersion)'" />
+  </Target>
+
 </Project>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -391,8 +391,7 @@ The .NET Foundation licenses this file to you under the MIT license.
   </Target>
 
   <Target Name="InitializeTheListOfLlvmObjects"
-      AfterTargets="IlcCompile"
-      BeforeTargets="CompileWasmObjects;LinkNativeLlvm">
+          DependsOnTargets="IlcCompile">
     <ReadLinesFromFile File="$(NativeIntermediateOutputPath)$(TargetName).results.txt">
       <Output TaskParameter="Lines" ItemName="_IlcProducedFiles" />
     </ReadLinesFromFile>
@@ -406,28 +405,10 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
   </Target>
 
-  <Target Name="CheckWasmSdks">
-    <!-- $(EMSDK) is typically set by the user and points to a standard emscripten layout. -->
-    <!-- $(EmscriptenSdkToolsPath) comes from upstream mono workload and points to the dotnet/emsdk-style SDK layout. -->
-    <!-- See https://github.com/dotnet/runtime/blob/main/src/mono/browser/build/EmSdkRepo.Defaults.props. -->
-    <Error Text="Emscripten not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Emscripten and ensure the EMSDK environment variable points to the directory containing emsdk.bat"
-           Condition="'$(EMSDK)' == '' and '$(EmscriptenSdkToolsPath)' == '' and '$(_targetOS)' == 'browser'" />
-
-    <!-- Verify the WASI SDK location and version (through indirect means...). -->
-    <Error Text="Wasi SDK not found, not compiling to WebAssembly. To enable WebAssembly compilation, install Wasi SDK and ensure the WASI_SDK_PATH environment variable points to the directory containing share/wasi-sysroot"
-           Condition="'$(_targetOS)' == 'wasi' and '$(WASI_SDK_PATH)' == ''" />
-    <Exec Command="&quot;$(WASI_SDK_PATH)/bin/wasm-component-ld&quot; --version" StandardOutputImportance="Low" ConsoleToMsBuild="true"
-          Condition="'$(_targetOS)' == 'wasi'">
-      <Output TaskParameter="ConsoleOutput" PropertyName="_WasmComponentLdVersion" />
-    </Exec>
-    <Warning Text="The WASI SDK version is too low. Please use WASI SDK 24 or newer."
-             Condition="'$(_targetOS)' == 'wasi' and $([MSBuild]::VersionLessThan($(_WasmComponentLdVersion.Replace('wasm-component-ld ', '')), '0.5.6'))" />
-  </Target>
-
   <Target Name="CompileWasmObjects"
       Inputs="@(LlvmObjects)"
       Outputs="@(LlvmObjects->'%(NativeObject)')"
-      DependsOnTargets="IlcCompile;CheckWasmSdks"
+      DependsOnTargets="InitializeTheListOfLlvmObjects;ValidateEmsdk;ValidateWasiSdk"
       Condition="'$(NativeCodeGen)' == 'llvm'">
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName($(NativeBinary)))" />

--- a/src/coreclr/nativeaot/BuildIntegration/OverrideImportRuntimeIlcPackageTarget.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/OverrideImportRuntimeIlcPackageTarget.targets
@@ -1,7 +1,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- NativeAOT-LLVM: override ImportRuntimeIlcPackageTarget to not depend on the SDK-provided ResolvedILCompilerPack item -->
   <Target Name="ImportRuntimeIlcPackageTarget" Condition="'$(BuildingFrameworkLibrary)' != 'true' and '$(_targetArchitecture)' == 'wasm'" DependsOnTargets="$(ImportRuntimeIlcPackageTargetDependsOn)" BeforeTargets="Publish">
-    <Error Condition="'@(PackageDefinitions)' == ''" Text="The PackageDefinitions ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
+    <Error Condition="'@(PackageDefinitions)' == ''"
+           Text="The PackageDefinitions ItemGroup is required for target ImportRuntimeIlcPackageTarget" />
+
+    <PropertyGroup>
+      <_IlcHostPackageVersion Condition="'%(PackageDefinitions.Name)' == '$(_hostPackageName)'">%(PackageDefinitions.Version)</_IlcHostPackageVersion>
+      <_IlcRuntimePackageVersion Condition="'%(PackageDefinitions.Name)' == '$(_targetPackageName)'">%(PackageDefinitions.Version)</_IlcRuntimePackageVersion>
+    </PropertyGroup>
+
+    <Warning Condition="'$(_IlcHostPackageVersion)' != '$(_IlcRuntimePackageVersion)'"
+             Text="$(_hostPackageName) version ($(_IlcHostPackageVersion)) differs from the Microsoft.DotNet.ILCompiler.LLVM version ($(_IlcRuntimePackageVersion)). This will likely result in build or runtime failures." />
 
     <PropertyGroup>
       <IlcHostPackagePath Condition="'%(PackageDefinitions.Name)' == '$(_hostPackageName)'">%(PackageDefinitions.ResolvedPath)</IlcHostPackagePath>


### PR DESCRIPTION
Also, move the WASM SDK targets to the WASM-specific `.targets`.

Fixes https://github.com/dotnet/runtimelab/issues/3156.