### PR TITLE
Add async Main support for wasi-wasm (NativeAOT-LLVM)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -819,7 +819,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AccessedThroughPropertyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncHelpers.Browser.cs" Condition="'$(TargetsBrowser)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncHelpers.NonBrowser.cs" Condition="'$(TargetsBrowser)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncHelpers.Wasi.cs" Condition="'$(TargetsWasi)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncHelpers.NonBrowser.cs" Condition="'$(TargetsBrowser)' != 'true' and '$(TargetsWasi)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncIteratorMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncIteratorStateMachineAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncMethodBuilderAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.Wasi.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.Wasi.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    public static partial class AsyncHelpers
+    {
+        // On WASI the process's main thread is the event-loop pump.
+        // Route the compiler-generated async entry point through it
+        // instead of AsyncHelpers.NonBrowser.cs's GetAwaiter().GetResult(),
+        // whose blocking wait throws PNSE on !IsMultithreadingSupported.
+        // The poll helper pumps the loop to completion and then propagates the
+        // result with await semantics via GetAwaiter().GetResult().
+
+        /// <summary>
+        /// This method is intended to be used by a compiler-generated async entry point.
+        /// </summary>
+        /// <param name="task">The result from the main entry point to await.</param>
+        [StackTraceHidden]
+        public static void HandleAsyncEntryPoint(Task task)
+        {
+            WasiEventLoop.PollWasiEventLoopUntilResolvedVoid(task);
+        }
+
+        /// <summary>
+        /// This method is intended to be used by a compiler-generated async entry point.
+        /// </summary>
+        /// <param name="task">The result from the main entry point to await.</param>
+        [StackTraceHidden]
+        public static int HandleAsyncEntryPoint(Task<int> task)
+        {
+            return WasiEventLoop.PollWasiEventLoopUntilResolved(task);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.Wasi.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.Wasi.cs
@@ -9,13 +9,6 @@ namespace System.Runtime.CompilerServices
 {
     public static partial class AsyncHelpers
     {
-        // On WASI the process's main thread is the event-loop pump.
-        // Route the compiler-generated async entry point through it
-        // instead of AsyncHelpers.NonBrowser.cs's GetAwaiter().GetResult(),
-        // whose blocking wait throws PNSE on !IsMultithreadingSupported.
-        // The poll helper pumps the loop to completion and then propagates the
-        // result with await semantics via GetAwaiter().GetResult().
-
         /// <summary>
         /// This method is intended to be used by a compiler-generated async entry point.
         /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Wasi/WasiEventLoop.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Wasi/WasiEventLoop.cs
@@ -63,13 +63,11 @@ namespace System.Threading
             {
                 s_mainTask = null;
             }
-            var exception = mainTask.Exception;
-            if (exception is not null)
-            {
-                throw exception;
-            }
 
-            return mainTask.Result;
+            // The pump loop above guarantees the task is completed, so GetResult() never
+            // reaches the blocking (PNSE-throwing) wait. It propagates with await semantics:
+            // the original exception for faults and TaskCanceledException for cancellation.
+            return mainTask.GetAwaiter().GetResult();
         }
 
         internal static void PollWasiEventLoopUntilResolvedVoid(Task mainTask)
@@ -87,11 +85,10 @@ namespace System.Threading
                 s_mainTask = null;
             }
 
-            var exception = mainTask.Exception;
-            if (exception is not null)
-            {
-                throw exception;
-            }
+            // The pump loop above guarantees the task is completed, so GetResult() never
+            // reaches the blocking (PNSE-throwing) wait. It propagates with await semantics:
+            // the original exception for faults and TaskCanceledException for cancellation.
+            mainTask.GetAwaiter().GetResult();
         }
 
         internal static void ScheduleCheck()


### PR DESCRIPTION
## Why

On `wasi-wasm`, `AsyncHelpers.NonBrowser.cs` routes the compiler-generated async entry point through a blocking `Task.GetAwaiter().GetResult()`. WASI is single-threaded (`!IsMultithreadingSupported`), so that blocking wait throws `PlatformNotSupportedException` at runtime — `async Task Main` / `async Task<int> Main` fail on wasi-wasm NativeAOT-LLVM.

## What changed

Two files, entirely in the managed framework (codegen-agnostic):

- **`src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.Wasi.cs`** (new) — routes `HandleAsyncEntryPoint(Task)` / `HandleAsyncEntryPoint(Task<int>)` through `WasiEventLoop.PollWasiEventLoopUntilResolvedVoid` / `PollWasiEventLoopUntilResolved`.
- **`src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems`** — compiles `AsyncHelpers.Wasi.cs` when `TargetsWasi == true`, and excludes `AsyncHelpers.NonBrowser.cs` on WASI.

`WasiEventLoop.PollWasiEventLoopUntilResolved{,Void}` already exist on this branch, so **no runtime/native change** is required — the fix ends up in the managed `System.Private.CoreLib.dll` that ILC links. Mirrors the pattern from [dotnet/runtime#130051](https://github.com/dotnet/runtime/pull/130051) (the CoreCLR wasi-wasm interpreter standup).

### Notes

- The C# compiler only emits the async-Main routing when `AsyncHelpers.HandleAsyncEntryPoint` is visible in the targeting pack — present in **net11**, absent in net10. Consumers must target net11.
