### PR TITLE
[NativeAOT-LLVM] Work around poor inlined `memset` code quality in LLVM

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -626,9 +626,11 @@ private:
     void emitAlignmentCheckForAddress(GenTree* addr, Value* addrValue, unsigned alignment DEBUGARG(GenTree* indir));
     bool isAddressAligned(GenTree* addr, unsigned alignment);
 
-    Value* consumeInitVal(GenTree* initVal);
+    Value* consumeInitVal(GenTree* initVal, uint8_t* pValue);
+    void consumeInitValAndEmitInitBlk(GenTree* initVal, Value* addrValue, ClassLayout* layout);
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
     unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
+    void emitMemSet(Value* addr, uint8_t value, unsigned size);
 
     void emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFunc DEBUGARG(GenTree* nodeThrowing));
     Value* emitCheckedArithmeticOperation(
@@ -666,6 +668,7 @@ private:
 
     Value* gepOrAddr(Value* addr, unsigned offset);
     Value* gepOrAddrInBounds(Value* addr, unsigned offset);
+    Value* emitAddLoadStoreOffset(Value* addr, unsigned offset);
     llvm::Constant* getIntPtrConst(target_size_t value, Type* llvmType = nullptr);
     Value* getShadowStack();
     Value* getShadowStackForCallee(bool isTailCall = false);

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -1329,9 +1329,7 @@ void Llvm::buildStoreLocalField(GenTreeLclFld* lclFld)
 
     if (lclFld->TypeIs(TYP_STRUCT) && genActualTypeIsInt(data))
     {
-        Value* fillValue = consumeInitVal(data);
-        Value* sizeValue = _builder.getInt32(layout->GetSize());
-        _builder.CreateMemSet(addrValue, fillValue, sizeValue, llvm::MaybeAlign());
+        consumeInitValAndEmitInitBlk(data, addrValue, layout);
     }
     else
     {
@@ -1931,8 +1929,7 @@ void Llvm::buildStoreBlk(GenTreeBlk* blockOp)
     // Check for the "initblk" operation ("dataNode" is either INIT_VAL or constant zero).
     if (blockOp->OperIsInitBlkOp())
     {
-        Value* fillValue = consumeInitVal(dataNode);
-        _builder.CreateMemSet(addrValue, fillValue, _builder.getInt32(layout->GetSize()), llvm::Align());
+        consumeInitValAndEmitInitBlk(dataNode, addrValue, layout);
         return;
     }
 
@@ -2467,17 +2464,31 @@ bool Llvm::isAddressAligned(GenTree* addr, unsigned alignment)
     return alignment == 1; // Any address is aligned to one byte.
 }
 
-Value* Llvm::consumeInitVal(GenTree* initVal)
+Value* Llvm::consumeInitVal(GenTree* initVal, uint8_t* pValue)
 {
     assert(initVal->isContained());
     if (initVal->IsIntegralConst())
     {
         assert(initVal->IsIntegralConst(0));
-        return _builder.getInt8(0);
+        *pValue = 0;
+        return nullptr;
     }
 
     assert(initVal->OperIsInitVal());
     return consumeValue(initVal->gtGetOp1(), Type::getInt8Ty(m_context->Context));
+}
+
+void Llvm::consumeInitValAndEmitInitBlk(GenTree* initVal, Value* addrValue, ClassLayout* layout)
+{
+    uint8_t constInitValue;
+    Value* initValue = consumeInitVal(initVal, &constInitValue);
+    if (initValue != nullptr)
+    {
+        _builder.CreateMemSet(addrValue, initValue, layout->GetSize(), llvm::MaybeAlign());
+        return;
+    }
+
+    emitMemSet(addrValue, constInitValue, layout->GetSize());
 }
 
 void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc)
@@ -2551,6 +2562,66 @@ unsigned Llvm::buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned en
     _builder.CreateMemCpy(destAddress, llvm::Align(), srcAddress, llvm::Align(), size);
 
     return size;
