### PR TITLE
[NativeAOT-LLVM] Add support for WASI SDK 26.0/27.0

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Wasm.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Wasm.targets
@@ -38,13 +38,13 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <!-- Verify the SDK version. We only issue a warning since it's **possible** a newer SDK might work. -->
     <PropertyGroup>
-      <_ExpectedWasiSdkVersion>25.0</_ExpectedWasiSdkVersion>
+      <_ExpectedWasiSdkVersions>25.0|26.0|27.0</_ExpectedWasiSdkVersions>
       <_ActualWasiSdkVersion>?</_ActualWasiSdkVersion>
       <_ActualWasiSdkVersion Condition="Exists('$(WASI_SDK_PATH)/VERSION')">$([System.IO.File]::ReadAllText('$(WASI_SDK_PATH)/VERSION').Split()[0])</_ActualWasiSdkVersion>
     </PropertyGroup>
 
-    <Warning Text="Wasi SDK version $(_ActualWasiSdkVersion) is being used. This differs from the expected $(_ExpectedWasiSdkVersion) and might result in build or runtime failures."
-             Condition="'$(_ExpectedWasiSdkVersion)' != '$(_ActualWasiSdkVersion)'" />
+    <Warning Text="Wasi SDK version $(_ActualWasiSdkVersion) is being used. This differs from the expected $(_ExpectedWasiSdkVersions) and might result in build or runtime failures."
+             Condition="!$(_ExpectedWasiSdkVersions.Contains($(_ActualWasiSdkVersion)))" />
   </Target>
 
 </Project>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -601,7 +601,8 @@ The .NET Foundation licenses this file to you under the MIT license.
 
     <ItemGroup Condition="'$(_targetOS)' == 'wasi'" >
       <CustomLinkerArg Include="@(_CustomLinkerArgExport->'-Wl,--export=%(Identity)')" />
-      <CustomLinkerArg Include="-lstdc++;-lwasi-emulated-process-clocks;-lwasi-emulated-signal;-lwasi-emulated-mman;-lwasi-emulated-getpid;-lwasi-emulated-pthread" />
+      <CustomLinkerArg Include="-lstdc++;-lwasi-emulated-process-clocks;-lwasi-emulated-signal;-lwasi-emulated-mman;-lwasi-emulated-getpid" />
+      <CustomLinkerArg Include="-lwasi-emulated-pthread" Condition="'$(_ActualWasiSdkVersion)' == '25.0'" />
       <CustomLinkerArg Include="-Wl,--max-memory=2147483648" />
       <CustomLinkerArg Include="-Wl,--global-base=$(IlcWasmGlobalBase)" />
       <CustomLinkerArg Include="-Wl,-z,stack-size=$(IlcWasmStackSize)" />


### PR DESCRIPTION
This should unblock the wit-bindgen CI. This is expected to be temporary, until we move the new SDK upstream (and then downstream).