### PR TITLE
[NativeAOT-LLVM] Restore some removed upstream publishing infrastructure

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -5,6 +5,118 @@
     <AutoGenerateSymbolPackages>false</AutoGenerateSymbolPackages>
   </PropertyGroup>
 
+  <!-- NativeAOT-LLVM: using the old publishing method from circa https://github.com/dotnet/runtime/pull/108990 -->
+  <ItemGroup>
+    <DownloadedArtifactFile Include="$(DownloadDirectory)**" />
+    <DownloadedSymbolNupkgFile Include="$(DownloadDirectory)**\*.symbols.nupkg" />
+    <DownloadedWixPdbFile Include="$(DownloadDirectory)**\*.wixpdb" />
+    <DownloadedWixpackFile Include="$(DownloadDirectory)**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
+    <DownloadedWorkloadsVSInsertionFile Include="$(DownloadDirectory)*\workloads-vs\**\*" />
+    <DownloadedNupkgFile Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolNupkgFile)" />
+
+    <!-- Exclude symbol packages from have a NuGet signature. These are never pushed to NuGet.org or
+          other feeds (in fact, that have identical identity to their non-symbol variant) -->
+    <DownloadedSymbolPackagesWithoutPaths Include="@(DownloadedSymbolNupkgFile->'%(Filename)%(Extension)')" />
+    <FileSignInfo Include="@(DownloadedSymbolPackagesWithoutPaths->Distinct())" CertificateName="None" />
+
+    <!-- Add files that are not affected by filtering and create checksum for them. -->
+    <UploadToBlobStorageFile
+      Include="@(DownloadedArtifactFile)"
+      Exclude="@(DownloadedSymbolNupkgFile);
+                @(DownloadedNupkgFile);
+                @(DownloadedWixPdbFile);
+                @(DownloadedWorkloadsVSInsertionFile);
+                @(DownloadedWixpackFile)" />
+
+    <!--
+      Filter out the RID-specific (Runtime) nupkgs and RID-agnostic nupkgs. RID-specific packages
+      are published from every job. RID-agnostic nupkgs are built with the same ID/version by
+      every job, so one specific job's outputs must be picked to sign and publish.
+    -->
+
+    <!-- RID-specific framework packs. -->
+    <RuntimeNupkgFile
+      Include="
+        $(DownloadDirectory)**\Microsoft.*.Runtime.*.nupkg;
+        $(DownloadDirectory)**\Microsoft.*.App.Host.*.nupkg;
+        $(DownloadDirectory)**\Microsoft.*.App.Crossgen2.*.nupkg"
+      Exclude="@(DownloadedSymbolNupkgFile)" />
+
+    <!-- VS insertion packages, carrying RID-specific installers. -->
+    <RuntimeNupkgFile
+      Include="$(DownloadDirectory)**\VS.Redist.Common.*.nupkg"
+      Exclude="@(DownloadedSymbolNupkgFile)" />
+
+    <!--
+      Workloads VS insertion artifacts produced by src/workloads/workloads.csproj. Only grab
+      the zip artifacts as they're grouped by SDK feature band which correlates with specific VS versions.
+    -->
+    <WorkloadsVSInsertionFile Include="$(DownloadDirectory)*\workloads-vs\**\*.zip" />
+
+    <!--
+      Runtime packages associated with some identity packages. Need to exclude "runtime.native.*"
+      because Libraries produces some "runtime.native.Foo" packages with
+      "runtime.<rid>.runtime.native.Foo" identity packages.
+    -->
+    <RuntimeNupkgFile
+      Include="$(DownloadDirectory)**\runtime.*.nupkg"
+      Exclude="
+        $(DownloadDirectory)**\runtime.native.*.nupkg;
+        @(DownloadedSymbolNupkgFile)" />
+
+    <!--
+      Packages that aren't matched above as RID-specific are considered RID-agnostic. Also include
+      the AllConfigurations packages from the Libraries build.
+    -->
+    <RidAgnosticNupkgToPublishFile
+      Include="
+        $(DownloadDirectory)**\Microsoft.NET.Workload.Mono.Toolchain.*Manifest-*.nupkg;
+        $(DownloadDirectory)**\Microsoft.NET.Sdk.WebAssembly.Pack.*.nupkg;
+        $(DownloadDirectory)*\$(PublishRidAgnosticPackagesFromPlatform)\**\*.nupkg;
+        $(DownloadDirectory)*\*AllConfigurations\**\*.nupkg"
+      Exclude="@(RuntimeNupkgFile);@(DownloadedSymbolNupkgFile)" />
+
+    <TransportPackagesToPublishFile
+      Include="$(DownloadDirectory)**\*Transport*.nupkg"
+      Exclude="@(RuntimeNupkgFile);@(RidAgnosticNupkgToPublishFile);@(DownloadedSymbolNupkgFile)" />
+
+    <NupkgToPublishFile Include="@(RuntimeNupkgFile);@(RidAgnosticNupkgToPublishFile);@(TransportPackagesToPublishFile)" />
+
+    <!--
+      Assuming all symbol packages ship and can be found by turning .nupkg => .symbols.nupkg, find
+      them. Don't check for missing symbol packages here: some nupkgs don't have them for valid
+      reasons, such as the VS insertion packages that transport MSIs. Symbol package validation
+      will check for symbol completeness with file-by-file granularity rather than looking for
+      missing symbols.nupkg files: https://github.com/dotnet/arcade/issues/2499.
+
+      Handles several conventions:
+      * NonShipping packages have symbol nupkgs that are Shipping.
+      * Shipping packages have symbol packages in a "symbols" subdirectory.
+    -->
+    <PotentialSymbolNupkgToPublishFile
+      Include="
+        @(NupkgToPublishFile->Replace('\NonShipping\', '\Shipping\')->Replace('.nupkg', '.symbols.nupkg'));
+        @(NupkgToPublishFile->Replace('\NonShipping\', '\NonShipping\symbols\')->Replace('.nupkg', '.symbols.nupkg'));
+        @(NupkgToPublishFile->Replace('\Shipping\', '\Shipping\symbols\')->Replace('.nupkg', '.symbols.nupkg'))" />
+
+    <SymbolNupkgToPublishFile Include="@(PotentialSymbolNupkgToPublishFile->Distinct()->Exists())" />
+
+    <!-- Packages -->
+    <Artifact Include="@(NupkgToPublishFile)"
+              IsShipping="$([System.String]::new('%(Identity)').Contains('\Shipping\'))"
+              PublishFlatContainer="false" />
+    <Artifact Include="@(SymbolNupkgToPublishFile)" PublishFlatContainer="false" />
+
+    <!-- Blob storage -->
+    <Artifact Include="@(UploadToBlobStorageFile)"
+              Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)"
+              IsShipping="$([System.String]::new('%(Identity)').Contains('\Shipping\'))"
+              ChecksumPath="%(FullPath).sha512" />
+    <Artifact Include="@(WorkloadsVSInsertionFile)"
+              SubBlobFolder="workloads/"
+              IsShipping="$([System.String]::new('%(Identity)').Contains('\Shipping\'))" />
+  </ItemGroup>
+
   <!-- The PGO runtime should always have External visibility, even if someone changes the default artifact visibility -->
   <ItemGroup>
     <Artifact Update="$(ArtifactsNonShippingPackagesDir)dotnet-runtime-pgo-*" Visibility="External" />


### PR DESCRIPTION
This is just a straight copy from https://github.com/dotnet/runtime/pull/108990.

Should in theory address the error in https://github.com/dotnet/runtimelab/issues/3200#issuecomment-3619512855. It is likely there are more missing pieces.

It is a big liability that we're staying on this old infrastructure. But it would require someone with access to the official build and knowledge of how this is now supposed to work to change that.