### PR TITLE
Update eng/common files to BAR ID 299554

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -45,7 +45,26 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisCSharpPackageVersion>5.3.0-1.25528.108</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersPackageVersion>10.0.100-rc.2.25528.108</MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
     <MicrosoftDotNetApiCompatTaskPackageVersion>10.0.100-rc.2.25528.108</MicrosoftDotNetApiCompatTaskPackageVersion>
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksArchivesPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksArchivesPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion>
+    <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25528.108</MicrosoftDotNetCecilPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenFacadesPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetPackageTestingPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetPackageTestingPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetSharedFrameworkSdkPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetSharedFrameworkSdkPackageVersion>
+    <MicrosoftDotNetXliffTasksPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetXliffTasksPackageVersion>
+    <MicrosoftDotNetXUnitAssertPackageVersion>2.9.3-beta.25528.108</MicrosoftDotNetXUnitAssertPackageVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.9.3-beta.25528.108</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>5.3.0-1.25528.108</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftNETSdkILPackageVersion>10.0.0-rc.1.25528.108</MicrosoftNETSdkILPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportPackageVersion>10.0.100-rc.2.25528.108</MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportPackageVersion>
@@ -60,26 +79,6 @@ This file should be imported by eng/Versions.props
     <SystemReflectionMetadataPackageVersion>10.0.0-rc.1.25528.108</SystemReflectionMetadataPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>10.0.0-rc.1.25528.108</SystemReflectionMetadataLoadContextPackageVersion>
     <SystemTextJsonPackageVersion>10.0.0-rc.1.25528.108</SystemTextJsonPackageVersion>
-    <!-- dotnet/arcade dependencies -->
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetBuildTasksArchivesPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksArchivesPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion>
-    <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetGenFacadesPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotNetPackageTestingPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetPackageTestingPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetSharedFrameworkSdkPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetSharedFrameworkSdkPackageVersion>
-    <MicrosoftDotNetXliffTasksPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetXliffTasksPackageVersion>
-    <MicrosoftDotNetXUnitAssertPackageVersion>2.9.3-beta.26080.3</MicrosoftDotNetXUnitAssertPackageVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.9.3-beta.26080.3</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <!-- dotnet/runtime-assets dependencies -->
     <MicrosoftDotNetCilStripSourcesPackageVersion>11.0.0-beta.25553.1</MicrosoftDotNetCilStripSourcesPackageVersion>
     <MicrosoftNETHostModelTestDataPackageVersion>11.0.0-beta.25553.1</MicrosoftNETHostModelTestDataPackageVersion>
@@ -161,7 +160,26 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>$(MicrosoftCodeAnalysisNetAnalyzersPackageVersion)</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftDotNetApiCompatTaskVersion>$(MicrosoftDotNetApiCompatTaskPackageVersion)</MicrosoftDotNetApiCompatTaskVersion>
+    <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
+    <MicrosoftDotNetBuildTasksArchivesVersion>$(MicrosoftDotNetBuildTasksArchivesPackageVersion)</MicrosoftDotNetBuildTasksArchivesVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>$(MicrosoftDotNetBuildTasksFeedPackageVersion)</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>$(MicrosoftDotNetBuildTasksInstallersPackageVersion)</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>$(MicrosoftDotNetBuildTasksPackagingPackageVersion)</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksTargetFrameworkVersion>$(MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion)</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsVersion>$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)</MicrosoftDotNetBuildTasksWorkloadsVersion>
     <MicrosoftDotNetCecilVersion>$(MicrosoftDotNetCecilPackageVersion)</MicrosoftDotNetCecilVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>$(MicrosoftDotNetCodeAnalysisPackageVersion)</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>$(MicrosoftDotNetGenAPIPackageVersion)</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>$(MicrosoftDotNetGenFacadesPackageVersion)</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetHelixSdkVersion>$(MicrosoftDotNetHelixSdkPackageVersion)</MicrosoftDotNetHelixSdkVersion>
+    <MicrosoftDotNetPackageTestingVersion>$(MicrosoftDotNetPackageTestingPackageVersion)</MicrosoftDotNetPackageTestingVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>$(MicrosoftDotNetRemoteExecutorPackageVersion)</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetSharedFrameworkSdkVersion>$(MicrosoftDotNetSharedFrameworkSdkPackageVersion)</MicrosoftDotNetSharedFrameworkSdkVersion>
+    <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksPackageVersion)</MicrosoftDotNetXliffTasksVersion>
+    <MicrosoftDotNetXUnitAssertVersion>$(MicrosoftDotNetXUnitAssertPackageVersion)</MicrosoftDotNetXUnitAssertVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>$(MicrosoftDotNetXUnitExtensionsPackageVersion)</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNETSdkILVersion>$(MicrosoftNETSdkILPackageVersion)</MicrosoftNETSdkILVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportPackageVersion)</MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportVersion>
@@ -176,26 +194,6 @@ This file should be imported by eng/Versions.props
     <SystemReflectionMetadataVersion>$(SystemReflectionMetadataPackageVersion)</SystemReflectionMetadataVersion>
     <SystemReflectionMetadataLoadContextVersion>$(SystemReflectionMetadataLoadContextPackageVersion)</SystemReflectionMetadataLoadContextVersion>
     <SystemTextJsonVersion>$(SystemTextJsonPackageVersion)</SystemTextJsonVersion>
