### PR TITLE
Add ZeroGC to Active Experimental Projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently, this repo contains the following experimental projects:
 - [ManagedZLib](https://github.com/dotnet/runtimelab/tree/feature/ManagedZLib) - Fully managed implementation of DEFLATE algorithm and GZip/ZLib envelope formats.
 - [SwiftBindings](https://github.com/dotnet/runtimelab/tree/feature/swift-bindings) - Swift bindings for .NET.
 - [CoreCLR Interpreter](https://github.com/dotnet/runtimelab/tree/feature/CoreclrInterpreter) - An interpreter for CoreCLR.
+- [ZeroGC](https://github.com/dotnet/runtimelab/tree/feature/ZeroGC) - A standalone, allocate-only CoreCLR GC for measuring the maximum achievable allocation throughput of an application.
 
 You can create your own experiment, learn more [here](CreateAnExperiment.md)!
 


### PR DESCRIPTION
Adds an entry for the new ZeroGC experiment (see dotnet/runtimelab#3281) to the `docs` branch's `README.md`, per `CreateAnExperiment.md`.