+}
+
+void Llvm::emitMemSet(Value* addr, uint8_t value, unsigned size)
+{
+    static const unsigned LLVM_MAX_UNROLL_SIZE = 64;
+
+    llvm::Align align(1);
+    if (size > LLVM_MAX_UNROLL_SIZE)
+    {
+        _builder.CreateMemSet(addr, _builder.getInt8(value), size, align);
+        return;
+    }
+
+    // TODO-LLVM: remove this manual unrolling once https://github.com/llvm/llvm-project/issues/79692 is fixed.
+    unsigned offset = 0;
+    Value* int64Value = nullptr;
+    for (; size - offset >= 8; offset += 8)
+    {
+        if (int64Value == nullptr)
+        {
+            int64Value = _builder.getInt64(0x0101010101010101ULL * value);
+        }
+        Value* addrAtOffset = emitAddLoadStoreOffset(addr, offset);
+        _builder.CreateAlignedStore(int64Value, addrAtOffset, llvm::commonAlignment(align, offset));
+    }
+
+    Value* int32Value = nullptr;
+    for (; size - offset >= 4; offset += 4)
+    {
+        if (int32Value == nullptr)
+        {
+            int32Value = _builder.getInt32(0x01010101u * value);
+        }
+        Value* addrAtOffset = emitAddLoadStoreOffset(addr, offset);
+        _builder.CreateAlignedStore(int32Value, addrAtOffset, llvm::commonAlignment(align, offset));
+    }
+
+    Value* int16Value = nullptr;
+    for (; size - offset >= 2; offset += 2)
+    {
+        if (int16Value == nullptr)
+        {
+            int16Value = _builder.getInt16(0x0101 * value);
+        }
+        Value* addrAtOffset = emitAddLoadStoreOffset(addr, offset);
+        _builder.CreateAlignedStore(int16Value, addrAtOffset, llvm::commonAlignment(align, offset));
+    }
+
+    Value* int8Value = nullptr;
+    for (; size - offset >= 1; offset += 1)
+    {
+        if (int8Value == nullptr)
+        {
+            int8Value = _builder.getInt8(value);
+        }
+        Value* addrAtOffset = emitAddLoadStoreOffset(addr, offset);
+        _builder.CreateAlignedStore(int8Value, addrAtOffset, llvm::commonAlignment(align, offset));
+    }
+
+    assert(offset == size);
 }
 
 void Llvm::emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFunc DEBUGARG(GenTree* nodeThrowing))
@@ -3249,6 +3320,21 @@ Value* Llvm::gepOrAddrInBounds(Value* addr, unsigned offset)
     }
 
     return _builder.CreateInBoundsGEP(Type::getInt8Ty(m_context->Context), addr, _builder.getInt32(offset));