-    <!-- dotnet/arcade dependencies -->
-    <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
-    <MicrosoftDotNetBuildTasksArchivesVersion>$(MicrosoftDotNetBuildTasksArchivesPackageVersion)</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>$(MicrosoftDotNetBuildTasksFeedPackageVersion)</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>$(MicrosoftDotNetBuildTasksInstallersPackageVersion)</MicrosoftDotNetBuildTasksInstallersVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>$(MicrosoftDotNetBuildTasksPackagingPackageVersion)</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetBuildTasksTargetFrameworkVersion>$(MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion)</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
-    <MicrosoftDotNetBuildTasksTemplatingVersion>$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)</MicrosoftDotNetBuildTasksTemplatingVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsVersion>$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)</MicrosoftDotNetBuildTasksWorkloadsVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>$(MicrosoftDotNetCodeAnalysisPackageVersion)</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>$(MicrosoftDotNetGenAPIPackageVersion)</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>$(MicrosoftDotNetGenFacadesPackageVersion)</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetHelixSdkVersion>$(MicrosoftDotNetHelixSdkPackageVersion)</MicrosoftDotNetHelixSdkVersion>
-    <MicrosoftDotNetPackageTestingVersion>$(MicrosoftDotNetPackageTestingPackageVersion)</MicrosoftDotNetPackageTestingVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>$(MicrosoftDotNetRemoteExecutorPackageVersion)</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetSharedFrameworkSdkVersion>$(MicrosoftDotNetSharedFrameworkSdkPackageVersion)</MicrosoftDotNetSharedFrameworkSdkVersion>
-    <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksPackageVersion)</MicrosoftDotNetXliffTasksVersion>
-    <MicrosoftDotNetXUnitAssertVersion>$(MicrosoftDotNetXUnitAssertPackageVersion)</MicrosoftDotNetXUnitAssertVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>$(MicrosoftDotNetXUnitExtensionsPackageVersion)</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/runtime-assets dependencies -->
     <MicrosoftDotNetCilStripSourcesVersion>$(MicrosoftDotNetCilStripSourcesPackageVersion)</MicrosoftDotNetCilStripSourcesVersion>
     <MicrosoftNETHostModelTestDataVersion>$(MicrosoftNETHostModelTestDataPackageVersion)</MicrosoftNETHostModelTestDataVersion>

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -45,26 +45,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisCSharpPackageVersion>5.3.0-1.25528.108</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisNetAnalyzersPackageVersion>10.0.100-rc.2.25528.108</MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
     <MicrosoftDotNetApiCompatTaskPackageVersion>10.0.100-rc.2.25528.108</MicrosoftDotNetApiCompatTaskPackageVersion>
-    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetArcadeSdkPackageVersion>
-    <MicrosoftDotNetBuildTasksArchivesPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksArchivesPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksFeedPackageVersion>
-    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksInstallersPackageVersion>
-    <MicrosoftDotNetBuildTasksPackagingPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksPackagingPackageVersion>
-    <MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion>
-    <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
     <MicrosoftDotNetCecilPackageVersion>0.11.5-alpha.25528.108</MicrosoftDotNetCecilPackageVersion>
-    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetCodeAnalysisPackageVersion>
-    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetGenAPIPackageVersion>
-    <MicrosoftDotNetGenFacadesPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetHelixSdkPackageVersion>
-    <MicrosoftDotNetPackageTestingPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetPackageTestingPackageVersion>
-    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetRemoteExecutorPackageVersion>
-    <MicrosoftDotNetSharedFrameworkSdkPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetSharedFrameworkSdkPackageVersion>
-    <MicrosoftDotNetXliffTasksPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetXliffTasksPackageVersion>
-    <MicrosoftDotNetXUnitAssertPackageVersion>2.9.3-beta.25528.108</MicrosoftDotNetXUnitAssertPackageVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.9.3-beta.25528.108</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.25528.108</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftNetCompilersToolsetPackageVersion>5.3.0-1.25528.108</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftNETSdkILPackageVersion>10.0.0-rc.1.25528.108</MicrosoftNETSdkILPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportPackageVersion>10.0.100-rc.2.25528.108</MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportPackageVersion>
@@ -79,6 +60,26 @@ This file should be imported by eng/Versions.props
     <SystemReflectionMetadataPackageVersion>10.0.0-rc.1.25528.108</SystemReflectionMetadataPackageVersion>
     <SystemReflectionMetadataLoadContextPackageVersion>10.0.0-rc.1.25528.108</SystemReflectionMetadataLoadContextPackageVersion>
     <SystemTextJsonPackageVersion>10.0.0-rc.1.25528.108</SystemTextJsonPackageVersion>
