### PR TITLE
NativeAOT-LLVM: Update sample NativeLibraryHost.html script path for net10.0

### DIFF
--- a/samples/NativeLibrary/NativeLibraryHost.html
+++ b/samples/NativeLibrary/NativeLibraryHost.html
@@ -85,6 +85,6 @@
         }
       };
     </script>
-    <script type="text/javascript" src="bin/Release/net9.0/browser-wasm/publish/NativeLibrary.js"></script>
+    <script type="text/javascript" src="bin/Release/net10.0/browser-wasm/publish/NativeLibrary.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Updates the script source path in `NativeLibraryHost.html` from `net9.0` to `net10.0`. 

The `TargetFramework` of `NativeLibrary.csproj` is currently set to `net10.0`, so the published artifact path needs to be updated accordingly to prevent path mismatches.