### PR TITLE
[NativeAOT-LLVM] Separate 'our' Microsoft.Interop.SourceGeneration from the ref pack's

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
@@ -12,18 +12,19 @@
     <Content Include="*.*" Exclude="$(MSBuildProjectFile)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-    <!-- TODO-LLVM-Upstream: https://github.com/dotnet/runtimelab/issues/2576 -->
+  <!-- TODO-LLVM-Upstream: https://github.com/dotnet/runtimelab/issues/2576 -->
   <ItemGroup>
-    <ProjectReference Include="$(LibrariesProjectRoot)\System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="$(LibrariesProjectRoot)\System.Runtime.InteropServices.JavaScript\gen\JSImportGenerator\JSImportGenerator.csproj"
+                      AdditionalProperties="NativeAotLlvmRefOverride=.NativeAOT_LLVM"
+                      OutputItemType="Analyzer" />
   </ItemGroup>
 
   <Target Name="CopyAfterBuild" AfterTargets="Build">
     <!-- TODO-LLVM-Upstream: https://github.com/dotnet/runtimelab/issues/2576 -->
     <ItemGroup>
-      <AnalyzerFile Include="$(ArtifactsBinDir)Microsoft.Interop.SourceGeneration\$(Configuration)\netstandard2.0\*" />
-      <AnalyzerFile Include="$(ArtifactsBinDir)JSImportGenerator\$(Configuration)\netstandard2.0\*" />
+      <Content Include="$(ArtifactsBinDir)Microsoft.Interop.SourceGeneration.NativeAOT_LLVM\$(Configuration)\netstandard2.0\*" />
+      <Content Include="$(ArtifactsBinDir)JSImportGenerator\$(Configuration)\netstandard2.0\*" />
     </ItemGroup>
-    <Copy SourceFiles="@(AnalyzerFile)" DestinationFolder="$(RuntimeBinDir)\analyzers\dotnet\cs" />
     <Copy SourceFiles="@(Content)" DestinationFolder="$(OutputPath)" />
   </Target>
 

--- a/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/DotNetJsApi.targets
@@ -117,8 +117,8 @@
   <!-- TODO-LLVM-Upstream: https://github.com/dotnet/runtimelab/issues/2576 -->
   <Target Name="ReplaceJSImportGenerator" AfterTargets="ResolveTargetingPackAssets">
     <ItemGroup>
-      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.AssemblyName)' == 'Microsoft.Interop.JavaScript.JSImportGenerator' or '%(Analyzer.AssemblyName)' == 'Microsoft.Interop.SourceGeneration'" />
-      <Analyzer Include="$(MSBuildThisFileDirectory)..\analyzers\**\*.dll" />
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.AssemblyName)' == 'Microsoft.Interop.JavaScript.JSImportGenerator'" />
+      <Analyzer Include="$(MSBuildThisFileDirectory)*.dll" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler.LLVM/Microsoft.DotNet.ILCompiler.LLVM.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler.LLVM/Microsoft.DotNet.ILCompiler.LLVM.pkgproj
@@ -15,10 +15,6 @@
     <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
       <File Include="$(CoreCLRBuildIntegrationDir)*" TargetPath="build" />
       <File Include="$(CoreCLRILCompilerDir)netstandard\*" TargetPath="tools/netstandard" />
-
-      <!-- TODO-LLVM-Upstream: https://github.com/dotnet/runtimelab/issues/2576 -->
-      <File Include="$(ArtifactsBinDir)Microsoft.Interop.SourceGeneration\$(Configuration)\netstandard2.0\*" TargetPath="analyzers/dotnet/cs" />
-      <File Include="$(ArtifactsBinDir)JSImportGenerator\$(Configuration)\netstandard2.0\*" TargetPath="analyzers/dotnet/cs" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(PackageTargetRuntime)' != '' and '$(BuildingIlcHostPackage)' == 'true'">

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSImportGenerator.csproj
@@ -17,8 +17,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
   </ItemGroup>
 
+  <!-- TODO-LLVM-Upstream: https://github.com/dotnet/runtimelab/issues/2576. -->
+  <!-- We rename the ISG assembly so that it doesn't conflict with the one in the ref pack (which may be older and used by other generators). -->
   <ItemGroup>