+    <!-- dotnet/arcade dependencies -->
+    <MicrosoftDotNetArcadeSdkPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetArcadeSdkPackageVersion>
+    <MicrosoftDotNetBuildTasksArchivesPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksArchivesPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksInstallersPackageVersion>
+    <MicrosoftDotNetBuildTasksPackagingPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksPackagingPackageVersion>
+    <MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion>
+    <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
+    <MicrosoftDotNetCodeAnalysisPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetCodeAnalysisPackageVersion>
+    <MicrosoftDotNetGenAPIPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetGenAPIPackageVersion>
+    <MicrosoftDotNetGenFacadesPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetHelixSdkPackageVersion>
+    <MicrosoftDotNetPackageTestingPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetPackageTestingPackageVersion>
+    <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetRemoteExecutorPackageVersion>
+    <MicrosoftDotNetSharedFrameworkSdkPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetSharedFrameworkSdkPackageVersion>
+    <MicrosoftDotNetXliffTasksPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetXliffTasksPackageVersion>
+    <MicrosoftDotNetXUnitAssertPackageVersion>2.9.3-beta.26080.3</MicrosoftDotNetXUnitAssertPackageVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerPackageVersion>2.9.3-beta.26080.3</MicrosoftDotNetXUnitConsoleRunnerPackageVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>11.0.0-beta.26080.3</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <!-- dotnet/runtime-assets dependencies -->
     <MicrosoftDotNetCilStripSourcesPackageVersion>11.0.0-beta.25553.1</MicrosoftDotNetCilStripSourcesPackageVersion>
     <MicrosoftNETHostModelTestDataPackageVersion>11.0.0-beta.25553.1</MicrosoftNETHostModelTestDataPackageVersion>
@@ -160,26 +161,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftCodeAnalysisCSharpVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisCSharpVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>$(MicrosoftCodeAnalysisNetAnalyzersPackageVersion)</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftDotNetApiCompatTaskVersion>$(MicrosoftDotNetApiCompatTaskPackageVersion)</MicrosoftDotNetApiCompatTaskVersion>
-    <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
-    <MicrosoftDotNetBuildTasksArchivesVersion>$(MicrosoftDotNetBuildTasksArchivesPackageVersion)</MicrosoftDotNetBuildTasksArchivesVersion>
-    <MicrosoftDotNetBuildTasksFeedVersion>$(MicrosoftDotNetBuildTasksFeedPackageVersion)</MicrosoftDotNetBuildTasksFeedVersion>
-    <MicrosoftDotNetBuildTasksInstallersVersion>$(MicrosoftDotNetBuildTasksInstallersPackageVersion)</MicrosoftDotNetBuildTasksInstallersVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>$(MicrosoftDotNetBuildTasksPackagingPackageVersion)</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetBuildTasksTargetFrameworkVersion>$(MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion)</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
-    <MicrosoftDotNetBuildTasksTemplatingVersion>$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)</MicrosoftDotNetBuildTasksTemplatingVersion>
-    <MicrosoftDotNetBuildTasksWorkloadsVersion>$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)</MicrosoftDotNetBuildTasksWorkloadsVersion>
     <MicrosoftDotNetCecilVersion>$(MicrosoftDotNetCecilPackageVersion)</MicrosoftDotNetCecilVersion>
-    <MicrosoftDotNetCodeAnalysisVersion>$(MicrosoftDotNetCodeAnalysisPackageVersion)</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>$(MicrosoftDotNetGenAPIPackageVersion)</MicrosoftDotNetGenAPIVersion>
-    <MicrosoftDotNetGenFacadesVersion>$(MicrosoftDotNetGenFacadesPackageVersion)</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetHelixSdkVersion>$(MicrosoftDotNetHelixSdkPackageVersion)</MicrosoftDotNetHelixSdkVersion>
-    <MicrosoftDotNetPackageTestingVersion>$(MicrosoftDotNetPackageTestingPackageVersion)</MicrosoftDotNetPackageTestingVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>$(MicrosoftDotNetRemoteExecutorPackageVersion)</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetSharedFrameworkSdkVersion>$(MicrosoftDotNetSharedFrameworkSdkPackageVersion)</MicrosoftDotNetSharedFrameworkSdkVersion>
-    <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksPackageVersion)</MicrosoftDotNetXliffTasksVersion>
-    <MicrosoftDotNetXUnitAssertVersion>$(MicrosoftDotNetXUnitAssertPackageVersion)</MicrosoftDotNetXUnitAssertVersion>
-    <MicrosoftDotNetXUnitConsoleRunnerVersion>$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>$(MicrosoftDotNetXUnitExtensionsPackageVersion)</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftNETSdkILVersion>$(MicrosoftNETSdkILPackageVersion)</MicrosoftNETSdkILVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportPackageVersion)</MicrosoftNETWorkloadEmscriptenCurrentManifest100100TransportVersion>
@@ -194,6 +176,26 @@ This file should be imported by eng/Versions.props
     <SystemReflectionMetadataVersion>$(SystemReflectionMetadataPackageVersion)</SystemReflectionMetadataVersion>
     <SystemReflectionMetadataLoadContextVersion>$(SystemReflectionMetadataLoadContextPackageVersion)</SystemReflectionMetadataLoadContextVersion>
     <SystemTextJsonVersion>$(SystemTextJsonPackageVersion)</SystemTextJsonVersion>
