### PR TITLE
Revert ZeroGC: stop depending on MethodTable internal layout for IsLargeObject (#3298)

### DIFF
--- a/src/ZeroGC/native/ZeroGCHeap.cpp
+++ b/src/ZeroGC/native/ZeroGCHeap.cpp
@@ -5,7 +5,6 @@
 //
 #include "ZeroGC.h"
 #include <cstdio>
-#include <map>
 
 #if defined(ZEROGC_TRACE) && defined(HOST_WINDOWS)
 static void ZeroGCTrace(const char* msg)
@@ -85,19 +84,6 @@ static const int MAX_FROZEN_SEGMENTS = 64;
 static FrozenSegment g_frozenSegments[MAX_FROZEN_SEGMENTS];
 static CRITICAL_SECTION g_frozenSegmentsLock;
 
-// Tracks the address range of every large/pinned object's dedicated chunk
-// (see the isLarge branch in AllocateFromArena), keyed by the chunk's start
-// address, so that IsLargeObject() can answer "was this pointer's chunk
-// carved out as large?" from our own bookkeeping instead of asking the
-// object's MethodTable for its size. This is what lets ZeroGC avoid
-// depending on MethodTable's internal field layout (which is private VM
-// implementation detail, not part of the versioned GC/EE interface, and can
-// change shape across runtime major versions without any interface version
-// bump) - the only thing IsLargeObject needs to know, we already decided
-// for ourselves at allocation time.
-static std::map<uint8_t*, uint8_t*> g_largeObjectRanges; // Start -> End (exclusive)
-static CRITICAL_SECTION g_largeObjectRangesLock;
-
 ZeroGCHeap* ZeroGCHeap::CreateAndInitialize()
 {
     // NOTE: do NOT call Initialize() here. IGCHeap::Initialize() is a real
@@ -112,7 +98,6 @@ HRESULT ZeroGCHeap::Initialize()
 {
     ZGC_TRACE("ZeroGCHeap::Initialize - enter");
     InitializeCriticalSection(&g_frozenSegmentsLock);
-    InitializeCriticalSection(&g_largeObjectRangesLock);
     QueryPerformanceFrequency(&m_qpcFrequency);
     QueryPerformanceCounter(&m_startTime);
 
@@ -330,18 +315,6 @@ Object* ZeroGCHeap::AllocateFromArena(gc_alloc_context* acontext, size_t size, u
         acontext->alloc_limit = chunkStart + alignedSize;
     }
 
-    // Record this object's range for IsLargeObject() iff it actually meets
-    // the LOH size threshold - not merely because it got routed through the
-    // isLarge chunk-placement path above, which also covers small pinned
-    // (POH) allocations that are NOT "large objects" by size. This mirrors
-    // the exact criterion the removed MethodTable::GetBaseSize() check used.
-    if (alignedSize >= LARGE_OBJECT_SIZE)
-    {
-        EnterCriticalSection(&g_largeObjectRangesLock);
-        g_largeObjectRanges[chunkStart] = chunkStart + alignedSize;
-        LeaveCriticalSection(&g_largeObjectRangesLock);
-    }
-
     acontext->alloc_bytes += (int64_t)alignedSize;
     acontext->alloc_count++;
 
@@ -520,23 +493,8 @@ size_t ZeroGCHeap::GetNow()
 
 bool ZeroGCHeap::IsLargeObject(Object* pObj)
 {
-    // Answered purely from our own allocation-time bookkeeping (see
-    // AllocateFromArena) instead of dereferencing the object's MethodTable -
-    // this is the only place ZeroGC used to depend on MethodTable's private,
-    // unversioned internal layout, which made ZeroGC.dll binaries brittle
-    // across runtime major versions. Object identity/address is the only
-    // thing we need here, so no VM-internal type's field layout is touched.
-    uint8_t* p = (uint8_t*)pObj;
-    bool found = false;
-    EnterCriticalSection(&g_largeObjectRangesLock);
-    auto it = g_largeObjectRanges.upper_bound(p); // first range starting after p
-    if (it != g_largeObjectRanges.begin())
-    {
-        --it;
-        found = (p >= it->first && p < it->second);
-    }
-    LeaveCriticalSection(&g_largeObjectRangesLock);
-    return found;
+    MethodTable* mt = pObj->GetGCSafeMethodTable();
+    return mt->GetBaseSize() >= LARGE_OBJECT_SIZE;
 }
 
 void ZeroGCHeap::ValidateObjectMember(Object* obj) { ZGC_TRACE("ZeroGCHeap::ValidateObjectMember"); }


### PR DESCRIPTION
## Summary

Reverts #3298 ("ZeroGC: stop depending on MethodTable internal layout for IsLargeObject"), restoring the original `pObj->GetGCSafeMethodTable()->GetBaseSize() >= LARGE_OBJECT_SIZE` implementation of `IsLargeObject`.

## Why

Per [review discussion on #3298](https://github.com/dotnet/runtimelab/pull/3298#issuecomment-5182895624): the GC/EE data-layout contract is versioned in a structured way, not just by convention.

- `LARGE_OBJECT_SIZE` (85,000 bytes) is a public constant from the versioned `gcinterface.h` - safe to depend on regardless.
- The one concrete historical layout break #3298 was defending against - `MethodTable::Collectible()`'s flag bit remap (dotnet/runtime#91821) - bumped `EE_INTERFACE_MAJOR_VERSION` 1→2 in that same PR. `gcenv.object.h`'s existing shim (`g_oldMethodTableFlags`), which ZeroGC's `dllmain.cpp` already plugs into (`g_runtimeSupportedVersion.MajorVersion < 2`), branches on exactly that signal. So this kind of layout drift *is* covered by a real, numbered contract, not just convention.
- `MethodTable::GetBaseSize()` itself has never needed such a compatibility shim.
- ZeroGC can't avoid depending on `MethodTable`/`Object` layout anyway - those types are mandatory for the `IGCHeap` interface signatures it implements. Removing this one call site didn't reduce ZeroGC's actual exposure to layout drift.

Net effect of #3298 was added ongoing cost (a `std::map` + critical section on every LOH-sized allocation) without closing off a real risk. This PR reverts it back to the simpler, original implementation.

## Testing

- Builds clean via `src/ZeroGC/native/build.ps1`.
- Diff against the commit immediately before #3298 for `ZeroGCHeap.cpp` is empty (exact revert, no residual changes).