### PR TITLE
Fix official pipeline Publish Build Assets: use V4 asset publishing consistently (supersedes #3292)

### DIFF
--- a/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/common/jobs/prepare-signed-artifacts.yml
@@ -21,6 +21,14 @@ jobs:
 
     enableMicrobuild: false
     enablePublishing: true
+    # publish-build-assets.yml (invoked below, in publish.yml) is called
+    # with publishingVersion: 4 (V4/"stages-based" asset publishing), which
+    # discovers assets by scanning every job's pipeline artifact for a
+    # 'manifests/**/*.xml' entry - it does NOT look for a V3-style artifact
+    # literally named 'AssetManifests'. Must match here so this job's
+    # auto-generated V4 output (below) and 'build.cmd -publish' (further
+    # below) both write/upload to the same V4 layout.
+    publishingVersion: 4
 
     variables:
       - name: '_SignType'
@@ -41,18 +49,13 @@ jobs:
         condition: succeededOrFailed()
         targetPath: '$(Build.StagingDirectory)\BuildLogs'
         artifactName: ${{ parameters.logArtifactName }}
-      # The subsequent "Publish Build Assets" stage (post-build.yml,
-      # publishingVersion 3 - our default) downloads a pipeline artifact
-      # literally named 'AssetManifests' to discover what this job staged
-      # for BAR/Maestro. 'build.cmd -publish' (above) writes that manifest
-      # XML to artifacts/log/<Configuration>/AssetManifest/*.xml (Arcade's
-      # AssetManifestFilePath convention) - upload that folder here so the
-      # download step in publish-build-assets.yml finds it.
-      - output: pipelineArtifact
-        displayName: 'Publish Asset Manifests'
-        condition: succeeded()
-        targetPath: '$(Build.SourcesDirectory)\artifacts\log\Release\AssetManifest'
-        artifactName: 'AssetManifests'
+      # NOTE: with publishingVersion: 4 set above, /eng/common/templates-official/job/job.yml
+      # automatically adds a '$(System.PhaseName)_Artifacts' pipelineArtifact
+      # output covering '$(Build.ArtifactStagingDirectory)/artifacts' - no
+      # manual output is needed here for asset manifests/packages, as long as
+      # 'build.cmd -publish' (below) is told to use PublishingVersion=4 too,
+      # so it stages the manifest under .../artifacts/manifests/*.xml instead
+      # of the legacy artifacts/log/<Configuration>/AssetManifest/*.xml path.
     
     steps:
     - powershell: |
@@ -77,6 +80,7 @@ jobs:
         -publish
         -pack
         -configuration Release
+        /p:PublishingVersion=4
         /p:PublishRidAgnosticPackagesFromPlatform=${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
         /p:OfficialBuildId=$(Build.BuildNumber)
         /p:SignType=$(_SignType)


### PR DESCRIPTION
Supersedes #3292 - that fix targeted the wrong publishing model and had zero effect (confirmed: a run on that exact merge commit still failed identically).

Root cause: `publish.yml` passes `publishingVersion: 4` to `publish-build-assets.yml`, which uses Arcade's V4 ("stages-based") asset discovery - it downloads every job's pipeline artifact and looks for `*/manifests/**/*.xml` inside them. It does **not** look for a V3-style artifact literally named `AssetManifests` (which is what #3292 added).

```
error : Required folder 'D:\a\_work\1\a/AssetManifests' does not exist.
```

Verified locally (setting `BUILD_ARTIFACTSTAGINGDIRECTORY` to simulate the CI agent environment) that the manifest needs to land at `$(Build.ArtifactStagingDirectory)/artifacts/manifests/*.xml` for the V4 download step to find it.

Two-part fix:
1. Pass `publishingVersion: 4` into this job's `job.yml` template call, so `/eng/common/templates-official/job/job.yml`'s built-in V4 auto-output (gated on `publishingVersion == 4` and `enablePublishing == 'true'`) fires and uploads `$(Build.ArtifactStagingDirectory)/artifacts` as this job's pipeline artifact. This makes the manual `AssetManifests` output from #3292 unnecessary, so it's removed.
2. Pass `/p:PublishingVersion=4` to the `build.cmd -publish -pack` invocation, so Arcade's `Publish.proj` stages the manifest under `.../artifacts/manifests/*.xml` (matching the V4 itemPattern) instead of the legacy `artifacts/log/<Configuration>/AssetManifest/*.xml` path used when `PublishingVersion` is unset.

Verified locally end-to-end: with `BUILD_ARTIFACTSTAGINGDIRECTORY` set and `/p:PublishingVersion=4`, the build produces exactly `<staging>\artifacts\manifests\Windows_NT-AnyCPU.xml` alongside the packages under `<staging>\artifacts\packages\shipping\`. `build.cmd -pack -publish -c Release` also still succeeds normally (0 warnings/errors) without the env var set.