+    <!-- dotnet/arcade dependencies -->
+    <MicrosoftDotNetArcadeSdkVersion>$(MicrosoftDotNetArcadeSdkPackageVersion)</MicrosoftDotNetArcadeSdkVersion>
+    <MicrosoftDotNetBuildTasksArchivesVersion>$(MicrosoftDotNetBuildTasksArchivesPackageVersion)</MicrosoftDotNetBuildTasksArchivesVersion>
+    <MicrosoftDotNetBuildTasksFeedVersion>$(MicrosoftDotNetBuildTasksFeedPackageVersion)</MicrosoftDotNetBuildTasksFeedVersion>
+    <MicrosoftDotNetBuildTasksInstallersVersion>$(MicrosoftDotNetBuildTasksInstallersPackageVersion)</MicrosoftDotNetBuildTasksInstallersVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>$(MicrosoftDotNetBuildTasksPackagingPackageVersion)</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksTargetFrameworkVersion>$(MicrosoftDotNetBuildTasksTargetFrameworkPackageVersion)</MicrosoftDotNetBuildTasksTargetFrameworkVersion>
+    <MicrosoftDotNetBuildTasksTemplatingVersion>$(MicrosoftDotNetBuildTasksTemplatingPackageVersion)</MicrosoftDotNetBuildTasksTemplatingVersion>
+    <MicrosoftDotNetBuildTasksWorkloadsVersion>$(MicrosoftDotNetBuildTasksWorkloadsPackageVersion)</MicrosoftDotNetBuildTasksWorkloadsVersion>
+    <MicrosoftDotNetCodeAnalysisVersion>$(MicrosoftDotNetCodeAnalysisPackageVersion)</MicrosoftDotNetCodeAnalysisVersion>
+    <MicrosoftDotNetGenAPIVersion>$(MicrosoftDotNetGenAPIPackageVersion)</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenFacadesVersion>$(MicrosoftDotNetGenFacadesPackageVersion)</MicrosoftDotNetGenFacadesVersion>
+    <MicrosoftDotNetHelixSdkVersion>$(MicrosoftDotNetHelixSdkPackageVersion)</MicrosoftDotNetHelixSdkVersion>
+    <MicrosoftDotNetPackageTestingVersion>$(MicrosoftDotNetPackageTestingPackageVersion)</MicrosoftDotNetPackageTestingVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>$(MicrosoftDotNetRemoteExecutorPackageVersion)</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetSharedFrameworkSdkVersion>$(MicrosoftDotNetSharedFrameworkSdkPackageVersion)</MicrosoftDotNetSharedFrameworkSdkVersion>
+    <MicrosoftDotNetXliffTasksVersion>$(MicrosoftDotNetXliffTasksPackageVersion)</MicrosoftDotNetXliffTasksVersion>
+    <MicrosoftDotNetXUnitAssertVersion>$(MicrosoftDotNetXUnitAssertPackageVersion)</MicrosoftDotNetXUnitAssertVersion>
+    <MicrosoftDotNetXUnitConsoleRunnerVersion>$(MicrosoftDotNetXUnitConsoleRunnerPackageVersion)</MicrosoftDotNetXUnitConsoleRunnerVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>$(MicrosoftDotNetXUnitExtensionsPackageVersion)</MicrosoftDotNetXUnitExtensionsVersion>
     <!-- dotnet/runtime-assets dependencies -->
     <MicrosoftDotNetCilStripSourcesVersion>$(MicrosoftDotNetCilStripSourcesPackageVersion)</MicrosoftDotNetCilStripSourcesVersion>
     <MicrosoftNETHostModelTestDataVersion>$(MicrosoftNETHostModelTestDataPackageVersion)</MicrosoftNETHostModelTestDataVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -55,77 +55,77 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitAssert" Version="2.9.3-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.XUnitAssert" Version="2.9.3-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.9.3-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.9.3-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
     <Dependency Name="System.ComponentModel.TypeConverter.TestData" Version="11.0.0-beta.25553.1">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
@@ -303,9 +303,9 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>5b5722171c6c28f6c9f6b6148f148199b9dd0f5b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="11.0.0-beta.25528.108">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
+    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="11.0.0-beta.26080.3">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.25502.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -55,77 +55,77 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitAssert" Version="2.9.3-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.XUnitAssert" Version="2.9.3-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.9.3-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.XUnitConsoleRunner" Version="2.9.3-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Archives" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Packaging" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Templating" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Workloads" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.CodeAnalysis" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.SharedFramework.Sdk" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
     <Dependency Name="System.ComponentModel.TypeConverter.TestData" Version="11.0.0-beta.25553.1">
       <Uri>https://github.com/dotnet/runtime-assets</Uri>
@@ -303,9 +303,9 @@
       <Uri>https://github.com/dotnet/xharness</Uri>
       <Sha>5b5722171c6c28f6c9f6b6148f148199b9dd0f5b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="11.0.0-beta.26080.3">
-      <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>b7be18aa9600f662a6da4b75c1ae2aa0b6ddda1c</Sha>
+    <Dependency Name="Microsoft.DotNet.PackageTesting" Version="11.0.0-beta.25528.108">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>e545239117919cda700be149a2e9a032374fc284</Sha>
     </Dependency>
     <Dependency Name="optimization.windows_nt-x64.MIBC.Runtime" Version="1.0.0-prerelease.25502.1">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-optimization</Uri>

