### PR TITLE
Update root README: prebuilt NuGet binaries are now published

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ exists to answer a simple question: how much of a real application's
 performance profile is actually GC-bound, and what would it look like with
 GC overhead reduced to (as close as possible to) zero?
 
-- **Want to try it against your own app?** No prebuilt binaries are
-  published (any officially distributed binary needs to be built and
-  hosted on Microsoft's own infrastructure, which this experiment doesn't
-  have set up yet). Build it from source using
-  [`src/ZeroGC/README.md`](src/ZeroGC/README.md), then see
+- **Want to try it against your own app?** Prebuilt, signed binaries are
+  published as NuGet packages (`Microsoft.DotNet.RuntimeLab.ZeroGC.Net10`/
+  `.Net11`) on Microsoft's public `dotnet-experimental` feed, built by the
+  official Arcade/Azure Pipelines infrastructure - no need to build from
+  source. See
   [`docs/zerogc/using-prebuilt-binaries.md`](docs/zerogc/using-prebuilt-binaries.md)
-  for how to drop the binary into your app and turn it on.
+  for the feed setup, package install, and how to drop the binary into
+  your app and turn it on (a "build it yourself" option is also documented
+  there for restricted-network environments or unpublished runtime
+  versions - see [`src/ZeroGC/README.md`](src/ZeroGC/README.md) for the
+  full build instructions).
 - Benchmark harness, sample apps (console, ASP.NET Core, GCPerfSim
   scenarios, a zero-alloc dotLLM inference server, a naturally-growing
   cache), and results: [`src/ZeroGC/`](src/ZeroGC/)


### PR DESCRIPTION
The top-level README still said 'no prebuilt binaries are published', predating the Arcade official-pipeline integration (#3284-#3293) and the docs update in #3294 (which only touched src/ZeroGC/README.md and docs/zerogc/using-prebuilt-binaries.md, missing this file). Updates it to point directly at the now-live dotnet-experimental feed packages.

Docs-only change; no code/build changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>