### PR TITLE
Fix official publish YAML expansion

### DIFF
--- a/eng/pipelines/common/templates/publish.yml
+++ b/eng/pipelines/common/templates/publish.yml
@@ -42,22 +42,6 @@ stages:
     enableNugetValidation: ${{ parameters.enableNugetValidation }}
     enableSourceLinkValidation: ${{ parameters.enableSourceLinkValidation }}
     publishAssetsImmediately: true
-    SDLValidationParameters:
-      enable: false
-      artifactNames:
-      - PackageArtifacts
-      - BlobArtifacts
-      params: >-
-        -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL "$(TsaInstanceURL)"
-        -TsaProjectName "$(TsaProjectName)"
-        -TsaNotificationEmail "$(TsaNotificationEmail)"
-        -TsaCodebaseAdmin "$(TsaCodebaseAdmin)"
-        -TsaBugAreaPath "$(TsaBugAreaPath)"
-        -TsaIterationPath "$(TsaIterationPath)"
-        -TsaRepositoryName "$(TsaRepositoryName)"
-        -TsaCodebaseName "$(TsaCodebaseName)"
-        -TsaPublish $True
     symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
     # Publish to blob storage.
     publishInstallersAndChecksums: true


### PR DESCRIPTION
The official runtimelab build fails during YAML expansion because the current post-build template no longer accepts `SDLValidationParameters`. Since this happens before any jobs are created, rerunning the build cannot recover it.

This removes the unsupported `SDLValidationParameters` block from the shared publish template while leaving the existing publishing and validation parameters unchanged.