--- a/eng/common/build.ps1
+++ b/eng/common/build.ps1
@@ -157,7 +157,6 @@ try {
     if (-not $excludeCIBinarylog) {
       $binaryLog = $true
     }
-
     $nodeReuse = $false
   }
 

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -73,6 +73,8 @@ jobs:
     templateContext: ${{ parameters.templateContext }}
 
   variables:
+  - name: AllowPtrToDetectTestRunRetryFiles
+    value: true
   - ${{ if ne(parameters.enableTelemetry, 'false') }}:
     - name: DOTNET_CLI_TELEMETRY_PROFILE
       value: '$(Build.Repository.Uri)'

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -80,7 +80,7 @@ jobs:
     # If it's not devdiv, it's dnceng
     ${{ if ne(variables['System.TeamProject'], 'DevDiv') }}:
       name: NetCore1ESPool-Publishing-Internal
-      image: windows.vs2019.amd64
+      image: windows.vs2022.amd64
       os: windows
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:
@@ -122,8 +122,9 @@ jobs:
 
     # Populate internal runtime variables.
     - template: /eng/common/templates/steps/enable-internal-sources.yml
-      parameters:
-        legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
+      ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+        parameters:
+            legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
 
     - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 
@@ -140,7 +141,7 @@ jobs:
           /p:MaestroApiEndpoint=https://maestro.dot.net
           /p:OfficialBuildId=$(OfficialBuildId)
           -runtimeSourceFeed https://ci.dot.net/internal
-          -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+          -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
 
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
@@ -189,6 +190,11 @@ jobs:
           BARBuildId: ${{ parameters.BARBuildId }}
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
+          
+      # Darc is targeting 8.0, so make sure it's installed
+      - task: UseDotNet@2
+        inputs:
+          version: 8.0.x
 
       - task: AzureCLI@2
         displayName: Publish Using Darc
@@ -205,8 +211,8 @@ jobs:
             -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
             -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
             -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
-            -runtimeSourceFeed https://ci.dot.net/internal 
-            -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+            -runtimeSourceFeed https://ci.dot.net/internal
+            -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
 
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
       - template: /eng/common/core-templates/steps/publish-logs.yml

--- a/eng/common/core-templates/job/source-build.yml
+++ b/eng/common/core-templates/job/source-build.yml
@@ -60,19 +60,19 @@ jobs:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore-Svc-Public' ), False, 'NetCore-Public')]
-          demands: ImageOverride -equals build.ubuntu.2004.amd64
+          demands: ImageOverride -equals Azure-Linux-3-Amd64-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]
-          image: 1es-mariner-2
+          image: Azure-Linux-3-Amd64
           os: linux
     ${{ else }}:
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
           name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore-Svc-Public' ), False, 'NetCore-Public')]
-          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+          demands: ImageOverride -equals Azure-Linux-3-Amd64-Public
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]
-          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
+          demands: ImageOverride -equals Azure-Linux-3-Amd64
   ${{ if ne(parameters.platform.pool, '') }}:
     pool: ${{ parameters.platform.pool }}
 

--- a/eng/common/core-templates/job/source-index-stage1.yml
+++ b/eng/common/core-templates/job/source-index-stage1.yml
@@ -3,7 +3,7 @@ parameters:
   sourceIndexBuildCommand: powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "eng/common/build.ps1 -restore -build -binarylog -ci"
   preSteps: []
   binlogPath: artifacts/log/Debug/Build.binlog
-  condition: ''
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   dependsOn: ''
   pool: ''
   is1ESPipeline: ''
@@ -25,10 +25,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $(DncEngPublicBuildPool)
-        image: windows.vs2022.amd64.open
+        image: windows.vs2026preview.scout.amd64.open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $(DncEngInternalBuildPool)
-        image: windows.vs2022.amd64
+        image: windows.vs2026preview.scout.amd64
 
   steps:
   - ${{ if eq(parameters.is1ESPipeline, '') }}:

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -127,11 +127,11 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
-            image: windows.vs2022.amd64
+            image: windows.vs2026preview.scout.amd64
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
 
       steps:
       - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
@@ -175,7 +175,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
       steps:
       - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
         parameters:
@@ -236,7 +236,7 @@ stages:
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64
+            demands: ImageOverride -equals windows.vs2026preview.scout.amd64
       steps:
       - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
         parameters:
@@ -293,11 +293,11 @@ stages:
         ${{ else }}:
           ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: NetCore1ESPool-Publishing-Internal
-            image: windows.vs2019.amd64
+            image: windows.vs2022.amd64
             os: windows
           ${{ else }}:
             name: NetCore1ESPool-Publishing-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
       steps:
       - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
         parameters:
@@ -305,13 +305,18 @@ stages:
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-      - task: NuGetAuthenticate@1 # Populate internal runtime variables.
+      - task: NuGetAuthenticate@1
 
+      # Populate internal runtime variables.
       - template: /eng/common/templates/steps/enable-internal-sources.yml
         parameters:
           legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
 
       - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+
+      - task: UseDotNet@2
+        inputs:
+          version: 8.0.x
 
       - task: AzureCLI@2
         displayName: Publish Using Darc