-    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration.csproj" />
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\Microsoft.Interop.SourceGeneration\Microsoft.Interop.SourceGeneration$(NativeAotLlvmRefOverride).csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.NativeAOT_LLVM.csproj
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.NativeAOT_LLVM.csproj
@@ -1,0 +1,4 @@
+<Project>
+  <!-- TODO-LLVM-Upstream: https://github.com/dotnet/runtimelab/issues/2576 -->
+  <Import Project="Microsoft.Interop.SourceGeneration.csproj" />
+</Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
@@ -18,6 +18,7 @@
     <ItemGroup>
       <PackagingTestProject Include="PackagingTests/PackagingTestProject.csproj">
         <BuildProperties>
+          TreatWarningsAsErrors=true;
           Test_Configuration=$(Test_Configuration);
           Test_TargetFramework=$(Test_TargetFramework);
           Test_RuntimeIdentifier=$(Test_RuntimeIdentifier);

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests.csproj
@@ -16,7 +16,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackagingTestProject Include="PackagingTests/PackagingTestProject.csproj">
+      <DotNetJsApiTestProject Include="PackagingTests/PackagingTestProject.DotNetJsApi.csproj"
+                              Condition="'$(TargetsBrowser)' == 'true'"
+                              ExpectedOutputName="dotnet.native.wasm" />
+
+      <PackagingTestProject Include="PackagingTests/PackagingTestProject.csproj;@(DotNetJsApiTestProject)">
         <BuildProperties>
           TreatWarningsAsErrors=true;
           Test_Configuration=$(Test_Configuration);
@@ -44,6 +48,8 @@
 
       <PackagingTestProject Include="@(SampleProject)"
                             Condition="'$(Test_HostPackageRuntimeIdentifier)' == '$(NETCoreSdkPortableRuntimeIdentifier)'" />
+
+      <PackagingTestProject Condition="'%(PackagingTestProject.ExpectedOutputName)' == ''" ExpectedOutputName="%(FileName).wasm" />
     </ItemGroup>
 
     <Error Condition="!Exists($(Test_RestoreSource))"
@@ -70,7 +76,7 @@
              Targets="Publish"
              Properties="%(BuildProperties)" />
 
-    <Error Condition="!Exists('%(OutputPathRoot)/bin/$(Test_Configuration)/$(Test_TargetFramework)/$(Test_RuntimeIdentifier)/publish/%(FileName).wasm')"
+    <Error Condition="!Exists('%(OutputPathRoot)/bin/$(Test_Configuration)/$(Test_TargetFramework)/$(Test_RuntimeIdentifier)/publish/%(ExpectedOutputName)')"
            Text="%(PackagingTestProject.FullPath) did not produce the expected native artifacts" />
   </Target>
 </Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.DotNetJsApi.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.DotNetJsApi.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DotNetJsApi>true</DotNetJsApi>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <Import Project="PackagingTestProject.props" />
+</Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.csproj
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.csproj
@@ -1,23 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <Configuration>$(Test_Config)</Configuration>
-    <TargetFramework>$(Test_TargetFramework)</TargetFramework>
-    <RuntimeIdentifier>$(Test_RuntimeIdentifier)</RuntimeIdentifier>
-
-    <PublishTrimmed>true</PublishTrimmed>
-    <SelfContained>true</SelfContained>
-    <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
-    <UseAppHost>false</UseAppHost>
-
-    <RestorePackagesPath>$(Test_RestorePackagesPath)</RestorePackagesPath>
-    <RestoreAdditionalProjectSources>$(Test_RestoreSource)</RestoreAdditionalProjectSources>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
-    <PackageReference Include="runtime.$(Test_HostPackageRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
-  </ItemGroup>
-
+  <Import Project="PackagingTestProject.props" />
 </Project>

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.props
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/PackagingTests/PackagingTestProject.props
@@ -1,0 +1,21 @@
+<Project>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Configuration>$(Test_Config)</Configuration>
+    <TargetFramework>$(Test_TargetFramework)</TargetFramework>
+    <RuntimeIdentifier>$(Test_RuntimeIdentifier)</RuntimeIdentifier>
+
+    <PublishTrimmed>true</PublishTrimmed>
+    <SelfContained>true</SelfContained>
+    <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
+    <UseAppHost>false</UseAppHost>
+
+    <RestorePackagesPath>$(Test_RestorePackagesPath)</RestorePackagesPath>
+    <RestoreAdditionalProjectSources>$(Test_RestoreSource)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
+    <PackageReference Include="runtime.$(Test_HostPackageRuntimeIdentifier).Microsoft.DotNet.ILCompiler.LLVM" Version="$(Test_PackageVersion)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
So that they don't conflict.

Fixes https://github.com/dotnet/runtimelab/issues/3234.