### PR TITLE
Upgrade to V4 arcade publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <PublishingVersion>3</PublishingVersion>
+    <PublishingVersion>4</PublishingVersion>
   </PropertyGroup>
 </Project>

--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -20,6 +20,7 @@ jobs:
       clean: all
 
     enableMicrobuild: true
+    enablePublishing: true
 
     variables:
       - name: '_SignType'
@@ -51,7 +52,6 @@ jobs:
         /p:OfficialBuildId=$(Build.BuildNumber)
         /p:SignType=$(_SignType)
         /p:DotNetSignType=$(_SignType)
-        /p:DotNetPublishUsingPipelines=true
         /bl:$(Build.SourcesDirectory)\prepare-artifacts.binlog
       displayName: Prepare artifacts and upload to build
     

--- a/eng/pipelines/common/templates/publish.yml
+++ b/eng/pipelines/common/templates/publish.yml
@@ -1,6 +1,6 @@
 parameters:
   PublishRidAgnosticPackagesFromPlatform: windows_x64
-  publishingInfraVersion: 3
+  publishingInfraVersion: 4
   enableSigningValidation: false
   enableNugetValidation: false
   enableSourceLinkValidation: false
@@ -21,6 +21,7 @@ stages:
   - template: /eng/common/templates-official/job/publish-build-assets.yml
     parameters:
       publishUsingPipelines: true
+      publishingVersion: 4
       publishAssetsImmediately: true
       dependsOn: PrepareSignedArtifacts
       pool:


### PR DESCRIPTION
## Summary
- switch Arcade publishing to V4 in ng/Publishing.props
- opt PrepareSignedArtifacts into V4 pipeline artifact publishing and remove the legacy MSBuild flag
- update the publishing template to use V4 build asset discovery and post-build validation

Part of dotnet/arcade#16697.