@@ -330,4 +335,4 @@ stages:
               -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
               -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
               -runtimeSourceFeed https://ci.dot.net/internal 
-              -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+              -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'

--- a/eng/common/core-templates/steps/install-microbuild-impl.yml
+++ b/eng/common/core-templates/steps/install-microbuild-impl.yml
@@ -18,16 +18,16 @@ parameters:
     type: boolean
 
 steps:
-- ${{ if eq(parameters.enablePreviewMicrobuild, 'true') }}:
+- ${{ if eq(parameters.enablePreviewMicrobuild, true) }}:
     - task: MicroBuildSigningPluginPreview@4
-      displayName: Install Preview MicroBuild plugin (Windows)
+      displayName: Install Preview MicroBuild plugin
       inputs: ${{ parameters.microbuildTaskInputs }}
       env: ${{ parameters.microbuildEnv }}
       continueOnError: ${{ parameters.continueOnError }}
       condition: ${{ parameters.condition }}
 - ${{ else }}:
   - task: MicroBuildSigningPlugin@4
-    displayName: Install MicroBuild plugin (Windows)
+    displayName: Install MicroBuild plugin
     inputs: ${{ parameters.microbuildTaskInputs }}
     env: ${{ parameters.microbuildEnv }}
     continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -13,6 +13,8 @@ parameters:
   # Unfortunately, _SignType can't be used to exclude the use of the service connection in non-real sign scenarios. The
   # variable is not available in template expression. _SignType has a very large proliferation across .NET, so replacing it is tough.
   microbuildUseESRP: true
+  # Microbuild installation directory
+  microBuildOutputFolder: $(Agent.TempDirectory)/MicroBuild
   # Microbuild version
   microbuildPluginVersion: 'latest'
 
@@ -21,16 +23,33 @@ parameters:
 steps:
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-      # Installing .NET 8 is required to use the MicroBuild signing plugin on non-Windows platforms
+      # Needed to download the MicroBuild plugin nupkgs on Mac and Linux when nuget.exe is unavailable
       - task: UseDotNet@2
         displayName: Install .NET 8.0 SDK for MicroBuild Plugin
         inputs:
           packageType: sdk
           version: 8.0.x
-          # Installing the SDK in a '.dotnet-microbuild' directory is required for signing.
-          # See target FindDotNetPathForMicroBuild in arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
-          # Do not remove '.dotnet-microbuild' from the path without changing the corresponding logic.
-          installationPath: $(Agent.TempDirectory)/.dotnet-microbuild
+          installationPath: ${{ parameters.microBuildOutputFolder }}/.dotnet-microbuild
+        condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
+
+      - script: |
+          set -euo pipefail
+
+          # UseDotNet@2 prepends the dotnet executable path to the PATH variable, so we can call dotnet directly
+          version=$(dotnet --version)
+          cat << 'EOF' > ${{ parameters.microBuildOutputFolder }}/global.json
+          {
+            "sdk": {
+              "version": "$version",
+              "paths": [
+                "${{ parameters.microBuildOutputFolder }}/.dotnet-microbuild"
+              ],
+              "errorMessage": "The .NET SDK version $version is required to install the MicroBuild signing plugin."
+            }
+          }
+          EOF
+        displayName: 'Add global.json to MicroBuild Installation path'
+        workingDirectory: ${{ parameters.microBuildOutputFolder }}
         condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
     - script: |
@@ -70,7 +89,7 @@ steps:
               ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
         microbuildEnv:
           TeamName: $(_TeamName)
-          MicroBuildOutputFolderOverride: $(Agent.TempDirectory)/MicroBuild
+          MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         continueOnError: ${{ parameters.continueOnError }}
         condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
@@ -84,6 +103,7 @@ steps:
             zipSources: false
             feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
             version: ${{ parameters.microbuildPluginVersion }}
+            workingDirectory: ${{ parameters.microBuildOutputFolder }}
             ${{ if eq(parameters.microbuildUseESRP, true) }}:
               ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
               ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
@@ -92,7 +112,7 @@ steps:
                 ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
           microbuildEnv:
             TeamName: $(_TeamName)
-            MicroBuildOutputFolderOverride: $(Agent.TempDirectory)/MicroBuild
+            MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           continueOnError: ${{ parameters.continueOnError }}
           condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -26,8 +26,10 @@ steps:
     #  If the file exists - sensitive data for redaction will be sourced from it
     #  (single entry per line, lines starting with '# ' are considered comments and skipped)
     arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs' 
-      -BinlogToolVersion ${{parameters.BinlogToolVersion}}
+      -BinlogToolVersion '${{parameters.BinlogToolVersion}}'
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
+      -runtimeSourceFeed https://ci.dot.net/internal 
+      -runtimeSourceFeedKey '$(dotnetbuilds-internal-container-read-token-base64)'
       '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(MaestroAccessToken)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'

--- a/eng/common/core-templates/steps/source-index-stage1-publish.yml
+++ b/eng/common/core-templates/steps/source-index-stage1-publish.yml
@@ -14,8 +14,8 @@ steps:
     workingDirectory: $(Agent.TempDirectory)
 
 - script: |
