### PR TITLE
[NativeAOT-LLVM] Add Mstat support

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -524,7 +524,8 @@ The .NET Foundation licenses this file to you under the MIT license.
         strip -no_code_signature_warning -x &quot;$(NativeBinary)&quot;" />
   </Target>
 
-  <!-- NativeAOT-LLVM: separate target to reduce conflicts -->
+  <!-- NativeAOT-LLVM: separate target to avoid conflicts -->
+  <UsingTask TaskName="RelocateMstat" AssemblyFile="$(IlcBuildTasksPath)" />
   <Target Name="LinkNativeLlvm"
       Inputs="@(NativeObjects);@(NativeLibrary)"
       Outputs="$(NativeBinary)"
@@ -611,12 +612,21 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-mexec-model=reactor" Condition="'$(NativeLib)' == 'Shared'" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(IlcGenerateMstatFile)' == 'true'">
+      <_LinkMapFilePath Include="$(NativeIntermediateOutputPath)$(TargetName).linkmap" />
+      <CustomLinkerArg Include="@(_LinkMapFilePath->Replace('\', '/')->'-Wl,--Map=&quot;%(Identity)&quot;')" />
+    </ItemGroup>
+
     <ItemGroup>
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(NativeIntermediateOutputPath)link.rsp" Lines="@(CustomLinkerArg)" Overwrite="true" Encoding="utf-8" />
     <Exec Command="$(WasmLinkerPath) @$(NativeIntermediateOutputPath)link.rsp $(EmccExtraArgs)" EnvironmentVariables="@(EmscriptenEnvVars)" />
