### PR TITLE
[NativeAOT-LLVM] Fix copies with significant padding and GC refs

### DIFF
--- a/src/coreclr/jit/llvm.h
+++ b/src/coreclr/jit/llvm.h
@@ -624,7 +624,6 @@ private:
     Value* consumeInitVal(GenTree* initVal, uint8_t* pValue);
     void consumeInitValAndEmitInitBlk(GenTree* initVal, Value* addrValue, ClassLayout* layout);
     void storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc);
-    unsigned buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress);
     void emitMemSet(Value* addr, uint8_t value, unsigned size);
 
     void emitJumpToThrowHelper(Value* jumpCondValue, CorInfoHelpFunc helperFunc DEBUGARG(GenTree* nodeThrowing));

--- a/src/coreclr/jit/llvmcodegen.cpp
+++ b/src/coreclr/jit/llvmcodegen.cpp
@@ -2477,26 +2477,39 @@ void Llvm::consumeInitValAndEmitInitBlk(GenTree* initVal, Value* addrValue, Clas
 void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* structDesc)
 {
     size_t fieldCount = structDesc->getFieldCount();
-    unsigned bytesStored = 0;
+    unsigned lastLlvmFieldIndex = INT32_MAX;
+
+    const llvm::StructLayout* dataLayout = nullptr;
+    if (data->getType()->isStructTy())
+    {
+        dataLayout = m_context->Module.getDataLayout().getStructLayout(static_cast<llvm::StructType*>(data->getType()));
+    }
+    auto copyPaddingFields = [=, &lastLlvmFieldIndex](unsigned endLlvmFieldIndex) {
+        for (unsigned llvmFieldIndex = lastLlvmFieldIndex + 1; llvmFieldIndex < endLlvmFieldIndex; llvmFieldIndex++)
+        {
+            if (dataLayout != nullptr)
+            {
+                unsigned offset = static_cast<unsigned>(dataLayout->getElementOffset(llvmFieldIndex).getFixedValue());
+                Value* fieldValue = _builder.CreateExtractValue(data, llvmFieldIndex);
+                Value* address = gepOrAddr(baseAddress, offset);
+                _builder.CreateStore(fieldValue, address);
+            }
+        }
+        lastLlvmFieldIndex = endLlvmFieldIndex;
+    };
 
     for (unsigned i = 0; i < fieldCount; i++)
     {
         FieldDesc* fieldDesc = structDesc->getFieldDesc(i);
         unsigned   fieldOffset = fieldDesc->getFieldOffset();
-        Value*     address     = gepOrAddr(baseAddress, fieldOffset);
-
-        if (structDesc->hasSignificantPadding() && fieldOffset > bytesStored)
-        {
-            bytesStored += buildMemCpy(baseAddress, bytesStored, fieldOffset, address);
-        }
 
         Value* fieldData = nullptr;
-        if (data->getType()->isStructTy())
+        if (dataLayout != nullptr)
         {
-            const llvm::StructLayout* structLayout = m_context->Module.getDataLayout().getStructLayout(static_cast<llvm::StructType*>(data->getType()));
+            unsigned llvmFieldIndex = dataLayout->getElementContainingOffset(fieldOffset);
+            copyPaddingFields(llvmFieldIndex);
 
-            unsigned llvmFieldIndex = structLayout->getElementContainingOffset(fieldOffset);
-            fieldData               = _builder.CreateExtractValue(data, llvmFieldIndex);
+            fieldData = _builder.CreateExtractValue(data, llvmFieldIndex);
         }
         else
         {
@@ -2504,6 +2517,7 @@ void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* struct
             fieldData = data;
         }
 
+        Value* address = gepOrAddr(baseAddress, fieldOffset);
         if (fieldData->getType()->isStructTy())
         {
             assert(fieldDesc->getClassHandle() != NO_CLASS_HANDLE);
@@ -2523,28 +2537,12 @@ void Llvm::storeObjAtAddress(Value* baseAddress, Value* data, StructDesc* struct
                 _builder.CreateStore(fieldData, address);
             }
         }
-
-        bytesStored += static_cast<unsigned>(fieldData->getType()->getPrimitiveSizeInBits() / BITS_PER_BYTE);
     }
 
-    unsigned llvmStructSize = static_cast<unsigned>(data->getType()->getPrimitiveSizeInBits() / BITS_PER_BYTE);
-    if (structDesc->hasSignificantPadding() && llvmStructSize > bytesStored)
+    if (dataLayout != nullptr)
     {
-        Value* srcAddress = gepOrAddr(baseAddress, bytesStored);
-
-        buildMemCpy(baseAddress, bytesStored, llvmStructSize, srcAddress);
+        copyPaddingFields(static_cast<unsigned>(dataLayout->getMemberOffsets().size()));
     }
-}
-
-// Copies endOffset - startOffset bytes, endOffset is exclusive.
-unsigned Llvm::buildMemCpy(Value* baseAddress, unsigned startOffset, unsigned endOffset, Value* srcAddress)
-{
-    Value* destAddress = gepOrAddr(baseAddress, startOffset);
-    unsigned size = endOffset - startOffset;
-
-    _builder.CreateMemCpy(destAddress, llvm::Align(), srcAddress, llvm::Align(), size);
-
-    return size;
 }
 
 void Llvm::emitMemSet(Value* addr, uint8_t value, unsigned size)