-    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --add-source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
-    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --add-source ${{parameters.SourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    $(Agent.TempDirectory)/dotnet/dotnet tool install BinLogToSln --version ${{parameters.sourceIndexProcessBinlogPackageVersion}} --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
+    $(Agent.TempDirectory)/dotnet/dotnet tool install UploadIndexStage1 --version ${{parameters.sourceIndexUploadPackageVersion}} --source ${{parameters.sourceIndexPackageSource}} --tool-path $(Agent.TempDirectory)/.source-index/tools
   displayName: "Source Index: Download netsourceindex Tools"
   # Set working directory to temp directory so 'dotnet' doesn't try to use global.json and use the repo's sdk.
   workingDirectory: $(Agent.TempDirectory)

--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -72,7 +72,7 @@ __AlpinePackages+=" krb5-dev"
 __AlpinePackages+=" openssl-dev"
 __AlpinePackages+=" zlib-dev"
 
-__FreeBSDBase="13.4-RELEASE"
+__FreeBSDBase="13.5-RELEASE"
 __FreeBSDPkg="1.21.3"
 __FreeBSDABI="13"
 __FreeBSDPackages="libunwind"
@@ -383,7 +383,7 @@ while :; do
             ;;
         freebsd14)
             __CodeName=freebsd
-            __FreeBSDBase="14.2-RELEASE"
+            __FreeBSDBase="14.3-RELEASE"
             __FreeBSDABI="14"
             __SkipUnmount=1
             ;;

--- a/eng/common/internal-feed-operations.ps1
+++ b/eng/common/internal-feed-operations.ps1
@@ -26,7 +26,7 @@ function SetupCredProvider {
   $url = 'https://raw.githubusercontent.com/microsoft/artifacts-credprovider/master/helpers/installcredprovider.ps1'
   
   Write-Host "Writing the contents of 'installcredprovider.ps1' locally..."
-  Invoke-WebRequest $url -OutFile installcredprovider.ps1
+  Invoke-WebRequest $url -UseBasicParsing -OutFile installcredprovider.ps1
   
   Write-Host 'Installing plugin...'
   .\installcredprovider.ps1 -Force

--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -27,7 +27,7 @@ case "$os" in
                 libssl-dev libkrb5-dev pigz cpio
 
             localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-        elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ] || [ "$ID" = "azurelinux" ]; then
+        elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ] || [ "$ID" = "azurelinux" ] || [ "$ID" = "centos" ]; then
             pkg_mgr="$(command -v tdnf 2>/dev/null || command -v dnf)"
             $pkg_mgr install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
         elif [ "$ID" = "amzn" ]; then