+
+    <RelocateMstat Condition="'$(IlcGenerateMstatFile)' == 'true'"
+        MstatFilePath="$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).mstat"
+        LinkMapPath="@(_LinkMapFilePath)" />
   </Target>
 
   <Target Name="LinkNative"

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/RelocateMstat.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/RelocateMstat.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+namespace Build.Tasks
+{
+    public class RelocateMstat : Task
+    {
+        [Required]
+        public string MstatFilePath { get; set; }
+
+        [Required]
+        public string LinkMapPath { get; set; }
+
+        public override bool Execute()
+        {
+            using FileStream stream = File.Open(MstatFilePath, FileMode.Open);
+            using PEReader reader = new(stream);
+
+            int methodsMethodRva = 0;
+            MetadataReader mdReader = reader.GetMetadataReader();
+            foreach (MethodDefinitionHandle methodDefHandle in mdReader.MethodDefinitions)
+            {
+                MethodDefinition methodDef = mdReader.GetMethodDefinition(methodDefHandle);
+                if (mdReader.GetString(methodDef.Name) == "Methods")
+                {
+                    methodsMethodRva = methodDef.RelativeVirtualAddress;
+                    break;
+                }
+            }
+            if (methodsMethodRva == 0)
+            {
+                return true;
+            }
+
+            Dictionary<string, int> linkMap = ParseLinkMap();
+            BlobReader methodsBody = reader.GetSectionData(methodsMethodRva).GetReader();
+            int ilHeaderSize = ((methodsBody.ReadByte() & 0x3) != 0) ? 12 : 1;
+
+            BlobReader relocs = reader.GetSectionData(".szreloc").GetReader();
+            BlobReader names = reader.GetSectionData(".names").GetReader();
+            List<(int, string)> relocList = new();
+            while (relocs.RemainingBytes != 0)
+            {
+                int ilOffset = relocs.ReadInt32();
+                names.Offset = relocs.ReadInt32();
+                string target = names.ReadSerializedString();
+                relocList.Add((ilOffset, target));
+            }
+
+            int sectionIndex = reader.PEHeaders.GetContainingSectionIndex(methodsMethodRva);
+            int sectionVA = reader.PEHeaders.SectionHeaders[sectionIndex].VirtualAddress;
+            int sectionFileOffset = reader.PEHeaders.SectionHeaders[sectionIndex].PointerToRawData;
+            int methodsMethodFileOffset = methodsMethodRva - sectionVA + sectionFileOffset;
+
+            BinaryWriter writer = new(stream);
+            foreach (var (ilOffset, target) in relocList)
+            {
+                if (linkMap.TryGetValue(target, out int size))
+                {
+                    writer.Seek(methodsMethodFileOffset + ilHeaderSize + ilOffset, SeekOrigin.Begin);
+                    writer.Write(size);
+                }
+            }
+            return true;
+        }
+
+        private Dictionary<string, int> ParseLinkMap()
+        {
+            using StreamReader reader = new(LinkMapPath, Encoding.UTF8);
+
+            char[] whitespace = [' '];
+            bool isCode = false;
+            Dictionary<string, int> result = new();
+            while (reader.ReadLine() is string line)
+            {
+                string[] parts = line.Split(whitespace, 4, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length >= 4 && parts[3] == "CODE")
+                {
+                    isCode = true;
+                    continue;
+                }
+                if (!isCode)
+                {
+                    continue;
+                }
+                if (parts[3] == "DATA")
+                {
+                    break;
+                }
+
+                string section = parts[3];
+                int symbolStart = section.LastIndexOf(":(", StringComparison.Ordinal);
+                if (symbolStart > 0 && section[section.Length - 1] == ')')
+                {
+                    symbolStart += 2;
+
+                    int size = int.Parse(parts[2], NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                    string symbol = section.Substring(symbolStart, section.Length - symbolStart - 1);
+                    if (result.ContainsKey(symbol))
+                    {
+                        result[symbol] += size;
+                    }
+                    else
+                    {
+                        result.Add(symbol, size);
+                    }
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/IObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/IObjectDumper.cs
@@ -5,7 +5,7 @@ using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public interface IObjectDumper
+    public partial interface IObjectDumper
     {
         void DumpObjectNode(NodeFactory factory, ObjectNode node, ObjectData objectData);
     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.Llvm.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.IL.Stubs;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    public partial interface IObjectDumper
+    {
+        // In the LLVM backend, compiled method bodies are represented by symbols of which by emission
+        // time we do not yet know the size. We support dumping them by creating "relocatable" dumps.
+        void DumpExternalObjectNode(NodeFactory factory, ISymbolNode node);
+    }
+}
+
+namespace ILCompiler
+{
+    public abstract partial class ObjectDumper
+    {
+        void IObjectDumper.DumpExternalObjectNode(NodeFactory factory, ISymbolNode node) => DumpExternalObjectNode(factory, node);
+
+        protected virtual void DumpExternalObjectNode(NodeFactory factory, ISymbolNode node) { }
+
+        private sealed partial class ComposedObjectDumper : ObjectDumper
+        {
+            protected override void DumpExternalObjectNode(NodeFactory factory, ISymbolNode node)
+            {
+                foreach (var d in _dumpers)
+                    d.DumpExternalObjectNode(factory, node);
+            }
+        }
+    }
+
+    public partial class MstatObjectDumper
+    {
+        private List<(MethodDesc Method, string MangledName)> _externalMethods = new();
+
+        protected override void DumpExternalObjectNode(NodeFactory factory, ISymbolNode node)
+        {
+            IMethodBodyNode methodNode = (IMethodBodyNode)node; // We currently only use this for methods.
+            _externalMethods.Add((methodNode.Method, methodNode.GetMangledName(factory.NameMangler)));
+        }
+
+        private void EmitRelocatableNodes(InstructionEncoder methods)
+        {
+            BlobBuilder relocs = new();
+            foreach (var m in _externalMethods)
+            {
+                methods.OpCode(ILOpCode.Ldtoken);
+                methods.Token(_emitter.EmitMetadataHandleForTypeSystemEntity(m.Method));
+                methods.OpCode(ILOpCode.Ldc_i4);
+                int sizeOffset = methods.Offset;
+                methods.Token(0);
+                methods.LoadConstantI4(0);
+                methods.LoadConstantI4(_methodEhInfo.GetValueOrDefault(m.Method));
+                int mangledNameOffset = AppendMangledName(m.MangledName);
+                methods.LoadConstantI4(mangledNameOffset);
+
+                relocs.WriteInt32(sizeOffset);
+                relocs.WriteInt32(mangledNameOffset);
+            }
+
+            _emitter.AddPESection(".szreloc", relocs);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.Llvm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.Llvm.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System.Collections.Generic;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MstatObjectDumper.cs
@@ -22,7 +22,7 @@ using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 
 namespace ILCompiler
 {
-    public class MstatObjectDumper : ObjectDumper
+    public partial class MstatObjectDumper : ObjectDumper
     {
         private const int VersionMajor = 2;
         private const int VersionMinor = 1;
@@ -160,6 +160,8 @@ namespace ILCompiler
                 methods.LoadConstantI4(_methodEhInfo.GetValueOrDefault(m.Method));
                 methods.LoadConstantI4(AppendMangledName(m.MangledName));
             }
+
+            EmitRelocatableNodes(methods);
 
             var blobs = new InstructionEncoder(new BlobBuilder());
             foreach (var b in _blobs)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDumper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDumper.cs
@@ -9,7 +9,7 @@ using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 
 namespace ILCompiler
 {
-    public abstract class ObjectDumper : IObjectDumper
+    public abstract partial class ObjectDumper : IObjectDumper
     {
         internal abstract void Begin();
         internal abstract void End();
@@ -47,7 +47,7 @@ namespace ILCompiler
             };
         }
 
-        private sealed class ComposedObjectDumper : ObjectDumper
+        private sealed partial class ComposedObjectDumper : ObjectDumper
         {
             private readonly ObjectDumper[] _dumpers;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -487,6 +487,7 @@
     <Compile Include="Compiler\MethodImportationErrorProvider.cs" />
     <Compile Include="Compiler\InlinedThreadStatics.cs" />
     <Compile Include="Compiler\MstatObjectDumper.cs" />
+    <Compile Include="Compiler\MstatObjectDumper.Llvm.cs" />
     <Compile Include="Compiler\NoMetadataBlockingPolicy.cs" />
     <Compile Include="Compiler\DependencyAnalysis\SerializedFrozenObjectNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\GCStaticsPreInitDataNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/WasmObjectWriter.EmitObject.cs
+++ b/src/coreclr/tools/aot/ILCompiler.LLVM/CodeGen/WasmObjectWriter.EmitObject.cs
@@ -35,7 +35,11 @@ namespace ILCompiler.ObjectWriter
             {
                 ObjectNode node = depNode as ObjectNode;
                 if (node == null)
+                {
+                    if (dumper != null && depNode is LLVMMethodCodeNode methodCodeNode)
+                        dumper.DumpExternalObjectNode(factory, methodCodeNode);
                     continue;
+                }
 
                 if (node.ShouldSkipEmittingObjectNode(factory))
                     continue;

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
@@ -15,7 +15,6 @@ Param(
     [ValidateSet("Debug","Checked","Release")][string]$Config = "Release",
     [ValidateSet("Debug","Checked","Release")][string]$IlcConfig = "Release",
     [string][Alias("bt")]$BaseTag = "",
-    [Nullable[bool]]$DebugSymbols = $null,
     [uint]$NumberOfDiffsToShow = 20,
     [string]$PassThrough = ""
 )
@@ -42,7 +41,6 @@ if ($ShowHelp)
     Write-Host "  -Config              : Test configuration (Debug/Release). Default is Release"
     Write-Host "  -IlcConfig           : ILC configuration (Debug/Checked/Release). Default is Release"
     Write-Host "  -BaseTag             : Suffix to use for the 'base' directory. Default is none"
-    Write-Host "  -DebugSymbols        : Whether to build with debug symbols. Default is yes"
     Write-Host "  -NumberOfDiffsToShow : Number of diffs to show. Default is 20"
     Write-Host "  -PassThrough         : Additional command line to pass directly to 'dotnet'"
     Write-Host ""
@@ -56,11 +54,6 @@ if ($ShowHelp)
     Write-Host " -Llvm depends on llvm-dis being available in PATH."
     Write-Host ""
     return
-}
-
-if ($DebugSymbols -eq $null)
-{
-    $DebugSymbols = $true
 }
 
 $RuntimelabDirectory = [System.IO.Path]::GetFullPath("./../../../../../", $PSScriptRoot)
@@ -121,7 +114,7 @@ if ($Build -or $Rebuild)
         Write-Host ""
     }
 
-    $UserBuildArgs = "/p:TargetOS=$OS /p:TargetArchitecture=$Arch /p:IlcConfig=$IlcConfig /p:NativeDebugSymbols=$DebugSymbols -c $Config $PassThrough"
+    $UserBuildArgs = "/p:TargetOS=$OS /p:TargetArchitecture=$Arch /p:IlcConfig=$IlcConfig -c $Config $PassThrough"
     $BuildExpression = "dotnet build $TestProjectPath /t:BuildNativeAot /p:TestBuildMode=nativeaot $UserBuildArgs"
     Write-Verbose "Invoking: '$BuildExpression'"
     Invoke-Expression $BuildExpression


### PR DESCRIPTION
Since we only know the size of the methods once we compile them, introduce a "relocatable object node" concept:
1) We record LLVM methods at object emission time with 0 sizes, recording the location in the IL stream where the size is set.
2) We request the linker to produce a link map.
3) We "relocate" the mstat in an MSBuild task by parsing the aforementioned section together with the link map.

Fixes https://github.com/dotnet/runtimelab/issues/3152.