### PR TITLE
Fix official pipeline Publish Build Assets stage: upload missing AssetManifests artifact

### DIFF
--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -41,6 +41,18 @@ jobs:
         condition: succeededOrFailed()
         targetPath: '$(Build.StagingDirectory)\BuildLogs'
         artifactName: ${{ parameters.logArtifactName }}
+      # The subsequent "Publish Build Assets" stage (post-build.yml,
+      # publishingVersion 3 - our default) downloads a pipeline artifact
+      # literally named 'AssetManifests' to discover what this job staged
+      # for BAR/Maestro. 'build.cmd -publish' (above) writes that manifest
+      # XML to artifacts/log/<Configuration>/AssetManifest/*.xml (Arcade's
+      # AssetManifestFilePath convention) - upload that folder here so the
+      # download step in publish-build-assets.yml finds it.
+      - output: pipelineArtifact
+        displayName: 'Publish Asset Manifests'
+        condition: succeeded()
+        targetPath: '$(Build.SourcesDirectory)\artifacts\log\Release\AssetManifest'
+        artifactName: 'AssetManifests'
     
     steps:
     - powershell: |


### PR DESCRIPTION
Further progress from #3290/#3291: the 'Prepare Signed Artifacts' job now completes (compiles, packs, signs) successfully. The next stage, 'Publish Build Assets' (Arcade's shared post-build.yml template, publishingVersion 3 - our default), failed:

\\\
error : Required folder 'D:\a\_work\1\a/AssetManifests' does not exist.
\\\

That stage downloads a pipeline artifact literally named \AssetManifests\ to learn what the signing job staged for BAR/Maestro. \uild.cmd -publish -pack\ (run inside 'Prepare Signed Artifacts') does write that manifest XML locally, to \rtifacts/log/<Configuration>/AssetManifest/*.xml\ (confirmed locally: it wrote \rtifacts\\log\\Release\\AssetManifest\\Windows_NT-AnyCPU.xml\) - but the job never uploaded that folder as a pipeline artifact, so the download in the later stage found nothing.

This adds a 'Publish Asset Manifests' pipelineArtifact output (alongside the existing BuildLogs output) uploading \rtifacts/log/Release/AssetManifest\ as the \AssetManifests\ artifact, matching what the downstream stage expects.

Verified locally: \uild.cmd -pack -publish -c Release\ succeeds and produces exactly the file path this change uploads.