### PR TITLE
ZeroGC: fix native build incorrectly attempted on macOS CI leg

### DIFF
--- a/src/ZeroGC/pkg/Microsoft.DotNet.RuntimeLab.ZeroGC.Net10/Microsoft.DotNet.RuntimeLab.ZeroGC.Net10.csproj
+++ b/src/ZeroGC/pkg/Microsoft.DotNet.RuntimeLab.ZeroGC.Net10/Microsoft.DotNet.RuntimeLab.ZeroGC.Net10.csproj
@@ -84,8 +84,18 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    ZeroGC only ships win-x64/linux-x64 native assets - there is no macOS
+    support (ZeroGCPal.h uses Linux/glibc-specific APIs like
+    sys/sysinfo.h that don't exist on Darwin). The repo's generic CI
+    matrix (eng/pipelines/runtimelab.yml) also runs an "OSX x64" leg that
+    isn't RID-specific to ZeroGC's packaging, so this target must key off
+    the actual OS, not merely "not Windows" - otherwise it would
+    incorrectly attempt (and fail) a Linux-flavored native build on
+    macOS agents.
+  -->
   <Target Name="BuildZeroGCNativeLinux"
-          Condition="'$(OS)' != 'Windows_NT'"
+          Condition="$([MSBuild]::IsOSPlatform('Linux'))"
           BeforeTargets="Build">
     <Error Condition="!Exists('$(ZeroGCReferenceRuntimeRepo)/src/coreclr')"
            Text="ZeroGCReferenceRuntimeRepo ('$(ZeroGCReferenceRuntimeRepo)') does not look like a dotnet/runtime checkout (expected 'src/coreclr' under it). Set the ZEROGC_NET10_RUNTIME_REPO environment variable or pass /p:ZeroGCReferenceRuntimeRepo=&lt;path&gt;." />

--- a/src/ZeroGC/pkg/Microsoft.DotNet.RuntimeLab.ZeroGC.Net11/Microsoft.DotNet.RuntimeLab.ZeroGC.Net11.csproj
+++ b/src/ZeroGC/pkg/Microsoft.DotNet.RuntimeLab.ZeroGC.Net11/Microsoft.DotNet.RuntimeLab.ZeroGC.Net11.csproj
@@ -68,8 +68,18 @@
     </ItemGroup>
   </Target>
 
+  <!--
+    ZeroGC only ships win-x64/linux-x64 native assets - there is no macOS
+    support (ZeroGCPal.h uses Linux/glibc-specific APIs like
+    sys/sysinfo.h that don't exist on Darwin). The repo's generic CI
+    matrix (eng/pipelines/runtimelab.yml) also runs an "OSX x64" leg that
+    isn't RID-specific to ZeroGC's packaging, so this target must key off
+    the actual OS, not merely "not Windows" - otherwise it would
+    incorrectly attempt (and fail) a Linux-flavored native build on
+    macOS agents.
+  -->
   <Target Name="BuildZeroGCNativeLinux"
-          Condition="'$(OS)' != 'Windows_NT'"
+          Condition="$([MSBuild]::IsOSPlatform('Linux'))"
           BeforeTargets="Build">
     <Error Condition="!Exists('$(ZeroGCReferenceRuntimeRepo)/src/coreclr')"
            Text="ZeroGCReferenceRuntimeRepo ('$(ZeroGCReferenceRuntimeRepo)') does not look like a dotnet/runtime checkout (expected 'src/coreclr' under it). Set the ZEROGC_NET11_RUNTIME_REPO environment variable or pass /p:ZeroGCReferenceRuntimeRepo=&lt;path&gt;." />


### PR DESCRIPTION
Fixes a real CI failure discovered on the second live run after #3284/#3285 merged: the repo's generic CI matrix (`eng/pipelines/runtimelab.yml`) runs an "OSX x64" leg that isn't RID-specific to ZeroGC's packaging, but `BuildZeroGCNativeLinux`'s condition (`'$(OS)' != 'Windows_NT'`) matched any non-Windows OS, including macOS. That target invokes `build-linux.sh`, which compiles against Linux/glibc-specific headers (`ZeroGCPal.h` includes `sys/sysinfo.h`, unavailable on Darwin) - the macOS leg failed with `fatal error: sys/sysinfo.h file not found`.

ZeroGC has no macOS support (no `runtimes/osx-x64` asset, no PAL code for it) and this was never intended. Fixed by scoping the condition to actual Linux via `$([MSBuild]::IsOSPlatform('Linux'))` instead of merely "not Windows". On macOS, neither native-build target now runs; `Pack` still succeeds producing a package with no native asset for that leg, which is fine since only the Windows and Linux CI/official legs are ever used to produce/ship ZeroGC's actual packages.

Verified locally: `build.cmd -pack -c Release` still builds cleanly on Windows (0 warnings/errors), unchanged output.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