+}
+
+Value* Llvm::emitAddLoadStoreOffset(Value* addr, unsigned offset)
+{
+    // TODO-LLVM: replace this with getelementptr 'nusw' once we move to LLVM 20+.
+    assert(addr->getType()->isPointerTy());
+    if (offset == 0)
+    {
+        return addr;
+    }
+
+    addr = _builder.CreatePtrToInt(addr, getIntPtrLlvmType());
+    addr = _builder.CreateNUWAdd(addr, getIntPtrConst(offset));
+    addr = _builder.CreateIntToPtr(addr, getPtrLlvmType());
+    return addr;
 }
 
 Value* Llvm::getShadowStack()

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/wasmjit-diff.ps1
@@ -140,7 +140,7 @@ if ($Analyze -or $Summary)
 
     if ($Llvm)
     {
-        $LlvmSummaryLineRegex = [Regex]::New('define.*@"?([^"]*)"?\(.*\).*{', "Compiled")
+        $LlvmSummaryLineRegex = [Regex]::New('define.*@"?([^"]*?)"?\(.*\).*{', "Compiled")
         function ParseLlvmSummary($ObjDirectory, $SummaryName)
         {
             Write-Host -NoNewLine "Analysing ${SummaryName}"
@@ -148,6 +148,7 @@ if ($Analyze -or $Summary)
             # Use the results file to be resilient against stale bitcode files.
             $SummaryList = [Collections.Generic.Dictionary[string, object]]::new()
             $BitcodeFiles = Get-Content "$ObjDirectory/$TestProjectName.results.txt"
+            $BitcodeFiles = $BitcodeFiles | Where-Object { $_.EndsWith(".bc") }
 
             # The results file in the 'base' directory will refer to the original ('diff') files. Fix this up.
             for ($i = 0; $i -lt $BitcodeFiles.Length; $i++)


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/79692.

The diffs are a bit mixed, but still overall significantly positive. The regressions are due to the use of the "opaque" `add` pattern to form non-wrapping offset additions, something we can remove in favor of the new `nusw` GEP feature once we update to the next EMSDK.

Diffs (WasmDebugging):
```
Summary of Code Size diffs:
(Lower is better)

Total bytes of base: 647680
Total bytes of diff: 646552
Total bytes of delta: -1128 (-0.17% % of base)
Average relative delta: -1.12%
    diff is an improvement
    average relative diff is an improvement

Top method regressions (percentages):
          21 ( 4.65% of base) : 1079.dasm - S_P_CoreLib_System_Text_EncoderExceptionFallbackBuffer__Fallback_0
           7 ( 3.08% of base) : 1126.dasm - S_P_CoreLib_System_Number__TryFormatFloat<Double__Char>
           7 ( 3.08% of base) : 1137.dasm - S_P_CoreLib_System_Number__TryFormatFloat<Single__Char>
           4 ( 2.74% of base) : 1081.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__get_Name
           7 ( 2.48% of base) : 1080.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeNamedTypeInfo__get_FullName
          42 ( 2.10% of base) : 1190.dasm - S_P_Reflection_Execution_Internal_Reflection_Execution_NativeFormatEnumInfo__GetEnumValuesAndNames
           4 ( 1.68% of base) : 1200.dasm - S_P_CoreLib_System_GC___AllocateUninitializedArray_g__AllocateNewUninitializedArray_52_0<Char>
           4 ( 1.68% of base) : 1139.dasm - S_P_CoreLib_System_GC___AllocateUninitializedArray_g__AllocateNewUninitializedArray_52_0<Bool>
          12 ( 1.07% of base) : 1173.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__IsCustomAttributeOfType
           4 ( 1.04% of base) : 1116.dasm - S_P_CoreLib_System_Collections_Generic_KeyValuePair__PairToString
           6 ( 0.95% of base) : 1084.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_NativeFormat_NativeFormatRuntimeNamedTypeInfo__ToString
           4 ( 0.82% of base) : 1175.dasm - S_P_TypeLoader_Internal_Metadata_NativeFormat_MetadataTypeHashingAlgorithms__ComputeHashCode
           2 ( 0.79% of base) : 1220.dasm - S_P_CoreLib_System_Buffers_ProbabilisticMapState__FindModulus
          10 ( 0.75% of base) : 1101.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_MethodNameFormatter__EmitMethodParameters_0
           7 ( 0.72% of base) : 1151.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NamespaceChain___ctor
           4 ( 0.54% of base) : 1165.dasm - S_P_CoreLib_System_CrashInfo__WriteHeader
           2 ( 0.53% of base) : 1171.dasm - S_P_CoreLib_System_Collections_Generic_ArraySortHelper_2<System___Canon__System___Canon>__HeapSort
           5 ( 0.47% of base) : 1182.dasm - S_P_CoreLib_System_Reflection_AssemblyNameFormatter__AppendQuoted
           7 ( 0.45% of base) : 1181.dasm - S_P_TypeLoader_Internal_Runtime_TypeLoader_TypeLoaderEnvironment__TryGetStaticGenericMethodComponents
           2 ( 0.23% of base) : 1205.dasm - S_P_CoreLib_System_Collections_Generic_ArraySortHelper_2<System___Canon__System___Canon>__IntroSort

Top method improvements (percentages):
         -48 (-8.50% of base) : 1217.dasm - S_P_CoreLib_System_SpanHelpers__ClearWithoutReferences
         -12 (-7.79% of base) : 1034.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_MethodNameFormatter__EmitTypeInstantiationName
         -21 (-6.38% of base) : 1038.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_MethodNameFormatter__EmitArrayTypeName
         -15 (-4.24% of base) : 1059.dasm - S_P_CoreLib_System_Reflection_Runtime_General_NativeFormatMetadataReaderExtensions__GetAttributeTypeHandle
         -17 (-4.15% of base) : 1162.dasm - S_P_CoreLib_System_Buffers_ProbabilisticWithAsciiCharSearchValues_1<S_P_CoreLib_System_Buffers_IndexOfAnyAsciiSearcher_Default>___ctor
         -10 (-4.05% of base) : 1037.dasm - S_P_StackTraceMetadata_Internal_StackTraceMetadata_MethodNameFormatter_SigTypeContext__GetHandleAt
          -6 (-3.92% of base) : 1166.dasm - S_P_CoreLib_System_CrashInfo__WriteIntValue
         -13 (-3.81% of base) : 1224.dasm - S_P_CoreLib_System_Number__FormatFloat<Double>
          -3 (-3.80% of base) : 1061.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeFunctionPointerTypeInfo__GetHashCode
          -3 (-3.80% of base) : 1237.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeConstructedGenericTypeInfo__GetHashCode
         -13 (-3.64% of base) : 1136.dasm - S_P_CoreLib_System_Number__FormatFloat<Single>
          -5 (-3.27% of base) : 1078.dasm - S_P_CoreLib_System_Text_EncoderExceptionFallbackBuffer__Fallback
          -5 (-3.23% of base) : 1167.dasm - S_P_CoreLib_System_ArgumentOutOfRangeException__ThrowNegativeOrZero<Int32>
          -5 (-3.23% of base) : 1141.dasm - S_P_CoreLib_System_ArgumentOutOfRangeException__ThrowNegative<Int32>
         -15 (-3.21% of base) : 1015.dasm - S_P_CoreLib_System_Reflection_Runtime_TypeInfos_RuntimeTypeInfo_TypeComponentsCache__CreatePerNameQueryCaches
          -3 (-3.16% of base) : 1202.dasm - String__Format_1
          -8 (-2.87% of base) : 1184.dasm - S_P_CoreLib_System_CrashInfo__WriteHexValue
          -8 (-2.87% of base) : 1186.dasm - S_P_CoreLib_System_CrashInfo__WriteHexValue_0
          -6 (-2.79% of base) : 1209.dasm - S_P_CoreLib_System_GC__GetGCMemoryInfo_0
          -5 (-2.70% of base) : 1164.dasm - S_P_CoreLib_System_ArgumentOutOfRangeException__ThrowLess<Int32>

239 total methods with Code Size differences (216 improved, 23 regressed)
```

