### PR TITLE
Update ZeroGC docs with verified NuGet consumption instructions

### DIFF
--- a/docs/zerogc/using-prebuilt-binaries.md
+++ b/docs/zerogc/using-prebuilt-binaries.md
@@ -36,9 +36,39 @@ Then add the package (use the exact prerelease version currently published -
 dotnet add package Microsoft.DotNet.RuntimeLab.ZeroGC.Net10 --version 1.0.0-zerogc.26381.4
 ```
 
-Alternatively, build `ZeroGC.dll`/`libZeroGC.so` yourself from source - see
+### Or: build it yourself from source
+
+You don't need the NuGet feed at all - `ZeroGC.dll`/`libZeroGC.so` is a
+small, self-contained native project you can build locally in a couple of
+minutes. This is the only option if you don't have access to the
+`dotnet-experimental` feed (e.g. an air-gapped/restricted network), or if
+you need a runtime version not currently published, or want to modify
+ZeroGC itself. Full details, including toolchain requirements, are in
 "Building ZeroGC.dll / libZeroGC.so" in
-[`../../src/ZeroGC/README.md`](../../src/ZeroGC/README.md#building-zerogcdll--libzerogcso).
+[`../../src/ZeroGC/README.md`](../../src/ZeroGC/README.md#building-zerogcdll--libzerogcso);
+short version:
+
+```powershell
+# Windows - from a Developer Command Prompt / PowerShell with cl.exe on PATH
+cd src\ZeroGC\native
+.\build.ps1
+# -> produces native\ZeroGC.dll (Release, x64)
+```
+
+```bash
+# Linux - requires clang++/g++ with C++17 and a local dotnet/runtime checkout
+# (used only as a read-only header dependency, never modified)
+cd src/ZeroGC/native
+./build-linux.sh --runtime-repo /path/to/runtime
+# -> produces native/obj-linux/Release/libZeroGC.so
+```
+
+Pick the `dotnet/runtime` tag/branch matching your app's target runtime
+major version (net10.0 GA vs. net11.0 preview) - see
+[Why per-version, and why it matters](#why-per-version-and-why-it-matters)
+below for why this matters. The resulting binary is used exactly the same
+way as the NuGet-sourced one - place it next to your app (step 2 below)
+and set `DOTNET_GCName` (step 3).
 
 ## 2. Place the binary next to your app
 

--- a/docs/zerogc/using-prebuilt-binaries.md
+++ b/docs/zerogc/using-prebuilt-binaries.md
@@ -6,36 +6,91 @@ See [`../../src/ZeroGC/README.md`](../../src/ZeroGC/README.md) for what
 ZeroGC is, how it's implemented, and its measured performance
 characteristics. This page only covers *consuming* a built binary.
 
-## 1. Build the right binary
+## 1. Get the binary
 
-**No prebuilt binaries are published for this experiment.** Any binary
-officially distributed from `dotnet/runtimelab` needs to be built and
-hosted on Microsoft's own infrastructure rather than a personal
-account/fork - ZeroGC doesn't have that build plumbing (Arcade/official
-Azure Pipelines integration producing a signed NuGet package) set up yet.
+Signed binaries are published as NuGet packages, built by Microsoft's own
+official Arcade/Azure Pipelines infrastructure and pushed to the
+`dotnet-experimental` feed - one package per targeted runtime major version
+(see [Why per-version, and why it matters](#why-per-version-and-why-it-matters)
+below for why you must pick the package matching your app's TFM):
 
-Build `ZeroGC.dll` (Windows) or `libZeroGC.so` (Linux) yourself following
-the "Building ZeroGC.dll / libZeroGC.so" section of
-[`../../src/ZeroGC/README.md`](../../src/ZeroGC/README.md#building-zerogcdll--libzerogcso),
-picking the `dotnet/runtime` tag/branch that matches your app's target
-runtime version (net10.0 GA vs. net11.0 preview - see
-[Why per-version, and why it matters](#why-per-version-and-why-it-matters)
-below for why this choice is a hard requirement, not just a
-recommendation).
+| Your app's TFM | Package |
+|---|---|
+| `net10.0` | `Microsoft.DotNet.RuntimeLab.ZeroGC.Net10` |
+| `net11.0` | `Microsoft.DotNet.RuntimeLab.ZeroGC.Net11` |
+
+Add the feed to a `nuget.config` in your project (or solution) directory:
+
+```xml
+<configuration>
+  <packageSources>
+    <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+Then add the package (use the exact prerelease version currently published -
+`--version` and `--prerelease` cannot be combined in the same command):
+
+```powershell
+dotnet add package Microsoft.DotNet.RuntimeLab.ZeroGC.Net10 --version 1.0.0-zerogc.26381.4
+```
+
+Alternatively, build `ZeroGC.dll`/`libZeroGC.so` yourself from source - see
+"Building ZeroGC.dll / libZeroGC.so" in
+[`../../src/ZeroGC/README.md`](../../src/ZeroGC/README.md#building-zerogcdll--libzerogcso).
 
 ## 2. Place the binary next to your app
 
-Copy the native binary you just built (see `native/build.ps1`'s or
-`native/build-linux.sh`'s output path) into your app's published output
-folder, next to `YourApp.dll`:
+The package only carries the native `ZeroGC.dll`/`libZeroGC.so` as a
+RID-specific native asset - it is **not** automatically flattened next to
+your app's executable by a plain `dotnet build`. You have two options,
+both verified end-to-end:
+
+### Option A - copy the file manually (lightweight, no publish required)
+
+Best if you just want to try ZeroGC against an existing `dotnet build`
+output without changing your deployment model. After `dotnet build`, copy
+the single native file from the NuGet package cache into your build
+output, next to `YourApp.dll`:
+
+```powershell
+# Windows, framework-dependent dotnet build output
+Copy-Item "$env:USERPROFILE\.nuget\packages\microsoft.dotnet.runtimelab.zerogc.net10\1.0.0-zerogc.26381.4\runtimes\win-x64\native\ZeroGC.dll" `
+          "bin\Release\net10.0\ZeroGC.dll"
+```
+
+```bash
+# Linux
+cp ~/.nuget/packages/microsoft.dotnet.runtimelab.zerogc.net10/1.0.0-zerogc.26381.4/runtimes/linux-x64/native/libZeroGC.so \
+   bin/Release/net10.0/libZeroGC.so
+```
+
+For repeat use, automate this with a post-build MSBuild `<Copy>` target or
+a CI script step, rather than copying by hand every time.
+
+### Option B - `dotnet publish -r` (RID-specific publish)
+
+If you're already publishing RID-specific output (self-contained or
+framework-dependent), the package's native asset is picked up and
+flattened automatically - no manual copy needed:
+
+```powershell
+dotnet publish -c Release -r win-x64 --self-contained false
+```
 
 ```
-YourApp/
+YourApp/bin/Release/net10.0/win-x64/publish/
   YourApp.dll
   YourApp.runtimeconfig.json
-  ZeroGC.dll          <-- copied here (Windows)
-  ... (or libZeroGC.so on Linux)
+  ZeroGC.dll          <-- placed here automatically (Windows)
+  ... (or libZeroGC.so on Linux, with -r linux-x64)
 ```
+
+Both options were validated to produce identical behavior (0 gen0
+collections, monotonically growing working set) - pick whichever fits
+your existing build/deploy process; Option A avoids the overhead of a
+RID-specific publish if you only want a quick experiment.
 
 ## 3. Tell the runtime to use it
 

--- a/src/ZeroGC/README.md
+++ b/src/ZeroGC/README.md
@@ -20,11 +20,12 @@ by this project — `C:\github\runtime` was used only as a read-only reference
 for the unmodified GC interface headers (`gcinterface.h`, `gcenv.*.h`, etc.)
 and to build a local, unmodified `coreclr.dll`/SDK for testing.
 
-> **No prebuilt binaries are published.** Officially distributed binaries
-> need to be built and hosted on Microsoft's own infrastructure rather than
-> a personal account/fork - this experiment doesn't have that build
-> plumbing (Arcade/official Azure Pipelines integration) set up yet. Build
-> ZeroGC yourself from source using the instructions below.
+> **Prebuilt binaries are published as NuGet packages** on Microsoft's
+> `dotnet-experimental` feed (built and signed via the official
+> Arcade/Azure Pipelines integration) - see
+> [`docs/zerogc/using-prebuilt-binaries.md`](../../docs/zerogc/using-prebuilt-binaries.md)
+> for exact consumption instructions, or "Building ZeroGC.dll / libZeroGC.so"
+> below to build from source instead.
 
 ## What works
 
@@ -179,8 +180,13 @@ published as `linux-x64` self-contained.
 
 ## Running an app with ZeroGC
 
+See [`docs/zerogc/using-prebuilt-binaries.md`](../../docs/zerogc/using-prebuilt-binaries.md)
+for the full, verified instructions (NuGet package feed, both the
+lightweight "copy one file" option and the `dotnet publish -r` option).
+Short version:
+
 Copy `ZeroGC.dll` (Windows) or `libZeroGC.so` (Linux) next to the app's
-published output, then:
+built/published output, then:
 
 ```powershell
 $env:DOTNET_GCName = "ZeroGC.dll"


### PR DESCRIPTION
## Summary

Updates the ZeroGC docs to reflect that prebuilt binaries are now
officially published, replacing outdated "no prebuilt binaries" guidance
with verified, exact end-user consumption instructions.

## Context

The official Arcade pipeline now successfully builds and publishes
signed `Microsoft.DotNet.RuntimeLab.ZeroGC.Net10`/`.Net11` NuGet packages
to the `dotnet-experimental` feed (see #3290, #3291, #3293). This PR
updates the docs accordingly, based on end-to-end testing performed
against the live feed with real net10.0 and net11.0 console apps.

## Changes

- **`src/ZeroGC/README.md`**: replaces the "no prebuilt binaries are
  published" callout with a pointer to the NuGet feed as the primary
  consumption path (keeping source-build as an alternative), and
  simplifies "Running an app with ZeroGC" to point at the detailed doc.
- **`docs/zerogc/using-prebuilt-binaries.md`**: rewrites "Get the
  binary" (nuget.config feed snippet + `dotnet add package` command) and
  "Place the binary next to your app", now presenting **two verified
  options**:
  - **Option A (lightweight)**: plain `dotnet build` + manually copying
    the single native file from the NuGet package cache next to the
    app - no publish required. Useful for a quick experiment/plug-in
    without changing your deployment model.
  - **Option B**: `dotnet publish -r <rid>` which flattens the native
    asset automatically.

## Verification

Both options were independently tested end-to-end this session against
the live `dotnet-experimental` feed packages, for both net10.0 and
net11.0 apps, using an allocation/collection-count diagnostic:

- Regular GC: 13-16 gen0 collections observed, working set reclaimed.
- ZeroGC (either consumption option): 0 gen0 collections, working set
  grows monotonically (never reclaimed) - confirming ZeroGC is genuinely
  loaded and active, not silently falling back.

Docs-only change; no code/build changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
