### PR TITLE
Fix official Prepare Signed Artifacts job failing to extract Linux partial nupkg (Expand-Archive vs .nupkg extension)

### DIFF
--- a/src/ZeroGC/pkg/Microsoft.DotNet.RuntimeLab.ZeroGC.Net10/Microsoft.DotNet.RuntimeLab.ZeroGC.Net10.csproj
+++ b/src/ZeroGC/pkg/Microsoft.DotNet.RuntimeLab.ZeroGC.Net10/Microsoft.DotNet.RuntimeLab.ZeroGC.Net10.csproj
@@ -122,7 +122,10 @@
     <Error Condition="'@(_ZeroGCLinuxPartialNupkg)' == ''"
            Text="Expected a Linux partial package matching '$(PackageId).*.nupkg' under artifacts\PackageDownload\IntermediateArtifacts\Linuxx64\Shipping, but none was found - did the official build's Linux leg fail to produce/upload its intermediate artifact?" />
     <RemoveDir Directories="$(_ZeroGCLinuxExtractDir)" Condition="Exists('$(_ZeroGCLinuxExtractDir)')" />
-    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;Expand-Archive -LiteralPath '%(_ZeroGCLinuxPartialNupkg.FullPath)' -DestinationPath '$(_ZeroGCLinuxExtractDir)' -Force&quot;" />
+    <!-- Expand-Archive refuses to extract .nupkg (it only recognizes the
+         .zip extension, even though a nupkg is a zip file), so extract via
+         System.IO.Compression.ZipFile directly instead. -->
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('%(_ZeroGCLinuxPartialNupkg.FullPath)', '$(_ZeroGCLinuxExtractDir)')&quot;" />
     <ItemGroup>
       <None Include="$(_ZeroGCLinuxExtractDir)runtimes\linux-x64\native\libZeroGC.so"
             PackagePath="runtimes/linux-x64/native"

--- a/src/ZeroGC/pkg/Microsoft.DotNet.RuntimeLab.ZeroGC.Net11/Microsoft.DotNet.RuntimeLab.ZeroGC.Net11.csproj
+++ b/src/ZeroGC/pkg/Microsoft.DotNet.RuntimeLab.ZeroGC.Net11/Microsoft.DotNet.RuntimeLab.ZeroGC.Net11.csproj
@@ -105,7 +105,10 @@
     <Error Condition="'@(_ZeroGCLinuxPartialNupkg)' == ''"
            Text="Expected a Linux partial package matching '$(PackageId).*.nupkg' under artifacts\PackageDownload\IntermediateArtifacts\Linuxx64\Shipping, but none was found - did the official build's Linux leg fail to produce/upload its intermediate artifact?" />
     <RemoveDir Directories="$(_ZeroGCLinuxExtractDir)" Condition="Exists('$(_ZeroGCLinuxExtractDir)')" />
-    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;Expand-Archive -LiteralPath '%(_ZeroGCLinuxPartialNupkg.FullPath)' -DestinationPath '$(_ZeroGCLinuxExtractDir)' -Force&quot;" />
+    <!-- Expand-Archive refuses to extract .nupkg (it only recognizes the
+         .zip extension, even though a nupkg is a zip file), so extract via
+         System.IO.Compression.ZipFile directly instead. -->
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('%(_ZeroGCLinuxPartialNupkg.FullPath)', '$(_ZeroGCLinuxExtractDir)')&quot;" />
     <ItemGroup>
       <None Include="$(_ZeroGCLinuxExtractDir)runtimes\linux-x64\native\libZeroGC.so"
             PackagePath="runtimes/linux-x64/native"


### PR DESCRIPTION
Progress from the previous fix (#3290): the runtime-checkout error is gone and both ZeroGC.dll builds (net10/net11) now compile successfully in the official 'Prepare Signed Artifacts' job. The next failure is in \IncludeLinuxNativeAssetFromIntermediateArtifacts\, which pulls \libZeroGC.so\ out of the Linux leg's uploaded partial package so the final combined Windows-built package carries both RIDs:

\\\
Expand-Archive : .nupkg is not a supported archive file format. .zip is the only supported archive file format.
\\\

PowerShell's \Expand-Archive\ only recognizes the \.zip\ extension and refuses anything else, even though a \.nupkg\ is a zip file internally. This replaces it with \[System.IO.Compression.ZipFile]::ExtractToDirectory\, which extracts based on content, not extension.

Verified locally:
- \uild.cmd -pack -c Release\ still succeeds, 0 warnings/errors.
- Standalone repro: renamed a \.zip\ to \.nupkg\ and confirmed \Expand-Archive\ fails on it while \ZipFile.ExtractToDirectory\ succeeds.

Seen failing in the official run with \OfficialBuildId=20260730.3\.