--- a/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
+++ b/src/tests/nativeaot/SmokeTests/HelloWasm/HelloWasm.cs
@@ -412,6 +412,8 @@ internal unsafe partial class Program
 
         TestStructStoreWithSignificantPadding();
 
+        TestGcStructStoreWithSignificantPadding();
+
         TestLclVarAddr(new LlvmStruct { i1 = 1, i2 = 2 });
 
         TestJitUseStruct();
@@ -625,6 +627,52 @@ internal unsafe partial class Program
         ptrCopySized = ptrCopySized + 1;
 
         EndTest(*ptrCopySized == 2);
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 8)]
+    private struct TestTwoInts_Explicit(int i0, int i1)
+    {
+        [FieldOffset(0)]
+        public int I0 = i0;
+        [FieldOffset(4)]
+        public int I1 = i1;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 8)]
+    private struct TestTwoInts_Sequential(int i0, int i1)
+    {
+        public int I0 = i0;
+        public int I1 = i1;
+    }
+
+    private struct TestTwoInts(int i0, int i1)
+    {
+        public int I0 = i0;
+        public int I1 = i1;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Size = 24)]
+    private struct TestSixInts(int i0, int i1, int i2, int i3, int i4, int i5)
+    {
+        public TestTwoInts Normal = new(i0, i1);
+        public TestTwoInts_Sequential Sequential = new(i2, i3);
+        public TestTwoInts_Explicit Explicit = new(i4, i5);
+
+        public int Value() => Normal.I0 + Normal.I1 + Sequential.I0 + Sequential.I1 + Explicit.I0 + Explicit.I1;
+    }
+
+    private struct TestNested(object obj, int i1, int i2, int i3, int i4, int i5, int i6)
+    {
+        public object Object = obj;
+        public TestSixInts SixInts = new(i1, i2, i3, i4, i5, i6);
+    }
+
+    private static unsafe void TestGcStructStoreWithSignificantPadding()
+    {
+        StartTest("TestGcStructStoreWithSignificantPadding");
+        object obj = new TestNested(new object(), 1, 2, 3, 4, 5, 6);
+        JitUse(&obj);
+        EndTest(((TestNested)obj).SixInts.Value() == 21);
     }
 
     struct LlvmStruct


### PR DESCRIPTION
The memcpy we were using was copying bytes from the copied-to object itself "back", therefore corrupting the already-copied data.

Replace with copies of padding fields we insert when constructing the LLVM type.

Fixes https://github.com/dotnet/runtimelab/issues/3257.