--- a/eng/common/post-build/nuget-verification.ps1
+++ b/eng/common/post-build/nuget-verification.ps1
@@ -65,7 +65,7 @@ if ($NuGetExePath) {
         Write-Host "Downloading nuget.exe from $nugetExeUrl..."
         $ProgressPreference = 'SilentlyContinue'
         try {
-            Invoke-WebRequest $nugetExeUrl -OutFile $downloadedNuGetExe
+            Invoke-WebRequest $nugetExeUrl -UseBasicParsing -OutFile $downloadedNuGetExe
             $ProgressPreference = 'Continue'
         } catch {
             $ProgressPreference = 'Continue'

--- a/eng/common/post-build/redact-logs.ps1
+++ b/eng/common/post-build/redact-logs.ps1
@@ -7,7 +7,9 @@ param(
   # File with strings to redact - separated by newlines.
   #  For comments start the line with '# ' - such lines are ignored 
   [Parameter(Mandatory=$false)][string] $TokensFilePath,
-  [Parameter(ValueFromRemainingArguments=$true)][String[]]$TokensToRedact
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$TokensToRedact,
+  [Parameter(Mandatory=$false)][string] $runtimeSourceFeed,
+  [Parameter(Mandatory=$false)][string] $runtimeSourceFeedKey
 )
 
 try {

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -70,7 +70,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.14.16" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "18.0.0" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/templates/variables/pool-providers.yml
+++ b/eng/common/templates/variables/pool-providers.yml
@@ -23,7 +23,7 @@
 #
 #        pool:
 #           name: $(DncEngInternalBuildPool)
-#           demands: ImageOverride -equals windows.vs2019.amd64
+#           demands: ImageOverride -equals windows.vs2022.amd64
 variables:
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
     - template: /eng/common/templates-official/variables/pool-providers.yml

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -157,9 +157,6 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
     return $global:_DotNetInstallDir
   }
 
-  # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
-  $env:DOTNET_MULTILEVEL_LOOKUP=0
-
   # Disable first run since we do not need all ASP.NET packages restored.
   $env:DOTNET_NOLOGO=1
 
@@ -225,7 +222,6 @@ function InitializeDotNetCli([bool]$install, [bool]$createSdkLocationFile) {
   # Make Sure that our bootstrapped dotnet cli is available in future steps of the Azure Pipelines build
   Write-PipelinePrependPath -Path $dotnetRoot
 
-  Write-PipelineSetVariable -Name 'DOTNET_MULTILEVEL_LOOKUP' -Value '0'
   Write-PipelineSetVariable -Name 'DOTNET_NOLOGO' -Value '1'
 
   return $global:_DotNetInstallDir = $dotnetRoot
@@ -277,7 +273,7 @@ function GetDotNetInstallScript([string] $dotnetRoot) {
 
     Retry({
       Write-Host "GET $uri"
-      Invoke-WebRequest $uri -OutFile $installScript
+      Invoke-WebRequest $uri -UseBasicParsing -OutFile $installScript
     })
   }
 
@@ -394,8 +390,8 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.14.16
-  $defaultXCopyMSBuildVersion = '17.14.16'
+  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/18.0.0
+  $defaultXCopyMSBuildVersion = '18.0.0'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {
@@ -510,7 +506,7 @@ function InitializeXCopyMSBuild([string]$packageVersion, [bool]$install) {
     Write-Host "Downloading $packageName $packageVersion"
     $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
     Retry({
-      Invoke-WebRequest "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/flat2/$packageName/$packageVersion/$packageName.$packageVersion.nupkg" -OutFile $packagePath
+      Invoke-WebRequest "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/flat2/$packageName/$packageVersion/$packageName.$packageVersion.nupkg" -UseBasicParsing -OutFile $packagePath
     })
 
     if (!(Test-Path $packagePath)) {
@@ -556,23 +552,30 @@ function LocateVisualStudio([object]$vsRequirements = $null){
     Write-Host "Downloading vswhere $vswhereVersion"
     $ProgressPreference = 'SilentlyContinue' # Don't display the console progress UI - it's a huge perf hit
     Retry({
-      Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -OutFile $vswhereExe
+      Invoke-WebRequest "https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/vswhere/$vswhereVersion/vswhere.exe" -UseBasicParsing -OutFile $vswhereExe
     })
   }
 
-  if (!$vsRequirements) { $vsRequirements = $GlobalJson.tools.vs }
+  if (!$vsRequirements) {
+    if (Get-Member -InputObject $GlobalJson.tools -Name 'vs' -ErrorAction SilentlyContinue) {
+      $vsRequirements = $GlobalJson.tools.vs
+    } else {
+      $vsRequirements = $null
+    }
+  }
+
   $args = @('-latest', '-format', 'json', '-requires', 'Microsoft.Component.MSBuild', '-products', '*')
 
   if (!$excludePrereleaseVS) {
     $args += '-prerelease'
   }
 
-  if (Get-Member -InputObject $vsRequirements -Name 'version') {
+  if ($vsRequirements -and (Get-Member -InputObject $vsRequirements -Name 'version' -ErrorAction SilentlyContinue)) {
     $args += '-version'
     $args += $vsRequirements.version
   }
 
-  if (Get-Member -InputObject $vsRequirements -Name 'components') {
+  if ($vsRequirements -and (Get-Member -InputObject $vsRequirements -Name 'components' -ErrorAction SilentlyContinue)) {
     foreach ($component in $vsRequirements.components) {
       $args += '-requires'
       $args += $component

--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -115,9 +115,6 @@ function InitializeDotNetCli {
 
   local install=$1
 
-  # Don't resolve runtime, shared framework, or SDK from other locations to ensure build determinism
-  export DOTNET_MULTILEVEL_LOOKUP=0
-
   # Disable first run since we want to control all package sources
   export DOTNET_NOLOGO=1
 
@@ -166,7 +163,6 @@ function InitializeDotNetCli {
   # build steps from using anything other than what we've downloaded.
   Write-PipelinePrependPath -path "$dotnet_root"
 
-  Write-PipelineSetVariable -name "DOTNET_MULTILEVEL_LOOKUP" -value "0"
   Write-PipelineSetVariable -name "DOTNET_NOLOGO" -value "1"
 
   # return value

--- a/global.json
+++ b/global.json
@@ -1,16 +1,16 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.2.25502.107",
+    "version": "11.0.100-preview.1.26078.121",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "10.0.100-rc.2.25502.107"
+    "dotnet": "11.0.100-preview.1.26078.121"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25528.108",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25528.108",
-    "Microsoft.DotNet.SharedFramework.Sdk": "11.0.0-beta.25528.108",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26080.3",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26080.3",
+    "Microsoft.DotNet.SharedFramework.Sdk": "11.0.0-beta.26080.3",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
     "Microsoft.NET.Sdk.IL": "10.0.0-rc.1.25528.108"

--- a/global.json
+++ b/global.json
@@ -8,9 +8,9 @@
     "dotnet": "11.0.100-preview.1.26078.121"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.26080.3",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.26080.3",
-    "Microsoft.DotNet.SharedFramework.Sdk": "11.0.0-beta.26080.3",
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25528.108",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25528.108",
+    "Microsoft.DotNet.SharedFramework.Sdk": "11.0.0-beta.25528.108",
     "Microsoft.Build.NoTargets": "3.7.0",
     "Microsoft.Build.Traversal": "3.4.0",
     "Microsoft.NET.Sdk.IL": "10.0.0-rc.1.25528.108"


### PR DESCRIPTION
Upgrade only minimal parts of the shared infra to BAR ID 299554. The full dependency upgrade has issues with some of the TFMs of test projects being old (i.e. net8.0), so that can be done in a larger update of the branch.